### PR TITLE
Add type column to overwatch page

### DIFF
--- a/lib/teiserver_web/live/moderation/overwatch/index.html.heex
+++ b/lib/teiserver_web/live/moderation/overwatch/index.html.heex
@@ -106,6 +106,9 @@
   </:col>
   
   <:col :let={report_group} label="Target"><%= report_group.target.name %></:col>
+  <:col :let={report_group} label="Type">
+    <%= Enum.join(MapSet.new(for report <- report_group.reports, do: report.name), ", ") %>
+  </:col>
   <:col :let={report_group} label="Reports"><%= report_group.report_count %></:col>
   <:col :let={report_group} label="Votes"><%= report_group.vote_count %></:col>
   <:col :let={report_group} label="Actions"><%= report_group.action_count %></:col>


### PR DESCRIPTION
Don't merge this yet, it blows up! I'm getting this error:

```
[error] an exception was raised:
** (Protocol.UndefinedError) protocol Enumerable not implemented for #Ecto.Association.NotLoaded<association :reports is not loaded> of type Ecto.Association.NotLoaded (a struct)
```

So I understand that I would need to pre-load reports for each
`report_group` in `lib/teiserver_web/live/moderation/overwatch/index.ex`
for this to work. I'm not sure how to do that, though... I gather that you're
pre-loading the report groups here:

```
    socket = socket
    |> assign(:site_menu_active, "moderation")
    |> assign(:view_colour, Teiserver.Moderation.colour())
    |> assign(:outstanding_report_groups, 0)
    |> assign(:report_groups, nil)                 <----- this?
    |> default_filters(params)
    |> add_breadcrumb(name: "Moderation", url: ~p"/moderation")
    |> add_breadcrumb(name: "Overwatch", url: ~p"/moderation/overwatch")
```

But I'm not sure how to extend that to also load something "belonging"
to those report groups.
