### PR TITLE
Added minimum players option to $splitlobby

### DIFF
--- a/lib/teiserver/coordinator/consul_commands.ex
+++ b/lib/teiserver/coordinator/consul_commands.ex
@@ -243,7 +243,16 @@ defmodule Teiserver.Coordinator.ConsulCommands do
     ConsulServer.say_command(cmd, state)
     sender_name = User.get_username(senderid)
 
-    min_players = get_default_min_players(rem)
+    min_players = case String.trim(rem) do
+      "" ->
+        1
+
+      _ ->
+        rem
+        |> String.trim
+        |> String.to_integer
+        |> max(1)
+    end
 
     LobbyChat.sayex(state.coordinator_id, "Split lobby sequence started ($y to move, $n to cancel, $follow <name> to follow user)", state.lobby_id)
 
@@ -1131,17 +1140,6 @@ defmodule Teiserver.Coordinator.ConsulCommands do
         |> Map.get(userid)
       false ->
         -1
-    end
-  end
-
-  defp get_default_min_players(str) do
-    case String.trim(str) do
-      "" ->
-      1
-
-      _ ->
-        String.to_integer(str |> String.trim)
-        |> max(1)
     end
   end
 

--- a/lib/teiserver/coordinator/consul_server.ex
+++ b/lib/teiserver/coordinator/consul_server.ex
@@ -211,8 +211,11 @@ defmodule Teiserver.Coordinator.ConsulServer do
 
       # If the first splitter is still in this lobby, move them to a new one
       cond do
-        Enum.count(players_to_move) == 1 ->
+        Enum.count(players_to_move) == 0 ->
           LobbyChat.sayex(state.coordinator_id, "Split failed, nobody followed the split leader", state.lobby_id)
+
+        Enum.count(players_to_move) < split.min_players ->
+          LobbyChat.sayex(state.coordinator_id, "Split failed, not enough players agreed to split (#{Enum.count(players_to_move)}/#{split.min_players})", state.lobby_id)
 
         new_lobby == nil ->
           LobbyChat.sayex(state.coordinator_id, "Split failed, unable to find empty lobby", state.lobby_id)

--- a/lib/teiserver/coordinator/coordinator_lib.ex
+++ b/lib/teiserver/coordinator/coordinator_lib.ex
@@ -22,7 +22,7 @@ defmodule Teiserver.Coordinator.CoordinatorLib do
       {"afks", [], "Lists possible afk players.", :everybody},
       {"password?", [], "Tells you the room password", :everybody},
       {"splitlobby", ["minimum players"], "Causes a \"vote\" to start where other players can elect to join you in splitting the lobby, follow someone
-of their choosing or remain in place. After 30 seconds, if at the minimum number of players agreed to split, you are moved to a new (empty) lobby and those that voted yes
+of their choosing or remain in place. After 30 seconds, if at least the minimum number of players agreed to split, you are moved to a new (empty) lobby and those that voted yes
 or are following someone that voted yes are also moved to that lobby.", :everybody},
       {"roll", ["range"], "Rolls a random number based on the range format.
 - Dice format: nDs, where n is number of dice and s is sides of die. E.g. 4D6 - 4 dice with 6 sides are rolled

--- a/lib/teiserver/coordinator/coordinator_lib.ex
+++ b/lib/teiserver/coordinator/coordinator_lib.ex
@@ -21,8 +21,8 @@ defmodule Teiserver.Coordinator.CoordinatorLib do
       {"status", [], "Status info about the battle lobby.", :everybody},
       {"afks", [], "Lists possible afk players.", :everybody},
       {"password?", [], "Tells you the room password", :everybody},
-      {"splitlobby", [], "Causes a \"vote\" to start where other players can elect to join you in splitting the lobby, follow someone
-of their choosing or remain in place. After 20 seconds you are moved to a new (empty) lobby and those that voted yes
+      {"splitlobby", ["minimum players"], "Causes a \"vote\" to start where other players can elect to join you in splitting the lobby, follow someone
+of their choosing or remain in place. After 30 seconds, if at the minimum number of players agreed to split, you are moved to a new (empty) lobby and those that voted yes
 or are following someone that voted yes are also moved to that lobby.", :everybody},
       {"roll", ["range"], "Rolls a random number based on the range format.
 - Dice format: nDs, where n is number of dice and s is sides of die. E.g. 4D6 - 4 dice with 6 sides are rolled


### PR DESCRIPTION
`$splitlobby` command can now be used with a minimum number of players.

Examples:
- `$splitlobby 4` 
Will pass only if at least 4 people agreed to split to the new lobby.
 - `$splitlobby` 
Works as before (sets minimum number to 1).

In addition to this, fixed a bug where the person who calls  `$splitlobby` would always be moved to a new lobby even if no one else voted to move.