### PR TITLE
Add ability to join user lobby from their profile page

### DIFF
--- a/lib/teiserver/libs/test_lib.ex
+++ b/lib/teiserver/libs/test_lib.ex
@@ -488,9 +488,10 @@ defmodule Teiserver.TeiserverTestLib do
         }
       }
       |> Map.merge(params)
+      |> Teiserver.Lobby.create_lobby()
+      |> Teiserver.Lobby.add_lobby()
 
-    lobby_pid = LobbyLib.start_lobby_server(lobby)
-    {lobby.id, lobby_pid}
+    lobby.id
   end
 
   @spec make_clan_membership(Integer.t(), Integer.t(), Map.t()) ::

--- a/lib/teiserver_web/live/account/profile/overview.ex
+++ b/lib/teiserver_web/live/account/profile/overview.ex
@@ -294,7 +294,8 @@ defmodule TeiserverWeb.Account.ProfileLive.Overview do
          :ok <- server_allows_join(lobby_id, current_user_id),
          :ok <- join_lobby(lobby_id, current_user_id) do
       {:noreply, put_flash(socket, :success, "Lobby joined")}
-    else {:error, reason} ->
+    else
+      {:error, reason} ->
         {:noreply, put_flash(socket, :warning, reason)}
     end
   end

--- a/lib/teiserver_web/live/account/profile/overview.html.heex
+++ b/lib/teiserver_web/live/account/profile/overview.html.heex
@@ -190,6 +190,10 @@
       </.link>
     <% end %>
 
+    <span phx-click="join" class="btn btn-outline-info mx-1">
+      Join
+    </span>
+
     <.link
       :if={allow?(@current_user, "Moderator")}
       navigate={~p"/teiserver/admin/user/#{@user.id}"}

--- a/lib/teiserver_web/live/account/profile/overview.html.heex
+++ b/lib/teiserver_web/live/account/profile/overview.html.heex
@@ -190,7 +190,7 @@
       </.link>
     <% end %>
 
-    <span phx-click="join" class="btn btn-outline-info mx-1">
+    <span :if={not is_nil(@client[:lobby_id])} phx-click="join" class="btn btn-outline-info mx-1">
       Join
     </span>
 

--- a/test/teiserver/lobby/commands/explain_command_test.exs
+++ b/test/teiserver/lobby/commands/explain_command_test.exs
@@ -13,7 +13,7 @@ defmodule Teiserver.Lobby.Commands.ExplainCommandTest do
     Coordinator.start_coordinator()
 
     user = TeiserverTestLib.new_user()
-    {lobby_id, _lobby_pid} = TeiserverTestLib.make_lobby()
+    lobby_id = TeiserverTestLib.make_lobby()
     chat_listener = PubsubListener.new_listener(["teiserver_lobby_chat:#{lobby_id}"])
     client_listener = PubsubListener.new_listener(["teiserver_client_messages:#{user.id}"])
 

--- a/test/teiserver_web/live/account/profile/overview_test.exs
+++ b/test/teiserver_web/live/account/profile/overview_test.exs
@@ -1,0 +1,59 @@
+defmodule TeiserverWeb.Live.Account.Profile.OverviewTest do
+  use TeiserverWeb.ConnCase, async: false
+  import Phoenix.LiveViewTest
+
+  alias Central.Helpers.GeneralTestLib
+  alias Teiserver.{Battle, TeiserverTestLib, Client}
+
+  setup do
+    {:ok, data} =
+      TeiserverTestLib.player_permissions()
+      |> GeneralTestLib.conn_setup()
+      |> TeiserverTestLib.conn_setup()
+
+    profile_user = GeneralTestLib.make_user()
+    login_user(profile_user)
+
+    %{conn: data[:conn], user: data[:user], profile_user: profile_user}
+  end
+
+  describe "join lobby" do
+    test "clicking join joins the client to the user's lobby", %{conn: conn, user: user, profile_user: profile_user} do
+      login_user(user)
+
+      lobby_id = TeiserverTestLib.make_lobby()
+
+      Battle.force_add_user_to_lobby(profile_user.id, lobby_id)
+
+      {:ok, view, _html} = live(conn, "/profile/#{profile_user.id}")
+
+      view
+      |> element("span[phx-click=join]")
+      |> render_click()
+
+      assert user.id in Battle.get_lobby_member_list(lobby_id)
+    end
+
+    test "renders error flash when client is not connected", %{conn: conn, profile_user: profile_user} do
+      # Skip client login
+
+      lobby_id = TeiserverTestLib.make_lobby()
+
+      Battle.force_add_user_to_lobby(profile_user.id, lobby_id)
+
+      {:ok, view, _html} = live(conn, "/profile/#{profile_user.id}")
+
+      view
+      |> element("span[phx-click=join]")
+      |> render_click()
+
+      assert render(view) =~ "Client is not connected"
+    end
+  end
+
+  defp login_user(user) do
+    user
+    |> Map.merge(%{rank: 1, print_client_messages: false, print_server_messages: false})
+    |> Client.login(:spring, "127.0.0.1")
+  end
+end

--- a/test/teiserver_web/live/account/profile/overview_test.exs
+++ b/test/teiserver_web/live/account/profile/overview_test.exs
@@ -34,6 +34,22 @@ defmodule TeiserverWeb.Live.Account.Profile.OverviewTest do
       assert user.id in Battle.get_lobby_member_list(lobby_id)
     end
 
+    test "only renders join button when user to join is in a lobby", %{conn: conn, profile_user: profile_user} do
+      lobby_id = TeiserverTestLib.make_lobby()
+
+      {:ok, view, _html} = live(conn, "/profile/#{profile_user.id}")
+
+      refute view
+        |> element("span[phx-click=join]")
+        |> has_element?()
+
+      Battle.force_add_user_to_lobby(profile_user.id, lobby_id)
+
+      assert view
+        |> element("span[phx-click=join]")
+        |> has_element?()
+    end
+
     test "renders error flash when client is not connected", %{conn: conn, profile_user: profile_user} do
       # Skip client login
 

--- a/test/teiserver_web/live/account/profile/overview_test.exs
+++ b/test/teiserver_web/live/account/profile/overview_test.exs
@@ -18,7 +18,11 @@ defmodule TeiserverWeb.Live.Account.Profile.OverviewTest do
   end
 
   describe "join lobby" do
-    test "clicking join joins the client to the user's lobby", %{conn: conn, user: user, profile_user: profile_user} do
+    test "clicking join joins the client to the user's lobby", %{
+      conn: conn,
+      user: user,
+      profile_user: profile_user
+    } do
       login_user(user)
 
       lobby_id = TeiserverTestLib.make_lobby()
@@ -34,23 +38,29 @@ defmodule TeiserverWeb.Live.Account.Profile.OverviewTest do
       assert user.id in Battle.get_lobby_member_list(lobby_id)
     end
 
-    test "only renders join button when user to join is in a lobby", %{conn: conn, profile_user: profile_user} do
+    test "only renders join button when user to join is in a lobby", %{
+      conn: conn,
+      profile_user: profile_user
+    } do
       lobby_id = TeiserverTestLib.make_lobby()
 
       {:ok, view, _html} = live(conn, "/profile/#{profile_user.id}")
 
       refute view
-        |> element("span[phx-click=join]")
-        |> has_element?()
+             |> element("span[phx-click=join]")
+             |> has_element?()
 
       Battle.force_add_user_to_lobby(profile_user.id, lobby_id)
 
       assert view
-        |> element("span[phx-click=join]")
-        |> has_element?()
+             |> element("span[phx-click=join]")
+             |> has_element?()
     end
 
-    test "renders error flash when client is not connected", %{conn: conn, profile_user: profile_user} do
+    test "renders error flash when client is not connected", %{
+      conn: conn,
+      profile_user: profile_user
+    } do
       # Skip client login
 
       lobby_id = TeiserverTestLib.make_lobby()


### PR DESCRIPTION
This is for https://github.com/beyond-all-reason/teiserver/issues/178.

I only tested this through tests and have been unable to test locally. When running locally, I get region errors trying to create a lobby. I've come to understand that it's because I don't have SPADS running, but I'm unable to get SPADS working locally.

Details
--
* Join button is only visible if the user is in a lobby

Screenshots
--
![image](https://github.com/beyond-all-reason/teiserver/assets/609992/bcf7f796-d0f2-40b1-b2fe-5729ee334aca)
