### PR TITLE
More info on Ratings page

### DIFF
--- a/lib/teiserver_web/templates/battle/match/ratings.html.heex
+++ b/lib/teiserver_web/templates/battle/match/ratings.html.heex
@@ -48,7 +48,7 @@
             </div>
 
             <div class="col-md-3">
-              Peak Balance Rating: <%= Enum.max_by(@logs, fn l -> l.value["rating_value"] end).value[
+              Peak balance rating: <%= Enum.max_by(@logs, fn l -> l.value["rating_value"] end).value[
                 "rating_value"
               ]
               |> round(2) %>
@@ -69,9 +69,8 @@
               <th>Players</th>
               <th>Type</th>
               <th colspan="2">Skill Rating</th>
-              <th colspan="2">Uncertainty</th>
-              <th>Balance rating<br /> (Skill - Uncertainty, non-negative)</th>
-              <th>Leaderboard rating<br /> (Skill - 3 x Uncertainty)</th>
+              <th colspan="2">Leaderboard rating<br /> (Skill - 3 x Uncertainty)</th>
+              <th colspan="2">Balance rating<br /> (Skill - Uncertainty, non-negative)</th>
               <th>Date</th>
               <th>&nbsp;</th>
             </tr>
@@ -92,7 +91,6 @@
                   <td colspan="2"><%= log.value["reason"] || "No match" %></td>
                 <% end %>
                 <td><%= @rating_type_id_lookup[log.rating_type_id] %></td>
-
                 <td><%= round(log.value["skill"], 2) %></td>
                 <td class={text_class}>
                   <i class={"fa-fw fa-solid fa-#{icon}"}></i>
@@ -100,16 +98,18 @@
                   <%= round(log.value["skill_change"], 2) %>
                 </td>
 
-                <td><%= round(log.value["uncertainty"], 2) %></td>
+                <td><%= round(log.value["skill"] - 3 * log.value["uncertainty"], 2) %></td>
                 <td class={text_class}>
                   <i class={"fa-fw fa-solid fa-#{icon}"}></i>
 
-                  <%= round(log.value["uncertainty_change"], 2) %>
+                  <%= round(log.value["skill_change"] - 3 * log.value["uncertainty_change"], 2) %>
                 </td>
+                <td><%= round(log.value["rating_value"], 2) %></td>
+                <td class={text_class}>
+                  <i class={"fa-fw fa-solid fa-#{icon}"}></i>
 
-                <td><%= round(log.value["skill"] - log.value["uncertainty"], 2) %></td>
-                <td><%= round(log.value["skill"] - log.value["uncertainty"] * 3, 2) %></td>
-
+                  <%= round(log.value["rating_value_change"], 2) %>
+                </td>
 
                 <td><%= date_to_str(log.inserted_at, format: :hms_or_dmy) %></td>
 

--- a/lib/teiserver_web/templates/battle/match/ratings.html.heex
+++ b/lib/teiserver_web/templates/battle/match/ratings.html.heex
@@ -48,14 +48,14 @@
             </div>
 
             <div class="col-md-3">
-              Peak Rating: <%= Enum.max_by(@logs, fn l -> l.value["rating_value"] end).value[
+              Peak Balance Rating: <%= Enum.max_by(@logs, fn l -> l.value["rating_value"] end).value[
                 "rating_value"
               ]
               |> round(2) %>
             </div>
 
             <div class="col-md-3">
-              Game rating change: <%= (@ratings[@filter].rating_value -
+              Balance rating change: <%= (@ratings[@filter].rating_value -
                                          @stats.first_log.value["rating_value"])
               |> round(2) %>
             </div>
@@ -65,11 +65,13 @@
         <table class="table table-sm mt-3">
           <thead>
             <tr>
-              <th>Game</th>
+              <th>Map name</th>
               <th>Players</th>
               <th>Type</th>
-              <th>Leaderboard rating</th>
-              <th colspan="2">Balance Rating</th>
+              <th colspan="2">Skill Rating</th>
+              <th colspan="2">Uncertainty</th>
+              <th>Balance rating<br /> (Skill - Uncertainty, non-negative)</th>
+              <th>Leaderboard rating<br /> (Skill - 3 x Uncertainty)</th>
               <th>Date</th>
               <th>&nbsp;</th>
             </tr>
@@ -77,7 +79,7 @@
           <tbody>
             <%= for log <- @logs do %>
               <% {text_class, icon} =
-                if log.value["rating_value_change"] > 0 do
+                if log.value["skill_change"] > 0 do
                   {"text-success", "up"}
                 else
                   {"text-danger", "down"}
@@ -91,14 +93,23 @@
                 <% end %>
                 <td><%= @rating_type_id_lookup[log.rating_type_id] %></td>
 
-                <td><%= round(log.value["skill"] - log.value["uncertainty"] * 3, 2) %></td>
-
-                <td><%= round(log.value["rating_value"], 2) %></td>
+                <td><%= round(log.value["skill"], 2) %></td>
                 <td class={text_class}>
                   <i class={"fa-fw fa-solid fa-#{icon}"}></i>
 
-                  <%= round(log.value["rating_value_change"], 2) %>
+                  <%= round(log.value["skill_change"], 2) %>
                 </td>
+
+                <td><%= round(log.value["uncertainty"], 2) %></td>
+                <td class={text_class}>
+                  <i class={"fa-fw fa-solid fa-#{icon}"}></i>
+
+                  <%= round(log.value["uncertainty_change"], 2) %>
+                </td>
+
+                <td><%= round(log.value["skill"] - log.value["uncertainty"], 2) %></td>
+                <td><%= round(log.value["skill"] - log.value["uncertainty"] * 3, 2) %></td>
+
 
                 <td><%= date_to_str(log.inserted_at, format: :hms_or_dmy) %></td>
 


### PR DESCRIPTION
This does a few things:

- adds Skill Rating and Uncertainty directly. People were already solving sets of equation to get at it, let's not force them to.
- Ties the color associated with the row to the difference in skill rating after the match (green on a win, red on a loss). This was previously done from delta(Balance Rating). Since that's capped at 0, the diffs would show 0 on wins, for example, [in this case](https://discord.com/channels/549281623154229250/1115432854919327745/1116833556417757274).
- Adds notes on how Balance and Leaderboard ratings are calculated and displayed
- Clarifies which rating is being taken for the peak/change summary calculations (it's balance).
- While for many, Supreme Strait may be the name of the game, I still renamed the column from "Game" to "Map name" ;)

This is how it looks for me with http://localhost:4000/teiserver/battle/matches/ratings?filter=Team. I know the colors look weird, but I have a sneaking suspicion that it's because the skill ratings and changes for test data are being generated inconsistently, as two independent random numbers for each match entry, while one the former *should* (but it adds a fair bit of complexity so let's ignore that) be a cumulative sum of the latter.

![image](https://github.com/beyond-all-reason/teiserver/assets/11289391/f8590619-7d10-46fb-90d1-ff0e1c1d4c16)

I don't *think* it looks too noisy, but that's me :)

I was also iffy on whether delta uncertainty should be colored, as it most likely will always remain negative, but it's simpler that way and I don't think it hurts at all.