### PR TITLE
Render the section to edit user stats

### DIFF
--- a/lib/teiserver_web/templates/admin/user/tab_details.html.heex
+++ b/lib/teiserver_web/templates/admin/user/tab_details.html.heex
@@ -125,7 +125,7 @@
         </tbody>
       </table>
 
-      <% if allow?(@conn, "Server") do %>
+      <%= if allow?(@conn, "Server") do %>
       <hr />
       <form action={Routes.ts_admin_user_path(@conn, :set_stat)} method="post" class="">
         <input type="hidden" name="_csrf_token" value={get_csrf_token()} />


### PR DESCRIPTION
Nothing was actually being rendered because of a typo.
Now we have this bit:
![2024-04-12-616x169-scrot](https://github.com/beyond-all-reason/teiserver/assets/1531763/9f9975f2-5ec7-44be-983e-381b1fdb4414)
