### PR TITLE
Dynamic discord integration

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -29,7 +29,10 @@ config :teiserver, TeiserverWeb.Endpoint,
     formats: [html: TeiserverWeb.ErrorHTML, json: TeiserverWeb.ErrorJSON],
     layout: false
   ],
-  pubsub_server: Teiserver.PubSub
+  pubsub_server: Teiserver.PubSub,
+  debug_errors: Config.config_env() == :dev,
+  code_reloader: Config.config_env() == :dev,
+  check_origin: Config.config_env() == :prod
 
 config :esbuild,
   version: "0.14.41",

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -20,9 +20,6 @@ config :teiserver, Teiserver.Repo,
 # with webpack to recompile .js and .css sources.
 config :teiserver, TeiserverWeb.Endpoint,
   http: [ip: {127, 0, 0, 1}, port: 4000],
-  debug_errors: true,
-  code_reloader: true,
-  check_origin: false,
   watchers: [
     # Start the esbuild watcher by calling Esbuild.install_and_run(:default, args)
     esbuild: {Esbuild, :install_and_run, [:default, ~w(--sourcemap=inline --watch)]},

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -14,11 +14,6 @@ config :teiserver, TeiserverWeb.Endpoint,
   https: [
     port: 8888,
     otp_app: :teiserver,
-    keyfile: "/var/www/tls/privkey.pem",
-    certfile: "/var/www/tls/cert.pem",
-    cacertfile: "/var/www/tls/fullchain.pem",
-    versions: [:"tlsv1.2"],
-    dhfile: '/var/www/tls/dh-params.pem',
     ciphers: [
       'ECDHE-ECDSA-AES256-GCM-SHA384',
       'ECDHE-RSA-AES256-GCM-SHA384',
@@ -66,7 +61,6 @@ config :teiserver, TeiserverWeb.Endpoint,
   root: ".",
   cache_static_manifest: "priv/static/cache_manifest.json",
   server: true,
-  check_origin: ["//yourdomain.com", "//*.yourdomain.com"],
   version: Mix.Project.config()[:version]
 
 config :teiserver, Teiserver,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -63,17 +63,6 @@ config :teiserver, TeiserverWeb.Endpoint,
   server: true,
   version: Mix.Project.config()[:version]
 
-config :teiserver, Teiserver,
-  certs: [
-    keyfile: "/var/www/tls/privkey.pem",
-    certfile: "/var/www/tls/cert.pem",
-    cacertfile: "/var/www/tls/fullchain.pem"
-  ],
-  enable_benchmark: false,
-  node_name: "node-name",
-  enable_managed_lobbies: true,
-  tachyon_schema_path: "/apps/teiserver/lib/teiserver-0.1.0/priv/tachyon/schema_v1/*/*/*.json"
-
 config :teiserver, Teiserver.Repo,
   pool_size: String.to_integer(System.get_env("POOL_SIZE") || "40"),
   timeout: 120_000,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -62,5 +62,3 @@ config :teiserver, TeiserverWeb.Endpoint,
   cache_static_manifest: "priv/static/cache_manifest.json",
   server: true,
   version: Mix.Project.config()[:version]
-
-import_config "prod.secret.exs"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -63,11 +63,6 @@ config :teiserver, TeiserverWeb.Endpoint,
   server: true,
   version: Mix.Project.config()[:version]
 
-config :teiserver, Teiserver.Repo,
-  pool_size: String.to_integer(System.get_env("POOL_SIZE") || "40"),
-  timeout: 120_000,
-  queue_interval: 2000
-
 # Do not print debug messages in production
 config :logger,
   format: "$date $time [$level] $metadata $message\n",

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -63,36 +63,4 @@ config :teiserver, TeiserverWeb.Endpoint,
   server: true,
   version: Mix.Project.config()[:version]
 
-# Do not print debug messages in production
-config :logger,
-  format: "$date $time [$level] $metadata $message\n",
-  metadata: [:request_id, :user_id],
-  level: :info
-
-config :logger,
-  backends: [
-    {LoggerFileBackend, :error_log},
-    {LoggerFileBackend, :notice_log},
-    {LoggerFileBackend, :info_log},
-    :console
-  ]
-
-config :logger, :error_log,
-  path: "/var/log/teiserver/error.log",
-  format: "$date $time [$level] $metadata $message\n",
-  metadata: [:request_id, :user_id],
-  level: :error
-
-config :logger, :notice_log,
-  path: "/var/log/teiserver/notice.log",
-  format: "$date $time [$level] $metadata $message\n",
-  metadata: [:request_id, :user_id],
-  level: :notice
-
-config :logger, :info_log,
-  path: "/var/log/teiserver/info.log",
-  format: "$date $time [$level] $metadata $message\n",
-  metadata: [:request_id, :user_id],
-  level: :info
-
 import_config "prod.secret.exs"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -95,8 +95,4 @@ config :logger, :info_log,
   metadata: [:request_id, :user_id],
   level: :info
 
-# Overwritten in secret
-config :teiserver, Teiserver.Account.Guardian,
-  secret_key: "yix2DcXsA9MzAI8WldmYiJ38j2GyyXf5beWGAOJHl0FKNH04n1VACYbepqutma27"
-
 import_config "prod.secret.exs"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -24,11 +24,32 @@ end
 # files are automatically recompiled on the fly and thus, config/{dev,test}.exs
 # are just fine
 if config_env() == :prod do
+  # used for mailing, checking origins, finding tls certs…
+  domain_name = System.get_env("DOMAIN_NAME", "beyondallreason.info")
+
+  certificates = [
+    keyfile: System.fetch_env!("TLS_PRIVATE_KEY_PATH"),
+    certfile: System.fetch_env!("TLS_CERT_PATH"),
+    cacertfile: System.fetch_env!("TLS_CA_CERT_PATH")
+  ]
 
   # this is used in lib/teiserver_web/controllers/account/setup_controller.ex
   # as a special endpoint to create the root user. Setting it to empty or nil
   # will disable the functionality completely.
   # There is already a root user, so disable it
   config :teiserver, Teiserver.Setup, key: nil
+
+  config :teiserver, TeiserverWeb.Endpoint,
+    url: [host: domain_name],
+    check_origin: ["//#{domain_name}", "//*.#{domain_name}"],
+    https:
+      certificates ++
+        [
+          versions: [:"tlsv1.2"],
+          # dhfile is not supported for tls 1.3
+          # https://www.erlang.org/doc/man/ssl.html#type-dh_file
+          dhfile: System.fetch_env!("TLS_DH_FILE_PATH")
+        ]
+
 
 end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -103,4 +103,37 @@ if config_env() == :prod do
     # auth: :if_available # can be `always`. If your smtp relay requires authentication set it to `always`.
     auth: :always
 
+  log_root_path = System.fetch_env("LOG_ROOT_PATH", "/var/log/teiserver/")
+
+  config :logger,
+    backends: [
+      {LoggerFileBackend, :error_log},
+      {LoggerFileBackend, :notice_log},
+      {LoggerFileBackend, :info_log},
+      :console
+    ]
+
+  # Do not print debug messages in production
+  config :logger,
+    format: "$date $time [$level] $metadata $message\n",
+    metadata: [:request_id, :user_id],
+    level: :info
+
+  config :logger, :error_log,
+    path: "#{log_root_path}error.log",
+    format: "$date $time [$level] $metadata $message\n",
+    metadata: [:request_id, :user_id],
+    level: :error
+
+  config :logger, :notice_log,
+    path: "#{log_root_path}notice.log",
+    format: "$date $time [$level] $metadata $message\n",
+    metadata: [:request_id, :user_id],
+    level: :notice
+
+  config :logger, :info_log,
+    path: "#{log_root_path}info.log",
+    format: "$date $time [$level] $metadata $message\n",
+    metadata: [:request_id, :user_id],
+    level: :info
 end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -63,16 +63,23 @@ if config_env() == :prod do
     timeout: 120_000,
     queue_interval: 2000
 
+  check_origin =
+    if Teiserver.ConfigHelpers.get_env("SHOULD_CHECK_ORIGIN", false, :bool) do
+      ["//#{domain_name}", "//*.#{domain_name}"]
+    else
+      false
+    end
+
   config :teiserver, TeiserverWeb.Endpoint,
     url: [host: domain_name],
-    check_origin: ["//#{domain_name}", "//*.#{domain_name}"],
+    check_origin: check_origin,
     https:
       certificates ++
         [
           versions: [:"tlsv1.2"],
           # dhfile is not supported for tls 1.3
           # https://www.erlang.org/doc/man/ssl.html#type-dh_file
-          dhfile: Teiserver.ConfigHelpers.get_env("TLS_DH_FILE_PATH")
+          dhfile: Teiserver.ConfigHelpers.get_env("TLS_DH_FILE_PATH", "/etc/ssl/dhparam.pem")
         ],
     http: [:inet6, port: Teiserver.ConfigHelpers.get_env("PORT", "4000", :int)],
     secret_key_base: Teiserver.ConfigHelpers.get_env("HTTP_SECRET_KEY_BASE")

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -7,6 +7,10 @@ import Config
 # any compile-time configuration in here, as it won't be applied.
 # The block below contains prod specific runtime configuration.
 
+# ## Sensitive values should be passed through the environment. An example
+# EnvironmentFile that can be used with systemd is under
+# documents/prod_files/example-environment-file
+
 # ## Using releases
 #
 # If you use `mix release`, you need to explicitly enable the server

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -182,5 +182,10 @@ if config_env() == :prod do
       log_full_events: true,
       log_dispatch_events: true,
       token: Teiserver.ConfigHelpers.get_env("TEI_DISCORD_BOT_TOKEN")
+
+    config :teiserver, Teiserver.Bridge.DiscordBridgeBot,
+      token: Teiserver.ConfigHelpers.get_env("TEI_DISCORD_BOT_TOKEN"),
+      guild_id: Teiserver.ConfigHelpers.get_env("TEI_DISCORD_GUILD_ID"),
+      bot_name: Teiserver.ConfigHelpers.get_env("TEI_DISCORD_BOT_NAME")
   end
 end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -94,34 +94,37 @@ if config_env() == :prod do
     issuer: Teiserver.ConfigHelpers.get_env("GUARDIAN_ISSUER", "teiserver"),
     secret_key: Teiserver.ConfigHelpers.get_env("GUARDIAN_SECRET_KEY")
 
+  if Teiserver.ConfigHelpers.get_env("ENABLE_EMAIL_INTEGRATION", :bool) do
+    smtp_server = Teiserver.ConfigHelpers.get_env("SMTP_HOSTNAME")
 
-  config :teiserver, Teiserver.Mailer,
-    adapter: Bamboo.SMTPAdapter,
-    contact_address:
-      Teiserver.ConfigHelpers.get_env("CONTACT_EMAIL_ADDRESS", "info@#{domain_name}"),
-    noreply_name: "Beyond All Reason",
-    noreply_address:
-      Teiserver.ConfigHelpers.get_env("NOREPLY_EMAIL_ADDRESS", "noreply@#{domain_name}"),
-    smtp_server: Teiserver.ConfigHelpers.get_env("SMTP_SERVER"),
-    hostname: Teiserver.ConfigHelpers.get_env("SMTP_HOSTNAME"),
-    # port: 1025,
-    port: Teiserver.ConfigHelpers.get_env("SMTP_PORT", "587", :int),
-    username: Teiserver.ConfigHelpers.get_env("SMTP_USERNAME"),
-    password: Teiserver.ConfigHelpers.get_env("SMTP_PASSWORD"),
-    # tls: :if_available, # can be `:always` or `:never`
-    # can be `:always` or `:never`
-    tls: :always,
-    tls_verify:
-      if(Teiserver.ConfigHelpers.get_env("SMTP_TLS_VERIFY", true, :bool),
-        do: :verify_peer,
-        else: :verify_none
-      ),
-    # or {":system", ALLOWED_TLS_VERSIONS"} w/ comma seprated values (e.g. "tlsv1.1,tlsv1.2")
-    allowed_tls_versions: [:"tlsv1.2"],
-    # can be `true`
-    no_mx_lookups: false,
-    # auth: :if_available # can be `always`. If your smtp relay requires authentication set it to `always`.
-    auth: :always
+    config :teiserver, Teiserver.Mailer,
+      adapter: Bamboo.SMTPAdapter,
+      contact_address:
+        Teiserver.ConfigHelpers.get_env("CONTACT_EMAIL_ADDRESS", "info@#{domain_name}"),
+      noreply_name: "Beyond All Reason",
+      noreply_address:
+        Teiserver.ConfigHelpers.get_env("NOREPLY_EMAIL_ADDRESS", "noreply@#{domain_name}"),
+      smtp_server: Teiserver.ConfigHelpers.get_env("SMTP_SERVER"),
+      hostname: Teiserver.ConfigHelpers.get_env("SMTP_HOSTNAME"),
+      # port: 1025,
+      port: Teiserver.ConfigHelpers.get_env("SMTP_PORT", "587", :int),
+      username: Teiserver.ConfigHelpers.get_env("SMTP_USERNAME"),
+      password: Teiserver.ConfigHelpers.get_env("SMTP_PASSWORD"),
+      # tls: :if_available, # can be `:always` or `:never`
+      # can be `:always` or `:never`
+      tls: :always,
+      tls_verify:
+        if(Teiserver.ConfigHelpers.get_env("SMTP_TLS_VERIFY", true, :bool),
+          do: :verify_peer,
+          else: :verify_none
+        ),
+      # or {":system", ALLOWED_TLS_VERSIONS"} w/ comma seprated values (e.g. "tlsv1.1,tlsv1.2")
+      allowed_tls_versions: [:"tlsv1.2"],
+      # can be `true`
+      no_mx_lookups: false,
+      # auth: :if_available # can be `always`. If your smtp relay requires authentication set it to `always`.
+      auth: :always
+  end
 
   log_root_path = Teiserver.ConfigHelpers.get_env("LOG_ROOT_PATH", "/var/log/teiserver/")
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -94,26 +94,30 @@ if config_env() == :prod do
     issuer: Teiserver.ConfigHelpers.get_env("GUARDIAN_ISSUER", "teiserver"),
     secret_key: Teiserver.ConfigHelpers.get_env("GUARDIAN_SECRET_KEY")
 
+
   config :teiserver, Teiserver.Mailer,
-    noreply_address: "noreply@#{domain_name}",
-    noreply_address:
-      Teiserver.ConfigHelpers.get_env("TEI_NOREPLY_EMAIL_ADDRESS", "noreply@#{domain_name}"),
-    contact_address:
-      Teiserver.ConfigHelpers.get_env("TEI_CONTACT_EMAIL_ADDRESS", "info@#{domain_name}"),
     adapter: Bamboo.SMTPAdapter,
-    server: Teiserver.ConfigHelpers.get_env("MAILER_SERVER"),
-    hostname: domain_name,
+    contact_address:
+      Teiserver.ConfigHelpers.get_env("CONTACT_EMAIL_ADDRESS", "info@#{domain_name}"),
+    noreply_name: "Beyond All Reason",
+    noreply_address:
+      Teiserver.ConfigHelpers.get_env("NOREPLY_EMAIL_ADDRESS", "noreply@#{domain_name}"),
+    smtp_server: Teiserver.ConfigHelpers.get_env("SMTP_SERVER"),
+    hostname: Teiserver.ConfigHelpers.get_env("SMTP_HOSTNAME"),
     # port: 1025,
-    port: Teiserver.ConfigHelpers.get_env("MAILER_PORT", "587", :bool),
-    # or {:system, "SMTP_USERNAME"}
-    username: Teiserver.ConfigHelpers.get_env("MAILER_USERNAME", "noreply@#{domain_name}"),
-    # or {:system, "SMTP_PASSWORD"}
-    password: Teiserver.ConfigHelpers.get_env("MAILER_PASSWORD"),
+    port: Teiserver.ConfigHelpers.get_env("SMTP_PORT", "587", :int),
+    username: Teiserver.ConfigHelpers.get_env("SMTP_USERNAME"),
+    password: Teiserver.ConfigHelpers.get_env("SMTP_PASSWORD"),
     # tls: :if_available, # can be `:always` or `:never`
     # can be `:always` or `:never`
     tls: :always,
+    tls_verify:
+      if(Teiserver.ConfigHelpers.get_env("SMTP_TLS_VERIFY", true, :bool),
+        do: :verify_peer,
+        else: :verify_none
+      ),
     # or {":system", ALLOWED_TLS_VERSIONS"} w/ comma seprated values (e.g. "tlsv1.1,tlsv1.2")
-    allowed_tls_versions: [:tlsv1, :"tlsv1.1", :"tlsv1.2"],
+    allowed_tls_versions: [:"tlsv1.2"],
     # can be `true`
     no_mx_lookups: false,
     # auth: :if_available # can be `always`. If your smtp relay requires authentication set it to `always`.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -69,6 +69,7 @@ if config_env() == :prod do
       "A verification code has been sent to your email address. Please read our terms of service at https://#{domain_name}/privacy_policy and the code of conduct at https://www.beyondallreason.info/code-of-conduct. Then enter your six digit code below if you agree to the terms."
 
   config :teiserver, Teiserver.Repo,
+    hostname: Teiserver.ConfigHelpers.get_env("TEI_DB_HOSTNAME"),
     username: Teiserver.ConfigHelpers.get_env("TEI_DB_USERNAME"),
     password: Teiserver.ConfigHelpers.get_env("TEI_DB_PASSWORD"),
     database: Teiserver.ConfigHelpers.get_env("TEI_DB_NAME"),

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -40,8 +40,8 @@ if config_env() == :prod do
   # this is used in lib/teiserver_web/controllers/account/setup_controller.ex
   # as a special endpoint to create the root user. Setting it to empty or nil
   # will disable the functionality completely.
-  # There is already a root user, so disable it
-  config :teiserver, Teiserver.Setup, key: nil
+  config :teiserver, Teiserver.Setup,
+    key: Teiserver.ConfigHelpers.get_env("TEI_SETUP_ROOT_KEY", nil)
 
   config :teiserver, Teiserver,
     game_name: "Beyond All Reason",

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -29,12 +29,12 @@ end
 # are just fine
 if config_env() == :prod do
   # used for mailing, checking origins, finding tls certs…
-  domain_name = Teiserver.ConfigHelpers.get_env("DOMAIN_NAME", "beyondallreason.info")
+  domain_name = Teiserver.ConfigHelpers.get_env("TEI_DOMAIN_NAME", "beyondallreason.info")
 
   certificates = [
-    keyfile: Teiserver.ConfigHelpers.get_env("TLS_PRIVATE_KEY_PATH"),
-    certfile: Teiserver.ConfigHelpers.get_env("TLS_CERT_PATH"),
-    cacertfile: Teiserver.ConfigHelpers.get_env("TLS_CA_CERT_PATH")
+    keyfile: Teiserver.ConfigHelpers.get_env("TEI_TLS_PRIVATE_KEY_PATH"),
+    certfile: Teiserver.ConfigHelpers.get_env("TEI_TLS_CERT_PATH"),
+    cacertfile: Teiserver.ConfigHelpers.get_env("TEI_TLS_CA_CERT_PATH")
   ]
 
   # this is used in lib/teiserver_web/controllers/account/setup_controller.ex
@@ -50,11 +50,11 @@ if config_env() == :prod do
     privacy_email: "privacy@beyondallreason.info",
     discord: "https://discord.gg/beyond-all-reason",
     ports: [
-      tcp: Teiserver.ConfigHelpers.get_env("SPRING_TCP_PORT", 8200, :int),
-      tls: Teiserver.ConfigHelpers.get_env("SPRING_TLS_PORT", 8201, :int),
+      tcp: Teiserver.ConfigHelpers.get_env("TEI_SPRING_TCP_PORT", 8200, :int),
+      tls: Teiserver.ConfigHelpers.get_env("TEI_SPRING_TLS_PORT", 8201, :int),
       # this can likely be deprecated and removed. It's for an old version
       # of tachyon running on another TLS socket
-      tachyon: Teiserver.ConfigHelpers.get_env("TACHYON_TLS_PORT", 8202, :int)
+      tachyon: Teiserver.ConfigHelpers.get_env("TEI_TACHYON_TLS_PORT", 8202, :int)
     ],
     certs: certificates,
     website: [
@@ -62,22 +62,22 @@ if config_env() == :prod do
     ],
     server_flag: "GB-WLS",
     enable_benchmark: false,
-    node_name: Teiserver.ConfigHelpers.get_env("NODE_NAME"),
+    node_name: Teiserver.ConfigHelpers.get_env("TEI_NODE_NAME"),
     extra_logging: false,
     enable_managed_lobbies: true,
     user_agreement:
       "A verification code has been sent to your email address. Please read our terms of service at https://#{domain_name}/privacy_policy and the code of conduct at https://www.beyondallreason.info/code-of-conduct. Then enter your six digit code below if you agree to the terms."
 
   config :teiserver, Teiserver.Repo,
-    username: Teiserver.ConfigHelpers.get_env("DB_USERNAME"),
-    password: Teiserver.ConfigHelpers.get_env("DB_PASSWORD"),
-    database: Teiserver.ConfigHelpers.get_env("DB_NAME"),
+    username: Teiserver.ConfigHelpers.get_env("TEI_DB_USERNAME"),
+    password: Teiserver.ConfigHelpers.get_env("TEI_DB_PASSWORD"),
+    database: Teiserver.ConfigHelpers.get_env("TEI_DB_NAME"),
     pool_size: 40,
     timeout: 120_000,
     queue_interval: 2000
 
   check_origin =
-    if Teiserver.ConfigHelpers.get_env("SHOULD_CHECK_ORIGIN", false, :bool) do
+    if Teiserver.ConfigHelpers.get_env("TEI_SHOULD_CHECK_ORIGIN", false, :bool) do
       ["//#{domain_name}", "//*.#{domain_name}"]
     else
       false
@@ -92,36 +92,34 @@ if config_env() == :prod do
           versions: [:"tlsv1.2"],
           # dhfile is not supported for tls 1.3
           # https://www.erlang.org/doc/man/ssl.html#type-dh_file
-          dhfile: Teiserver.ConfigHelpers.get_env("TLS_DH_FILE_PATH", "/etc/ssl/dhparam.pem")
+          dhfile: Teiserver.ConfigHelpers.get_env("TEI_TLS_DH_FILE_PATH", "/etc/ssl/dhparam.pem")
         ],
-    http: [:inet6, port: Teiserver.ConfigHelpers.get_env("PORT", "4000", :int)],
-    secret_key_base: Teiserver.ConfigHelpers.get_env("HTTP_SECRET_KEY_BASE")
+    http: [:inet6, port: Teiserver.ConfigHelpers.get_env("TEI_PORT", "4000", :int)],
+    secret_key_base: Teiserver.ConfigHelpers.get_env("TEI_HTTP_SECRET_KEY_BASE")
 
   config :teiserver, Teiserver.Account.Guardian,
-    issuer: Teiserver.ConfigHelpers.get_env("GUARDIAN_ISSUER", "teiserver"),
-    secret_key: Teiserver.ConfigHelpers.get_env("GUARDIAN_SECRET_KEY")
+    issuer: Teiserver.ConfigHelpers.get_env("TEI_GUARDIAN_ISSUER", "teiserver"),
+    secret_key: Teiserver.ConfigHelpers.get_env("TEI_GUARDIAN_SECRET_KEY")
 
-  if Teiserver.ConfigHelpers.get_env("ENABLE_EMAIL_INTEGRATION", :bool) do
-    smtp_server = Teiserver.ConfigHelpers.get_env("SMTP_HOSTNAME")
-
+  if Teiserver.ConfigHelpers.get_env("TEI_ENABLE_EMAIL_INTEGRATION", :bool) do
     config :teiserver, Teiserver.Mailer,
       adapter: Bamboo.SMTPAdapter,
       contact_address:
-        Teiserver.ConfigHelpers.get_env("CONTACT_EMAIL_ADDRESS", "info@#{domain_name}"),
+        Teiserver.ConfigHelpers.get_env("TEI_CONTACT_EMAIL_ADDRESS", "info@#{domain_name}"),
       noreply_name: "Beyond All Reason",
       noreply_address:
-        Teiserver.ConfigHelpers.get_env("NOREPLY_EMAIL_ADDRESS", "noreply@#{domain_name}"),
-      smtp_server: Teiserver.ConfigHelpers.get_env("SMTP_SERVER"),
-      hostname: Teiserver.ConfigHelpers.get_env("SMTP_HOSTNAME"),
+        Teiserver.ConfigHelpers.get_env("TEI_NOREPLY_EMAIL_ADDRESS", "noreply@#{domain_name}"),
+      smtp_server: Teiserver.ConfigHelpers.get_env("TEI_SMTP_SERVER"),
+      hostname: Teiserver.ConfigHelpers.get_env("TEI_SMTP_HOSTNAME"),
       # port: 1025,
-      port: Teiserver.ConfigHelpers.get_env("SMTP_PORT", "587", :int),
-      username: Teiserver.ConfigHelpers.get_env("SMTP_USERNAME"),
-      password: Teiserver.ConfigHelpers.get_env("SMTP_PASSWORD"),
+      port: Teiserver.ConfigHelpers.get_env("TEI_SMTP_PORT", "587", :int),
+      username: Teiserver.ConfigHelpers.get_env("TEI_SMTP_USERNAME"),
+      password: Teiserver.ConfigHelpers.get_env("TEI_SMTP_PASSWORD"),
       # tls: :if_available, # can be `:always` or `:never`
       # can be `:always` or `:never`
       tls: :always,
       tls_verify:
-        if(Teiserver.ConfigHelpers.get_env("SMTP_TLS_VERIFY", true, :bool),
+        if(Teiserver.ConfigHelpers.get_env("TEI_SMTP_TLS_VERIFY", true, :bool),
           do: :verify_peer,
           else: :verify_none
         ),
@@ -133,7 +131,7 @@ if config_env() == :prod do
       auth: :always
   end
 
-  log_root_path = Teiserver.ConfigHelpers.get_env("LOG_ROOT_PATH", "/var/log/teiserver/")
+  log_root_path = Teiserver.ConfigHelpers.get_env("TEI_LOG_ROOT_PATH", "/var/log/teiserver/")
 
   config :logger,
     backends: [

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -44,16 +44,22 @@ if config_env() == :prod do
   config :teiserver, Teiserver.Setup, key: nil
 
   config :teiserver, Teiserver,
-    game_name: "Beyond all reason",
+    game_name: "Beyond All Reason",
     game_name_short: "BAR",
     main_website: "https://www.beyondallreason.info/",
     privacy_email: "privacy@beyondallreason.info",
-    discord: Teiserver.ConfigHelpers.get_env("DISCORD_LINK", nil),
+    discord: "https://discord.gg/beyond-all-reason",
     certs: certificates,
+    website: [
+      url: "beyondallreason.info"
+    ],
+    server_flag: "GB-WLS",
     enable_benchmark: false,
     node_name: Teiserver.ConfigHelpers.get_env("NODE_NAME"),
+    extra_logging: false,
     enable_managed_lobbies: true,
-    tachyon_schema_path: "/apps/teiserver/lib/teiserver-0.1.0/priv/tachyon/schema_v1/*/*/*.json"
+    user_agreement:
+      "A verification code has been sent to your email address. Please read our terms of service at https://#{domain_name}/privacy_policy and the code of conduct at https://www.beyondallreason.info/code-of-conduct. Then enter your six digit code below if you agree to the terms."
 
   config :teiserver, Teiserver.Repo,
     username: Teiserver.ConfigHelpers.get_env("DB_USERNAME"),

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -51,6 +51,14 @@ if config_env() == :prod do
     enable_managed_lobbies: true,
     tachyon_schema_path: "/apps/teiserver/lib/teiserver-0.1.0/priv/tachyon/schema_v1/*/*/*.json"
 
+  config :teiserver, Teiserver.Repo,
+    username: System.fetch_env!("DB_USERNAME"),
+    password: System.fetch_env!("DB_PASSWORD"),
+    database: System.fetch_env!("DB_NAME"),
+    pool_size: 40,
+    timeout: 120_000,
+    queue_interval: 2000
+
   config :teiserver, TeiserverWeb.Endpoint,
     url: [host: domain_name],
     check_origin: ["//#{domain_name}", "//*.#{domain_name}"],

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -77,5 +77,30 @@ if config_env() == :prod do
     issuer: System.fetch_env!("GUARDIAN_ISSUER"),
     secret_key: System.fetch_env!("GUARDIAN_SECRET_KEY")
 
+  config :teiserver, Teiserver.Mailer,
+    noreply_address: "noreply@#{domain_name}",
+    contact_address: "info@#{domain_name}",
+    noreply_name: "Beyond all reason team",
+    adapter: Bamboo.SMTPAdapter,
+    server: System.fetch_env!("MAILER_SERVER"),
+    hostname: domain_name,
+    # port: 1025,
+    port: String.to_integer(System.get_env("MAILER_PORT", "587")),
+    # or {:system, "SMTP_USERNAME"}
+    username: System.get_env("MAILER_USERNAME", "noreply@#{domain_name}"),
+    # or {:system, "SMTP_PASSWORD"}
+    password: System.fetch_env!("MAILER_PASSWORD"),
+    # tls: :if_available, # can be `:always` or `:never`
+    # can be `:always` or `:never`
+    tls: :always,
+    # or {":system", ALLOWED_TLS_VERSIONS"} w/ comma seprated values (e.g. "tlsv1.1,tlsv1.2")
+    allowed_tls_versions: [:tlsv1, :"tlsv1.1", :"tlsv1.2"],
+    # can be `true`
+    ssl: false,
+    retries: 1,
+    # can be `true`
+    no_mx_lookups: false,
+    # auth: :if_available # can be `always`. If your smtp relay requires authentication set it to `always`.
+    auth: :always
 
 end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -110,7 +110,7 @@ if config_env() == :prod do
       noreply_name: "Beyond All Reason",
       noreply_address:
         Teiserver.ConfigHelpers.get_env("TEI_NOREPLY_EMAIL_ADDRESS", "noreply@#{domain_name}"),
-      smtp_server: Teiserver.ConfigHelpers.get_env("TEI_SMTP_SERVER"),
+      server: Teiserver.ConfigHelpers.get_env("TEI_SMTP_SERVER"),
       hostname: Teiserver.ConfigHelpers.get_env("TEI_SMTP_HOSTNAME"),
       # port: 1025,
       port: Teiserver.ConfigHelpers.get_env("TEI_SMTP_PORT", "587", :int),

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -39,6 +39,18 @@ if config_env() == :prod do
   # There is already a root user, so disable it
   config :teiserver, Teiserver.Setup, key: nil
 
+  config :teiserver, Teiserver,
+    game_name: "Beyond all reason",
+    game_name_short: "BAR",
+    main_website: "https://www.beyondallreason.info/",
+    privacy_email: "privacy@beyondallreason.info",
+    discord: System.get_env("DISCORD_LINK"),
+    certs: certificates,
+    enable_benchmark: false,
+    node_name: System.fetch_env!("NODE_NAME"),
+    enable_managed_lobbies: true,
+    tachyon_schema_path: "/apps/teiserver/lib/teiserver-0.1.0/priv/tachyon/schema_v1/*/*/*.json"
+
   config :teiserver, TeiserverWeb.Endpoint,
     url: [host: domain_name],
     check_origin: ["//#{domain_name}", "//*.#{domain_name}"],

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -49,6 +49,13 @@ if config_env() == :prod do
     main_website: "https://www.beyondallreason.info/",
     privacy_email: "privacy@beyondallreason.info",
     discord: "https://discord.gg/beyond-all-reason",
+    ports: [
+      tcp: Teiserver.ConfigHelpers.get_env("SPRING_TCP_PORT", 8200, :int),
+      tls: Teiserver.ConfigHelpers.get_env("SPRING_TLS_PORT", 8201, :int),
+      # this can likely be deprecated and removed. It's for an old version
+      # of tachyon running on another TLS socket
+      tachyon: Teiserver.ConfigHelpers.get_env("TACHYON_TLS_PORT", 8202, :int)
+    ],
     certs: certificates,
     website: [
       url: "beyondallreason.info"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -73,6 +73,9 @@ if config_env() == :prod do
     http: [:inet6, port: String.to_integer(System.get_env("PORT", "4000"))],
     secret_key_base: System.fetch_env!("HTTP_SECRET_KEY_BASE")
 
+  config :teiserver, Teiserver.Account.Guardian,
+    issuer: System.fetch_env!("GUARDIAN_ISSUER"),
+    secret_key: System.fetch_env!("GUARDIAN_SECRET_KEY")
 
 
 end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,0 +1,27 @@
+import Config
+
+# config/runtime.exs is executed for all environments, including
+# during releases. It is executed after compilation and before the
+# system starts, so it is typically used to load production configuration
+# and secrets from environment variables or elsewhere. Do not define
+# any compile-time configuration in here, as it won't be applied.
+# The block below contains prod specific runtime configuration.
+
+# ## Using releases
+#
+# If you use `mix release`, you need to explicitly enable the server
+# by passing the PHX_SERVER=true when you start it:
+#
+#     PHX_SERVER=true bin/teiserver start
+#
+# Alternatively, you can use `mix phx.gen.release` to generate a `bin/server`
+# script that automatically sets the env var above.
+if System.get_env("PHX_SERVER") do
+  config :teiserver, TeiserverWeb.Endpoint, server: true
+end
+
+# Only do some runtime configuration in production since in dev and tests the
+# files are automatically recompiled on the fly and thus, config/{dev,test}.exs
+# are just fine
+if config_env() == :prod do
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -49,7 +49,10 @@ if config_env() == :prod do
           # dhfile is not supported for tls 1.3
           # https://www.erlang.org/doc/man/ssl.html#type-dh_file
           dhfile: System.fetch_env!("TLS_DH_FILE_PATH")
-        ]
+        ],
+    http: [:inet6, port: String.to_integer(System.get_env("PORT", "4000"))],
+    secret_key_base: System.fetch_env!("HTTP_SECRET_KEY_BASE")
+
 
 
 end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -43,12 +43,15 @@ if config_env() == :prod do
   config :teiserver, Teiserver.Setup,
     key: Teiserver.ConfigHelpers.get_env("TEI_SETUP_ROOT_KEY", nil)
 
+  enable_discord_bridge = Teiserver.ConfigHelpers.get_env("TEI_ENABLE_DISCORD_BRIDGE", true, :bool)
+
   config :teiserver, Teiserver,
     game_name: "Beyond All Reason",
     game_name_short: "BAR",
     main_website: "https://www.beyondallreason.info/",
     privacy_email: "privacy@beyondallreason.info",
     discord: "https://discord.gg/beyond-all-reason",
+    enable_discord_bridge: enable_discord_bridge,
     ports: [
       tcp: Teiserver.ConfigHelpers.get_env("TEI_SPRING_TCP_PORT", 8200, :int),
       tls: Teiserver.ConfigHelpers.get_env("TEI_SPRING_TLS_PORT", 8201, :int),
@@ -165,4 +168,19 @@ if config_env() == :prod do
     format: "$date $time [$level] $metadata $message\n",
     metadata: [:request_id, :user_id],
     level: :info
+
+  if enable_discord_bridge do
+    config :nostrum,
+      gateway_intents: [
+        :guilds,
+        :guild_messages,
+        :guild_message_reactions,
+        :direct_messages,
+        :message_content,
+        :direct_message_reactions
+      ],
+      log_full_events: true,
+      log_dispatch_events: true,
+      token: Teiserver.ConfigHelpers.get_env("TEI_DISCORD_BOT_TOKEN")
+  end
 end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -16,7 +16,7 @@ import Config
 #
 # Alternatively, you can use `mix phx.gen.release` to generate a `bin/server`
 # script that automatically sets the env var above.
-if System.get_env("PHX_SERVER") do
+if Teiserver.ConfigHelpers.get_env("PHX_SERVER", nil) do
   config :teiserver, TeiserverWeb.Endpoint, server: true
 end
 
@@ -25,12 +25,12 @@ end
 # are just fine
 if config_env() == :prod do
   # used for mailing, checking origins, finding tls certs…
-  domain_name = System.get_env("DOMAIN_NAME", "beyondallreason.info")
+  domain_name = Teiserver.ConfigHelpers.get_env("DOMAIN_NAME", "beyondallreason.info")
 
   certificates = [
-    keyfile: System.fetch_env!("TLS_PRIVATE_KEY_PATH"),
-    certfile: System.fetch_env!("TLS_CERT_PATH"),
-    cacertfile: System.fetch_env!("TLS_CA_CERT_PATH")
+    keyfile: Teiserver.ConfigHelpers.get_env("TLS_PRIVATE_KEY_PATH"),
+    certfile: Teiserver.ConfigHelpers.get_env("TLS_CERT_PATH"),
+    cacertfile: Teiserver.ConfigHelpers.get_env("TLS_CA_CERT_PATH")
   ]
 
   # this is used in lib/teiserver_web/controllers/account/setup_controller.ex
@@ -44,17 +44,17 @@ if config_env() == :prod do
     game_name_short: "BAR",
     main_website: "https://www.beyondallreason.info/",
     privacy_email: "privacy@beyondallreason.info",
-    discord: System.get_env("DISCORD_LINK"),
+    discord: Teiserver.ConfigHelpers.get_env("DISCORD_LINK", nil),
     certs: certificates,
     enable_benchmark: false,
-    node_name: System.fetch_env!("NODE_NAME"),
+    node_name: Teiserver.ConfigHelpers.get_env("NODE_NAME"),
     enable_managed_lobbies: true,
     tachyon_schema_path: "/apps/teiserver/lib/teiserver-0.1.0/priv/tachyon/schema_v1/*/*/*.json"
 
   config :teiserver, Teiserver.Repo,
-    username: System.fetch_env!("DB_USERNAME"),
-    password: System.fetch_env!("DB_PASSWORD"),
-    database: System.fetch_env!("DB_NAME"),
+    username: Teiserver.ConfigHelpers.get_env("DB_USERNAME"),
+    password: Teiserver.ConfigHelpers.get_env("DB_PASSWORD"),
+    database: Teiserver.ConfigHelpers.get_env("DB_NAME"),
     pool_size: 40,
     timeout: 120_000,
     queue_interval: 2000
@@ -68,42 +68,41 @@ if config_env() == :prod do
           versions: [:"tlsv1.2"],
           # dhfile is not supported for tls 1.3
           # https://www.erlang.org/doc/man/ssl.html#type-dh_file
-          dhfile: System.fetch_env!("TLS_DH_FILE_PATH")
+          dhfile: Teiserver.ConfigHelpers.get_env("TLS_DH_FILE_PATH")
         ],
-    http: [:inet6, port: String.to_integer(System.get_env("PORT", "4000"))],
-    secret_key_base: System.fetch_env!("HTTP_SECRET_KEY_BASE")
+    http: [:inet6, port: Teiserver.ConfigHelpers.get_env("PORT", "4000", :int)],
+    secret_key_base: Teiserver.ConfigHelpers.get_env("HTTP_SECRET_KEY_BASE")
 
   config :teiserver, Teiserver.Account.Guardian,
-    issuer: System.fetch_env!("GUARDIAN_ISSUER"),
-    secret_key: System.fetch_env!("GUARDIAN_SECRET_KEY")
+    issuer: Teiserver.ConfigHelpers.get_env("GUARDIAN_ISSUER", "teiserver"),
+    secret_key: Teiserver.ConfigHelpers.get_env("GUARDIAN_SECRET_KEY")
 
   config :teiserver, Teiserver.Mailer,
     noreply_address: "noreply@#{domain_name}",
-    contact_address: "info@#{domain_name}",
-    noreply_name: "Beyond all reason team",
+    noreply_address:
+      Teiserver.ConfigHelpers.get_env("TEI_NOREPLY_EMAIL_ADDRESS", "noreply@#{domain_name}"),
+    contact_address:
+      Teiserver.ConfigHelpers.get_env("TEI_CONTACT_EMAIL_ADDRESS", "info@#{domain_name}"),
     adapter: Bamboo.SMTPAdapter,
-    server: System.fetch_env!("MAILER_SERVER"),
+    server: Teiserver.ConfigHelpers.get_env("MAILER_SERVER"),
     hostname: domain_name,
     # port: 1025,
-    port: String.to_integer(System.get_env("MAILER_PORT", "587")),
+    port: Teiserver.ConfigHelpers.get_env("MAILER_PORT", "587", :bool),
     # or {:system, "SMTP_USERNAME"}
-    username: System.get_env("MAILER_USERNAME", "noreply@#{domain_name}"),
+    username: Teiserver.ConfigHelpers.get_env("MAILER_USERNAME", "noreply@#{domain_name}"),
     # or {:system, "SMTP_PASSWORD"}
-    password: System.fetch_env!("MAILER_PASSWORD"),
+    password: Teiserver.ConfigHelpers.get_env("MAILER_PASSWORD"),
     # tls: :if_available, # can be `:always` or `:never`
     # can be `:always` or `:never`
     tls: :always,
     # or {":system", ALLOWED_TLS_VERSIONS"} w/ comma seprated values (e.g. "tlsv1.1,tlsv1.2")
     allowed_tls_versions: [:tlsv1, :"tlsv1.1", :"tlsv1.2"],
     # can be `true`
-    ssl: false,
-    retries: 1,
-    # can be `true`
     no_mx_lookups: false,
     # auth: :if_available # can be `always`. If your smtp relay requires authentication set it to `always`.
     auth: :always
 
-  log_root_path = System.fetch_env("LOG_ROOT_PATH", "/var/log/teiserver/")
+  log_root_path = Teiserver.ConfigHelpers.get_env("LOG_ROOT_PATH", "/var/log/teiserver/")
 
   config :logger,
     backends: [

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -24,4 +24,11 @@ end
 # files are automatically recompiled on the fly and thus, config/{dev,test}.exs
 # are just fine
 if config_env() == :prod do
+
+  # this is used in lib/teiserver_web/controllers/account/setup_controller.ex
+  # as a special endpoint to create the root user. Setting it to empty or nil
+  # will disable the functionality completely.
+  # There is already a root user, so disable it
+  config :teiserver, Teiserver.Setup, key: nil
+
 end

--- a/documents/guides/deployment.md
+++ b/documents/guides/deployment.md
@@ -5,9 +5,6 @@ If you've not already setup your server you might want to check out [documents/g
 - Locally running Elixir
 - Docker installed on your computer
 
-### prod.secret.exs
-`config/prod.secret.exs` is ignored in the gitignore for obvious reasons. This means you will need to create your own one. Luckily I [made a template for you](/documents/prod_files/example_prod_secret.exs).
-
 #### Dockerfile
 A docker file is included in the repo but within [documents/prod_files](documents/prod_files) are other docker images providing more control over the building of your image and might be of interest.
 

--- a/documents/guides/production_setup_linux.md
+++ b/documents/guides/production_setup_linux.md
@@ -341,7 +341,7 @@ tsapp eval "Teiserver.Release.migrate"
 [Deployment itself is located in a different file.](/documents/guides/deployment.md), you will need to execute a deployment as part of the setup. There will be additional steps to take after your first deployment.
 
 #### Creating the first user
-To create your first root user make a note of `config :teiserver, Teiserver.Setup, key:` within `config/prod.secret.exs` as you will need that value here. Go to `https://domain.com/initial_setup/$KEY` where `$KEY` is replaced with the value in this config. This link will only work while a user with an email "root@localhost" has not been created. It is advised that once the user is created you set the initial_setup key to be an empty string which will disable the function entirely.
+To create your first root user make a note of `config :teiserver, Teiserver.Setup, key:` within `config/runtime.exs` as you will need that value here. Go to `https://domain.com/initial_setup/$KEY` where `$KEY` is replaced with the value in this config. This link will only work while a user with an email "root@localhost" has not been created. It is advised that once the user is created you set the initial_setup key to be an empty string which will disable the function entirely.
 
 A new user with developer level access will be created with the email `root@localhost` and a password identical to the setup key you just used. You can now login as that user, it is advised your first action should be to change/update the password and set the user details (name/email) to the ones you intend to use as admin.
 

--- a/documents/prod_files/example-environment-file
+++ b/documents/prod_files/example-environment-file
@@ -19,22 +19,33 @@ PHX_SERVER=true
 TEI_NODE_NAME=staging-node-1
 
 # DB configuration
-TEI_DB_USERNAME=teiserver-prod
-TEI_DB_PASSWORD=verysecret-password
-TEI_DB_NAME=teiserver_prod
+TEI_DB_HOSTNAME=localhost
+TEI_DB_USERNAME=teiserver_dev
+TEI_DB_PASSWORD=123456789
+TEI_DB_NAME=teiserver_dev
 
 # TLS config
-TEI_HTTPS_DH_FILE_PATH=/var/www/tls/dh-params.pem
+TEI_TLS_PRIVATE_KEY_PATH=priv/certs/localhost.key
+TEI_TLS_CERT_PATH=priv/certs/localhost.crt
+TEI_TLS_CA_CERT_PATH=priv/certs/localhost.crt
+TEI_TLS_DH_FILE_PATH=priv/certs/dh-params.pem
 
-# For cookie encryption
-TEI_HTTP_SECRET_KEY_BASE=another-very-long-secret
+# For cookie encryption, must be at least 64 bytes
+TEI_HTTP_SECRET_KEY_BASE=2f894df108701d787156761fe6c122050a8f0f78426de0ea62593e766b9ffcf0f321ce66aef5e8948bb89dc9cc2f687797e2c30100eb001ff87bab23a005091e
 
 # For Guardian (authentication)
 TEI_GUARDIAN_SECRET_KEY=yet-another-random-key-to-keep-secret
 
 # Email
-TEI_SMTP_SERVER=mailserver
+TEI_ENABLE_EMAIL_INTEGRATION=true
+# this assume you're running the container smtp4dev as explained in:
+# https://github.com/beyond-all-reason/ansible-teiserver?tab=readme-ov-file#email
+TEI_SMTP_SERVER=127.0.0.1
+TEI_SMTP_PORT=2525
+# the domain of the email
+TEI_SMTP_HOSTNAME=beyondallreason.info
 TEI_SMTP_USERNAME=noreply@beyondallreason.info
 TEI_SMTP_PASSWORD=correct-battery-staple-horse-xkcd-936
+TEI_SMTP_TLS_VERIFY=false
 
 # vim: ft=systemd

--- a/documents/prod_files/example-environment-file
+++ b/documents/prod_files/example-environment-file
@@ -16,25 +16,25 @@
 
 # General secrets
 PHX_SERVER=true
-NODE_NAME=staging-node-1
+TEI_NODE_NAME=staging-node-1
 
 # DB configuration
-DB_USERNAME=teiserver-prod
-DB_PASSWORD=verysecret-password
-DB_NAME=teiserver_prod
+TEI_DB_USERNAME=teiserver-prod
+TEI_DB_PASSWORD=verysecret-password
+TEI_DB_NAME=teiserver_prod
 
 # TLS config
-HTTPS_DH_FILE_PATH=/var/www/tls/dh-params.pem
+TEI_HTTPS_DH_FILE_PATH=/var/www/tls/dh-params.pem
 
 # For cookie encryption
-HTTP_SECRET_KEY_BASE=another-very-long-secret
+TEI_HTTP_SECRET_KEY_BASE=another-very-long-secret
 
 # For Guardian (authentication)
-GUARDIAN_SECRET_KEY=yet-another-random-key-to-keep-secret
+TEI_GUARDIAN_SECRET_KEY=yet-another-random-key-to-keep-secret
 
 # Email
-SMTP_SERVER=mailserver
-SMTP_USERNAME=noreply@beyondallreason.info
-SMTP_PASSWORD=correct-battery-staple-horse-xkcd-936
+TEI_SMTP_SERVER=mailserver
+TEI_SMTP_USERNAME=noreply@beyondallreason.info
+TEI_SMTP_PASSWORD=correct-battery-staple-horse-xkcd-936
 
 # vim: ft=systemd

--- a/documents/prod_files/example-environment-file
+++ b/documents/prod_files/example-environment-file
@@ -33,8 +33,8 @@ HTTP_SECRET_KEY_BASE=another-very-long-secret
 GUARDIAN_SECRET_KEY=yet-another-random-key-to-keep-secret
 
 # Email
-MAILER_SERVER=mailserver
-MAILER_USERNAME=noreply@beyondallreason.info
-MAILER_PASSWORD=correct-battery-staple-horse-xkcd-936
+SMTP_SERVER=mailserver
+SMTP_USERNAME=noreply@beyondallreason.info
+SMTP_PASSWORD=correct-battery-staple-horse-xkcd-936
 
 # vim: ft=systemd

--- a/documents/prod_files/example-environment-file
+++ b/documents/prod_files/example-environment-file
@@ -48,4 +48,6 @@ TEI_SMTP_USERNAME=noreply@beyondallreason.info
 TEI_SMTP_PASSWORD=correct-battery-staple-horse-xkcd-936
 TEI_SMTP_TLS_VERIFY=false
 
+TEI_ENABLE_DISCORD_BRIDGE=false
+
 # vim: ft=systemd

--- a/documents/prod_files/example-environment-file
+++ b/documents/prod_files/example-environment-file
@@ -1,0 +1,41 @@
+# This file is an example of a systemd environment file to configure a running service
+# In the systemd unit file, it should be setup with a line:
+# EnvironmentFile=/etc/sysconfig/teiserver
+# Be careful, if this line is in the systemd unit definition but the file doesn't exist
+# the service will be silently disabled
+
+# For more info, see:
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#EnvironmentFile=
+# and also:
+# https://fedoraproject.org/wiki/Packaging:Systemd#EnvironmentFiles_and_support_for_/etc/sysconfig_files
+
+# To easily load all these in your shell's environment:
+# ```
+# set -o allexport; source documents/prod_files/example-environment-file; set +o allexport
+# ```
+
+# General secrets
+PHX_SERVER=true
+DISCORD_LINK=https://discord.com/whatever-link
+NODE_NAME=staging-node-1
+
+# DB configuration
+DB_USERNAME=teiserver-prod
+DB_PASSWORD=verysecret-password
+DB_NAME=teiserver_prod
+
+# TLS config
+HTTPS_DH_FILE_PATH=/var/www/tls/dh-params.pem
+
+# For cookie encryption
+HTTP_SECRET_KEY_BASE=another-very-long-secret
+
+# For Guardian (authentication)
+GUARDIAN_SECRET_KEY=yet-another-random-key-to-keep-secret
+
+# Email
+MAILER_SERVER=mailserver
+MAILER_USERNAME=noreply@beyondallreason.info
+MAILER_PASSWORD=correct-battery-staple-horse-xkcd-936
+
+# vim: ft=systemd

--- a/documents/prod_files/example-environment-file
+++ b/documents/prod_files/example-environment-file
@@ -16,7 +16,6 @@
 
 # General secrets
 PHX_SERVER=true
-DISCORD_LINK=https://discord.com/whatever-link
 NODE_NAME=staging-node-1
 
 # DB configuration

--- a/documents/prod_files/example_prod_secret.exs
+++ b/documents/prod_files/example_prod_secret.exs
@@ -5,29 +5,3 @@
 import Config
 
 secret_key_base = "mix phx.gen.secret"
-
-config :teiserver, Teiserver.Mailer,
-  noreply_address: "noreply@yourdomain.com",
-  contact_address: "info@yourdomain.com",
-  noreply_name: "Name of your game",
-  adapter: Bamboo.SMTPAdapter,
-  server: "mailserver",
-  hostname: "yourdomain.com",
-  # port: 1025,
-  port: 587,
-  # or {:system, "SMTP_USERNAME"}
-  username: "noreply@yourdomain.com",
-  # or {:system, "SMTP_PASSWORD"}
-  password: "mix phx.gen.secret",
-  # tls: :if_available, # can be `:always` or `:never`
-  # can be `:always` or `:never`
-  tls: :always,
-  # or {":system", ALLOWED_TLS_VERSIONS"} w/ comma seprated values (e.g. "tlsv1.1,tlsv1.2")
-  allowed_tls_versions: [:tlsv1, :"tlsv1.1", :"tlsv1.2"],
-  # can be `true`
-  ssl: false,
-  retries: 1,
-  # can be `true`
-  no_mx_lookups: false,
-  # auth: :if_available # can be `always`. If your smtp relay requires authentication set it to `always`.
-  auth: :always

--- a/documents/prod_files/example_prod_secret.exs
+++ b/documents/prod_files/example_prod_secret.exs
@@ -6,17 +6,6 @@ import Config
 
 secret_key_base = "mix phx.gen.secret"
 
-# This can be part of your standard prod.exs but I wanted it to
-# default to not going into a github repo
-config :teiserver, TeiserverWeb.Endpoint,
-  url: [host: "yourdomain.com"],
-  https: [
-    keyfile: "/etc/letsencrypt/live/yourdomain.com/privkey.pem",
-    certfile: "/etc/letsencrypt/live/yourdomain.com/cert.pem",
-    cacertfile: "/etc/letsencrypt/live/yourdomain.com/fullchain.pem"
-  ],
-  check_origin: ["//yourdomain.com", "//*.yourdomain.com"]
-
 config :teiserver, Teiserver,
   game_name: "My game name",
   game_name_short: "GN",

--- a/documents/prod_files/example_prod_secret.exs
+++ b/documents/prod_files/example_prod_secret.exs
@@ -6,10 +6,6 @@ import Config
 
 secret_key_base = "mix phx.gen.secret"
 
-config :teiserver, Teiserver.Account.Guardian,
-  issuer: "teiserver",
-  secret_key: "mix phx.gen.secret"
-
 config :teiserver, Teiserver.Mailer,
   noreply_address: "noreply@yourdomain.com",
   contact_address: "info@yourdomain.com",

--- a/documents/prod_files/example_prod_secret.exs
+++ b/documents/prod_files/example_prod_secret.exs
@@ -6,13 +6,6 @@ import Config
 
 secret_key_base = "mix phx.gen.secret"
 
-config :teiserver, Teiserver.Repo,
-  username: "teiserver_prod",
-  password: "mix phx.gen.secret",
-  database: "teiserver_prod",
-  pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
-  timeout: 30_000
-
 config :teiserver, Teiserver.Account.Guardian,
   issuer: "teiserver",
   secret_key: "mix phx.gen.secret"

--- a/documents/prod_files/example_prod_secret.exs
+++ b/documents/prod_files/example_prod_secret.exs
@@ -6,9 +6,6 @@ import Config
 
 secret_key_base = "mix phx.gen.secret"
 
-config :teiserver, Teiserver.Setup,
-  key: "---- random string of alpha numeric characters ----"
-
 # This can be part of your standard prod.exs but I wanted it to
 # default to not going into a github repo
 config :teiserver, TeiserverWeb.Endpoint,

--- a/documents/prod_files/example_prod_secret.exs
+++ b/documents/prod_files/example_prod_secret.exs
@@ -25,10 +25,6 @@ config :teiserver, Teiserver.Repo,
   pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
   timeout: 30_000
 
-config :teiserver, TeiserverWeb.Endpoint,
-  http: [:inet6, port: String.to_integer(System.get_env("PORT") || "4000")],
-  secret_key_base: secret_key_base
-
 config :teiserver, Teiserver.Account.Guardian,
   issuer: "teiserver",
   secret_key: "mix phx.gen.secret"

--- a/documents/prod_files/example_prod_secret.exs
+++ b/documents/prod_files/example_prod_secret.exs
@@ -1,7 +1,0 @@
-# In this file, we load production configuration and secrets
-# from environment variables. You can also hardcode secrets,
-# although such is generally not recommended and you have to
-# remember to add this file to your .gitignore.
-import Config
-
-secret_key_base = "mix phx.gen.secret"

--- a/documents/prod_files/example_prod_secret.exs
+++ b/documents/prod_files/example_prod_secret.exs
@@ -6,18 +6,6 @@ import Config
 
 secret_key_base = "mix phx.gen.secret"
 
-config :teiserver, Teiserver,
-  game_name: "My game name",
-  game_name_short: "GN",
-  main_website: "https://site.com",
-  privacy_email: "privacy@site.com",
-  discord: "My discord link"# Set to nil to not have link,
-  certs: [
-    keyfile: "/etc/letsencrypt/live/yourdomain.com/privkey.pem",
-    certfile: "/etc/letsencrypt/live/yourdomain.com/cert.pem",
-    cacertfile: "/etc/letsencrypt/live/yourdomain.com/fullchain.pem"
-  ]
-
 config :teiserver, Teiserver.Repo,
   username: "teiserver_prod",
   password: "mix phx.gen.secret",

--- a/lib/teiserver/application.ex
+++ b/lib/teiserver/application.ex
@@ -197,7 +197,10 @@ defmodule Teiserver.Application do
 
   defp discord_start do
     if Teiserver.Communication.use_discord?() do
-      [{Teiserver.Bridge.DiscordBridgeBot, name: Teiserver.Bridge.DiscordBridgeBot}]
+      [
+        Nostrum.Application,
+        {Teiserver.Bridge.DiscordBridgeBot, name: Teiserver.Bridge.DiscordBridgeBot}
+      ]
     else
       []
     end

--- a/lib/teiserver/config_helpers.ex
+++ b/lib/teiserver/config_helpers.ex
@@ -1,0 +1,36 @@
+# Taken from https://gitlab.com/code-stats/code-stats/-/blob/b1cf53462a3fa34369eaa06494754c7ae38aed2a/lib/code_stats/config_helpers.ex
+defmodule Teiserver.ConfigHelpers do
+  @type config_type :: :str | :int | :bool | :json
+
+  @doc """
+  Get value from environment variable, converting it to the given type if needed.
+
+  If no default value is given, or `:no_default` is given as the default, an error is raised if the variable is not
+  set.
+  """
+  @spec get_env(String.t(), :no_default | any(), config_type()) :: any()
+  def get_env(var, default \\ :no_default, type \\ :str)
+
+  def get_env(var, :no_default, type) do
+    System.fetch_env!(var)
+    |> get_with_type(type)
+  end
+
+  def get_env(var, default, type) do
+    with {:ok, val} <- System.fetch_env(var) do
+      get_with_type(val, type)
+    else
+      :error -> default
+    end
+  end
+
+  @spec get_with_type(String.t(), config_type()) :: any()
+  defp get_with_type(val, type)
+
+  defp get_with_type(val, :str), do: val
+  defp get_with_type(val, :int), do: String.to_integer(val)
+  defp get_with_type("true", :bool), do: true
+  defp get_with_type("false", :bool), do: false
+  defp get_with_type(val, :json), do: Jason.decode!(val)
+  defp get_with_type(val, type), do: raise("Cannot convert to #{inspect(type)}: #{inspect(val)}")
+end

--- a/mix.exs
+++ b/mix.exs
@@ -31,9 +31,12 @@ defmodule Teiserver.MixProject do
 
   # Run "mix help compile.app" to learn about applications.
   def application do
+    # get that with mix app.tree nostrum
+    nostrum_extras = [:certifi, :gun, :inets, :jason, :kcl, :mime]
     [
       mod: {Teiserver.Application, []},
-      extra_applications: [:logger, :runtime_tools, :os_mon, :iex]
+      included_applications: [:nostrum],
+      extra_applications: [:logger, :runtime_tools, :os_mon, :iex] ++ nostrum_extras
     ]
   end
 
@@ -99,12 +102,7 @@ defmodule Teiserver.MixProject do
       {:etop, "~> 0.7.0"},
       {:cowlib, "~> 2.11", hex: :remedy_cowlib, override: true},
       {:json_xema, "~> 0.3"},
-
-      # If you want to connect to discord in dev mode, use this
-      # {:nostrum, "~> 0.8", runtime: Mix.env() != :test},
-
-      # If you only want to connect to discord in prod, use this
-      {:nostrum, "~> 0.8", runtime: Mix.env() == :prod}
+      {:nostrum, "~> 0.8"}
     ]
   end
 


### PR DESCRIPTION
# ONLY LOOK AT THE LAST 4 COMMITS

This enable or disable the discord bridge through environment variable. This way, we can have one release bundle of teiserver that can be used for staging with the integration disabled, and the same bundle in prod.
This was done following the [nostrum doc about bundling it with the app](https://hexdocs.pm/nostrum/multi_node.html#bundling-nostrum-with-our-app).

This assume https://github.com/beyond-all-reason/teiserver/pull/278 is merged first (hence the warning about only looking at the last 4 commits).

@p2004a I think that's going to be useful for your work on ansible+docker