### PR TITLE
More fix spring auth

### DIFF
--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -27,13 +27,16 @@ defmodule Teiserver.DataCase do
     end
   end
 
+  @doc """
+  Sets up the sandbox based on the test tags.
+  """
+  def setup_sandbox(tags) do
+    pid = Ecto.Adapters.SQL.Sandbox.start_owner!(Teiserver.Repo, shared: not tags[:async])
+    on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
+  end
+
   setup tags do
-    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Teiserver.Repo)
-
-    unless tags[:async] do
-      Ecto.Adapters.SQL.Sandbox.mode(Teiserver.Repo, {:shared, self()})
-    end
-
+    setup_sandbox(tags)
     :ok
   end
 

--- a/test/support/server_case.ex
+++ b/test/support/server_case.ex
@@ -28,17 +28,8 @@ defmodule Teiserver.ServerCase do
   end
 
   setup tags do
-    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Teiserver.Repo)
-
-    unless tags[:async] do
-      Ecto.Adapters.SQL.Sandbox.mode(Teiserver.Repo, {:shared, self()})
-    end
-
+    Teiserver.DataCase.setup_sandbox(tags)
     on_exit(&Teiserver.TeiserverTestLib.clear_all_con_caches/0)
-
-    :ok = Supervisor.terminate_child(Teiserver.Supervisor, Teiserver.Repo)
-    {:ok, _} = Supervisor.restart_child(Teiserver.Supervisor, Teiserver.Repo)
-
     :ok
   end
 

--- a/test/teiserver/protocols/spring/spring_auth_test.exs
+++ b/test/teiserver/protocols/spring/spring_auth_test.exs
@@ -294,6 +294,9 @@ CLIENTS test_room #{user.name}\n"
   test "JOINBATTLE, SAYBATTLE, MYBATTLESTATUS, LEAVEBATTLE", %{socket: socket1, user: user1} do
     hash = "-1540855590"
 
+    # Give user Bot role so they can manage battle
+    UserCacheLib.update_user(%{user1 | roles: ["Bot" | user1.roles]}, persist: false)
+
     _send_raw(
       socket1,
       "OPENBATTLE 0 0 empty 52200 16 #{hash} 0 1565299817 spring\t104.0.1-1784-gf6173b4 BAR\tauth_joinbattle_test\tEU - 00\tBeyond All Reason test-15658-85bf66d\n"

--- a/test/teiserver/protocols/spring/spring_auth_test.exs
+++ b/test/teiserver/protocols/spring/spring_auth_test.exs
@@ -511,6 +511,8 @@ CLIENTS test_room #{user.name}\n"
 
     # Un-flood them
     CacheUser.set_flood_level(userid, 0)
+    # And re-verify them
+    user.id |> Teiserver.CacheUser.get_user_by_id() |> Teiserver.CacheUser.verify_user()
 
     # Now they can log in again
     _send_raw(

--- a/test/teiserver/protocols/spring/spring_auth_test.exs
+++ b/test/teiserver/protocols/spring/spring_auth_test.exs
@@ -138,6 +138,7 @@ defmodule Teiserver.SpringAuthTest do
 
     # Now lets ignore them
     _send_raw(socket1, "IGNORE userName=#{user2.name}\n")
+    _send_raw(socket1, "IGNORELIST\n")
     reply = _recv_raw(socket1)
     assert reply == "IGNORELISTBEGIN
 IGNORELIST userName=#{user2.name}
@@ -150,6 +151,7 @@ IGNORELISTEND\n"
 
     # Now unignore them
     _send_raw(socket1, "UNIGNORE userName=#{user2.name}\n")
+    _send_raw(socket1, "IGNORELIST\n")
     reply = _recv_raw(socket1)
     assert reply == "IGNORELISTBEGIN
 IGNORELISTEND\n"

--- a/test/teiserver/protocols/spring/spring_auth_test.exs
+++ b/test/teiserver/protocols/spring/spring_auth_test.exs
@@ -567,7 +567,7 @@ CLIENTS test_room #{user.name}\n"
     assert reply == "SERVERMSG You do not have permission to execute that command\n"
 
     # Give mod access, recache the user
-    UserCacheLib.update_user(%{user | moderator: true}, persist: false)
+    UserCacheLib.update_user(%{user | roles: ["Moderator" | user.roles]}, persist: false)
     :timer.sleep(100)
 
     _send_raw(socket, "CREATEBOTACCOUNT test_bot_account #{user.name}\n")
@@ -678,7 +678,7 @@ CLIENTS test_room #{user.name}\n"
     reply = _recv_raw(socket)
     assert reply == :timeout
 
-    UserCacheLib.update_user(%{user | moderator: true}, persist: false)
+    UserCacheLib.update_user(%{user | roles: ["Moderator" | user.roles]}, persist: false)
     :timer.sleep(500)
     _recv_until(socket)
 
@@ -697,7 +697,7 @@ CLIENTS test_room #{user.name}\n"
     reply = _recv_raw(socket)
     assert reply == :timeout
 
-    UserCacheLib.update_user(%{user | moderator: true}, persist: false)
+    UserCacheLib.update_user(%{user | roles: ["Moderator" | user.roles]}, persist: false)
     :timer.sleep(500)
     _recv_until(socket)
 

--- a/test/teiserver/protocols/spring/spring_auth_test.exs
+++ b/test/teiserver/protocols/spring/spring_auth_test.exs
@@ -20,7 +20,6 @@ defmodule Teiserver.SpringAuthTest do
 
   setup do
     %{socket: socket, user: user} = auth_setup()
-    on_exit(fn -> Client.disconnect(user.id) end)
     {:ok, socket: socket, user: user}
   end
 
@@ -582,6 +581,7 @@ CLIENTS test_room #{user.name}\n"
 
     assert reply ==
              "SERVERMSG No incomming match for CREATEBOTACCOUNT with data '\"nomatchname\"'. Userid #{user.id}\n"
+
   end
 
   # test "c.moderation.report", %{socket: socket, user: user} do

--- a/test/teiserver/protocols/spring/spring_auth_test.exs
+++ b/test/teiserver/protocols/spring/spring_auth_test.exs
@@ -197,49 +197,38 @@ IGNORELISTEND\n"
 
     # Now we send the friend request
     _send_raw(socket2, "FRIENDREQUEST userName=#{user.name}\n")
+
+    # and the target receives it
     reply = _recv_raw(socket1)
-    assert reply == "FRIENDREQUESTLISTBEGIN
-FRIENDREQUESTLIST userName=#{user2.name}
-FRIENDREQUESTLISTEND\n"
+    assert reply == "s.user.new_incoming_friend_request #{user2.id}\n"
 
     # Accept the friend request
     _send_raw(socket1, "ACCEPTFRIENDREQUEST userName=#{user2.name}\n")
-    reply = _recv_raw(socket1)
-    assert reply == "FRIENDLISTBEGIN
-FRIENDLIST userName=#{user2.name}
-FRIENDLISTEND
-FRIENDREQUESTLISTBEGIN
-FRIENDREQUESTLISTEND\n"
+    # there's no expected response for this command
 
     reply = _recv_raw(socket2)
-    assert reply == "FRIENDLISTBEGIN
-FRIENDLIST userName=#{user.name}
-FRIENDLISTEND\n"
+    assert reply == "s.user.friend_request_accepted #{user.id}\n"
 
     # Change of plan, remove them
     _send_raw(socket1, "UNFRIEND userName=#{user2.name}\n")
     reply = _recv_raw(socket1)
-    assert reply == "FRIENDLISTBEGIN
-FRIENDLISTEND\n"
+    assert reply == "s.user.friend_deleted #{user2.id}\n"
 
     reply = _recv_raw(socket2)
-    assert reply == "FRIENDLISTBEGIN
-FRIENDLISTEND\n"
+    assert reply == "s.user.friend_deleted #{user.id}\n"
 
     # Request a friend again so we can decline it
     _send_raw(socket2, "FRIENDREQUEST userName=#{user.name}\n")
     reply = _recv_raw(socket1)
-    assert reply == "FRIENDREQUESTLISTBEGIN
-FRIENDREQUESTLIST userName=#{user2.name}
-FRIENDREQUESTLISTEND\n"
+    assert reply == "s.user.new_incoming_friend_request #{user2.id}\n"
 
     # Decline the friend request
     _send_raw(socket1, "DECLINEFRIENDREQUEST userName=#{user2.name}\n")
-    reply = _recv_raw(socket1)
-    assert reply == "FRIENDREQUESTLISTBEGIN
-FRIENDREQUESTLISTEND\n"
-
+    # the other users receive the notice that it was declined
     reply = _recv_raw(socket2)
+    assert reply == "s.user.friend_request_declined #{user.id}\n"
+
+    reply = _recv_raw(socket1)
     assert reply == :timeout
   end
 

--- a/test/teiserver/protocols/spring/spring_auth_test.exs
+++ b/test/teiserver/protocols/spring/spring_auth_test.exs
@@ -20,6 +20,7 @@ defmodule Teiserver.SpringAuthTest do
 
   setup do
     %{socket: socket, user: user} = auth_setup()
+    on_exit(fn -> Client.disconnect(user.id) end)
     {:ok, socket: socket, user: user}
   end
 

--- a/test/teiserver/protocols/spring/spring_auth_test.exs
+++ b/test/teiserver/protocols/spring/spring_auth_test.exs
@@ -344,14 +344,17 @@ CLIENTS test_room #{user.name}\n"
       host_bstatus,
       # bstatus,
       request,
+      client_status,
       ""
     ] = reply
 
     assert joinbattle == "JOINBATTLE #{lobby_id} #{hash}"
     assert joinedbattle == "JOINEDBATTLE #{lobby_id} #{user2.name} sPassword"
-    assert tags =~ "SETSCRIPTTAGS server/match/uuid="
-    assert host_bstatus == "CLIENTBATTLESTATUS #{user1.name} 8388608 0"
+    assert tags =~ ~r"SETSCRIPTTAGS .*server/match/uuid="
+    # the \d+ is the team colour
+    assert host_bstatus =~ ~r"CLIENTBATTLESTATUS #{user1.name} \d+ 0"
     assert request == "REQUESTBATTLESTATUS"
+    assert client_status == "CLIENTSTATUS #{user2.name} 0"
 
     _send_raw(socket2, "SAYBATTLE Hello there!\n")
     reply = _recv_raw(socket2)
@@ -359,7 +362,7 @@ CLIENTS test_room #{user.name}\n"
 
     _send_raw(socket2, "MYBATTLESTATUS 12 0\n")
     reply = _recv_raw(socket2)
-    assert reply == "CLIENTBATTLESTATUS #{user2.name} 8388620 0\n"
+    assert reply =~ ~r"CLIENTBATTLESTATUS #{user2.name} \d+ 0\n"
 
     # SAYBATTLEPRIVATEEX
     _send_raw(socket1, "SAYBATTLEPRIVATEEX #{user2.name} This is a test priv battle msg\n")


### PR DESCRIPTION
A few fixes for some old tests.
`mix test test/teiserver/protocols/spring/spring_auth_test.exs` now returns 16 tests passed out of 16 vs 7 failures out of 16 tests on master.

Although there are still some async errors regarding tests teardown, it doesn't actually fail any tests. More info in af604750fedf11730dc9f52a53db84f3f29b9f79