### PR TITLE
Adjust chat search 'When' field

### DIFF
--- a/lib/teiserver_web/templates/admin/chat/index.html.heex
+++ b/lib/teiserver_web/templates/admin/chat/index.html.heex
@@ -49,7 +49,7 @@
                       </a>
                     </td>
                     <td class="message"><%= msg.content %></td>
-                    <td><%= date_to_str(msg.inserted_at, :hms_or_dmy) %></td>
+                    <td><%= date_to_str(msg.inserted_at, :hms_dmy) %></td>
                   </tr>
                 <% end %>
               </tbody>
@@ -75,7 +75,7 @@
                       </a>
                     </td>
                     <td class="message"><%= msg.content %></td>
-                    <td><%= date_to_str(msg.inserted_at, :hms_or_dmy) %></td>
+                    <td><%= date_to_str(msg.inserted_at, :hms_dmy) %></td>
                   </tr>
                 <% end %>
               </tbody>
@@ -105,7 +105,7 @@
                       </a>
                     </td>
                     <td class="message"><%= msg.content %></td>
-                    <td><%= date_to_str(msg.inserted_at, :hms_or_dmy) %></td>
+                    <td><%= date_to_str(msg.inserted_at, :hms_dmy) %></td>
                   </tr>
                 <% end %>
               </tbody>


### PR DESCRIPTION
This forces chat search to also display times, not just dates. Sure it's more noise, but it beats binary-searching to figure out the lobby where an outdated, or even yesterday's, report happened.

(I'm having some issues with dependency setup right now, so I wasn't able to test this one, but it should be simple enough.)