### PR TITLE
Don't create a reset code at user creation

### DIFF
--- a/lib/teiserver/common/email_helper.ex
+++ b/lib/teiserver/common/email_helper.ex
@@ -22,14 +22,6 @@ defmodule Teiserver.EmailHelper do
     website_url = "https://#{host}"
     verification_code = stats["verification_code"]
 
-    {:ok, _code} =
-      Teiserver.Account.create_code(%{
-        value: UUID.uuid4(),
-        purpose: "reset_password",
-        expires: Timex.now() |> Timex.shift(hours: 24),
-        user_id: user.id
-      })
-
     message_id = "<#{UUID.uuid4()}@#{host}>"
 
     game_name = Application.get_env(:teiserver, Teiserver)[:game_name]


### PR DESCRIPTION
The code to verify the email is created and stored under user.stat.verification_code, and the reset code created was just useless.
The code that removed the use of this token was introduced in 6668f473c "general cleanup", that seems to have been an oversight.
Fixes https://github.com/beyond-all-reason/teiserver/issues/310