### PR TITLE
Fix incorrect text for admin tools button

### DIFF
--- a/lib/teiserver/admin/libs/tool_lib.ex
+++ b/lib/teiserver/admin/libs/tool_lib.ex
@@ -6,5 +6,5 @@ defmodule Teiserver.Admin.ToolLib do
   def colours(), do: :info
 
   @spec icon :: String.t()
-  def icon(), do: "fa-regular fa-tools"
+  def icon(), do: "fa-solid fa-tools"
 end

--- a/lib/teiserver_web/templates/admin/general/index.html.heex
+++ b/lib/teiserver_web/templates/admin/general/index.html.heex
@@ -154,7 +154,7 @@
     url={~p"/teiserver/admin/tools"}
     size={:small}
   >
-    Site config
+    Admin tools
   </.menu_card>
 </div>
 


### PR DESCRIPTION
## Summary

closes #241 

relating to #242, I also updated the font awesome icon for this to be a freely available one to reduce reliance on the premium version of font awesome

## Test Evidence

Before (on my local teiserver master branch, I'm not an an actual admin so I don't have access to this page in prod):
![image](https://github.com/beyond-all-reason/teiserver/assets/37338122/882eafe2-23f4-4d93-bbfa-3afb0d67089a)


After:
![image](https://github.com/beyond-all-reason/teiserver/assets/37338122/9d0853bd-2fee-4aec-a0a2-29528105178b)


