### PR TITLE
Fix profile_link leading to NotFound error

### DIFF
--- a/lib/teiserver/bridge/message_commands.ex
+++ b/lib/teiserver/bridge/message_commands.ex
@@ -169,7 +169,7 @@ defmodule Teiserver.Bridge.MessageCommands do
     spectator_hours = (Map.get(stats, "spectator_minutes", 0) / 60) |> round
 
     host = Application.get_env(:central, TeiserverWeb.Endpoint)[:url][:host]
-    profile_link = "https://#{host}/teiserver/profile/#{user.id}"
+    profile_link = "https://#{host}/profile/#{user.id}"
 
     accolades = AccoladeLib.get_player_accolades(user.id)
 

--- a/lib/teiserver/coordinator/coordinator_commands.ex
+++ b/lib/teiserver/coordinator/coordinator_commands.ex
@@ -142,7 +142,7 @@ defmodule Teiserver.Coordinator.CoordinatorCommands do
     spectator_hours = (Map.get(stats, "spectator_minutes", 0) / 60) |> round
 
     host = Application.get_env(:central, TeiserverWeb.Endpoint)[:url][:host]
-    profile_link = "https://#{host}/teiserver/profile/#{senderid}"
+    profile_link = "https://#{host}/profile/#{senderid}"
 
     accolades = AccoladeLib.get_player_accolades(senderid)
 
@@ -241,7 +241,7 @@ defmodule Teiserver.Coordinator.CoordinatorCommands do
           end
 
         host = Application.get_env(:central, TeiserverWeb.Endpoint)[:url][:host]
-        profile_link = "https://#{host}/teiserver/profile/#{user.id}"
+        profile_link = "https://#{host}/profile/#{user.id}"
 
         ratings =
           Account.list_ratings(


### PR DESCRIPTION
remove a path for teiserver, as the production API throws Not Found.

![image](https://github.com/beyond-all-reason/teiserver/assets/7465747/1e514cd0-1243-4292-8b34-d87843822fd2)
![image](https://github.com/beyond-all-reason/teiserver/assets/7465747/0e4425e3-8b73-43a4-b621-bc503c3320d6)

and after investigation the path element teiserver is not needed.