### PR TITLE
Show intuitive chevron rank number

### DIFF
--- a/lib/teiserver_web/live/account/profile/profile_components.ex
+++ b/lib/teiserver_web/live/account/profile/profile_components.ex
@@ -97,7 +97,7 @@ defmodule TeiserverWeb.Account.ProfileComponents do
 
           <%= @user.name %> &nbsp;&nbsp;&nbsp;&nbsp;
           <span style="font-size: 0.7em;">
-            Chevron rank: <%= (@user.rank || 0) + 1 %>
+            Chevron level: <%= (@user.rank || 0) + 1 %>
           </span>
         </h3>
       </div>

--- a/lib/teiserver_web/live/account/profile/profile_components.ex
+++ b/lib/teiserver_web/live/account/profile/profile_components.ex
@@ -97,7 +97,7 @@ defmodule TeiserverWeb.Account.ProfileComponents do
 
           <%= @user.name %> &nbsp;&nbsp;&nbsp;&nbsp;
           <span style="font-size: 0.7em;">
-            Chevron rank: <%= @user.rank || 0 %>
+            Chevron rank: <%= (@user.rank || 0) + 1 %>
           </span>
         </h3>
       </div>

--- a/lib/teiserver_web/live/account/relationship/index.html.heex
+++ b/lib/teiserver_web/live/account/relationship/index.html.heex
@@ -284,7 +284,7 @@
 
         <%= @found_user.name %> &nbsp;&nbsp;&nbsp;&nbsp;
         <span style="font-size: 0.7em;">
-          Chevron rank: <%= @found_user.data["rank"] || 0 %>
+          Chevron rank: <%= (@found_user.data["rank"] || 0) + 1 %>
         </span>
       </h3>
 

--- a/lib/teiserver_web/live/account/relationship/index.html.heex
+++ b/lib/teiserver_web/live/account/relationship/index.html.heex
@@ -284,7 +284,7 @@
 
         <%= @found_user.name %> &nbsp;&nbsp;&nbsp;&nbsp;
         <span style="font-size: 0.7em;">
-          Chevron rank: <%= (@found_user.data["rank"] || 0) + 1 %>
+          Chevron level: <%= (@found_user.data["rank"] || 0) + 1 %>
         </span>
       </h3>
 


### PR DESCRIPTION
## Summary

Users expect chevron ranks to start at 1, but internally they start at 0. This PR just updates the number displayed on the page to be one more than the internally tracked value so users don't get confused.

closes #254 

## Test evidence

Before
![image](https://github.com/beyond-all-reason/teiserver/assets/37338122/4578f12c-fc13-4c8f-946c-23dd84021c8d)

After
![image](https://github.com/beyond-all-reason/teiserver/assets/37338122/5cd4858e-878e-452e-a129-c89bf8c027f2)
