### PR TITLE
Extend leaderboards from 30 to 100

### DIFF
--- a/lib/teiserver_web/controllers/api/public_controller.ex
+++ b/lib/teiserver_web/controllers/api/public_controller.ex
@@ -25,7 +25,7 @@ defmodule TeiserverWeb.API.PublicController do
             ],
             order_by: "Leaderboard rating high to low",
             preload: [:user],
-            limit: 30
+            limit: 100
           )
           |> Enum.map(fn rating ->
             %{

--- a/lib/teiserver_web/controllers/battle/ratings_controller.ex
+++ b/lib/teiserver_web/controllers/battle/ratings_controller.ex
@@ -45,7 +45,7 @@ defmodule TeiserverWeb.Battle.RatingsController do
         ],
         order_by: "Leaderboard rating high to low",
         preload: [:user],
-        limit: 30
+        limit: 100
       )
 
     conn


### PR DESCRIPTION
This will let leaderboards include up to 100 players instead of the previous 30. The top 30 leaderboards are remnants of a time when we literally didn't have 100 active players to fill a top 100 leaderboard. They could be expanded to top 100 now that our playerbase has grown 20-fold.

I have tested this PR in my local dev-environment where it functioned as expected.

Solves https://github.com/beyond-all-reason/teiserver/issues/203.