### PR TITLE
Added country to leaderboard public API response

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,9 @@
-## in progress:
-
+## In progress
 #### Features
+- Added `country` to public [leaderboard API response](https://server4.beyondallreason.info/teiserver/api/public/leaderboard/Team)
 
+## v1.2.0
+#### Features
 - New spring friendship commands added
 - Spring `c.user.whois` command added
 - Spring `c.user.accept_friend_request` command added
@@ -17,7 +19,6 @@
 - Added ability to manually add smurf keys
 
 #### Bugfixes
-
 - Relationships report now correctly combines Block/Avoid
 - Relationships report correctly reports on Ignore counts
 - Fixed issue where a LobbyPolicy bot could repeatedly rename a lobby
@@ -30,7 +31,6 @@
 - Fixed an auth bug on the admin chat interface
 
 #### Internal improvements
-
 - Added `Communication.use_discord?/1` to make it easier to not make discord calls in dev
 - Unit tests for microblog system
 - Converted some tests for old pages into the new liveview pages
@@ -41,7 +41,6 @@
 - Better internal event tracking for disconnects
 
 ## v1.1.1
-
 * Report forms now include the option to ignore players along with buttons to avoid or block them
 * Ignoring is now separate from avoiding or blocking
 * The `$meme` commands have been expanded significantly (credit: robertthepie)

--- a/lib/teiserver_web/controllers/api/public_controller.ex
+++ b/lib/teiserver_web/controllers/api/public_controller.ex
@@ -31,6 +31,7 @@ defmodule TeiserverWeb.API.PublicController do
             %{
               name: rating.user.name,
               icon: rating.user.icon,
+              country: Map.get(rating.user.data, "country", "??"),
               colour: rating.user.colour,
               rating: rating.leaderboard_rating,
               age: Timex.diff(Timex.now(), rating.last_updated, :days)


### PR DESCRIPTION
Resolves #201.

User with country:
```
        {
            "name": "AccoladesBot",
            "icon": "fa-solid fa-regular fa-award",
            "colour": "#0066AA",
            "rating": 0,
            "country": "GB",
            "age": 7
        }
  ```

User without country:
```
        {
            "name": "SpryCherryTick",
            "icon": "fa-solid lemon",
            "colour": "#FF7777",
            "rating": 0,
            "country": "??",
            "age": 8
        }
```
