### PR TITLE
Added tzdata package to get timezones

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -158,6 +158,8 @@ config :central, Oban,
   ],
   queues: [logging: 1, cleanup: 1, teiserver: 10]
 
+config :central, :time_zone_database, Tzdata.TimeZoneDatabase
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"

--- a/lib/central/general/startup.ex
+++ b/lib/central/general/startup.ex
@@ -130,11 +130,7 @@ defmodule Central.General.Startup do
     })
 
     # Need to get the timezones
-    zones = "timedatectl"
-      |> System.cmd(["list-timezones"])
-      |> elem(0)
-      |> String.trim
-      |> String.split("\n")
+    zones = Tzdata.zone_list()
 
     add_user_config_type(%{
       key: "general.Timezone",

--- a/mix.exs
+++ b/mix.exs
@@ -83,6 +83,7 @@ defmodule Central.MixProject do
       {:dialyxir, "~> 1.1", only: [:dev], runtime: false},
       {:dart_sass, "~> 0.3", only: [:dev]},
       {:libcluster, "~> 3.3"},
+      {:tzdata, "~> 1.1"},
 
       # Teiserver libs
       {:openskill, "~> 1.0.1"},


### PR DESCRIPTION
Mac-Users are not able to get timezone information with `timedatectl list-timezones`, because of that I added a general solution for getting a list of timezones by adding the hex package [tzdata](https://hexdocs.pm/tzdata/readme.html)