### PR TITLE
Fix report target button

### DIFF
--- a/lib/teiserver_web/templates/moderation/report/index.html.heex
+++ b/lib/teiserver_web/templates/moderation/report/index.html.heex
@@ -85,7 +85,7 @@
 
             <td>
               <a
-                href={Routes.moderation_report_path(@conn, :user, report.target_id)}
+                href={Routes.profile_overview_path(@conn, :overview, report.target_id)}
                 class={"btn btn-sm btn-#{Teiserver.Account.UserLib.colour()}"}
               >
                 <Fontawesome.icon


### PR DESCRIPTION
Fixes #211 with the edit that it will now point to `profile/<userid>` instead of the suggested `teiserver/admin/<userid>`.
The reason for this is that, while Overwatch members can view the list of reports, they cannot access the admin user view which causes an error. For moderators and those with access the overview page already has a button that leads to the admin user view ( `teiserver/admin/<userid>`).