### PR TITLE
Rename headers in matches/ratings web page to match website guide

### DIFF
--- a/lib/teiserver_web/templates/battle/match/ratings.html.heex
+++ b/lib/teiserver_web/templates/battle/match/ratings.html.heex
@@ -68,9 +68,9 @@
               <th>Map name</th>
               <th>Players</th>
               <th>Type</th>
-              <th colspan="2">Skill value</th>
-              <th colspan="2">Game rating <small class="text-secondary">(Skill - Uncertainty, non-negative only)</small></th>
-              <th colspan="2">Leaderboard rating <small class="text-secondary">(Skill - 3 x Uncertainty)</small></th>
+              <th colspan="2">Skill</th>
+              <th colspan="2">Match Rating <small class="text-secondary">(Skill - Uncertainty, non-negative only)</small></th>
+              <th colspan="2">Leaderboard Rating <small class="text-secondary">(Skill - 3 x Uncertainty)</small></th>
               <th>Date</th>
               <th>&nbsp;</th>
             </tr>


### PR DESCRIPTION
As described - will be good to unify the terminology