### PR TITLE
Make minimal game duration to treat game as ranked configurable, lower default 180 -> 90

### DIFF
--- a/lib/teiserver/game/libs/match_rating_lib.ex
+++ b/lib/teiserver/game/libs/match_rating_lib.ex
@@ -4,7 +4,7 @@ defmodule Teiserver.Game.MatchRatingLib do
   to balance matches. For that use Teiserver.Battle.BalanceLib.
   """
 
-  alias Teiserver.{Account, Coordinator, Game, Battle}
+  alias Teiserver.{Account, Coordinator, Config, Game, Battle,}
   alias Teiserver.Data.Types, as: T
   alias Teiserver.Repo
   alias Teiserver.Battle.{BalanceLib, MatchLib}
@@ -71,7 +71,7 @@ defmodule Teiserver.Game.MatchRatingLib do
       match.team_count < 2 ->
         {:error, :not_enough_teams}
 
-      match.game_duration < 180 ->
+      match.game_duration < Config.get_site_config_cache("matchmaking.Time to treat game as ranked") ->
         {:error, :too_short}
 
       Map.get(match.tags, "game/modoptions/ranked_game", "1") == "0" ->

--- a/lib/teiserver/libs/teiserver_configs.ex
+++ b/lib/teiserver/libs/teiserver_configs.ex
@@ -37,6 +37,16 @@ defmodule Teiserver.TeiserverConfigs do
     })
 
     add_site_config_type(%{
+      key: "matchmaking.Time to treat game as ranked",
+      section: "Matchmaking",
+      type: "integer",
+      permissions: ["Server"],
+      description: "Games shorter than this time in seconds will not be treated as ranked.",
+      default: 90,
+      value_label: "Require ready check"
+    })
+
+    add_site_config_type(%{
       key: "bots.Flag",
       section: "Bots",
       type: "string",


### PR DESCRIPTION
Fixes #214.

Relevant discussion in
https://discord.com/channels/549281623154229250/855772061095559179/1210540660604538951

Basically, some 1v1 games do legitimately conclude before 3:00, notably 2:33 is a reported today timing to shut down a comm drop. Also tick/rover rushes. This keeps coming up on the discord. 90s should be pretty optimal. And if it isn't, well, it's now configurable so we can just change the duration :)

Tested to not blow up the site, not tested in-game yet.