### PR TITLE
Can scroll big tables on narrow screens

### DIFF
--- a/assets/scss/mdb/_card.scss
+++ b/assets/scss/mdb/_card.scss
@@ -3,6 +3,7 @@
 .card {
   border: 0;
   box-shadow: $card-box-shadow;
+  overflow: scroll;
 
   .bg-image {
     border-top-left-radius: $card-border-radius;


### PR DESCRIPTION
A tiny fix, where I cannot scroll left-right.
![scroll](https://github.com/beyond-all-reason/teiserver/assets/1531763/072a6866-8473-49b2-b7e5-fd6df7529e69)
