### PR TITLE
WIP: Fix cannot start match in dev environment when BAR in Windows and SPADS in WSL

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -63,7 +63,9 @@ config :teiserver, Teiserver,
   heartbeat_timeout: nil,
   enable_discord_bridge: false,
   enable_hailstorm: true,
-  accept_all_emails: true
+  accept_all_emails: true,
+  # Enter WSL ip address here if BAR is in Windows and SPADS is in WSL. Otherwise leave nil.
+  spads_ip_override: nil
 
 # Watch static and templates for browser reloading.
 config :teiserver, TeiserverWeb.Endpoint,

--- a/lib/teiserver/protocols/spring/spring_out.ex
+++ b/lib/teiserver/protocols/spring/spring_out.ex
@@ -216,7 +216,13 @@ defmodule Teiserver.Protocols.SpringOut do
     max_players = 16
     rank = 0
 
-    "BATTLEOPENED #{battle.id} #{type} #{nattype} #{battle.founder_name} #{battle.ip} #{battle.port} #{max_players} #{passworded} #{rank} #{battle.map_hash} #{battle.engine_name}\t#{battle.engine_version}\t#{battle.map_name}\t#{battle.name}\t#{battle.game_name}\n"
+    spads_ip_override = Application.get_env(:teiserver, Teiserver)[:spads_ip_override]
+    battle_ip = cond do
+      !!spads_ip_override -> spads_ip_override
+      true -> battle_ip = battle.ip
+    end
+
+    "BATTLEOPENED #{battle.id} #{type} #{nattype} #{battle.founder_name} #{battle_ip} #{battle.port} #{max_players} #{passworded} #{rank} #{battle.map_hash} #{battle.engine_name}\t#{battle.engine_version}\t#{battle.map_name}\t#{battle.name}\t#{battle.game_name}\n"
   end
 
   defp do_reply(:battle_opened, lobby_id) when is_integer(lobby_id) do


### PR DESCRIPTION
### Context
Fixes #239 
If you've set up your dev environment as follows:
- BAR app in Windows
- Teiserver and SPADS in WSL

You will not be able to start a match

### Test Instruction
Inside config/dev.exs add your wsl ip address to this line:
```
  spads_ip_override: "Enter ip here"
```
You can find your wsl ip address via command prompt/powershell:
```
wsl hostname -I
```

Launch Teiserver and SPADS. Now launch BAR app. Try starting a match and it will work.