### PR TITLE
(Blocked) Add rank_icon to ADDUSER command

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -88,7 +88,7 @@ config :teiserver, Oban,
   crontab: false
 
 # Do not include metadata nor timestamps in development logs
-config :logger, :console, format: "[$level] $message\n"
+config :logger, :console, format: "[$level] $message\n", level: :info
 
 config :logger,
   backends: [

--- a/lib/teiserver/account.ex
+++ b/lib/teiserver/account.ex
@@ -137,7 +137,7 @@ defmodule Teiserver.Account do
     |> Repo.one()
   end
 
-  @spec get_user_stat_data(integer()) :: Map.t()
+  @spec get_user_stat_data(integer()) :: map()
   def get_user_stat_data(userid) do
     Teiserver.cache_get_or_store(:teiserver_user_stat_cache, userid, fn ->
       case get_user_stat(userid) do

--- a/lib/teiserver/account/libs/role_lib.ex
+++ b/lib/teiserver/account/libs/role_lib.ex
@@ -263,7 +263,7 @@ defmodule Teiserver.Account.RoleLib do
   end
 
   def allowed_role_management("Moderator") do
-    global_roles() ++ moderation_roles() ++ property_roles()
+    global_roles() ++ moderation_roles() ++ property_roles() ++ community_roles()
   end
 
   def allowed_role_management(_) do

--- a/lib/teiserver/account/libs/role_lib.ex
+++ b/lib/teiserver/account/libs/role_lib.ex
@@ -259,11 +259,12 @@ defmodule Teiserver.Account.RoleLib do
   end
 
   def allowed_role_management("Admin") do
-    staff_roles() ++ privileged_roles() ++ allowed_role_management("Moderator")
+    # Remove this code later; it has been fixed in another PR
+    staff_roles() ++ privileged_roles() ++ allowed_role_management("Moderator") ++ community_roles()
   end
 
   def allowed_role_management("Moderator") do
-    global_roles() ++ moderation_roles() ++ property_roles() ++ community_roles()
+    global_roles() ++ moderation_roles() ++ property_roles()
   end
 
   def allowed_role_management(_) do

--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -1335,21 +1335,23 @@ defmodule Teiserver.CacheUser do
     end
   end
 
-  def get_rank_icon(userid) do
-    stats = Account.get_user_stat_data(userid)
+  @doc"""
+  stats_data will be data column from teiserver_acctoun_users_stats
+  """
+  def get_rank_icon(%{roles: roles} = _user, stats_data) do
+    stats_data
     # Play time Rank
     rank =
       cond do
         # This is only for tournament winners
-        stats["rank_override"] != nil ->
-          stats["rank_override"] |> int_parse
+        stats_data["rank_override"] != nil ->
+          stats_data["rank_override"] |> int_parse
 
         true ->
-          hours = rank_time(stats)
+          hours = rank_time(stats_data)
           convert_hours_to_rank(hours)
       end
 
-    %{roles: roles} = Account.get_user_by_id(userid)
     chev_level = rank + 1
 
     cond do

--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -1339,7 +1339,7 @@ defmodule Teiserver.CacheUser do
   stats_data will be data column from teiserver_acctoun_users_stats
   """
   def get_rank_icon(%{roles: roles} = _user, stats_data) do
-    stats_data
+
     # Play time Rank
     rank =
       cond do

--- a/lib/teiserver/data/client.ex
+++ b/lib/teiserver/data/client.ex
@@ -95,7 +95,7 @@ defmodule Teiserver.Client do
     lobby_client =  stats["lobby_client"]
 
     rank_icon = cond do
-      lobby_client == "Teiserver Internal Client" -> "Bot"
+      protocol == :internal -> "Bot"
       is_bot? -> "Bot"
       true -> CacheUser.get_rank_icon(user, stats)
     end

--- a/lib/teiserver/libs/teiserver_configs.ex
+++ b/lib/teiserver/libs/teiserver_configs.ex
@@ -572,7 +572,7 @@ defmodule Teiserver.TeiserverConfigs do
       key: "profile.Rank method",
       section: "Profiles",
       type: "select",
-      default: "Leaderboard rating",
+      default: "Role",
       permissions: ["Admin"],
       description: "The value used to assign rank icons at login",
       opts: [choices: ["Leaderboard rating", "Rating value", "Playtime", "Role"]]

--- a/lib/teiserver/protocols/spring/spring_out.ex
+++ b/lib/teiserver/protocols/spring/spring_out.ex
@@ -147,7 +147,6 @@ defmodule Teiserver.Protocols.SpringOut do
   defp do_reply(:add_user, %{userid: nil}), do: ""
 
   defp do_reply(:add_user, client) do
-    IO.inspect(client, label: "client", charlists: :as_lists)
     #rank_icon is not in Spring protocol and is an extra argument
     #Full definition of client can be found in client.ex in the login function
     "ADDUSER #{client.name} #{client.country} #{client.userid} #{client.lobby_client} #{client.rank_icon}\n"

--- a/lib/teiserver/protocols/spring/spring_out.ex
+++ b/lib/teiserver/protocols/spring/spring_out.ex
@@ -149,7 +149,7 @@ defmodule Teiserver.Protocols.SpringOut do
   defp do_reply(:add_user, client) do
     #rank_icon is not in Spring protocol and is an extra argument
     #Full definition of client can be found in client.ex in the login function
-    "ADDUSER #{client.name} #{client.country} #{client.userid} #{client.lobby_client} #{client.rank_icon}\n"
+    "ADDUSER #{client.name} #{client.country} #{client.userid} #{client.lobby_client}\t#{client.rank_icon}\n"
   end
 
   defp do_reply(:friendlist, nil), do: "FRIENDLISTBEGIN\FRIENDLISTEND\n"

--- a/lib/teiserver/protocols/spring/spring_out.ex
+++ b/lib/teiserver/protocols/spring/spring_out.ex
@@ -328,8 +328,16 @@ defmodule Teiserver.Protocols.SpringOut do
   defp do_reply(:client_status, nil), do: ""
 
   defp do_reply(:client_status, client) do
+
+    rank_icon = cond do
+      client.lobby_client == "Teiserver Internal Client" -> "Bot"
+      client.bot -> "Bot"
+      true -> CacheUser.get_rank_icon(client.userid)
+    end
+
+
     status = Spring.create_client_status(client)
-    "CLIENTSTATUS #{client.name} #{status}\n"
+    "CLIENTSTATUS #{client.name} #{status} #{rank_icon}\n"
   end
 
   defp do_reply(:client_battlestatus, nil), do: nil

--- a/lib/teiserver/protocols/spring/spring_out.ex
+++ b/lib/teiserver/protocols/spring/spring_out.ex
@@ -147,7 +147,10 @@ defmodule Teiserver.Protocols.SpringOut do
   defp do_reply(:add_user, %{userid: nil}), do: ""
 
   defp do_reply(:add_user, client) do
-    "ADDUSER #{client.name} #{client.country} #{client.userid} #{client.lobby_client}\n"
+    IO.inspect(client, label: "client", charlists: :as_lists)
+    #rank_icon is not in Spring protocol and is an extra argument
+    #Full definition of client can be found in client.ex in the login function
+    "ADDUSER #{client.name} #{client.country} #{client.userid} #{client.lobby_client} #{client.rank_icon}\n"
   end
 
   defp do_reply(:friendlist, nil), do: "FRIENDLISTBEGIN\FRIENDLISTEND\n"
@@ -328,16 +331,8 @@ defmodule Teiserver.Protocols.SpringOut do
   defp do_reply(:client_status, nil), do: ""
 
   defp do_reply(:client_status, client) do
-
-    rank_icon = cond do
-      client.lobby_client == "Teiserver Internal Client" -> "Bot"
-      client.bot -> "Bot"
-      true -> CacheUser.get_rank_icon(client.userid)
-    end
-
-
     status = Spring.create_client_status(client)
-    "CLIENTSTATUS #{client.name} #{status} #{rank_icon}\n"
+    "CLIENTSTATUS #{client.name} #{status}\n"
   end
 
   defp do_reply(:client_battlestatus, nil), do: nil

--- a/lib/test_util/test_script.ex
+++ b/lib/test_util/test_script.ex
@@ -1,0 +1,196 @@
+defmodule TestScript do
+  @moduledoc """
+  This module is not used anywhere but it can be called while developing to create 4 users for testing:
+  Alpha, Bravo, Charlie, Delta
+  password is password
+
+
+  Run the server while enabling iex commands:
+
+  iex -S mix phx.server
+  TestScript.run()
+  """
+  alias Teiserver.Helper.StylingHelper
+  require Logger
+  alias Teiserver.{Account, CacheUser}
+  alias Teiserver.Game.MatchRatingLib
+
+  def run() do
+    if Application.get_env(:teiserver, Teiserver)[:enable_hailstorm] do
+      # Start by rebuilding the database
+
+
+      users = [
+        %{
+          name: "1Chev",
+          player_minutes: 0,
+          os: 17
+        },
+        %{
+          name: "2Chev",
+          player_minutes: 5 * 60,
+          os: 17
+        },
+        %{
+          name: "3Chev",
+          player_minutes: 15 * 60,
+          os: 17
+        },
+        %{
+          name: "4Chev",
+          player_minutes: 100 * 60,
+          os: 17
+        },
+        %{
+          name: "5Chev",
+          player_minutes: 250 * 60,
+          os: 17
+        },
+        %{
+          name: "6Chev",
+          player_minutes: 1001 * 60,
+          os: 17
+        },
+        %{
+          name: "7Chev",
+          player_minutes: 1001 * 60,
+          os: 17,
+          rank_override: 6
+        },
+        %{
+          name: "8Chev",
+          player_minutes: 1001 * 60,
+          os: 17,
+          rank_override: 7
+        }
+      ]
+
+      user_names = Enum.map(users, fn x -> x.name end)
+      make_accounts(user_names)
+      update_stats(users)
+
+      "Test script finished successfully"
+    else
+      Logger.error("Hailstorm mode is not enabled, you cannot run the fakedata task")
+    end
+  end
+
+  defp make_accounts(list_of_names) do
+    root_user = Teiserver.Repo.get_by(Teiserver.Account.User, email: "root@localhost")
+
+    fixed_users =
+      list_of_names
+      |> Enum.map(fn x -> make_user(x, root_user) end)
+      |> Enum.filter(fn x -> x != nil end)
+
+    Ecto.Multi.new()
+    |> Ecto.Multi.insert_all(:insert_all, Teiserver.Account.User, fixed_users)
+    |> Teiserver.Repo.transaction()
+  end
+
+  # root_user is used to copy password and hash
+  # returns nil if user exists
+  defp make_user(name, root_user, day \\ 0, minutes \\ 0) do
+    name = name |> String.replace(" ", "")
+
+    case Teiserver.Account.UserCacheLib.get_user_by_name(name) do
+      nil ->
+        %{
+          name: name,
+          email: "#{name}",
+          password: root_user.password,
+          permissions: ["admin.dev.developer"],
+          icon: "fa-solid #{StylingHelper.random_icon()}",
+          colour: StylingHelper.random_colour(),
+          trust_score: 10_000,
+          behaviour_score: 10_000,
+          roles: ["Verified"],
+          data: %{
+            lobby_client: "FakeData",
+            bot: false,
+            password_hash: root_user.data["password_hash"]
+          },
+          inserted_at: Timex.shift(Timex.now(), days: -day, minutes: -minutes) |> time_convert,
+          updated_at: Timex.shift(Timex.now(), days: -day, minutes: -minutes) |> time_convert
+        }
+
+      # Handle not nil
+      _ ->
+        Logger.info("#{name} already exists")
+        nil
+    end
+  end
+
+  # This allows us to round off microseconds and convert datetime to naive_datetime
+  defp time_convert(t) do
+    t
+    |> Timex.to_unix()
+    |> Timex.from_unix()
+    |> Timex.to_naive_datetime()
+  end
+
+  defp update_stats(users) when is_list(users) do
+    for user <- users, do: update_stats(user.name, user.player_minutes, user.os, user[:rank_override])
+  end
+
+  # Update the database with player minutes
+  def update_stats(username, player_minutes, os, rank_override \\ nil) do
+    user = Teiserver.Account.UserCacheLib.get_user_by_name(username)
+    user_id = user.id
+
+    user_stat = %{
+      player_minutes: player_minutes,
+      total_minutes: player_minutes
+    }
+
+    user_stat = cond do
+      rank_override != nil -> Map.put(user_stat, :rank_override, rank_override)
+      true -> user_stat
+    end
+
+    Account.update_user_stat(user_id, user_stat)
+
+    # Now recalculate ranks
+    # This calc would usually be done in do_login
+    rank = CacheUser.calculate_rank(user_id)
+
+    user = %{
+      user
+      | rank: rank
+    }
+
+    CacheUser.update_user(user, true)
+    update_rating(user.id, os)
+  end
+
+  defp update_rating(user_id, os) do
+    new_uncertainty = 6
+    new_skill = os + new_uncertainty
+    new_rating_value = os
+    new_leaderboard_rating = os - 2 * new_uncertainty
+    rating_type = "Team"
+    rating_type_id = MatchRatingLib.rating_type_name_lookup()[rating_type]
+
+    case Account.get_rating(user_id, rating_type_id) do
+      nil ->
+        Account.create_rating(%{
+          user_id: user_id,
+          rating_type_id: rating_type_id,
+          rating_value: new_rating_value,
+          skill: new_skill,
+          uncertainty: new_uncertainty,
+          leaderboard_rating: new_leaderboard_rating,
+          last_updated: Timex.now()
+        })
+
+      existing ->
+        Account.update_rating(existing, %{
+          rating_value: new_rating_value,
+          skill: new_skill,
+          uncertainty: new_uncertainty,
+          leaderboard_rating: new_leaderboard_rating,
+          last_updated: Timex.now()
+        })
+    end
+  end
+end


### PR DESCRIPTION
# Context
Contributors use a high rank to determine their rank icon. The problem is that this makes contributors look like pro gamers and they might not be. In order to create more flexibility to rank icons, we should separate them from rank. If we can separate it from rank we could use [rank icons made by Ice](https://discord.com/channels/549281623154229250/564591092360675328/1212462364960497716)

![1](https://github.com/beyond-all-reason/teiserver/assets/1305569/36a364d8-cd86-4ee7-a4ce-0864bb8693f4)

Teiserver currently sends this for [ADDUSER ](https://springrts.com/dl/LobbyProtocol/ProtocolDescription.html#ADDUSER:server):
```
    "ADDUSER #{client.name} #{client.country} #{client.userid} #{client.lobby_client}\n"

```


# Proposed Changes
I propose to send this instead from TeiServer
```
    "ADDUSER #{client.name} #{client.country} #{client.userid} #{client.lobby_client} #{client.rank_icon}\n"
```
where `rank_icon` is a string that can take these values:

- 1Chev, 2Chev, ...8Chev
- 1Moderator, 2Moderator, ...8Moderator
- 1Contributor, 2Contributor, ...8Contributor
- 1Streamer, 2Streamer, ...8Streamer
- 1Mentor, 2Mentor, ...8Mentor
- Bot

But it's very flexible and can really be anything. The numeric prefix represents their chev level purely based on playtime. After that the postfix depends on if they have a special role or not. If a user has multiple roles it will pick one in this order: Moderator > Contributor > Streamer > Mentor.

# Required SPADS modification
SPADS doesn't error with this modification. However I have no idea why it doesn't error.

# Required Chobby Modifications
No change is required to Chobby to prevent errors. Chobby is using regex that will simply ignore the extra argument.

# Test Steps
### 1. Launch SPADS
```
perl spads.pl etc/spads.conf
```
This is the normal command to launch spads.

### 2. Add TeiServer Test Users
Launch teiserver with this command (that allows running Elixir commands)
```
iex -S mix phx.server
```
In the same terminal run this to generate test users
```
TestScript.run()
```

This will generate the following users:
```
1Chev, 2Chev, 3Chev, 4Chev, 5Chev, 6Chev, 7Chev, 8Chev
```
Each of them will have a password of `password`. Their chev level is defined by their name.

### 3. Login with test users
Launch Chobby and login with any of the test users. Check via logs what rank_icon is being send (Not sure how to log this)

Now go to Teiserver website and login with `root@localhost` with password `password`
Go to Users > Find the user > Edit > Change their role to include any of Moderator/Contributor/Streamer/Mentor

Relogin with that user in Chobby. Check the logs and it should be different.