### PR TITLE
Fix splitlobby to ignore passworded lobbies. Increase splitlobby time to 60 seconds

### DIFF
--- a/lib/teiserver/coordinator/consul_commands.ex
+++ b/lib/teiserver/coordinator/consul_commands.ex
@@ -18,7 +18,7 @@ defmodule Teiserver.Coordinator.ConsulCommands do
     }
   """
   @splitter "---------------------------"
-  @split_delay 30_000
+  @split_delay 60_000
   @spec handle_command(Map.t(), Map.t()) :: Map.t()
   @default_ban_reason "Banned"
 

--- a/lib/teiserver/coordinator/consul_server.ex
+++ b/lib/teiserver/coordinator/consul_server.ex
@@ -273,7 +273,10 @@ defmodule Teiserver.Coordinator.ConsulServer do
           if client.lobby_id == state.lobby_id or client.lobby_id == nil do
             # If the first splitter is still in this lobby, move them to a new one
             # with the same engine version as the starting lobby
-            Lobby.find_empty_lobby(fn a -> a.engine_version == old_lobby.engine_version end)
+            Lobby.find_empty_lobby(fn a ->
+              a.engine_version == old_lobby.engine_version and
+              a.passworded == false
+            end)
           else
             %{id: client.lobby_id}
           end

--- a/lib/teiserver/coordinator/coordinator_lib.ex
+++ b/lib/teiserver/coordinator/coordinator_lib.ex
@@ -28,7 +28,7 @@ defmodule Teiserver.Coordinator.CoordinatorLib do
       {"password?", [], "Tells you the room password", :everybody},
       {"splitlobby", ["minimum players"],
        "Causes a \"vote\" to start where other players can elect to join you in splitting the lobby, follow someone
-of their choosing or remain in place. After 30 seconds, if at least the minimum number of players agreed to split, you are moved to a new (empty) lobby and those that voted yes
+of their choosing or remain in place. After 60 seconds, if at least the minimum number of players agreed to split, you are moved to a new (empty) lobby and those that voted yes
 or are following someone that voted yes are also moved to that lobby.", :everybody},
       {"roll", ["range"], "Rolls a random number based on the range format.
 - Dice format: nDs, where n is number of dice and s is sides of die. E.g. 4D6 - 4 dice with 6 sides are rolled


### PR DESCRIPTION
Fixes #141 
Increases split time from 30 to 60 seconds.