### PR TITLE
Fix local setup documentation for root user

### DIFF
--- a/documents/guides/local_setup.md
+++ b/documents/guides/local_setup.md
@@ -139,8 +139,8 @@ When running locally it's likely you won't want to connect the server to an emai
 Run your server with `iex -S mix phx.server` and then once it has started up use the following code to update your password.
 
 ```elixir
-user = Teiserver.Account.get_user_by_email("root@localhost")
-Teiserver.Account.update_user(user, %{"password" => "your password here"})
+user = Teiserver.Repo.get_by(Teiserver.Account.User, email: "root@localhost")
+Teiserver.Account.update_user(user, %{"password" => "password"})
 ```
 
 ### Main 3rd party dependencies


### PR DESCRIPTION
At some point this broke because `get_user_by_email/1` is now returning a map (cached user) instead of the user ecto struct. Let's just use the general functions provided by Ecto to fetch the root user.