### PR TITLE
Delete reset token if email failure

### DIFF
--- a/lib/teiserver/account/emails.ex
+++ b/lib/teiserver/account/emails.ex
@@ -1,7 +1,34 @@
 defmodule Teiserver.Account.Emails do
   @moduledoc false
+  require Logger
   alias Bamboo.Email
   alias Teiserver.Helper.TimexHelper
+
+  def send_password_reset(user, code \\ nil) do
+    {code, email} = password_reset(user, code)
+    response = Teiserver.Mailer.deliver_now(email, response: true)
+
+    case response do
+      {:ok, _email, _response} ->
+        :ok
+
+      {:error, error} ->
+        case Teiserver.Account.delete_code(code) do
+          # the cursed path
+          {:error, err} ->
+            Logger.error(
+              "Failed to delete code #{inspect(code)} for user at #{user.email}: #{inspect(err)}"
+            )
+
+          _ ->
+            Logger.info(
+              "Deleted password reset token for user at #{user.email} because email failed"
+            )
+        end
+
+        {:error, error}
+    end
+  end
 
   def password_reset(user, code \\ nil) do
     # We need this to enable recreating the email if we know it
@@ -46,16 +73,19 @@ defmodule Teiserver.Account.Emails do
     message_id = "<#{UUID.uuid1()}@#{Application.get_env(:teiserver, Teiserver)[:host]}>"
     subject = Application.get_env(:teiserver, Teiserver)[:game_name] <> " - Password reset"
 
-    Email.new_email()
-    |> Email.to({user.name, user.email})
-    |> Email.from(
-      {Application.get_env(:teiserver, Teiserver.Mailer)[:noreply_name],
-       Teiserver.Mailer.noreply_address()}
-    )
-    |> Email.subject(subject)
-    |> Email.put_header("Date", date)
-    |> Email.put_header("Message-Id", message_id)
-    |> Email.html_body(html_body)
-    |> Email.text_body(text_body)
+    email =
+      Email.new_email()
+      |> Email.to({user.name, user.email})
+      |> Email.from(
+        {Application.get_env(:teiserver, Teiserver.Mailer)[:noreply_name],
+         Teiserver.Mailer.noreply_address()}
+      )
+      |> Email.subject(subject)
+      |> Email.put_header("Date", date)
+      |> Email.put_header("Message-Id", message_id)
+      |> Email.html_body(html_body)
+      |> Email.text_body(text_body)
+
+    {code, email}
   end
 end

--- a/lib/teiserver/common/email_helper.ex
+++ b/lib/teiserver/common/email_helper.ex
@@ -69,6 +69,6 @@ defmodule Teiserver.EmailHelper do
     |> Email.put_header("Message-Id", message_id)
     |> Email.html_body(html_body)
     |> Email.text_body(text_body)
-    |> Teiserver.Mailer.deliver_now()
+    |> Teiserver.Mailer.deliver_now(response: true)
   end
 end

--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -500,13 +500,6 @@ defmodule Teiserver.CacheUser do
     :ok
   end
 
-  def request_password_reset(user) do
-    db_user = Account.get_user!(user.id)
-
-    Teiserver.Account.Emails.password_reset(db_user)
-    |> Teiserver.Mailer.deliver_now()
-  end
-
   def request_email_change(nil, _), do: nil
 
   def request_email_change(user, new_email) do

--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -296,9 +296,8 @@ defmodule Teiserver.CacheUser do
               :no_verify ->
                 verify_user(get_user_by_id(user.id))
 
-              {:ok, _} ->
+              {:ok, _, _} ->
                 :ok
-                # Logger.error("Email sent, response of #{Kernel.inspect response}")
             end
         end
 
@@ -339,7 +338,7 @@ defmodule Teiserver.CacheUser do
               verify_user(get_user_by_id(user.id))
               :ok
 
-            {:ok, _} ->
+            {:ok, _, _} ->
               :ok
           end
         end

--- a/lib/teiserver_web/components/layouts/app.html.heex
+++ b/lib/teiserver_web/components/layouts/app.html.heex
@@ -54,8 +54,6 @@
     current_user={@current_user}
   />
 
-  <.flash_group flash={@flash} />
-
   <main>
     <.breadcrumb_trail :if={assigns[:breadcrumb_trails]} trails={assigns[:breadcrumb_trails]} />
 

--- a/lib/teiserver_web/components/layouts/root.html.heex
+++ b/lib/teiserver_web/components/layouts/root.html.heex
@@ -42,6 +42,7 @@
     </script>
   </head>
   <body class="container-fluid px-0 d-flex flex-column">
+    <.flash_group flash={@flash} />
     <%= @inner_content %>
   </body>
 </html>


### PR DESCRIPTION
Address https://github.com/beyond-all-reason/teiserver/issues/289

If, for whatever reason, sending the password reset email fails, then attempt to delete the reset code so that the operation can be retried.

Also fixed a template so that flashes are shown on the login page as well.

This is what the admin UI looks like:
![2024-05-18-971x497-scrot](https://github.com/beyond-all-reason/teiserver/assets/1531763/43bcc54c-6b87-4acb-bf2d-cb3cfc0b2323)
![2024-05-18-1010x577-scrot](https://github.com/beyond-all-reason/teiserver/assets/1531763/10e380aa-ebaa-426c-8389-694093b3e041)

and this is what the user facing interface looks like:
![2024-05-18-1937x473-scrot](https://github.com/beyond-all-reason/teiserver/assets/1531763/61c4cb39-e241-46a5-aa71-56d63c9b95ca)
![2024-05-18-1937x386-scrot](https://github.com/beyond-all-reason/teiserver/assets/1531763/9eea1076-1130-4d50-a360-bfd206fff3cb)

