### PR TITLE
Add community roles to roles managed by Admin.

### DIFF
--- a/lib/teiserver/account/libs/role_lib.ex
+++ b/lib/teiserver/account/libs/role_lib.ex
@@ -259,7 +259,7 @@ defmodule Teiserver.Account.RoleLib do
   end
 
   def allowed_role_management("Admin") do
-    staff_roles() ++ privileged_roles() ++ allowed_role_management("Moderator")
+    staff_roles() ++ community_roles() ++ privileged_roles() ++ allowed_role_management("Moderator")
   end
 
   def allowed_role_management("Moderator") do


### PR DESCRIPTION
Fixes #272.

Added the community roles under admin, since admin can manage the roles on the sides of the community roles. If a moderator should have ability to assign these roles, I can  change it. 