### PR TITLE
Redirect to previous page after logging in

### DIFF
--- a/lib/teiserver/account/error_handler.ex
+++ b/lib/teiserver/account/error_handler.ex
@@ -6,7 +6,9 @@ defmodule Teiserver.Account.ErrorHandler do
   @impl Guardian.Plug.ErrorHandler
 
   def auth_error(conn, {:unauthenticated, _reason}, _opts) do
+    redirect_to = "#{conn.request_path}?#{conn.query_string}"
     conn
+    |> put_resp_cookie("_redirect_to", redirect_to, sign: true, max_age: 60*5)
     |> Phoenix.Controller.redirect(
       to: TeiserverWeb.Router.Helpers.account_session_path(conn, :login)
     )

--- a/lib/teiserver_web/controllers/account/session_controller.ex
+++ b/lib/teiserver_web/controllers/account/session_controller.ex
@@ -100,11 +100,14 @@ defmodule TeiserverWeb.Account.SessionController do
   end
 
   defp login_reply({:ok, user}, conn) do
+    cookies = Plug.Conn.fetch_cookies(conn, signed: ~w(_redirect_to)).cookies
+
     conn
     |> put_flash(:info, "Welcome back!")
     |> Guardian.Plug.sign_in(user)
     |> Guardian.Plug.remember_me(user)
-    |> redirect(to: "/")
+    |> Plug.Conn.delete_resp_cookie("_redirect_to", sign: true)
+    |> redirect(to: Map.get(cookies, "_redirect_to", "/"))
   end
 
   defp login_reply({:error, reason}, conn) do


### PR DESCRIPTION
How to test?

* Log out of your account.
* go to http://localhost:4000/teiserver/account/parties
* get redirected to login page
* login correctly
* you should land on the `/teiserver/account/parties` page instead of the default `/`

This is convenient for now, but it's going to be important when implementing OAuth2 (for tachyon).