### PR TITLE
Fix lookup for email integration enablement env var

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -105,7 +105,7 @@ if config_env() == :prod do
     issuer: Teiserver.ConfigHelpers.get_env("TEI_GUARDIAN_ISSUER", "teiserver"),
     secret_key: Teiserver.ConfigHelpers.get_env("TEI_GUARDIAN_SECRET_KEY")
 
-  if Teiserver.ConfigHelpers.get_env("TEI_ENABLE_EMAIL_INTEGRATION", :bool) do
+  if Teiserver.ConfigHelpers.get_env("TEI_ENABLE_EMAIL_INTEGRATION", true, :bool) do
     config :teiserver, Teiserver.Mailer,
       adapter: Bamboo.SMTPAdapter,
       contact_address:


### PR DESCRIPTION
Because of wrong list of arguments to function, it was impossible to disable email integration.