### PR TITLE
Log Oban jobs in milliseconds

### DIFF
--- a/lib/teiserver/helpers/oban_logger.ex
+++ b/lib/teiserver/helpers/oban_logger.ex
@@ -40,6 +40,6 @@ defmodule Teiserver.Helper.ObanLogger do
   end
 
   def handle_event([:oban, :job, event], measure, meta, _) do
-    Logger.info("[Oban] #{event} #{meta.worker} ran in #{measure.duration}")
+    Logger.info("[Oban] #{event} #{meta.worker} ran in #{System.convert_time_unit(measure.duration, :native, :milliseconds)}ms")
   end
 end


### PR DESCRIPTION
measure.duration should be in :native time units, so this seems correct and works on integration server.