### PR TITLE
Fix Clyret bug (Visual bug on progress for high TS players), fix how rating values are shown, and improve progression styling

### DIFF
--- a/lib/teiserver_web/controllers/battle/match_controller.ex
+++ b/lib/teiserver_web/controllers/battle/match_controller.ex
@@ -174,15 +174,16 @@ defmodule TeiserverWeb.Battle.MatchController do
         Map.update(
           acc,
           TimexHelper.date_to_str(rating.inserted_at, format: :ymd),
-          {rating.value["rating_value"], rating.value["uncertainty"], 1},
-          fn {match_rating, uncertainty, count} ->
-            {match_rating + rating.value["rating_value"], uncertainty + rating.value["uncertainty"], count + 1}
+          {rating.value["skill"], rating.value["uncertainty"], rating.value["rating_value"], 1},
+          fn {skill, uncertainty, rating_value, count} ->
+            {skill + rating.value["skill"], uncertainty + rating.value["uncertainty"], rating_value + rating.value["rating_value"], count + 1}
           end
         )
       end)
-      |> Enum.map(fn {date, {rating_value, uncertainty, count}} -> %{
+      |> Enum.map(fn {date, {skill, uncertainty, rating_value, count}} -> %{
           date: date,
           rating_value: Float.round(rating_value / count, 2),
+          skill: Float.round(skill / count, 2),
           uncertainty: Float.round(uncertainty / count, 2),
           count: count,
         }

--- a/lib/teiserver_web/templates/battle/match/ratings_graph.html.heex
+++ b/lib/teiserver_web/templates/battle/match/ratings_graph.html.heex
@@ -79,10 +79,22 @@ var margin = {
   'bottom' : 20,
   'left'   : 20
 };
+// The percentage of the range to show as an offset above and below the uncertainty bars
+var RANGE_OFFSET_PERCENTAGE = 0.35;
 
 var colors = {};
 
 var data = <%= raw Jason.encode!(@data) %>;
+
+var colors = {
+  pageBackground: '#303030',
+  graphBackground: '#303030',
+
+  confidenceIntervalTop: '#2E3E32',
+  skillValueLine: '#1C561E',
+  confidenceIntervalBottom: '#2B5533',
+  ratingValueLine: '#007C00',
+};
 
 
 // https://d3-graph-gallery.com/graph/line_confidence_interval.html
@@ -107,30 +119,60 @@ $(function() {
     .domain(d3.extent(data, function(d) { return dateFormat(d.date); }))
     .range([ 0, width ]);
 
+  var min = d3.min(data, function (d) { return d.skill - d.uncertainty });
+  var max = d3.max(data, function (d) { return d.skill + d.uncertainty });
+  var range = (max - min);
+  var graphBottom = Math.max(0, Math.floor(min - range * RANGE_OFFSET_PERCENTAGE));
+  var graphTop = Math.ceil(max + range * RANGE_OFFSET_PERCENTAGE);
+
   // Add Y axis
   var y = d3.scaleLinear()
-    //.domain(d3.max(data, function(d) { return d.rating_value; }))
-    .domain([0, 50])
+    .domain([graphBottom, graphTop])
     .range([ height, 0 ]);
 
-  // Show confidence interval
+  // Show top part of confidence interval
   g.append("path")
     .datum(data)
-    .attr("fill", "#343a40")
+    .attr("fill", colors.confidenceIntervalTop)
     .attr("stroke", "none")
     .attr("d", d3.area()
       .x(function(d) { return x(dateFormat(d.date)) })
-      .y0(function(d) { return y(d.rating_value - d.uncertainty) })
-      .y1(function(d) { return y(d.rating_value + d.uncertainty) })
+      .y0(function(d) { return y(d.skill) })
+      .y1(function(d) { return y(d.skill + d.uncertainty) })
       .curve(d3.curveCardinal)
       )
 
-  // Add the line
+  // Show bottom part of confidence interval
+  g.append("path")
+    .datum(data)
+    .attr("fill", colors.confidenceIntervalBottom)
+    .attr("stroke", "none")
+    .attr("d", d3.area()
+      .x(function(d) { return x(dateFormat(d.date)) })
+      .y0(function(d) { return y(d.skill - d.uncertainty) })
+      .y1(function(d) { return y(d.skill) })
+      .curve(d3.curveCardinal)
+      )
+
+  // Add skill value line (in middle of uncertainty)
   g
     .append("path")
     .datum(data)
     .attr("fill", "none")
-    .attr("stroke", "#007C00")
+    .attr("stroke", colors.skillValueLine)
+    .attr("stroke-width", 1.5)
+    .attr("d", d3.line()
+      .x(function(d) { return x(dateFormat(d.date)) })
+      .y(function(d) { return y(d.skill) })
+      .curve(d3.curveCardinal)
+      )
+
+  // Add skill value line (minimum of uncertainty)
+  g
+    .append("path")
+    .datum(data)
+    .attr("fill", "none")
+    .attr("stroke", colors.ratingValueLine)
     .attr("stroke-width", 1.5)
     .attr("d", d3.line()
       .x(function(d) { return x(dateFormat(d.date)) })
@@ -139,8 +181,9 @@ $(function() {
       )
 
 
+  // Add X and Y axis
   g.append("g")
-    .attr("transform", "translate(0," + y(0) + ")")
+    .attr("transform", "translate(0," + y(graphBottom) + ")")
     .call(d3.axisBottom(x));
   g.append("g")
     .attr("transform", "translate(0, 0)")
@@ -167,6 +210,7 @@ $(function() {
 
       tooltip.select("#date").text(closestDataPoint.date);
       tooltip.select("#rating_value").text(closestDataPoint.rating_value);
+      tooltip.select("#skill").text(closestDataPoint.skill);
       tooltip.select("#uncertainty").text(closestDataPoint.uncertainty);
       tooltip.select("#count").text(closestDataPoint.count);
 
@@ -228,10 +272,13 @@ $(function() {
                     Games Played: <span id="count"></span>
                   </div>
                   <div>
-                    Average Rating: <span id="rating_value"></span>
+                    Skill: <span id="skill"></span>
                   </div>
                   <div>
                     Uncertainty: <span id="uncertainty"></span>
+                  </div>
+                  <div>
+                    Rating Value: <span id="rating_value"></span>
                   </div>
                 </div>
             </div>


### PR DESCRIPTION
This PR does the following:

1. Closes #127 - the minimum and maximum range of the y axis is now calculated based on the extent of the skill, plus a buffer range
2. Change the mid value to be the users _skill_ not their rating value. Previously, we were showing the confidence interval to be +- the rating value even though the rating value is actual skill - certainty. The mid point now reflects the skill value and the rating_value is the line at the bottom of the graph.
3. Changes the color of the ratings values and confidence intervals to more indicative of their purpose

Updated graph:

![image](https://github.com/beyond-all-reason/teiserver/assets/1368558/e477fc48-9dfc-4bf5-9529-605c3d241c97)

Another example with an extreme ratings jump to the 60s: 
![image](https://github.com/beyond-all-reason/teiserver/assets/1368558/b207dad5-01e7-4e7b-9597-48db0c1a381e)


The progression graph DOES NOT indicate the difference between _skill_ and _rating value_ even though they indicate both of them. I'm not sure if this is necessary as it's a fairly hidden graph, but it might be useful to explain here.