### PR TITLE
Add indexes for foreign key constraints

### DIFF
--- a/priv/repo/migrations/20240513165706_add_fk_battle_matches_lobby_messages.exs
+++ b/priv/repo/migrations/20240513165706_add_fk_battle_matches_lobby_messages.exs
@@ -1,0 +1,17 @@
+defmodule Teiserver.Repo.Migrations.AddFkBattleMatchesLobbyMessages do
+  use Ecto.Migration
+  # This change is being done to reduce the CPU load of the hourly Teiserver.Battle.Tasks.CleanupTask
+  # As deleting rows from tables with non-indexed foreign keys is probably expensive
+  # This migration adds indexes on the columns used as foreign key on the battle_matches table
+
+  def change do
+    create index(:teiserver_battle_match_memberships, [:match_id])
+    create index(:teiserver_lobby_messages, [:match_id])
+    create index(:moderation_reports, [:match_id])
+    create index(:telemetry_simple_match_events, [:match_id])
+    create index(:telemetry_complex_match_events, [:match_id])
+    create index(:telemetry_simple_lobby_events, [:match_id])
+    create index(:telemetry_complex_lobby_events, [:match_id])
+    create index(:moderation_report_groups, [:match_id])
+  end
+end


### PR DESCRIPTION
Related to the discussion on discord.
Once merged, the migration will be applied on the next server startup.

This can also be applied manually before:
```bash
mix ecto.migrations # display migrations status
mix ecto.migrate --log-migrations-sql # apply pending migrations and print the SQL used
mix ecto.rollback # rollback the last applied migration
```

The indexes are coming from `\d+ teiserver_battle_matches` and creating any index in the `Referenced by` section that don't already exist.