### PR TITLE
Replace Parallel with ParallelStream

### DIFF
--- a/lib/teiserver/account/libs/accolade_lib.ex
+++ b/lib/teiserver/account/libs/accolade_lib.ex
@@ -384,10 +384,10 @@ defmodule Teiserver.Account.AccoladeLib do
 
           pings =
             children
-            |> Parallel.filter(fn {_, _, _, [module]} ->
+            |> ParallelStream.filter(fn {_, _, _, [module]} ->
               module == Teiserver.Account.AccoladeChatServer
             end)
-            |> Parallel.map(fn {_, pid, _, _} ->
+            |> ParallelStream.map(fn {_, pid, _, _} ->
               case GenServer.call(pid, :ping, 5000) do
                 :ok -> :ok
                 _ -> :not_okay

--- a/lib/teiserver/data/matchmaking.ex
+++ b/lib/teiserver/data/matchmaking.ex
@@ -449,7 +449,7 @@ defmodule Teiserver.Data.Matchmaking do
 
     queue_count =
       Game.list_queues(limit: :infinity)
-      |> Parallel.map(fn queue ->
+      |> ParallelStream.map(fn queue ->
         queue
         |> convert_queue
         |> add_queue

--- a/lib/teiserver/game/libs/lobby_policy_lib.ex
+++ b/lib/teiserver/game/libs/lobby_policy_lib.ex
@@ -111,7 +111,7 @@ defmodule Teiserver.Game.LobbyPolicyLib do
   def pre_cache_policies() do
     policy_count =
       Game.list_lobby_policies()
-      |> Parallel.map(&add_policy_from_db/1)
+      |> ParallelStream.map(&add_policy_from_db/1)
       |> Enum.count()
 
     Logger.info("pre_cache_policies, got #{policy_count} policies")

--- a/lib/teiserver/mix_tasks/fake_data.ex
+++ b/lib/teiserver/mix_tasks/fake_data.ex
@@ -86,9 +86,9 @@ defmodule Mix.Tasks.Teiserver.Fakedata do
 
     new_users =
       Range.new(0, @settings.days)
-      |> Parallel.map(fn day ->
+      |> ParallelStream.map(fn day ->
         Range.new(0, users_per_day())
-        |> Parallel.map(fn _ ->
+        |> ParallelStream.map(fn _ ->
           minutes = :rand.uniform(24 * 60)
 
           %{

--- a/lib/teiserver_web/live/queues/index.ex
+++ b/lib/teiserver_web/live/queues/index.ex
@@ -38,7 +38,7 @@ defmodule TeiserverWeb.Matchmaking.QueueLive.Index do
 
     queue_membership =
       Map.keys(db_queues)
-      |> Parallel.reject(fn queue_id ->
+      |> ParallelStream.reject(fn queue_id ->
         p = Matchmaking.get_queue_wait_pid(queue_id)
 
         if p != nil do

--- a/mix.exs
+++ b/mix.exs
@@ -76,7 +76,7 @@ defmodule Teiserver.MixProject do
       {:bodyguard, "~> 2.4"},
       {:human_time, "~> 0.3.0"},
       {:oban, "~> 2.15"},
-      {:parallel, "~> 0.0"},
+      {:parallel_stream, "~> 1.1.0"},
       {:con_cache, "~> 1.0"},
       {:phoenix_pubsub, "~> 2.0"},
       {:elixir_uuid, "~> 1.2"},


### PR DESCRIPTION
The original Parallel has not been updated since 2015 and is causing an error during compilation on newer Elixir versions.
This PR replaces Parallel with ParallelStream, a newer version with same functionality that compiles without errors on newer Elixir versions.

I recommend running 
`mix deps.clean --unused` or `mix deps.clean parallel`
`mix deps.get`
`mix deps.compile`
after merge or for testing