### PR TITLE
Fix case sensitive email field and add tests

### DIFF
--- a/lib/central/account.ex
+++ b/lib/central/account.ex
@@ -125,7 +125,7 @@ defmodule Central.Account do
   @spec get_user_by_email(String.t()) :: User.t() | nil
   def get_user_by_email(email) do
     UserQueries.get_users()
-    |> UserQueries.search(%{email: String.trim(email)})
+    |> UserQueries.search(%{email_lower: String.trim(email)})
     |> Repo.one()
   end
 
@@ -280,9 +280,7 @@ defmodule Central.Account do
   end
 
   def authenticate_user(conn, email, plain_text_password) do
-    query = from u in User, where: u.email == ^email
-
-    case Repo.one(query) do
+    case get_user_by_email(email) do
       nil ->
         Argon2.no_user_verify()
         Argon2.no_user_verify()

--- a/lib/central/account/queries/user_queries.ex
+++ b/lib/central/account/queries/user_queries.ex
@@ -77,6 +77,11 @@ defmodule Central.Account.UserQueries do
       where: users.email == ^email
   end
 
+  def _search(query, :email_lower, value) do
+    from users in query,
+      where: lower(users.email) == ^String.downcase(value)
+  end
+
   def _search(query, :name_or_email, value) do
     from users in query,
       where: users.email == ^value or users.name == ^value

--- a/lib/teiserver/account/caches/user_cache.ex
+++ b/lib/teiserver/account/caches/user_cache.ex
@@ -71,7 +71,7 @@ defmodule Teiserver.Account.UserCache do
         user =
           Account.get_user(nil,
             search: [
-              email: email
+              email_lower: email
             ],
             select: [:id]
           )

--- a/test/central/account/accounts_test.exs
+++ b/test/central/account/accounts_test.exs
@@ -12,7 +12,7 @@ defmodule Central.AccountTest do
       icon: "fa-regular fa-home",
       name: "some name",
       permissions: [],
-      email: "some email",
+      email: "AnEmailAddress@email.com",
       password: "some password"
     }
     @update_attrs %{
@@ -48,6 +48,19 @@ defmodule Central.AccountTest do
       assert user.name == "some name"
       assert user.permissions == []
       assert user.name == "some name"
+    end
+
+    test "get_user_by_email/1 returns the user with the given email" do
+      user = AccountTestLib.user_fixture()
+      assert Account.get_user_by_email(user.email) == user
+    end
+
+    test "get_user_by_email/1 returns the user with given email in a case-insenitive way" do
+      assert {:ok, %User{} = user} = Account.create_user(@valid_attrs)
+      assert user.email == "AnEmailAddress@email.com"
+      assert Account.get_user_by_email("anemailaddress@email.com") == user
+      assert Account.get_user_by_email("AnemailaddreSS@email.com") == user
+      assert Account.get_user_by_email("AnEmailAddress@email.com") == user
     end
 
     test "create_user/1 with invalid data returns error changeset" do


### PR DESCRIPTION
**Issue:** 
Login page at https://server4.beyondallreason.info/ is case-sensitive for email. Meaning I might be providing the correct email but in the wrong case and I get an "Invalid Credentials" error.

**Proposed Fix:**
- Added tests to expose case-sensitivity
- Added user query for case-insensitive email
- Modified several calls to use case-insensitve email query

I ran the server locally and confirmed this is solving the original bug, I can now type in my email in any cAsE and login successfully.