### PR TITLE
Fix spring auth async tests

### DIFF
--- a/test/support/server_case.ex
+++ b/test/support/server_case.ex
@@ -36,6 +36,9 @@ defmodule Teiserver.ServerCase do
 
     on_exit(&Teiserver.TeiserverTestLib.clear_all_con_caches/0)
 
+    :ok = Supervisor.terminate_child(Teiserver.Supervisor, Teiserver.Repo)
+    {:ok, _} = Supervisor.restart_child(Teiserver.Supervisor, Teiserver.Repo)
+
     :ok
   end
 

--- a/test/support/server_case.ex
+++ b/test/support/server_case.ex
@@ -34,6 +34,8 @@ defmodule Teiserver.ServerCase do
       Ecto.Adapters.SQL.Sandbox.mode(Teiserver.Repo, {:shared, self()})
     end
 
+    on_exit(&Teiserver.TeiserverTestLib.clear_all_con_caches/0)
+
     :ok
   end
 

--- a/test/teiserver/protocols/spring/spring_auth_async_test.exs
+++ b/test/teiserver/protocols/spring/spring_auth_async_test.exs
@@ -13,7 +13,6 @@ defmodule Teiserver.SpringAuthAsyncTest do
 
   setup do
     %{user: user, state: state} = async_auth_setup(Spring)
-    on_exit(fn -> teardown(user) end)
     {:ok, state: state, user: user}
   end
 
@@ -21,15 +20,17 @@ defmodule Teiserver.SpringAuthAsyncTest do
     Client.disconnect(user.id)
   end
 
-  test "PING", %{state: state} do
+  test "PING", %{state: state, user: user} do
     _send_lines(state, "#4 PING\n")
     reply = _recv_lines()
+    teardown(user)
     assert reply == "#4 PONG\n"
   end
 
   test "GETUSERINFO", %{state: state, user: user} do
     _send_lines(state, "GETUSERINFO\n")
     reply = _recv_lines(3)
+    teardown(user)
     assert reply =~ "SERVERMSG Registration date: "
     assert reply =~ "SERVERMSG Email address: #{user.email}"
     assert reply =~ "SERVERMSG Ingame time: "

--- a/test/teiserver/protocols/spring/spring_battle_host_async_test.exs
+++ b/test/teiserver/protocols/spring/spring_battle_host_async_test.exs
@@ -12,7 +12,6 @@ defmodule Teiserver.Protocols.Spring.SpringBattleHostAsyncTest do
 
   setup do
     %{user: user, state: state} = async_auth_setup(Spring)
-    on_exit(fn -> teardown(user) end)
     {:ok, state: state, user: user}
   end
 
@@ -20,13 +19,14 @@ defmodule Teiserver.Protocols.Spring.SpringBattleHostAsyncTest do
     Client.disconnect(user.id)
   end
 
-  test "battle commands when not in a battle", %{state: state} do
+  test "battle commands when not in a battle", %{state: state, user: user, user: user} do
     _send_lines(state, "LEAVEBATTLE\n")
     reply = _recv_lines()
     assert reply == ""
 
     _send_lines(state, "MYBATTLESTATUS 123 123\n")
     reply = _recv_lines()
+    teardown(user)
     assert reply == ""
   end
 end

--- a/test/teiserver/protocols/spring/spring_battle_host_async_test.exs
+++ b/test/teiserver/protocols/spring/spring_battle_host_async_test.exs
@@ -19,7 +19,7 @@ defmodule Teiserver.Protocols.Spring.SpringBattleHostAsyncTest do
     Client.disconnect(user.id)
   end
 
-  test "battle commands when not in a battle", %{state: state, user: user, user: user} do
+  test "battle commands when not in a battle", %{state: state, user: user} do
     _send_lines(state, "LEAVEBATTLE\n")
     reply = _recv_lines()
     assert reply == ""


### PR DESCRIPTION
With these changes, the command `mix test test/teiserver/protocols/spring/spring_auth_async_test.exs` now pass.

There are two important things:

* The `ConCache` is persisted across test. Some caches seems to be important to the application and the tests use that, so don't wipe everything blindly. More explanations in the commit itself (f4dd22fc5240d1cab7ad1ff8f22f0ddca304796a).
* As explained in 5668624ee537cd92d41b92c7f4a0b7b12228916b the `on_exit` is done in a separate process, and that messes up the "shareness" of the db pool.
