### PR TITLE
FixChange fake data accounts to generate a list. 

### DIFF
--- a/lib/teiserver/mix_tasks/fake_data.ex
+++ b/lib/teiserver/mix_tasks/fake_data.ex
@@ -109,8 +109,8 @@ defmodule Mix.Tasks.Teiserver.Fakedata do
             inserted_at: Timex.shift(Timex.now(), days: -day, minutes: -minutes) |> time_convert,
             updated_at: Timex.shift(Timex.now(), days: -day, minutes: -minutes) |> time_convert
           }
-        end) |> Enum.to_list
-      end) |> Enum.to_list
+        end) |> Enum.to_list()
+      end) |> Enum.to_list()
       |> List.flatten()
 
     Ecto.Multi.new()

--- a/lib/teiserver/mix_tasks/fake_data.ex
+++ b/lib/teiserver/mix_tasks/fake_data.ex
@@ -109,8 +109,8 @@ defmodule Mix.Tasks.Teiserver.Fakedata do
             inserted_at: Timex.shift(Timex.now(), days: -day, minutes: -minutes) |> time_convert,
             updated_at: Timex.shift(Timex.now(), days: -day, minutes: -minutes) |> time_convert
           }
-        end)
-      end)
+        end) |> Enum.to_list
+      end) |> Enum.to_list
       |> List.flatten()
 
     Ecto.Multi.new()

--- a/lib/teiserver_web/live/queues/index.ex
+++ b/lib/teiserver_web/live/queues/index.ex
@@ -53,6 +53,7 @@ defmodule TeiserverWeb.Matchmaking.QueueLive.Index do
           true
         end
       end)
+      |> Enum.to_list()
 
     is_admin = allow?(socket.assigns[:current_user], "Admin")
 


### PR DESCRIPTION
Fake data could not be loaded since accounts did not generated into a list.