### PR TITLE
Allow friends to join private battles without a password

### DIFF
--- a/lib/teiserver/coordinator/consul_server.ex
+++ b/lib/teiserver/coordinator/consul_server.ex
@@ -1001,7 +1001,7 @@ defmodule Teiserver.Coordinator.ConsulServer do
 
       state.gatekeeper == "friends" ->
         if is_on_friendlist?(userid, state, :all) do
-          {true, nil}
+          {true, :allow_friends}
         else
           {false, "Friends only gatekeeper"}
         end

--- a/lib/teiserver/lobby.ex
+++ b/lib/teiserver/lobby.ex
@@ -565,7 +565,7 @@ defmodule Teiserver.Lobby do
       Enum.any?([
         CacheUser.is_moderator?(user),
         Enum.member?(user.roles, "Caster"),
-        consul_reason == :override_approve
+        consul_reason in [:override_approve, :allow_friends]
       ])
 
     ignore_locked =


### PR DESCRIPTION
I want to allow friends to join private lobbies without having to enter a password.
This should be easy by bypassing the password requirement when the gatekeeper of a lobby is set to friends.


General Idea:
https://github.com/beyond-all-reason/BYAR-Chobby/issues/654