### PR TITLE
Fix verification related test errors

### DIFF
--- a/lib/teiserver/account/caches/user_cache_lib.ex
+++ b/lib/teiserver/account/caches/user_cache_lib.ex
@@ -232,7 +232,7 @@ defmodule Teiserver.Account.UserCacheLib do
   # be pulled out next time the user is accessed/recached
   # The special case here is to prevent the benchmark and test users causing issues
   @spec persist_user(CacheUser.t()) :: CacheUser.t() | nil
-  defp persist_user(%{name: "TEST_" <> _}), do: nil
+  defp persist_user(%{name: "test_" <> _}), do: nil
 
   defp persist_user(user) do
     db_user = Account.get_user!(user.id)

--- a/test/teiserver/coordinator/split_test.exs
+++ b/test/teiserver/coordinator/split_test.exs
@@ -2,7 +2,7 @@ defmodule Teiserver.Coordinator.SplitTest do
   use Teiserver.ServerCase, async: false
   alias Teiserver.Account.ClientLib
   alias Teiserver.Common.PubsubListener
-  alias Teiserver.{User, Client, Coordinator, Lobby}
+  alias Teiserver.{CacheUser, Client, Coordinator, Lobby}
   alias Teiserver.Coordinator.CoordinatorLib
 
   import Teiserver.TeiserverTestLib,
@@ -14,8 +14,8 @@ defmodule Teiserver.Coordinator.SplitTest do
     %{socket: hsocket_empty} = tachyon_auth_setup()
     %{socket: psocket, user: player} = tachyon_auth_setup()
 
-    User.update_user(%{host | moderator: true})
-    User.update_user(%{player | moderator: true})
+    CacheUser.update_user(%{host | moderator: true})
+    CacheUser.update_user(%{player | moderator: true})
     ClientLib.refresh_client(host.id)
     ClientLib.refresh_client(player.id)
 


### PR DESCRIPTION
Fixes `You are creating a user without verifying in ` errors in tests and makes Hailstorm work again by fixing the issue of unverified bot users.