### PR TITLE
$splitlobby - filter different engine versions

### DIFF
--- a/lib/teiserver/coordinator/consul_server.ex
+++ b/lib/teiserver/coordinator/consul_server.ex
@@ -207,9 +207,11 @@ defmodule Teiserver.Coordinator.ConsulServer do
         |> Map.keys
 
       client = Client.get_client_by_id(split.first_splitter_id)
+      old_lobby = Lobby.get_lobby(client.lobby_id)
       new_lobby = if client.lobby_id == state.lobby_id or client.lobby_id == nil do
         # If the first splitter is still in this lobby, move them to a new one
-        Lobby.find_empty_lobby()
+        # with the same engine version as the starting lobby
+        Lobby.find_empty_lobby(fn a -> a.engine_version == old_lobby.engine_version end)
       else
         %{id: client.lobby_id}
       end

--- a/test/teiserver/coordinator/split_test.exs
+++ b/test/teiserver/coordinator/split_test.exs
@@ -171,6 +171,79 @@ defmodule Teiserver.Coordinator.SplitTest do
     assert Client.get_client_by_id(player6.id).lobby_id == empty_lobby_id
   end
 
+  test "test split with different engine version", %{host: _host, player: player1, psocket: psocket1, lobby_id: lobby_id, listener: listener, empty_lobby_id: empty_lobby_id} do
+    %{user: player2, socket: psocket2} = tachyon_auth_setup()
+    %{user: player3, socket: psocket3} = tachyon_auth_setup()
+    %{user: player4, socket: psocket4} = tachyon_auth_setup()
+    %{user: player5, socket: psocket5} = tachyon_auth_setup()
+    %{user: player6, socket: psocket6} = tachyon_auth_setup()
+
+    # Add players to the lobby
+    Lobby.add_user_to_battle(player2.id, lobby_id, "script_password")
+    Lobby.add_user_to_battle(player3.id, lobby_id, "script_password")
+    Lobby.add_user_to_battle(player4.id, lobby_id, "script_password")
+    Lobby.add_user_to_battle(player5.id, lobby_id, "script_password")
+    Lobby.add_user_to_battle(player6.id, lobby_id, "script_password")
+
+    # Normally the player joins through the standard means but we're doing a test so it's a bit janky atm
+    send(Client.get_client_by_id(player1.id).tcp_pid, {:put, :lobby_id, lobby_id})
+    send(Client.get_client_by_id(player2.id).tcp_pid, {:put, :lobby_id, lobby_id})
+    send(Client.get_client_by_id(player3.id).tcp_pid, {:put, :lobby_id, lobby_id})
+    send(Client.get_client_by_id(player4.id).tcp_pid, {:put, :lobby_id, lobby_id})
+    send(Client.get_client_by_id(player5.id).tcp_pid, {:put, :lobby_id, lobby_id})
+    send(Client.get_client_by_id(player6.id).tcp_pid, {:put, :lobby_id, lobby_id})
+
+    # Remove empty lobby with matching engine version
+    Lobby.close_lobby(empty_lobby_id)
+
+    # Add an empty lobby but with a different engine version
+    lobby_data = %{
+      cmd: "c.lobby.create",
+      name: "Empty battle - #{:rand.uniform(999_999_999)}",
+      nattype: "none",
+      port: 1234,
+      game_hash: "string_of_characters",
+      map_hash: "string_of_characters",
+      map_name: "empty valley",
+      game_name: "BAR",
+      engine_name: "spring-105",
+      engine_version: "lex.1.2.3",
+      settings: %{
+        max_players: 12
+      }
+    }
+    %{socket: hsocket_empty} = tachyon_auth_setup()
+    data = %{cmd: "c.lobby.create", lobby: lobby_data}
+    _tachyon_send(hsocket_empty, data)
+    [reply] = _tachyon_recv(hsocket_empty)
+    empty_lobby_id = reply["lobby"]["id"]
+
+    data = %{cmd: "c.lobby.message", message: "$splitlobby"}
+    _tachyon_send(psocket1, data)
+
+    # Check what got sent
+    messages = PubsubListener.get(listener)
+    assert messages == [{:lobby_chat, :say, lobby_id, player1.id, "$splitlobby"}]
+
+    # Check state
+    _tachyon_send(psocket1, %{cmd: "c.lobby.message", message: "$y"})
+    _tachyon_send(psocket2, %{cmd: "c.lobby.message", message: "$y"})
+    _tachyon_send(psocket3, %{cmd: "c.lobby.message", message: "$y"})
+    :timer.sleep(200)
+
+    # Time to resolve
+    _tachyon_send(psocket1, %{cmd: "c.lobby.message", message: "$dosplit"})
+    :timer.sleep(200)
+
+    # Split should fail because there are no empty lobbies with the same engine version as the starting one
+    assert Client.get_client_by_id(player1.id).lobby_id == lobby_id
+    assert Client.get_client_by_id(player2.id).lobby_id == lobby_id
+    assert Client.get_client_by_id(player3.id).lobby_id == lobby_id
+    assert Client.get_client_by_id(player4.id).lobby_id == lobby_id
+    assert Client.get_client_by_id(player5.id).lobby_id == lobby_id
+    assert Client.get_client_by_id(player6.id).lobby_id == lobby_id
+  end
+
   test "test split resolving" do
     # Basic test
     result = CoordinatorLib.resolve_split(%{


### PR DESCRIPTION
`$splitlobby` command will now only split to an empty lobby if it's engine version matches the starting lobby's engine version.
This fixes the issue where players could end in the hidden Engine testing lobby.