### PR TITLE
Add bar live services button to report page

### DIFF
--- a/lib/teiserver_web/controllers/moderation/report_controller.ex
+++ b/lib/teiserver_web/controllers/moderation/report_controller.ex
@@ -60,7 +60,7 @@ defmodule TeiserverWeb.Moderation.ReportController do
   def show(conn, %{"id" => id}) do
     report =
       Moderation.get_report!(id,
-        preload: [:target, :reporter, :responses]
+        preload: [:target, :reporter, :responses, :match]
       )
 
     fav =

--- a/lib/teiserver_web/templates/moderation/report/tab_details.html.heex
+++ b/lib/teiserver_web/templates/moderation/report/tab_details.html.heex
@@ -53,8 +53,8 @@
           <td>Replay search:</td>
           <td>
             <a
-              href={"https://bar-rts.com/replays/?players=#{@report.target.name}&date=#{date_to_str((if @report.match, do: @report.match.started, else: @report.inserted_at), format: :ymd, tz: @tz)}"}
-              }
+              href={"https://bar-rts.com/replays/?players=#{@report.target.name}&date=#{date_to_str((if @report.match, do: @report.match.started, else: @report.inserted_at), format: :ymd, tz: @tz)}" <>
+              (if @report.match, do: "&maps=#{@report.match.map}", else: "") }
               class="btn btn-secondary btn-sm"
             >
               BAR Live Services

--- a/lib/teiserver_web/templates/moderation/report/tab_details.html.heex
+++ b/lib/teiserver_web/templates/moderation/report/tab_details.html.heex
@@ -47,8 +47,22 @@
             <td>Relationship:</td>
             <td><%= @report.relationship %></td>
           </tr>
-        <% end %>
 
+          <tr>
+            <td>Replay search:</td>
+            <td>
+              <a
+                href={"https://bar-rts.com/replays/?" <>
+                "&date=" <> date_to_str(@report.inserted_at, format: :ymd, tz: @tz) <>
+                "&players=" <> @report.target.name
+                }
+                class="btn btn-secondary btn-sm"
+              >
+                BAR Live Services
+              </a>
+            </td>
+          </tr>
+        <% end %>
         <%= if @report.result_id do %>
           <tr>
             <td>Result</td>

--- a/lib/teiserver_web/templates/moderation/report/tab_details.html.heex
+++ b/lib/teiserver_web/templates/moderation/report/tab_details.html.heex
@@ -48,21 +48,19 @@
             <td><%= @report.relationship %></td>
           </tr>
 
-          <tr>
-            <td>Replay search:</td>
-            <td>
-              <a
-                href={"https://bar-rts.com/replays/?" <>
-                "&date=" <> date_to_str(@report.inserted_at, format: :ymd, tz: @tz) <>
-                "&players=" <> @report.target.name
-                }
-                class="btn btn-secondary btn-sm"
-              >
-                BAR Live Services
-              </a>
-            </td>
-          </tr>
         <% end %>
+        <tr>
+          <td>Replay search:</td>
+          <td>
+            <a
+              href={"https://bar-rts.com/replays/?players=#{@report.target.name}&date=#{date_to_str(@report.inserted_at, format: :ymd, tz: @tz)}"}
+              }
+              class="btn btn-secondary btn-sm"
+            >
+              BAR Live Services
+            </a>
+          </td>
+        </tr>
         <%= if @report.result_id do %>
           <tr>
             <td>Result</td>

--- a/lib/teiserver_web/templates/moderation/report/tab_details.html.heex
+++ b/lib/teiserver_web/templates/moderation/report/tab_details.html.heex
@@ -53,7 +53,7 @@
           <td>Replay search:</td>
           <td>
             <a
-              href={"https://bar-rts.com/replays/?players=#{@report.target.name}&date=#{date_to_str(@report.inserted_at, format: :ymd, tz: @tz)}"}
+              href={"https://bar-rts.com/replays/?players=#{@report.target.name}&date=#{date_to_str((if @report.match, do: @report.match.started, else: @report.inserted_at), format: :ymd, tz: @tz)}"}
               }
               class="btn btn-secondary btn-sm"
             >


### PR DESCRIPTION
This adds a small button to the report page that tries to find the associated match's replay. Pretty much a small convenience for finding replays. I have a local Python script that actually calls bar-rts.com's API, but I wanted to keep this simple for now.

I bet the string interpolation can be done in a much cleaner way, but I had trouble nesting the curly brackets without, I think, Phoenix complaining about it, so this is my initial proof of concept version.

I also tried adding a line such as `"&maps=" <> @report.match.map`, but then I got the following:

<details>
<summary>Traceback</summary>

# KeyError at GET /moderation/report/6

Exception:

    ** (KeyError) key :map not found in: #Ecto.Association.NotLoaded&lt;association :match is not loaded&gt;
        (central 0.1.0) lib/teiserver_web/templates/moderation/report/tab_details.html.heex:58: anonymous fn/2 in TeiserverWeb.Moderation.ReportView."tab_details.html"/1
        (phoenix_live_view 0.18.18) lib/phoenix_live_view/engine.ex:137: Phoenix.HTML.Safe.Phoenix.LiveView.Rendered.to_iodata/1
        (phoenix_live_view 0.18.18) lib/phoenix_live_view/engine.ex:153: Phoenix.HTML.Safe.Phoenix.LiveView.Rendered.to_iodata/3
        (phoenix 1.7.2) lib/phoenix/controller.ex:1010: anonymous fn/5 in Phoenix.Controller.template_render_to_iodata/4
        (telemetry 1.2.1) /home/dominik/Projects/BAR/teiserver/deps/telemetry/src/telemetry.erl:321: :telemetry.span/3
        (phoenix 1.7.2) lib/phoenix/controller.ex:976: Phoenix.Controller.render_and_send/4
        (central 0.1.0) lib/teiserver_web/controllers/moderation/report_controller.ex:1: TeiserverWeb.Moderation.ReportController.action/2
        (central 0.1.0) lib/teiserver_web/controllers/moderation/report_controller.ex:1: TeiserverWeb.Moderation.ReportController.phoenix_controller_pipeline/2
        (phoenix 1.7.2) lib/phoenix/router.ex:430: Phoenix.Router.__call__/5
        (central 0.1.0) lib/central_web/endpoint.ex:1: CentralWeb.Endpoint.plug_builder_call/2
        (central 0.1.0) lib/plug/debugger.ex:136: CentralWeb.Endpoint."call (overridable 3)"/2
        (central 0.1.0) lib/central_web/endpoint.ex:1: CentralWeb.Endpoint.call/2
        (phoenix 1.7.2) lib/phoenix/endpoint/sync_code_reload_plug.ex:22: Phoenix.Endpoint.SyncCodeReloadPlug.do_call/4
        (plug_cowboy 2.6.1) lib/plug/cowboy/handler.ex:11: Plug.Cowboy.Handler.init/2
        (cowboy 2.9.0) /home/dominik/Projects/BAR/teiserver/deps/cowboy/src/cowboy_handler.erl:37: :cowboy_handler.execute/2
        (cowboy 2.9.0) /home/dominik/Projects/BAR/teiserver/deps/cowboy/src/cowboy_stream_h.erl:306: :cowboy_stream_h.execute/3
        (cowboy 2.9.0) /home/dominik/Projects/BAR/teiserver/deps/cowboy/src/cowboy_stream_h.erl:295: :cowboy_stream_h.request_process/3
        (stdlib 4.3) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
    

Code:

`lib/teiserver_web/templates/moderation/report/tab_details.html.heex`

    53               &lt;td&gt;
    54                 &lt;a
    55                   href={"https://bar-rts.com/replays/?page=1&amp;limit=24" &lt;&gt;
    56                   "&amp;date=" &lt;&gt; date_to_str(@report.inserted_at, format: :ymd, tz: @tz) &lt;&gt;
    57                   "&amp;players=" &lt;&gt; @report.target.name &lt;&gt;
    58&gt;                  "&amp;maps=" &lt;&gt; @report.match.map
    59                   }
    60                   class="btn btn-secondary btn-sm"
    61                 &gt;
    62                   BAR Live Services
    63                 &lt;/a&gt;
    
`lib/phoenix_live_view/engine.ex`

    132                  line :: pos_integer()}
    133           }
    134   
    135     defimpl Phoenix.HTML.Safe do
    136       def to_iodata(%Phoenix.LiveView.Rendered{static: static, dynamic: dynamic}) do
    137&gt;        to_iodata(static, dynamic.(false), [])
    138       end
    139   
    140       def to_iodata(%_{} = struct) do
    141         Phoenix.HTML.Safe.to_iodata(struct)
    142       end
    
`lib/phoenix_live_view/engine.ex`

    148       def to_iodata(other) do
    149         other
    150       end
    151   
    152       defp to_iodata([static_head | static_tail], [dynamic_head | dynamic_tail], acc) do
    153&gt;        to_iodata(static_tail, dynamic_tail, [to_iodata(dynamic_head), static_head | acc])
    154       end
    155   
    156       defp to_iodata([static_head], [], acc) do
    157         Enum.reverse([static_head | acc])
    158       end
    
`lib/phoenix/controller.ex`

    1005   
    1006     defp template_render_to_iodata(view, template, format, assigns) do
    1007       metadata = %{view: view, template: template, format: format}
    1008   
    1009       :telemetry.span([:phoenix, :controller, :render], metadata, fn -&gt;
    1010&gt;        {Phoenix.Template.render_to_iodata(view, template, format, assigns), metadata}
    1011       end)
    1012     end
    1013   
    1014     defp prepare_assigns(conn, assigns, template, format) do
    1015       assigns = to_map(assigns)
    
`/home/dominik/Projects/BAR/teiserver/deps/telemetry/src/telemetry.erl`

    316           EventPrefix ++ [start],
    317           #{monotonic_time =&gt; StartTime, system_time =&gt; erlang:system_time()},
    318           merge_ctx(StartMetadata, DefaultCtx)
    319       ),
    320   
    321&gt;      try {_, #{}} = SpanFunction() of
    322         {Result, StopMetadata} -&gt;
    323             StopTime = erlang:monotonic_time(),
    324             execute(
    325                 EventPrefix ++ [stop],
    326                 #{duration =&gt; StopTime - StartTime, monotonic_time =&gt; StopTime},
    
`lib/phoenix/controller.ex`

    971     end
    972   
    973     defp render_and_send(conn, format, template, assigns) do
    974       view = view_module(conn, format)
    975       conn = prepare_assigns(conn, assigns, template, format)
    976&gt;      data = render_with_layouts(conn, view, template, format)
    977   
    978       conn
    979       |&gt; ensure_resp_content_type(MIME.type(format))
    980       |&gt; send_resp(conn.status || 200, data)
    981     end
    
`lib/teiserver_web/controllers/moderation/report_controller.ex`

    1&gt;  defmodule TeiserverWeb.Moderation.ReportController do
    2     @moduledoc false
    3     use CentralWeb, :controller
    4   
    5     alias Teiserver.{Moderation, Account}
    6     alias Teiserver.Account.UserLib
    
`lib/teiserver_web/controllers/moderation/report_controller.ex`

    1&gt;  defmodule TeiserverWeb.Moderation.ReportController do
    2     @moduledoc false
    3     use CentralWeb, :controller
    4   
    5     alias Teiserver.{Moderation, Account}
    6     alias Teiserver.Account.UserLib
    
`lib/phoenix/router.ex`

    425           :telemetry.execute([:phoenix, :router_dispatch, :stop], measurements, metadata)
    426           halted_conn
    427   
    428         %Plug.Conn{} = piped_conn -&gt;
    429           try do
    430&gt;            plug.call(piped_conn, plug.init(opts))
    431           else
    432             conn -&gt;
    433               measurements = %{duration: System.monotonic_time() - start}
    434               metadata = %{metadata | conn: conn}
    435               :telemetry.execute([:phoenix, :router_dispatch, :stop], measurements, metadata)
    
`lib/central_web/endpoint.ex`

    1&gt;  defmodule CentralWeb.Endpoint do
    2     use Phoenix.Endpoint, otp_app: :central
    3   
    4     @session_options [
    5       store: :cookie,
    6       key: "_central_key",
    
`lib/plug/debugger.ex`

    No code available.

`lib/central_web/endpoint.ex`

    1&gt;  defmodule CentralWeb.Endpoint do
    2     use Phoenix.Endpoint, otp_app: :central
    3   
    4     @session_options [
    5       store: :cookie,
    6       key: "_central_key",
    
`lib/phoenix/endpoint/sync_code_reload_plug.ex`

    17   
    18     def call(conn, {endpoint, opts}), do: do_call(conn, endpoint, opts, true)
    19   
    20     defp do_call(conn, endpoint, opts, retry?) do
    21       try do
    22&gt;        endpoint.call(conn, opts)
    23       rescue
    24         exception in [UndefinedFunctionError] -&gt;
    25           case exception do
    26             %UndefinedFunctionError{module: ^endpoint} when retry? -&gt;
    27               # Sync with the code reloader and retry once
    
`lib/plug/cowboy/handler.ex`

    6     def init(req, {plug, opts}) do
    7       conn = @connection.conn(req)
    8   
    9       try do
    10         conn
    11&gt;        |&gt; plug.call(opts)
    12         |&gt; maybe_send(plug)
    13         |&gt; case do
    14           %Plug.Conn{adapter: {@connection, %{upgrade: {:websocket, websocket_args}} = req}} = conn -&gt;
    15             {handler, state, cowboy_opts} = websocket_args
    16             {__MODULE__, copy_resp_headers(conn, req), {handler, state}, cowboy_opts}
    
`/home/dominik/Projects/BAR/teiserver/deps/cowboy/src/cowboy_handler.erl`

    32   -optional_callbacks([terminate/3]).
    33   
    34   -spec execute(Req, Env) -&gt; {ok, Req, Env}
    35   	when Req::cowboy_req:req(), Env::cowboy_middleware:env().
    36   execute(Req, Env=#{handler := Handler, handler_opts := HandlerOpts}) -&gt;
    37&gt;  	try Handler:init(Req, HandlerOpts) of
    38   		{ok, Req2, State} -&gt;
    39   			Result = terminate(normal, Req2, State, Handler),
    40   			{ok, Req2, Env#{result =&gt; Result}};
    41   		{Mod, Req2, State} -&gt;
    42   			Mod:upgrade(Req2, Env, Handler, State);
    
`/home/dominik/Projects/BAR/teiserver/deps/cowboy/src/cowboy_stream_h.erl`

    301   	end.
    302   
    303   execute(_, _, []) -&gt;
    304   	ok;
    305   execute(Req, Env, [Middleware|Tail]) -&gt;
    306&gt;  	case Middleware:execute(Req, Env) of
    307   		{ok, Req2, Env2} -&gt;
    308   			execute(Req2, Env2, Tail);
    309   		{suspend, Module, Function, Args} -&gt;
    310   			proc_lib:hibernate(?MODULE, resume, [Env, Tail, Module, Function, Args]);
    311   		{stop, _Req2} -&gt;
    
`/home/dominik/Projects/BAR/teiserver/deps/cowboy/src/cowboy_stream_h.erl`

    290   %% to simplify the debugging of errors. The proc_lib library
    291   %% already adds the stacktrace to other types of exceptions.
    292   -spec request_process(cowboy_req:req(), cowboy_middleware:env(), [module()]) -&gt; ok.
    293   request_process(Req, Env, Middlewares) -&gt;
    294   	try
    295&gt;  		execute(Req, Env, Middlewares)
    296   	catch
    297   		exit:Reason={shutdown, _}:Stacktrace -&gt;
    298   			erlang:raise(exit, Reason, Stacktrace);
    299   		exit:Reason:Stacktrace when Reason =/= normal, Reason =/= shutdown -&gt;
    300   			erlang:raise(exit, {Reason, Stacktrace}, Stacktrace)
    
`proc_lib.erl`

    No code available.


## Connection details

### Params

    %{"id" =&gt; "6"}

### Request info

  * URI: http://localhost:4000/moderation/report/6
  * Query string: 

### Headers
  
  * accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8
  * accept-encoding: gzip, deflate, br
  * accept-language: en-US,en;q=0.5
  * connection: keep-alive
  * cookie: _central_key=SFMyNTY.g3QAAAACbQAAAAtfY3NyZl90b2tlbm0AAAAYQVJtcVhKQWkxazl5eVZMWVVvWmhlUFpfbQAAABZndWFyZGlhbl9kZWZhdWx0X3Rva2VubQAAAUpleUpoYkdjaU9pSklVelV4TWlJc0luUjVjQ0k2SWtwWFZDSjkuZXlKaGRXUWlPaUpqWlc1MGNtRnNJaXdpWlhod0lqb3hOamc0TXpBd01USTRMQ0pwWVhRaU9qRTJPRFUzTURneE1qZ3NJbWx6Y3lJNkltTmxiblJ5WVd3aUxDSnFkR2tpT2lKaVlqY3pZVEZoTVMwd01HWTVMVFJsWldFdFlUWXhOQzAzWkdFNVlqQXdNMkl4TkRraUxDSnVZbVlpT2pFMk9EVTNNRGd4TWpjc0luTjFZaUk2SWpRaUxDSjBlWEFpT2lKaFkyTmxjM01pZlEueDJrX05uc1QzeURVem5qV0ktLS0wVmpoU3RoUXBxU2ZCNG5WWGxEMS01aFhQaHFVM3QzSlBtcHBPRlFrY1FYcTNzOVFGbnJPWm9xVHpvUmhkUm5YZXc.Uw0tx11Etmsfs_ozBzL-BEtuQ7HwPT613bcrk1_WYqU; guardian_default_token=eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJjZW50cmFsIiwiZXhwIjoxNjg4MzAwMTI4LCJpYXQiOjE2ODU3MDgxMjgsImlzcyI6ImNlbnRyYWwiLCJqdGkiOiJmMTYyZDc4ZS1lMmNhLTRlNWMtYWIzNC0yZjVmNzdmNGQ0NDEiLCJuYmYiOjE2ODU3MDgxMjcsInN1YiI6IjQiLCJ0eXAiOiJyZWZyZXNoIn0.0n-2QkFpnMxSTul1hrAoSrhSBWJclIICK9rpWnLEE8UglmsZ3vgtZoeSzM6x1pBU0ySXTnQpCl-TKpIT4-dyew; sessionid-HUGVD=dQhfgAdxddE3RNDPrSrbVXr5DwcSgV4o; CSRF-Token-HUGVD=ru5DFRMe7iqcMmP6Q4HckaPiARSJ2SqE
  * host: localhost:4000
  * referer: http://localhost:4000/moderation/report
  * sec-fetch-dest: document
  * sec-fetch-mode: navigate
  * sec-fetch-site: same-origin
  * sec-fetch-user: ?1
  * upgrade-insecure-requests: 1
  * user-agent: Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/113.0

### Session

    %{"_csrf_token" =&gt; "ARmqXJAi1k9yyVLYUoZhePZ_", "guardian_default_token" =&gt; "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJjZW50cmFsIiwiZXhwIjoxNjg4MzAwMTI4LCJpYXQiOjE2ODU3MDgxMjgsImlzcyI6ImNlbnRyYWwiLCJqdGkiOiJiYjczYTFhMS0wMGY5LTRlZWEtYTYxNC03ZGE5YjAwM2IxNDkiLCJuYmYiOjE2ODU3MDgxMjcsInN1YiI6IjQiLCJ0eXAiOiJhY2Nlc3MifQ.x2k_NnsT3yDUznjWI---0VjhSthQpqSfB4nVXlD1-5hXPhqU3t3JPmppOFQkcQXq3s9QFnrOZoqTzoRhdRnXew"}


</details>

Which I can vaguely understand on a conceptual level, but not on a problem-solving level 😅 
