### PR TITLE
balance: use Team rating for TeamFFA games

### DIFF
--- a/lib/teiserver_web/controllers/api/spads_controller.ex
+++ b/lib/teiserver_web/controllers/api/spads_controller.ex
@@ -22,7 +22,7 @@ defmodule TeiserverWeb.API.SpadsController do
       }) do
     actual_type =
       case type do
-        "TeamFFA" -> "FFA"
+        "TeamFFA" -> "Team"
         v -> v
       end
 


### PR DESCRIPTION
TeamFFA games are currently using FFA rating for balance, with the TeamFFA rating itself never being actually used (even though it does get updated on win/loss).

A specific handling for FFA ratings was initially added in 569d74b644b777f1768e9b3dd71c5d78f03874d1 due to both FFA and TeamFFA ratings being bugged. At this time, TeamFFA rating was based off Team rating, and it was changed to the current state of being based off FFA in bbe2fc758395bfe193b3d851fe6a3d7343611fb2 when FFA rating got fixed.

This commit reverts to using Team rating for balancing TeamFFA games.

The TeamFFA rating itself still cannot be used right now because there are still bugs as explained by Teifion, and also because the very low volume of TeamFFA games would not allow proper balance to occur in a timely manner anyway.

At the same time, TeamFFA games are closer in terms of gameplay to Team games than to FFA games, and since FFA games are also lower volume than regular Team games, TeamFFA games are currently regularly unbalanced because of strong Team players having severely underrated FFA ratings due to rarely playing FFA.

This stopgap solution works mostly the same way as it is now since TeamFFA games are basically "thrown away" already due to TeamFFA rating not being used anywhere but still being the one updated on win/loss, but it should help balancing TeamFFA games immediately until a better solution is devised.