### PR TITLE
Display uncertainy values for each match

### DIFF
--- a/lib/teiserver_web/live/battles/match/ratings.html.heex
+++ b/lib/teiserver_web/live/battles/match/ratings.html.heex
@@ -77,14 +77,14 @@
         <%= for log <- @logs do %>
           <% {skill_text_class, skill_icon} =
             cond do
-              log.value["skill_change"] > 0 -> {"text-success", "up"}
-              log.value["skill_change"] < 0 -> {"text-danger", "down"}
+              log.value["skill_change"] > 0 -> {"text-success", "arrow-up"}
+              log.value["skill_change"] < 0 -> {"text-danger", "arrow-down"}
               true -> {"text-warning", "pause"}
             end %>
           <% {uncertainty_text_class, uncertainty_icon} =
             cond do
-              log.value["uncertainty_change"] > 0 -> {"text-success", "up"}
-              log.value["uncertainty_change"] < 0 -> {"text-danger", "down"}
+              log.value["uncertainty_change"] > 0 -> {"text-success", "arrow-up"}
+              log.value["uncertainty_change"] < 0 -> {"text-danger", "arrow-down"}
               true -> {"text-warning", "pause"}
             end %>
           <tr phx-click={"[[\"navigate\",{\"href\":\"/battle/#{log.match_id}\",\"replace\":false}]]"}>

--- a/lib/teiserver_web/live/battles/match/ratings.html.heex
+++ b/lib/teiserver_web/live/battles/match/ratings.html.heex
@@ -61,6 +61,7 @@
           <th>Players</th>
           <th>Type</th>
           <th colspan="2">Skill</th>
+          <th colspan="2">Uncertainty</th>
           <th colspan="2">
             Match Rating
             <small class="text-secondary">(Skill - Uncertainty, non-negative only)</small>
@@ -94,7 +95,8 @@
 
               <%= round(log.value["skill_change"], 2) %>
             </td>
-
+            <td><%= round(log.value["uncertainty"], 2) %></td>
+            <td><%= round(log.value["uncertainty_change"], 2) %></td>
             <td><%= round(log.value["rating_value"], 2) %></td>
             <td class={text_class}>
               <i class={"fa-fw fa-solid fa-#{icon}"}></i>

--- a/lib/teiserver_web/live/battles/match/ratings.html.heex
+++ b/lib/teiserver_web/live/battles/match/ratings.html.heex
@@ -75,10 +75,16 @@
       </thead>
       <tbody>
         <%= for log <- @logs do %>
-          <% {text_class, icon} =
+          <% {skill_text_class, skill_icon} =
             cond do
               log.value["skill_change"] > 0 -> {"text-success", "up"}
               log.value["skill_change"] < 0 -> {"text-danger", "down"}
+              true -> {"text-warning", "pause"}
+            end %>
+          <% {uncertainty_text_class, uncertainty_icon} =
+            cond do
+              log.value["uncertainty_change"] > 0 -> {"text-success", "up"}
+              log.value["uncertainty_change"] < 0 -> {"text-danger", "down"}
               true -> {"text-warning", "pause"}
             end %>
           <tr phx-click={"[[\"navigate\",{\"href\":\"/battle/#{log.match_id}\",\"replace\":false}]]"}>
@@ -90,23 +96,27 @@
             <% end %>
             <td><%= @rating_type_id_lookup[log.rating_type_id] %></td>
             <td><%= round(log.value["skill"], 2) %></td>
-            <td class={text_class}>
-              <i class={"fa-fw fa-solid fa-#{icon}"}></i>
+            <td class={skill_text_class}>
+              <i class={"fa-fw fa-solid fa-#{skill_icon}"}></i>
 
               <%= round(log.value["skill_change"], 2) %>
             </td>
             <td><%= round(log.value["uncertainty"], 2) %></td>
-            <td><%= round(log.value["uncertainty_change"], 2) %></td>
+            <td class={uncertainty_text_class}>
+              <i class={"fa-fw fa-solid fa-#{uncertainty_icon}"}></i>
+
+              <%= round(log.value["uncertainty_change"], 2) %>
+            </td>
             <td><%= round(log.value["rating_value"], 2) %></td>
-            <td class={text_class}>
-              <i class={"fa-fw fa-solid fa-#{icon}"}></i>
+            <td class={skill_text_class}>
+              <i class={"fa-fw fa-solid fa-#{skill_icon}"}></i>
 
               <%= round(log.value["rating_value_change"], 2) %>
             </td>
 
             <td><%= round(log.value["skill"] - 3 * log.value["uncertainty"], 2) %></td>
-            <td class={text_class}>
-              <i class={"fa-fw fa-solid fa-#{icon}"}></i>
+            <td class={skill_text_class}>
+              <i class={"fa-fw fa-solid fa-#{skill_icon}"}></i>
 
               <%= round(log.value["skill_change"] - 3 * log.value["uncertainty_change"], 2) %>
             </td>


### PR DESCRIPTION
## Summary

This PR adds in the `uncertainty` and `uncertainty_change` values to the match rating table so that players can know what their uncertainty was and how much each match impacted their uncertainty values.

I've chosen to not highlight the change values red/green because uncertainty changes aren't inherently good/bad, and the value should only really go down over time.

relates to #255 (and might close it if this is deemed sufficient to resolve the confusion)

## Test Evidence

![image](https://github.com/beyond-all-reason/teiserver/assets/37338122/975a0d73-a639-4a18-bbf1-281b9e154267)
