### PR TITLE
Tachyon oauth

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -24,13 +24,13 @@ if Teiserver.ConfigHelpers.get_env("PHX_SERVER", nil) do
   config :teiserver, TeiserverWeb.Endpoint, server: true
 end
 
+# used for mailing, checking origins, finding tls certs…
+domain_name = Teiserver.ConfigHelpers.get_env("TEI_DOMAIN_NAME", "beyondallreason.info")
+
 # Only do some runtime configuration in production since in dev and tests the
 # files are automatically recompiled on the fly and thus, config/{dev,test}.exs
 # are just fine
 if config_env() == :prod do
-  # used for mailing, checking origins, finding tls certs…
-  domain_name = Teiserver.ConfigHelpers.get_env("TEI_DOMAIN_NAME", "beyondallreason.info")
-
   certificates = [
     keyfile: Teiserver.ConfigHelpers.get_env("TEI_TLS_PRIVATE_KEY_PATH"),
     certfile: Teiserver.ConfigHelpers.get_env("TEI_TLS_CERT_PATH"),
@@ -190,3 +190,5 @@ if config_env() == :prod do
       bot_name: Teiserver.ConfigHelpers.get_env("TEI_DISCORD_BOT_NAME")
   end
 end
+
+config :teiserver, Teiserver.OAuth, issuer: "https://#{domain_name}"

--- a/lib/teiserver/account.ex
+++ b/lib/teiserver/account.ex
@@ -9,6 +9,8 @@ defmodule Teiserver.Account do
 
   alias Teiserver.Account.UserLib
 
+  @type t :: UserLib.t()
+
   @spec icon :: String.t()
   def icon, do: "fa-solid fa-user-alt"
 

--- a/lib/teiserver/account/error_handler.ex
+++ b/lib/teiserver/account/error_handler.ex
@@ -6,7 +6,12 @@ defmodule Teiserver.Account.ErrorHandler do
   @impl Guardian.Plug.ErrorHandler
 
   def auth_error(conn, {:unauthenticated, _reason}, _opts) do
-    redirect_to = "#{conn.request_path}?#{conn.query_string}"
+    redirect_to =
+      if conn.query_string != nil && conn.query_string != "" do
+        "#{conn.request_path}?#{conn.query_string}"
+      else
+        "#{conn.request_path}"
+      end
 
     conn
     |> put_resp_cookie("_redirect_to", redirect_to, sign: true, max_age: 60 * 5)

--- a/lib/teiserver/account/schemas/user.ex
+++ b/lib/teiserver/account/schemas/user.ex
@@ -5,6 +5,9 @@ defmodule Teiserver.Account.User do
 
   alias Argon2
 
+  # TODO: this is where a user should be defined. This is only a placeholder for now
+  @type t :: term()
+
   schema "account_users" do
     field :name, :string
     field :email, :string

--- a/lib/teiserver/autohost.ex
+++ b/lib/teiserver/autohost.ex
@@ -1,0 +1,12 @@
+defmodule Teiserver.Autohost do
+  alias Teiserver.Autohost.Autohost
+  alias Teiserver.Repo
+
+  def create_autohost(attrs \\ %{}) do
+    %Autohost{}
+    |> Autohost.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  defdelegate get_autohost(id), to: Teiserver.AutohostQueries
+end

--- a/lib/teiserver/autohost/queries/autohost_query.ex
+++ b/lib/teiserver/autohost/queries/autohost_query.ex
@@ -1,0 +1,20 @@
+defmodule Teiserver.AutohostQueries do
+  use TeiserverWeb, :queries
+  alias Teiserver.Autohost.Autohost
+
+  @spec get_autohost(Autohost.id()) :: Autohost.t() | nil
+  def get_autohost(nil), do: nil
+
+  def get_autohost(id) do
+    base_query() |> where_id(id) |> Repo.one()
+  end
+
+  def base_query() do
+    from autohost in Autohost, as: :autohost
+  end
+
+  def where_id(query, id) do
+    from autohost in query,
+      where: autohost.id == ^id
+  end
+end

--- a/lib/teiserver/autohost/schemas/autohost.ex
+++ b/lib/teiserver/autohost/schemas/autohost.ex
@@ -1,0 +1,21 @@
+defmodule Teiserver.Autohost.Autohost do
+  @moduledoc false
+  use TeiserverWeb, :schema
+
+  @type id :: integer()
+  @type t :: %__MODULE__{
+          id: id(),
+          name: String.t()
+        }
+
+  schema "teiserver_autohosts" do
+    field :name, :string
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def changeset(autohost, attrs) do
+    autohost
+    |> cast(attrs, [:name])
+  end
+end

--- a/lib/teiserver/o_auth.ex
+++ b/lib/teiserver/o_auth.ex
@@ -1,0 +1,21 @@
+defmodule Teiserver.OAuth do
+  alias Teiserver.Repo
+  alias Teiserver.OAuth.{Application, ApplicationQueries}
+
+  def create_application(attrs \\ %{}) do
+    %Application{}
+    |> Application.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @spec delete_application(Application.t()) :: :ok | {:error, term()}
+  def delete_application(app) do
+    case Repo.delete(app) do
+      {:ok, _} -> :ok
+      {:error, err} -> {:error, err}
+    end
+  end
+
+  @spec get_application_by_uid(Application.app_id()) :: Application.t() | nil
+  defdelegate get_application_by_uid(uid), to: ApplicationQueries
+end

--- a/lib/teiserver/o_auth.ex
+++ b/lib/teiserver/o_auth.ex
@@ -329,7 +329,7 @@ defmodule Teiserver.OAuth do
           String.t(),
           String.t()
         ) ::
-          {:ok, Secret.t()} | {:error, term()}
+          {:ok, Credential.t()} | {:error, term()}
   def create_credentials(%Application{} = app, autohost, client_id, secret),
     do: create_credentials(app.id, autohost, client_id, secret)
 

--- a/lib/teiserver/o_auth.ex
+++ b/lib/teiserver/o_auth.ex
@@ -1,6 +1,6 @@
 defmodule Teiserver.OAuth do
   alias Teiserver.Repo
-  alias Teiserver.OAuth.{Application, Code, ApplicationQueries, CodeQueries}
+  alias Teiserver.OAuth.{Application, Code, Token, ApplicationQueries, CodeQueries, TokenQueries}
   alias Teiserver.Account.User
   alias Teiserver.Data.Types, as: T
 
@@ -73,6 +73,101 @@ defmodule Teiserver.OAuth do
         else
           {:ok, code}
         end
+    end
+  end
+
+  @spec create_token(User.t() | T.userid(), Application.t(), options()) ::
+          {:ok, Token.t()} | {:error, Ecto.Changeset.t()}
+  def create_token(user_id, application, opts \\ [])
+
+  def create_token(%User{} = user, application, opts) do
+    create_token(user.id, application, opts)
+  end
+
+  def create_token(user, application, opts) when is_map(user) do
+    create_token(user.id, application, opts)
+  end
+
+  def create_token(user_id, application, opts) do
+    now = Keyword.get(opts, :now, DateTime.utc_now())
+
+    refresh_attrs = %{
+      value: Base.hex_encode32(:crypto.strong_rand_bytes(32), padding: false),
+      owner_id: user_id,
+      application_id: application.id,
+      scopes: application.scopes,
+      # there's no real recourse when the refresh token expires and it's
+      # quite annoying, so make it "never" expire.
+      expires_at: Timex.add(now, Timex.Duration.from_days(365 * 100)),
+      type: :refresh,
+      refresh_token: nil
+    }
+
+    token_attrs = %{
+      value: Base.hex_encode32(:crypto.strong_rand_bytes(32), padding: false),
+      owner_id: user_id,
+      application_id: application.id,
+      scopes: application.scopes,
+      expires_at: Timex.add(now, Timex.Duration.from_minutes(30)),
+      type: :bearer,
+      refresh_token: refresh_attrs
+    }
+
+    %Token{}
+    |> Token.changeset(token_attrs)
+    |> Repo.insert()
+  end
+
+  # TODO: get_valid_token is basically the same as get_valid_code, refactor later
+
+  @doc """
+  Given a code returns the corresponding db object, making sure
+  it is valid (exists, not expired, not revoked)
+  """
+  @spec get_valid_token(String.t(), options()) :: {:ok, Token.t()} | {:error, term()}
+  def get_valid_token(value, opts \\ [])
+
+  def get_valid_token(value, opts) do
+    case TokenQueries.get_token(value) do
+      nil ->
+        {:error, :no_token}
+
+      token ->
+        now = Keyword.get(opts, :now, Timex.now())
+
+        if Timex.after?(now, token.expires_at) do
+          {:error, :expired}
+        else
+          {:ok, token}
+        end
+    end
+  end
+
+  @spec refresh_token(Token.t(), options()) :: {:ok, Token.t()} | {:error, term()}
+  def refresh_token(token, opts \\ [])
+
+  def refresh_token(token, _opts) when token.type != :refresh do
+    {:error, :invalid_token}
+  end
+
+  def refresh_token(token, opts) do
+    now = Keyword.get(opts, :now, Timex.now())
+
+    if expired?(token, now) do
+      {:error, :expired}
+    else
+      token =
+        if Ecto.assoc_loaded?(token.application) do
+          token
+        else
+          TokenQueries.get_token(token.value)
+        end
+
+      Repo.transaction(fn ->
+        {:ok, new_token} = create_token(token.owner_id, token.application, opts)
+        TokenQueries.delete_refresh_token(token)
+        new_token
+      end)
     end
   end
 

--- a/lib/teiserver/o_auth.ex
+++ b/lib/teiserver/o_auth.ex
@@ -1,6 +1,8 @@
 defmodule Teiserver.OAuth do
   alias Teiserver.Repo
-  alias Teiserver.OAuth.{Application, ApplicationQueries}
+  alias Teiserver.OAuth.{Application, Code, ApplicationQueries, CodeQueries}
+  alias Teiserver.Account.User
+  alias Teiserver.Data.Types, as: T
 
   def create_application(attrs \\ %{}) do
     %Application{}
@@ -16,6 +18,68 @@ defmodule Teiserver.OAuth do
     end
   end
 
+  @type option :: {:now, DateTime.t()}
+  @type options :: [option]
+
+  @doc """
+  Create an authorization token for the given user and application.
+  The token scopes are the same as the application
+  """
+  @spec create_code(User.t() | T.userid(), Application.t(), options()) ::
+          {:ok, Code.t()} | {:error, Ecto.Changeset.t()}
+  def create_code(user, application, opts \\ [])
+
+  def create_code(%User{} = user, application, opts) do
+    create_code(user.id, application, opts)
+  end
+
+  def create_code(user, application, opts) when is_map(user) do
+    create_code(user.id, application, opts)
+  end
+
+  def create_code(user_id, application, opts) do
+    now = Keyword.get(opts, :now, Timex.now())
+
+    attrs = %{
+      value: Base.hex_encode32(:crypto.strong_rand_bytes(32)),
+      owner_id: user_id,
+      application_id: application.id,
+      scopes: application.scopes,
+      expires_at: Timex.add(now, Timex.Duration.from_minutes(5))
+    }
+
+    %Code{}
+    |> Code.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Given a code returns the corresponding db object, making sure
+  it is valid (exists, not expired, not revoked)
+  """
+  @spec get_valid_code(String.t(), options()) :: {:ok, Code.t()} | {:error, term()}
+  def get_valid_code(code, opts \\ [])
+
+  def get_valid_code(code, opts) do
+    case CodeQueries.get_code(code) do
+      nil ->
+        {:error, :no_code}
+
+      code ->
+        now = Keyword.get(opts, :now, Timex.now())
+
+        if expired?(code, now) do
+          {:error, :expired}
+        else
+          {:ok, code}
+        end
+    end
+  end
+
   @spec get_application_by_uid(Application.app_id()) :: Application.t() | nil
   defdelegate get_application_by_uid(uid), to: ApplicationQueries
+
+  defp expired?(obj, now) do
+    Timex.after?(now, Map.fetch!(obj, :expires_at))
+  end
 end

--- a/lib/teiserver/o_auth/queries/application_query.ex
+++ b/lib/teiserver/o_auth/queries/application_query.ex
@@ -1,0 +1,24 @@
+defmodule Teiserver.OAuth.ApplicationQueries do
+  use TeiserverWeb, :queries
+
+  alias Teiserver.OAuth.Application
+
+  @doc """
+  Returns the application corresponding to the given uid/client id
+  """
+  @spec get_application_by_uid(String.t()) :: Application.t() | nil
+  def get_application_by_uid(nil), do: nil
+
+  def get_application_by_uid(uid) do
+    base_query() |> where_uid(uid) |> Repo.one()
+  end
+
+  def base_query() do
+    from app in Application, as: :app
+  end
+
+  def where_uid(query, uid) do
+    from e in query,
+      where: e.uid == ^uid
+  end
+end

--- a/lib/teiserver/o_auth/queries/application_query.ex
+++ b/lib/teiserver/o_auth/queries/application_query.ex
@@ -21,4 +21,14 @@ defmodule Teiserver.OAuth.ApplicationQueries do
     from e in query,
       where: e.uid == ^uid
   end
+
+  def join_application(query, name \\ :application) do
+    if has_named_binding?(query, :application) do
+      query
+    else
+      from token in query,
+        join: app in assoc(token, ^name),
+        as: :application
+    end
+  end
 end

--- a/lib/teiserver/o_auth/queries/code_query.ex
+++ b/lib/teiserver/o_auth/queries/code_query.ex
@@ -1,0 +1,24 @@
+defmodule Teiserver.OAuth.CodeQueries do
+  use TeiserverWeb, :queries
+  alias Teiserver.OAuth.Code
+
+  @doc """
+  Return the db object corresponding to the given code.
+  This doesn't validate anything, use the context function instead
+  """
+  @spec get_code(String.t() | nil) :: Code.t() | nil
+  def get_code(nil), do: nil
+
+  def get_code(code) do
+    base_query() |> where_code(code) |> Repo.one()
+  end
+
+  def base_query() do
+    from code in Code, as: :code
+  end
+
+  def where_code(query, value) do
+    from e in query,
+      where: e.value == ^value
+  end
+end

--- a/lib/teiserver/o_auth/queries/credential_query.ex
+++ b/lib/teiserver/o_auth/queries/credential_query.ex
@@ -1,0 +1,23 @@
+defmodule Teiserver.OAuth.CredentialQueries do
+  use TeiserverWeb, :queries
+  alias Teiserver.OAuth.Credential
+
+  def get_credential(nil), do: nil
+
+  def get_credential(client_id) do
+    base_query()
+    |> preload(:application)
+    |> where_client_id(client_id)
+    |> Repo.one()
+  end
+
+  def base_query() do
+    from credential in Credential,
+      as: :credential
+  end
+
+  def where_client_id(query, client_id) do
+    from credential in query,
+      where: credential.client_id == ^client_id
+  end
+end

--- a/lib/teiserver/o_auth/queries/token_query.ex
+++ b/lib/teiserver/o_auth/queries/token_query.ex
@@ -9,7 +9,10 @@ defmodule Teiserver.OAuth.TokenQueries do
   def get_token(nil), do: nil
 
   def get_token(value) do
-    base_query() |> where_token(value) |> with_app() |> Repo.one()
+    base_query()
+    |> where_token(value)
+    |> preload(:application)
+    |> Repo.one()
   end
 
   def base_query() do
@@ -21,23 +24,6 @@ defmodule Teiserver.OAuth.TokenQueries do
   def where_token(query, value) do
     from e in query,
       where: e.value == ^value
-  end
-
-  @doc """
-  ensure the related application is loaded
-  """
-  def with_app(query) do
-    query =
-      if has_named_binding?(query, :app) do
-        query
-      else
-        from token in query,
-          join: app in assoc(token, :application),
-          as: :app
-      end
-
-    from [app: app] in query,
-      preload: [application: app]
   end
 
   @doc """

--- a/lib/teiserver/o_auth/queries/token_query.ex
+++ b/lib/teiserver/o_auth/queries/token_query.ex
@@ -1,0 +1,50 @@
+defmodule Teiserver.OAuth.TokenQueries do
+  use TeiserverWeb, :queries
+  alias Teiserver.OAuth.Token
+
+  @doc """
+  Return the db object corresponding to the given token.
+  This doesn't validate anything, use the context function instead
+  """
+  def get_token(nil), do: nil
+
+  def get_token(value) do
+    base_query() |> where_token(value) |> with_app() |> Repo.one()
+  end
+
+  def base_query() do
+    from token in Token,
+      as: :token,
+      preload: [refresh_token: token]
+  end
+
+  def where_token(query, value) do
+    from e in query,
+      where: e.value == ^value
+  end
+
+  @doc """
+  ensure the related application is loaded
+  """
+  def with_app(query) do
+    query =
+      if has_named_binding?(query, :app) do
+        query
+      else
+        from token in query,
+          join: app in assoc(token, :application),
+          as: :app
+      end
+
+    from [app: app] in query,
+      preload: [application: app]
+  end
+
+  @doc """
+  given a refresh token, deletes it and its potential associated token
+  """
+  def delete_refresh_token(token) do
+    from(tok in Token, where: tok.id == ^token.id or tok.refresh_token_id == ^token.id)
+    |> Repo.delete_all()
+  end
+end

--- a/lib/teiserver/o_auth/schemas/application.ex
+++ b/lib/teiserver/o_auth/schemas/application.ex
@@ -1,0 +1,55 @@
+defmodule Teiserver.OAuth.Application do
+  @moduledoc false
+  use TeiserverWeb, :schema
+  alias Teiserver.Account.User
+
+  @type app_id() :: String.t()
+  @type scopes() :: nonempty_list(String.t())
+  @type t :: %__MODULE__{
+          name: String.t(),
+          owner: User.t(),
+          uid: app_id(),
+          scopes: scopes(),
+          redirect_uris: [String.t()],
+          description: String.t(),
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  schema "oauth_applications" do
+    field :name, :string
+    belongs_to :owner, Teiserver.Account.User, primary_key: true
+    field :uid, :string
+    field :scopes, {:array, :string}
+    field :redirect_uris, {:array, :string}, default: []
+    field :description, :string
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def allowed_scopes do
+    ~w(tachyon.lobby)
+  end
+
+  def changeset(application, attrs) do
+    attrs = attrs |> uniq_lists(~w(scopes)a)
+
+    application
+    |> cast(attrs, [:name, :owner_id, :uid, :scopes, :redirect_uris, :description])
+    |> validate_required([:name, :owner_id, :uid, :scopes])
+    |> Ecto.Changeset.validate_change(:redirect_uris, fn :redirect_uris, uris ->
+      invalid_uris = Enum.filter(uris, fn uri -> is_nil(URI.parse(uri).host) end)
+
+      if Enum.empty?(invalid_uris) do
+        []
+      else
+        [redirect_uris: "invalid uri found: #{Enum.join(invalid_uris, ", ")}"]
+      end
+    end)
+    |> Ecto.Changeset.unique_constraint(:uid)
+    |> Ecto.Changeset.validate_subset(:scopes, allowed_scopes(),
+      message: "Must be #{allowed_scopes()}"
+    )
+    |> Ecto.Changeset.validate_length(:scopes, min: 1)
+  end
+end

--- a/lib/teiserver/o_auth/schemas/code.ex
+++ b/lib/teiserver/o_auth/schemas/code.ex
@@ -9,7 +9,8 @@ defmodule Teiserver.OAuth.Code do
           owner: User.t(),
           application: OAuth.Application.t(),
           scopes: OAuth.Application.scopes(),
-          expires_at: DateTime.t()
+          expires_at: DateTime.t(),
+          redirect_uri: String.t() | nil
         }
 
   schema "oauth_codes" do
@@ -18,6 +19,7 @@ defmodule Teiserver.OAuth.Code do
     belongs_to :application, OAuth.Application, primary_key: true
     field :scopes, {:array, :string}
     field :expires_at, :utc_datetime
+    field :redirect_uri, :string
 
     timestamps()
   end
@@ -26,8 +28,21 @@ defmodule Teiserver.OAuth.Code do
     attrs = attrs |> uniq_lists(~w(scopes)a)
 
     code
-    |> cast(attrs, [:value, :owner_id, :application_id, :scopes, :expires_at])
-    |> validate_required([:value, :owner_id, :application_id, :scopes, :expires_at])
+    |> cast(attrs, [
+      :value,
+      :owner_id,
+      :application_id,
+      :scopes,
+      :expires_at,
+      :redirect_uri
+    ])
+    |> validate_required([
+      :value,
+      :owner_id,
+      :application_id,
+      :scopes,
+      :expires_at
+    ])
     |> Ecto.Changeset.validate_subset(:scopes, OAuth.Application.allowed_scopes())
   end
 end

--- a/lib/teiserver/o_auth/schemas/code.ex
+++ b/lib/teiserver/o_auth/schemas/code.ex
@@ -3,6 +3,7 @@ defmodule Teiserver.OAuth.Code do
   use TeiserverWeb, :schema
 
   alias Teiserver.OAuth
+  alias Teiserver.Account.User
 
   @type t :: %__MODULE__{
           value: String.t(),

--- a/lib/teiserver/o_auth/schemas/code.ex
+++ b/lib/teiserver/o_auth/schemas/code.ex
@@ -1,0 +1,33 @@
+defmodule Teiserver.OAuth.Code do
+  @moduledoc false
+  use TeiserverWeb, :schema
+
+  alias Teiserver.OAuth
+
+  @type t :: %__MODULE__{
+          value: String.t(),
+          owner: User.t(),
+          application: OAuth.Application.t(),
+          scopes: OAuth.Application.scopes(),
+          expires_at: DateTime.t()
+        }
+
+  schema "oauth_codes" do
+    field :value, :string
+    belongs_to :owner, Teiserver.Account.User, primary_key: true
+    belongs_to :application, OAuth.Application, primary_key: true
+    field :scopes, {:array, :string}
+    field :expires_at, :utc_datetime
+
+    timestamps()
+  end
+
+  def changeset(code, attrs) do
+    attrs = attrs |> uniq_lists(~w(scopes)a)
+
+    code
+    |> cast(attrs, [:value, :owner_id, :application_id, :scopes, :expires_at])
+    |> validate_required([:value, :owner_id, :application_id, :scopes, :expires_at])
+    |> Ecto.Changeset.validate_subset(:scopes, OAuth.Application.allowed_scopes())
+  end
+end

--- a/lib/teiserver/o_auth/schemas/code.ex
+++ b/lib/teiserver/o_auth/schemas/code.ex
@@ -10,7 +10,9 @@ defmodule Teiserver.OAuth.Code do
           application: OAuth.Application.t(),
           scopes: OAuth.Application.scopes(),
           expires_at: DateTime.t(),
-          redirect_uri: String.t() | nil
+          redirect_uri: String.t() | nil,
+          challenge: String.t() | nil,
+          challenge_method: :plain | :S256 | nil
         }
 
   schema "oauth_codes" do
@@ -20,6 +22,8 @@ defmodule Teiserver.OAuth.Code do
     field :scopes, {:array, :string}
     field :expires_at, :utc_datetime
     field :redirect_uri, :string
+    field :challenge, :string
+    field :challenge_method, Ecto.Enum, values: [:plain, :S256]
 
     timestamps()
   end
@@ -34,14 +38,18 @@ defmodule Teiserver.OAuth.Code do
       :application_id,
       :scopes,
       :expires_at,
-      :redirect_uri
+      :redirect_uri,
+      :challenge,
+      :challenge_method
     ])
     |> validate_required([
       :value,
       :owner_id,
       :application_id,
       :scopes,
-      :expires_at
+      :expires_at,
+      :challenge,
+      :challenge_method
     ])
     |> Ecto.Changeset.validate_subset(:scopes, OAuth.Application.allowed_scopes())
   end

--- a/lib/teiserver/o_auth/schemas/credential.ex
+++ b/lib/teiserver/o_auth/schemas/credential.ex
@@ -1,0 +1,27 @@
+defmodule Teiserver.OAuth.Credential do
+  @moduledoc false
+  use TeiserverWeb, :schema
+
+  alias Teiserver.OAuth
+
+  @type t :: %__MODULE__{
+          application: OAuth.Application.t(),
+          autohost: Teiserver.Autohost.Autohost.t(),
+          hashed_secret: binary()
+        }
+
+  schema "oauth_credentials" do
+    belongs_to :application, OAuth.Application
+    belongs_to :autohost, Teiserver.Autohost.Autohost, primary_key: true
+    field :client_id, :string
+    field :hashed_secret, :binary
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def changeset(credential, attrs) do
+    credential
+    |> cast(attrs, [:application_id, :autohost_id, :client_id, :hashed_secret])
+    |> validate_required([:client_id, :hashed_secret])
+  end
+end

--- a/lib/teiserver/o_auth/schemas/token.ex
+++ b/lib/teiserver/o_auth/schemas/token.ex
@@ -1,0 +1,38 @@
+defmodule Teiserver.OAuth.Token do
+  @moduledoc false
+  use TeiserverWeb, :schema
+
+  alias Teiserver.OAuth
+
+  @type t :: %__MODULE__{
+          value: String.t(),
+          owner: User.t(),
+          application: OAuth.Application.t(),
+          scopes: OAuth.Application.scopes(),
+          expires_at: DateTime.t(),
+          type: :access | :refresh,
+          refresh_token: t()
+        }
+
+  schema "oauth_tokens" do
+    field :value, :string
+    belongs_to :owner, Teiserver.Account.User, primary_key: true
+    belongs_to :application, OAuth.Application, primary_key: true
+    field :scopes, {:array, :string}
+    field :expires_at, :utc_datetime
+    field :type, Ecto.Enum, values: [:access, :refresh]
+    belongs_to :refresh_token, __MODULE__
+
+    timestamps()
+  end
+
+  def changeset(token, attrs) do
+    attrs = attrs |> uniq_lists(~w(scopes)a)
+
+    token
+    |> cast(attrs, [:value, :owner_id, :application_id, :scopes, :expires_at, :type])
+    |> cast_assoc(:refresh_token)
+    |> validate_required([:value, :owner_id, :application_id, :scopes, :expires_at, :type])
+    |> Ecto.Changeset.validate_subset(:scopes, OAuth.Application.allowed_scopes())
+  end
+end

--- a/lib/teiserver/o_auth/schemas/token.ex
+++ b/lib/teiserver/o_auth/schemas/token.ex
@@ -3,6 +3,7 @@ defmodule Teiserver.OAuth.Token do
   use TeiserverWeb, :schema
 
   alias Teiserver.OAuth
+  alias Teiserver.Account.User
 
   @type t :: %__MODULE__{
           value: String.t(),

--- a/lib/teiserver/o_auth/schemas/token.ex
+++ b/lib/teiserver/o_auth/schemas/token.ex
@@ -16,7 +16,7 @@ defmodule Teiserver.OAuth.Token do
 
   schema "oauth_tokens" do
     field :value, :string
-    belongs_to :owner, Teiserver.Account.User, primary_key: true
+    belongs_to :owner, Teiserver.Account.User
     belongs_to :application, OAuth.Application, primary_key: true
     field :scopes, {:array, :string}
     field :expires_at, :utc_datetime
@@ -32,7 +32,7 @@ defmodule Teiserver.OAuth.Token do
     token
     |> cast(attrs, [:value, :owner_id, :application_id, :scopes, :expires_at, :type])
     |> cast_assoc(:refresh_token)
-    |> validate_required([:value, :owner_id, :application_id, :scopes, :expires_at, :type])
+    |> validate_required([:value, :application_id, :scopes, :expires_at, :type])
     |> Ecto.Changeset.validate_subset(:scopes, OAuth.Application.allowed_scopes())
   end
 end

--- a/lib/teiserver/o_auth/schemas/token.ex
+++ b/lib/teiserver/o_auth/schemas/token.ex
@@ -12,7 +12,7 @@ defmodule Teiserver.OAuth.Token do
           scopes: OAuth.Application.scopes(),
           expires_at: DateTime.t(),
           type: :access | :refresh,
-          refresh_token: t()
+          refresh_token: t() | nil
         }
 
   schema "oauth_tokens" do

--- a/lib/teiserver/o_auth/schemas/token.ex
+++ b/lib/teiserver/o_auth/schemas/token.ex
@@ -22,6 +22,7 @@ defmodule Teiserver.OAuth.Token do
     field :expires_at, :utc_datetime
     field :type, Ecto.Enum, values: [:access, :refresh]
     belongs_to :refresh_token, __MODULE__
+    belongs_to :autohost, Teiserver.Autohost.Autohost
 
     timestamps()
   end
@@ -30,7 +31,7 @@ defmodule Teiserver.OAuth.Token do
     attrs = attrs |> uniq_lists(~w(scopes)a)
 
     token
-    |> cast(attrs, [:value, :owner_id, :application_id, :scopes, :expires_at, :type])
+    |> cast(attrs, [:value, :owner_id, :application_id, :scopes, :expires_at, :type, :autohost_id])
     |> cast_assoc(:refresh_token)
     |> validate_required([:value, :application_id, :scopes, :expires_at, :type])
     |> Ecto.Changeset.validate_subset(:scopes, OAuth.Application.allowed_scopes())

--- a/lib/teiserver_web/controllers/o_auth/authorize_controller.ex
+++ b/lib/teiserver_web/controllers/o_auth/authorize_controller.ex
@@ -89,7 +89,13 @@ defmodule TeiserverWeb.OAuth.AuthorizeController do
             query =
               URI.decode_query(redir_url.query || "")
               |> Map.put(:code, code.value)
-              |> Map.merge(Map.take(params, ["state"]))
+              |> then(fn query ->
+                # only include state if it was provided in the first place
+                case Map.get(params, "state", "") do
+                  "" -> query
+                  st -> Map.put(query, "state", st)
+                end
+              end)
               |> URI.encode_query()
 
             conn |> redirect(external: URI.to_string(%{redir_url | query: query}))

--- a/lib/teiserver_web/controllers/o_auth/authorize_controller.ex
+++ b/lib/teiserver_web/controllers/o_auth/authorize_controller.ex
@@ -1,0 +1,131 @@
+defmodule TeiserverWeb.OAuth.AuthorizeController do
+  use TeiserverWeb, :controller
+
+  alias Teiserver.OAuth
+
+  def authorize(conn, params) when not is_map_key(params, "client_id") do
+    bad_request(conn, "missing client_id")
+  end
+
+  def authorize(conn, %{"client_id" => client_id} = params) do
+    case OAuth.get_application_by_uid(client_id) do
+      nil ->
+        bad_request(conn, "invalid client_id")
+
+      app ->
+        case OAuth.get_redirect_uri(app, Map.get(conn.params, "redirect_uri")) do
+          {:error, _err} ->
+            bad_request(conn, "invalid redirection uri")
+
+          {:ok, redir_uri} ->
+            reject_uri =
+              error_redirect_uri(
+                conn,
+                redir_uri,
+                "access_denied",
+                "user refused to authorize application"
+              )
+
+            conn
+            |> render("authorize.html",
+              app_name: app.name,
+              params: params,
+              reject_uri: reject_uri
+            )
+        end
+    end
+  end
+
+  def authorize(conn, _params) do
+    conn |> render("bad_request.html")
+  end
+
+  def generate_code(conn, params) when not is_map_key(params, "client_id") do
+    bad_request(conn, "missing client_id")
+  end
+
+  def generate_code(conn, params) when not is_map_key(params, "redirect_uri") do
+    bad_request(conn, "missing redirect_uri")
+  end
+
+  def generate_code(conn, %{"client_id" => client_id, "redirect_uri" => redirect_uri} = params) do
+    case OAuth.get_application_by_uid(client_id) do
+      nil ->
+        bad_request(conn, "invalid client_id")
+
+      app ->
+        case OAuth.get_redirect_uri(app, redirect_uri) do
+          {:error, _} -> bad_request(conn, "invalid redirection url")
+          {:ok, redir_url} -> do_generate_code(conn, app, redir_url, params)
+        end
+    end
+  end
+
+  defp do_generate_code(conn, app, redir_url, params) do
+    cond do
+      Map.get(params, "response_type") != "code" ->
+        error_redirect(conn, redir_url, "unsupported_response_type", "only code is supported")
+
+      Map.get(params, "code_challenge_method") != "S256" ->
+        error_redirect(conn, redir_url, "invalid_request", "only S256 is supported")
+
+      Map.get(params, "code_challenge") == nil ->
+        error_redirect(conn, redir_url, "invalid_request", "a code challenge must be provided")
+
+      true ->
+        code_params = %{
+          id: app.id,
+          redirect_uri: URI.to_string(redir_url),
+          scopes: app.scopes,
+          challenge: Map.get(params, "code_challenge"),
+          challenge_method: "S256"
+        }
+
+        case OAuth.create_code(conn.assigns.current_user, code_params) do
+          {:error, _} ->
+            error_redirect(conn, redir_url, "server_error", "something went wrong")
+
+          {:ok, code} ->
+            query =
+              URI.decode_query(redir_url.query || "")
+              |> Map.put(:code, code.value)
+              |> Map.merge(Map.take(params, ["state"]))
+              |> URI.encode_query()
+
+            conn |> redirect(external: URI.to_string(%{redir_url | query: query}))
+        end
+    end
+  end
+
+  # If the server can validate the client id and the redirection url
+  # it should use the redirect url with an added query string to indicate failure
+  # otherwise notify the user of the error. See
+  # https://www.rfc-editor.org/rfc/rfc6749.html#section-4.1.2.1
+  defp bad_request(conn, reason) do
+    conn
+    |> put_status(400)
+    |> render("bad_request.html", reason: reason)
+  end
+
+  defp error_redirect_uri(conn, %URI{} = redir_url, error, description) do
+    final_query =
+      URI.decode_query(redir_url.query || "")
+      |> Map.put(:error, error)
+      |> Map.put(:error_description, description)
+      |> then(fn q ->
+        case Map.get(conn.params, "state") do
+          nil -> q
+          st -> Map.put(q, :state, st)
+        end
+      end)
+      |> URI.encode_query()
+
+    URI.to_string(%{redir_url | query: final_query})
+  end
+
+  defp error_redirect(conn, redir_url, error, description) do
+    uri = error_redirect_uri(conn, redir_url, error, description)
+
+    conn |> redirect(external: uri)
+  end
+end

--- a/lib/teiserver_web/controllers/o_auth/authorize_controller.ex
+++ b/lib/teiserver_web/controllers/o_auth/authorize_controller.ex
@@ -14,8 +14,8 @@ defmodule TeiserverWeb.OAuth.AuthorizeController do
 
       app ->
         case OAuth.get_redirect_uri(app, Map.get(conn.params, "redirect_uri")) do
-          {:error, _err} ->
-            bad_request(conn, "invalid redirection uri")
+          {:error, err} ->
+            bad_request(conn, "invalid redirection uri: #{inspect(err)}")
 
           {:ok, redir_uri} ->
             reject_uri =

--- a/lib/teiserver_web/controllers/o_auth/code_controller.ex
+++ b/lib/teiserver_web/controllers/o_auth/code_controller.ex
@@ -1,0 +1,39 @@
+defmodule TeiserverWeb.OAuth.CodeController do
+  use TeiserverWeb, :controller
+  alias Teiserver.OAuth
+
+  # https://www.rfc-editor.org/rfc/rfc6749.html#section-4.1.3
+  @spec exchange_code(Conn.t(), %{}) :: Conn.t()
+
+  def exchange_code(conn, %{"grant_type" => grant_type})
+      when grant_type != "authorization_code" do
+    conn
+    |> put_status(400)
+    |> render(:error, error_description: "grant_type must be authorization_code")
+  end
+
+  def exchange_code(conn, params) do
+    case Enum.find(
+           ["client_id", "code", "redirect_uri", "client_id", "code_verifier", "grant_type"],
+           fn key -> not Map.has_key?(params, key) end
+         ) do
+      nil ->
+        do_exchange_token(conn, params)
+
+      missing_key ->
+        conn |> put_status(400) |> render(:error, error_description: "missing #{missing_key}")
+    end
+  end
+
+  defp do_exchange_token(conn, params) do
+    with app when app != nil <- OAuth.get_application_by_uid(params["client_id"]),
+         {:ok, code} <- OAuth.get_valid_code(params["code"]),
+         true <- code.application_id == app.id,
+         {:ok, token} <-
+           OAuth.exchange_code(code, params["code_verifier"], params["redirect_uri"]) do
+      conn |> put_status(200) |> render(:token, token: token)
+    else
+      _ -> conn |> put_status(400) |> render(:error, error_description: "invalid request")
+    end
+  end
+end

--- a/lib/teiserver_web/controllers/o_auth/code_controller.ex
+++ b/lib/teiserver_web/controllers/o_auth/code_controller.ex
@@ -7,7 +7,7 @@ defmodule TeiserverWeb.OAuth.CodeController do
 
   def token(conn, %{"grant_type" => "authorization_code"} = params) do
     case Enum.find(
-           ["client_id", "code", "redirect_uri", "client_id", "code_verifier", "grant_type"],
+           ["client_id", "code", "redirect_uri", "code_verifier", "grant_type"],
            fn key -> not Map.has_key?(params, key) end
          ) do
       nil ->

--- a/lib/teiserver_web/controllers/o_auth/code_controller.ex
+++ b/lib/teiserver_web/controllers/o_auth/code_controller.ex
@@ -79,4 +79,8 @@ defmodule TeiserverWeb.OAuth.CodeController do
       _ -> conn |> put_status(400) |> render(:error, error_description: "invalid request")
     end
   end
+
+  def metadata(conn, _params) do
+    conn |> put_status(200) |> render(:metadata)
+  end
 end

--- a/lib/teiserver_web/controllers/o_auth/code_controller.ex
+++ b/lib/teiserver_web/controllers/o_auth/code_controller.ex
@@ -3,7 +3,7 @@ defmodule TeiserverWeb.OAuth.CodeController do
   alias Teiserver.OAuth
 
   # https://www.rfc-editor.org/rfc/rfc6749.html#section-4.1.3
-  @spec token(Conn.t(), %{}) :: Conn.t()
+  @spec token(Plug.Conn.t(), %{}) :: Plug.Conn.t()
 
   def token(conn, %{"grant_type" => "authorization_code"} = params) do
     case Enum.find(

--- a/lib/teiserver_web/router.ex
+++ b/lib/teiserver_web/router.ex
@@ -588,6 +588,12 @@ defmodule TeiserverWeb.Router do
     end
   end
 
+  scope "/oauth/", TeiserverWeb.OAuth do
+    pipe_through([:browser, :app_layout, :protected])
+    get("/authorize", AuthorizeController, :authorize)
+    post("/authorize", AuthorizeController, :generate_code)
+  end
+
   scope "/admin", TeiserverWeb.Admin do
     pipe_through([:live_browser, :protected])
 

--- a/lib/teiserver_web/router.ex
+++ b/lib/teiserver_web/router.ex
@@ -598,7 +598,7 @@ defmodule TeiserverWeb.Router do
   # but I'd rather have all of the oauth stuff contained
   scope "/oauth/", TeiserverWeb.OAuth do
     pipe_through(:api)
-    post("/token", CodeController, :exchange_code)
+    post("/token", CodeController, :token)
   end
 
   scope "/admin", TeiserverWeb.Admin do

--- a/lib/teiserver_web/router.ex
+++ b/lib/teiserver_web/router.ex
@@ -601,6 +601,12 @@ defmodule TeiserverWeb.Router do
     post("/token", CodeController, :token)
   end
 
+  scope "/", TeiserverWeb.OAuth do
+    pipe_through(:api)
+    # https://datatracker.ietf.org/doc/html/rfc8414
+    get("/.well-known/oauth-authorization-server", CodeController, :metadata)
+  end
+
   scope "/admin", TeiserverWeb.Admin do
     pipe_through([:live_browser, :protected])
 

--- a/lib/teiserver_web/router.ex
+++ b/lib/teiserver_web/router.ex
@@ -594,6 +594,13 @@ defmodule TeiserverWeb.Router do
     post("/authorize", AuthorizeController, :generate_code)
   end
 
+  # it's slightly weird to mix html and json api endpoints under the same prefix
+  # but I'd rather have all of the oauth stuff contained
+  scope "/oauth/", TeiserverWeb.OAuth do
+    pipe_through(:api)
+    post("/token", CodeController, :exchange_code)
+  end
+
   scope "/admin", TeiserverWeb.Admin do
     pipe_through([:live_browser, :protected])
 

--- a/lib/teiserver_web/templates/o_auth/authorize/authorize.html.heex
+++ b/lib/teiserver_web/templates/o_auth/authorize/authorize.html.heex
@@ -1,0 +1,37 @@
+<div class="row" style="padding-top: 15vh;">
+  <div class="col-sm-12 col-md-10 offset-md-1 col-lg-8 offset-lg-2 col-xl-6 offset-xl-3 col-xxl-4 offset-xxl-4">
+    <div class="card mb-3">
+      <div class="card-header">
+        <h3>
+          <img
+            src={Routes.static_path(@conn, "/images/logo/logo_favicon.png")}
+            height="42"
+            style="margin-right: 5px;"
+            class="d-inline align-top"
+          /> Authorize
+        </h3>
+      </div>
+
+      <div class="card-body">
+        <p>
+          The application <b><%= @app_name %></b> would like to have access to
+          your Beyond All Reason account.
+        </p>
+
+        <% keys_to_copy =
+          ~w(client_id response_type code_challenge code_challenge_method redirect_uri state) %>
+        <form action={~p"/oauth/authorize"} method="post">
+          <input type="hidden" name="_csrf_token" value={get_csrf_token()} />
+          <%= for key <- keys_to_copy do %>
+            <input type="hidden" name={key} value={@params[key]} />
+          <% end %>
+          <button type="submit" class="btn btn-primary btn-block">Let's go!</button>
+        </form>
+        <br />
+        <a href={@reject_uri}>
+          <button class="btn btn-danger btn-block">Nope!</button>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/lib/teiserver_web/templates/o_auth/authorize/bad_request.html.heex
+++ b/lib/teiserver_web/templates/o_auth/authorize/bad_request.html.heex
@@ -1,0 +1,16 @@
+<div class="row" style="padding-top: 15vh;">
+  <div class="col-sm-12 col-md-10 offset-md-1 col-lg-8 offset-lg-2 col-xl-6 offset-xl-3 col-xxl-4 offset-xxl-4">
+    <div class="card mb-3">
+      <div class="card-header">
+        <h3>
+          <img
+            src={Routes.static_path(@conn, "/images/logo/logo_favicon.png")}
+            height="42"
+            style="margin-right: 5px;"
+            class="d-inline align-top"
+          /> Bad request: <%= @reason %>
+        </h3>
+      </div>
+    </div>
+  </div>
+</div>

--- a/lib/teiserver_web/views/api/o_auth/code_view.ex
+++ b/lib/teiserver_web/views/api/o_auth/code_view.ex
@@ -23,7 +23,7 @@ defmodule TeiserverWeb.OAuth.CodeView do
       issuer: base,
       authorization_endpoint: base <> ~p"/oauth/authorize",
       token_endpoint: base <> ~p"/oauth/token",
-      token_endpoint_auth_methods_supported: ["none", "client_secret_post"],
+      token_endpoint_auth_methods_supported: ["none", "client_secret_post", "client_secret_basic"],
       grant_types_supported: [
         "authorization_code",
         "refresh_token",

--- a/lib/teiserver_web/views/api/o_auth/code_view.ex
+++ b/lib/teiserver_web/views/api/o_auth/code_view.ex
@@ -1,4 +1,6 @@
 defmodule TeiserverWeb.OAuth.CodeView do
+  use TeiserverWeb, :view
+
   def token(%{token: token}) do
     expires_in = DateTime.diff(token.expires_at, DateTime.utc_now(), :second)
 
@@ -12,5 +14,22 @@ defmodule TeiserverWeb.OAuth.CodeView do
 
   def error(conn) do
     Map.take(conn, [:error_description]) |> Map.put("error", "invalid_request")
+  end
+
+  def metadata(_) do
+    base = Application.fetch_env!(:teiserver, Teiserver.OAuth)[:issuer]
+
+    %{
+      issuer: base,
+      authorization_endpoint: base <> ~p"/oauth/authorize",
+      token_endpoint: base <> ~p"/oauth/token",
+      token_endpoint_auth_methods_supported: ["none", "client_secret_post"],
+      grant_types_supported: [
+        "authorization_code",
+        "refresh_token",
+        "client_credentials"
+      ],
+      code_challenge_methods_supported: ["S256"]
+    }
   end
 end

--- a/lib/teiserver_web/views/api/o_auth/code_view.ex
+++ b/lib/teiserver_web/views/api/o_auth/code_view.ex
@@ -7,9 +7,14 @@ defmodule TeiserverWeb.OAuth.CodeView do
     %{
       access_token: token.value,
       expires_in: expires_in,
-      refresh_token: token.refresh_token.value,
       token_type: "Bearer"
     }
+    |> then(fn res ->
+      case Map.get(token, :refresh_token) do
+        nil -> res
+        refresh_token -> Map.put(res, :refresh_token, refresh_token.value)
+      end
+    end)
   end
 
   def error(conn) do

--- a/lib/teiserver_web/views/api/o_auth/code_view.ex
+++ b/lib/teiserver_web/views/api/o_auth/code_view.ex
@@ -1,0 +1,16 @@
+defmodule TeiserverWeb.OAuth.CodeView do
+  def token(%{token: token}) do
+    expires_in = DateTime.diff(token.expires_at, DateTime.utc_now(), :second)
+
+    %{
+      access_token: token.value,
+      expires_in: expires_in,
+      refresh_token: token.refresh_token.value,
+      token_type: "Bearer"
+    }
+  end
+
+  def error(conn) do
+    Map.take(conn, [:error_description]) |> Map.put("error", "invalid_request")
+  end
+end

--- a/lib/teiserver_web/views/o_auth/authorize_view.ex
+++ b/lib/teiserver_web/views/o_auth/authorize_view.ex
@@ -1,0 +1,3 @@
+defmodule TeiserverWeb.OAuth.AuthorizeView do
+  use TeiserverWeb, :view
+end

--- a/priv/repo/migrations/20240607052027_autohost_setup.exs
+++ b/priv/repo/migrations/20240607052027_autohost_setup.exs
@@ -1,0 +1,15 @@
+defmodule Teiserver.Repo.Migrations.AutohostSetup do
+  use Ecto.Migration
+
+  # This migration is really more a placeholder for the "new" autohost table
+  # used in tachyon. It'll be extended later as we implement tachyon and
+  # figure out what's required here.
+  # For now, only the basics so that we can bind oauth client secrets creds
+  # to the correct table from the start
+  def change do
+    create_if_not_exists table(:teiserver_autohosts) do
+      add :name, :string, comment: "short name to identify the host"
+      timestamps(type: :utc_datetime)
+    end
+  end
+end

--- a/priv/repo/migrations/20240608144340_oauth_setup.exs
+++ b/priv/repo/migrations/20240608144340_oauth_setup.exs
@@ -1,0 +1,17 @@
+defmodule Teiserver.Repo.Migrations.OauthSetup do
+  use Ecto.Migration
+
+  def change do
+    create_if_not_exists table(:oauth_applications) do
+      add :name, :string, null: false, comment: "display name"
+      add :owner_id, references(:account_users, on_delete: :delete_all)
+      add :uid, :string, null: false, comment: "aka client_id"
+      add :scopes, {:array, :string}, null: false
+      add :redirect_uris, {:array, :string}, null: false, default: []
+      add :description, :text
+
+      timestamps(type: :utc_datetime)
+    end
+    create_if_not_exists unique_index(:oauth_applications, [:uid])
+  end
+end

--- a/priv/repo/migrations/20240608144340_oauth_setup.exs
+++ b/priv/repo/migrations/20240608144340_oauth_setup.exs
@@ -19,6 +19,7 @@ defmodule Teiserver.Repo.Migrations.OauthSetup do
       add :application_id, references(:oauth_applications, on_delete: :delete_all), null: false
       add :scopes, {:array, :string}, null: false
       add :expires_at, :utc_datetime, null: false
+      add :redirect_uri, :string
 
       timestamps(type: :utc_datetime)
     end

--- a/priv/repo/migrations/20240608144340_oauth_setup.exs
+++ b/priv/repo/migrations/20240608144340_oauth_setup.exs
@@ -25,6 +25,7 @@ defmodule Teiserver.Repo.Migrations.OauthSetup do
 
       timestamps(type: :utc_datetime)
     end
+
     create_if_not_exists unique_index(:oauth_codes, [:value])
 
     create_if_not_exists table(:oauth_tokens, comment: "auth tokens and refresh") do
@@ -39,7 +40,18 @@ defmodule Teiserver.Repo.Migrations.OauthSetup do
 
       timestamps(type: :utc_datetime)
     end
+
     create_if_not_exists unique_index(:oauth_tokens, [:value])
 
+    create_if_not_exists table(:oauth_credentials, comment: "for client_credentials flow") do
+      add :application_id, references(:oauth_applications, on_delete: :delete_all), null: false
+      add :autohost_id, references(:teiserver_autohosts, on_delete: :delete_all), null: false
+      add :client_id, :string, null: false
+      add :hashed_secret, :binary, null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create_if_not_exists unique_index(:oauth_credentials, [:client_id])
   end
 end

--- a/priv/repo/migrations/20240608144340_oauth_setup.exs
+++ b/priv/repo/migrations/20240608144340_oauth_setup.exs
@@ -12,6 +12,17 @@ defmodule Teiserver.Repo.Migrations.OauthSetup do
 
       timestamps(type: :utc_datetime)
     end
-    create_if_not_exists unique_index(:oauth_applications, [:uid])
+
+    create_if_not_exists table(:oauth_codes, comment: "authorisation codes") do
+      add :value, :string, null: false
+      add :owner_id, references(:account_users, on_delete: :delete_all), null: false
+      add :application_id, references(:oauth_applications, on_delete: :delete_all), null: false
+      add :scopes, {:array, :string}, null: false
+      add :expires_at, :utc_datetime, null: false
+
+      timestamps(type: :utc_datetime)
+    end
+    create_if_not_exists unique_index(:oauth_codes, [:value])
+
   end
 end

--- a/priv/repo/migrations/20240608144340_oauth_setup.exs
+++ b/priv/repo/migrations/20240608144340_oauth_setup.exs
@@ -24,5 +24,19 @@ defmodule Teiserver.Repo.Migrations.OauthSetup do
     end
     create_if_not_exists unique_index(:oauth_codes, [:value])
 
+    create_if_not_exists table(:oauth_tokens, comment: "auth tokens and refresh") do
+      add :value, :string, null: false
+      add :owner_id, references(:account_users, on_delete: :delete_all), null: false
+      add :application_id, references(:oauth_applications, on_delete: :delete_all), null: false
+      add :scopes, {:array, :string}, null: false
+      add :expires_at, :utc_datetime, null: false
+      add :type, :string, null: false
+      # we should create a new refresh token when deleting an auth token and vice versa
+      add :refresh_token_id, references(:oauth_tokens)
+
+      timestamps(type: :utc_datetime)
+    end
+    create_if_not_exists unique_index(:oauth_tokens, [:value])
+
   end
 end

--- a/priv/repo/migrations/20240608144340_oauth_setup.exs
+++ b/priv/repo/migrations/20240608144340_oauth_setup.exs
@@ -20,6 +20,8 @@ defmodule Teiserver.Repo.Migrations.OauthSetup do
       add :scopes, {:array, :string}, null: false
       add :expires_at, :utc_datetime, null: false
       add :redirect_uri, :string
+      add :challenge, :string
+      add :challenge_method, :string
 
       timestamps(type: :utc_datetime)
     end

--- a/priv/repo/migrations/20240608144340_oauth_setup.exs
+++ b/priv/repo/migrations/20240608144340_oauth_setup.exs
@@ -13,6 +13,8 @@ defmodule Teiserver.Repo.Migrations.OauthSetup do
       timestamps(type: :utc_datetime)
     end
 
+    create_if_not_exists unique_index(:oauth_applications, [:uid])
+
     create_if_not_exists table(:oauth_codes, comment: "authorisation codes") do
       add :value, :string, null: false
       add :owner_id, references(:account_users, on_delete: :delete_all), null: false

--- a/test/support/o_auth.ex
+++ b/test/support/o_auth.ex
@@ -18,10 +18,12 @@ defmodule Teiserver.Test.Support.OAuth do
   def create_code(user, app, opts \\ []) do
     {verifier, challenge, method} = generate_challenge()
 
+    redir_uri = Map.get(app, :redirect_uri, "http://some.host/a/path")
+
     attrs = %{
       id: app.id,
       scopes: app.scopes,
-      redirect_uri: "http://some.host/a/path",
+      redirect_uri: redir_uri,
       challenge: challenge,
       challenge_method: method
     }
@@ -33,7 +35,12 @@ defmodule Teiserver.Test.Support.OAuth do
   defp generate_challenge() do
     # A-Z,a-z,0-9 and -._~ are authorized, but can't be bothered to cover all
     # of that. hex encoding will fit
-    verifier = Base.hex_encode32(:crypto.strong_rand_bytes(40), padding: false)
+    # hardcoded random bytes generated with :crypto.strong_rand_bytes(32)
+    bytes =
+      <<30, 33, 141, 180, 13, 27, 42, 190, 106, 230, 111, 140, 162, 230, 128, 110, 149, 65, 33,
+        124, 129, 9, 89, 93, 94, 248, 46, 34, 116, 186, 8, 24>>
+
+    verifier = Base.hex_encode32(bytes, padding: false)
 
     challenge = hash_verifier(verifier)
 

--- a/test/support/o_auth.ex
+++ b/test/support/o_auth.ex
@@ -1,0 +1,45 @@
+defmodule Teiserver.Test.Support.OAuth do
+  alias Teiserver.OAuth
+
+  @doc """
+  utility to create an OAuth authorization code for the given user and application
+  """
+  @spec create_code(
+          Teiserver.Account.User.t(),
+          %{
+            id: integer(),
+            scopes: OAuth.Application.scopes(),
+            redirect_uri: String.t(),
+            challenge: String.t(),
+            challenge_method: String.t()
+          },
+          OAuth.options()
+        ) :: {:ok, OAuth.Code.t(), map()}
+  def create_code(user, app, opts \\ []) do
+    {verifier, challenge, method} = generate_challenge()
+
+    attrs = %{
+      id: app.id,
+      scopes: app.scopes,
+      redirect_uri: "http://some.host/a/path",
+      challenge: challenge,
+      challenge_method: method
+    }
+
+    {:ok, code} = OAuth.create_code(user, attrs, opts)
+    {:ok, code, Map.put(attrs, :verifier, verifier)}
+  end
+
+  defp generate_challenge() do
+    # A-Z,a-z,0-9 and -._~ are authorized, but can't be bothered to cover all
+    # of that. hex encoding will fit
+    verifier = Base.hex_encode32(:crypto.strong_rand_bytes(40), padding: false)
+
+    challenge = hash_verifier(verifier)
+
+    {verifier, challenge, "S256"}
+  end
+
+  def hash_verifier(verifier),
+    do: Base.url_encode64(:crypto.hash(:sha256, verifier), padding: false)
+end

--- a/test/teiserver/autohost/autohost_test.exs
+++ b/test/teiserver/autohost/autohost_test.exs
@@ -1,0 +1,10 @@
+defmodule Teiserver.Autohost.AutohostTest do
+  use Teiserver.DataCase, async: true
+  alias Teiserver.Autohost
+
+  test "can create autohost" do
+    {:ok, autohost} = Autohost.create_autohost(%{name: "autohost_test"})
+    assert autohost != nil
+    assert Autohost.get_autohost(autohost.id) == autohost
+  end
+end

--- a/test/teiserver/o_auth/application_test.exs
+++ b/test/teiserver/o_auth/application_test.exs
@@ -1,0 +1,51 @@
+defmodule Teiserver.OAuth.ApplicationTest do
+  use Teiserver.DataCase, async: true
+  alias Teiserver.OAuth
+
+  test "reject unknown scopes at creation" do
+    user = Teiserver.TeiserverTestLib.new_user()
+
+    assert {:error, changeset} = 
+             OAuth.create_application(%{
+               name: "Testing app",
+               uid: "test_app_uid",
+               owner_id: user.id,
+               scopes: ["lol"]
+             })
+    assert Keyword.fetch!(changeset.errors, :scopes)
+  end
+
+  test "can retrieve an app by uid" do
+    user = Teiserver.TeiserverTestLib.new_user()
+
+    assert {:ok, expected_app} =
+             OAuth.create_application(%{
+               name: "Testing app",
+               uid: "test_app_uid",
+               owner_id: user.id,
+               scopes: ["tachyon.lobby"]
+             })
+
+    assert expected_app == OAuth.get_application_by_uid("test_app_uid")
+  end
+
+  test "delete app" do
+    user = Teiserver.TeiserverTestLib.new_user()
+
+    assert {:ok, expected_app} =
+             OAuth.create_application(%{
+               name: "Testing app",
+               uid: "test_app_uid",
+               owner_id: user.id,
+               scopes: ["tachyon.lobby"]
+             })
+
+    assert :ok = OAuth.delete_application(expected_app)
+    assert OAuth.get_application_by_uid(expected_app.uid) == nil
+  end
+
+  test "non existant uid returns nil" do
+    assert OAuth.get_application_by_uid("u_wot_mate?") == nil
+    assert OAuth.get_application_by_uid(nil) == nil
+  end
+end

--- a/test/teiserver/o_auth/application_test.exs
+++ b/test/teiserver/o_auth/application_test.exs
@@ -5,13 +5,14 @@ defmodule Teiserver.OAuth.ApplicationTest do
   test "reject unknown scopes at creation" do
     user = Teiserver.TeiserverTestLib.new_user()
 
-    assert {:error, changeset} = 
+    assert {:error, changeset} =
              OAuth.create_application(%{
                name: "Testing app",
                uid: "test_app_uid",
                owner_id: user.id,
                scopes: ["lol"]
              })
+
     assert Keyword.fetch!(changeset.errors, :scopes)
   end
 
@@ -47,5 +48,87 @@ defmodule Teiserver.OAuth.ApplicationTest do
   test "non existant uid returns nil" do
     assert OAuth.get_application_by_uid("u_wot_mate?") == nil
     assert OAuth.get_application_by_uid(nil) == nil
+  end
+
+  defp valid_attrs(user) do
+    %{
+      name: "Testing app",
+      uid: "test_app_uid",
+      owner_id: user.id,
+      scopes: ["tachyon.lobby"]
+    }
+  end
+
+  test "get redirect uri" do
+    user = Teiserver.TeiserverTestLib.new_user()
+
+    {:ok, app} =
+      OAuth.create_application(
+        Map.put(valid_attrs(user), :redirect_uris, ["http://foo.bar/callback/path"])
+      )
+
+    assert {:ok, uri} = OAuth.get_redirect_uri(app, "http://foo.bar/callback/path?state=xyz")
+    # ensure query string is preserved
+    assert URI.to_string(uri) == "http://foo.bar/callback/path?state=xyz"
+  end
+
+  test "redirect uri validation" do
+    user = Teiserver.TeiserverTestLib.new_user()
+
+    {:ok, app} =
+      OAuth.create_application(
+        Map.put(valid_attrs(user), :redirect_uris, ["http://foo.bar/callback/path"])
+      )
+
+    # fragments aren't allowed
+    assert {:error, _} = OAuth.get_redirect_uri(app, "http://foo.bar/callback/path#fragment")
+
+    assert {:error, _} = OAuth.get_redirect_uri(app, "http://another.host/callback/path")
+    assert {:error, _} = OAuth.get_redirect_uri(app, "http://foo.bar/different/path")
+  end
+
+  test "validate the various ways to handle localhost" do
+    user = Teiserver.TeiserverTestLib.new_user()
+
+    {:ok, app} =
+      OAuth.create_application(
+        Map.put(valid_attrs(user), :redirect_uris, ["http://localhost/callback/path"])
+      )
+
+    assert {:ok, _} = OAuth.get_redirect_uri(app, "http://localhost/callback/path")
+    assert {:ok, _} = OAuth.get_redirect_uri(app, "http://localhost:7689/callback/path")
+    assert {:ok, _} = OAuth.get_redirect_uri(app, "http://127.0.0.1/callback/path")
+    assert {:ok, _} = OAuth.get_redirect_uri(app, "http://127.0.0.1:7689/callback/path")
+    assert {:ok, _} = OAuth.get_redirect_uri(app, "http://[::1]/callback/path")
+    assert {:ok, _} = OAuth.get_redirect_uri(app, "http://[::1]:7689/callback/path")
+    assert {:ok, _} = OAuth.get_redirect_uri(app, "http://[0:0:0:0:0:0:0:1]/callback/path")
+    assert {:ok, _} = OAuth.get_redirect_uri(app, "http://[0:0:0:0:0:0:0:1]:7689/callback/path")
+  end
+
+  test "ignore ports for localhost only" do
+    user = Teiserver.TeiserverTestLib.new_user()
+
+    uri = URI.parse("http://some.host:7890/callback/path")
+
+    {:ok, app} =
+      OAuth.create_application(Map.put(valid_attrs(user), :redirect_uris, [URI.to_string(uri)]))
+
+    assert {:error, _} = OAuth.get_redirect_uri(app, "http://some.host:1234/callback/path")
+    assert {:ok, _} = OAuth.get_redirect_uri(app, "http://some.host:7890/callback/path")
+  end
+
+  test "can validate against multiple registered uris" do
+    user = Teiserver.TeiserverTestLib.new_user()
+
+    {:ok, app} =
+      OAuth.create_application(
+        Map.put(valid_attrs(user), :redirect_uris, [
+          "http://some.host/callback",
+          "http://another.host/another/callback"
+        ])
+      )
+
+    assert {:ok, _} = OAuth.get_redirect_uri(app, "http://some.host/callback")
+    assert {:ok, _} = OAuth.get_redirect_uri(app, "http://another.host/another/callback")
   end
 end

--- a/test/teiserver/o_auth/code_test.exs
+++ b/test/teiserver/o_auth/code_test.exs
@@ -16,36 +16,78 @@ defmodule Teiserver.OAuth.CodeTest do
     {:ok, user: user, app: app}
   end
 
+  defp generate_challenge(method \\ :S256) do
+    # A-Z,a-z,0-9 and -._~ are authorized, but can't be bothered to cover all
+    # of that. hex encoding will fit
+    verifier = Base.hex_encode32(:crypto.strong_rand_bytes(40), padding: false)
+
+    challenge =
+      case method do
+        :plain -> verifier
+        :S256 -> hash_verifier(verifier)
+      end
+
+    {verifier, challenge, method}
+  end
+
+  defp hash_verifier(verifier),
+    do: Base.url_encode64(:crypto.hash(:sha256, verifier), padding: false)
+
+  defp create_code(user, app, opts \\ []) do
+    {verifier, challenge, method} = generate_challenge()
+
+    attrs = %{
+      id: app.id,
+      scopes: app.scopes,
+      redirect_uri: "http://some.host/a/path",
+      challenge: challenge,
+      challenge_method: method
+    }
+
+    {:ok, code} = OAuth.create_code(user, attrs, opts)
+    {:ok, code, Map.put(attrs, :verifier, verifier)}
+  end
+
   test "can get valid code", %{user: user, app: app} do
-    assert {:ok, code} = OAuth.create_code(user, app)
+    assert {:ok, code, _} = create_code(user, app)
     assert {:ok, ^code} = OAuth.get_valid_code(code.value)
     assert {:error, :no_code} = OAuth.get_valid_code(nil)
   end
 
   test "cannot retrieve expired code", %{user: user, app: app} do
     yesterday = Timex.shift(Timex.now(), days: -1)
-    assert {:ok, code} = OAuth.create_code(user, app, %{}, now: yesterday)
+    assert {:ok, code, _} = create_code(user, app, now: yesterday)
     assert {:error, :expired} = OAuth.get_valid_code(code.value)
   end
 
   test "can exchange valid code for token", %{user: user, app: app} do
-    assert {:ok, code} = OAuth.create_code(user, app)
-    assert {:ok, token} = OAuth.exchange_code(code)
+    assert {:ok, code, attrs} = create_code(user, app)
+    assert {:ok, token} = OAuth.exchange_code(code, attrs.verifier, attrs.redirect_uri)
     assert token.scopes == code.scopes
     assert token.owner_id == user.id
     # the code is now consumed and not available anymore
     assert {:error, :no_code} = OAuth.get_valid_code(code.value)
   end
 
-  test "redirect uri must be provided and match", %{user: user, app: app} do
-    assert {:ok, code} = OAuth.create_code(user, app, %{redirect_uri: "http://127.0.0.1/foo"})
-    assert {:error, :redirect_uri_mismatch} = OAuth.exchange_code(code)
-    assert {:error, :redirect_uri_mismatch} = OAuth.exchange_code(code, "http://another.url/")
-  end
-
   test "cannot exchange expired code for token", %{user: user, app: app} do
     yesterday = Timex.shift(Timex.now(), days: -1)
-    assert {:ok, code} = OAuth.create_code(user, app, %{}, now: yesterday)
-    assert {:error, :expired} = OAuth.exchange_code(code)
+    assert {:ok, code, attrs} = create_code(user, app, now: yesterday)
+    assert {:error, :expired} = OAuth.exchange_code(code, attrs.verifier)
+  end
+
+  test "must use valid verifier", %{user: user, app: app} do
+    assert {:ok, code, attrs} = create_code(user, app)
+    no_match = Base.hex_encode32(:crypto.strong_rand_bytes(38), padding: false)
+    assert {:error, _} = OAuth.exchange_code(code, no_match)
+
+    verifier = "TOO_SHORT"
+    challenge = hash_verifier(verifier)
+    {:ok, code} = OAuth.create_code(user, %{attrs | challenge: challenge})
+    assert {:error, _} = OAuth.exchange_code(code, verifier)
+
+    verifier = String.duplicate("a", 129)
+    challenge = hash_verifier(verifier)
+    {:ok, code} = OAuth.create_code(user, %{attrs | challenge: challenge})
+    assert {:error, _} = OAuth.exchange_code(code, verifier)
   end
 end

--- a/test/teiserver/o_auth/code_test.exs
+++ b/test/teiserver/o_auth/code_test.exs
@@ -11,7 +11,8 @@ defmodule Teiserver.OAuth.CodeTest do
         name: "Testing app",
         uid: "test_app_uid",
         owner_id: user.id,
-        scopes: ["tachyon.lobby"]
+        scopes: ["tachyon.lobby"],
+        redirect_uri: ["http://localhost/callback"]
       })
 
     {:ok, user: user, app: app}
@@ -41,22 +42,34 @@ defmodule Teiserver.OAuth.CodeTest do
   test "cannot exchange expired code for token", %{user: user, app: app} do
     yesterday = Timex.shift(Timex.now(), days: -1)
     assert {:ok, code, attrs} = OAuthTest.create_code(user, app, now: yesterday)
-    assert {:error, :expired} = OAuth.exchange_code(code, attrs.verifier)
+    assert {:error, :expired} = OAuth.exchange_code(code, attrs.verifier, attrs.redirect_uri)
   end
 
   test "must use valid verifier", %{user: user, app: app} do
     assert {:ok, code, attrs} = OAuthTest.create_code(user, app)
-    no_match = Base.hex_encode32(:crypto.strong_rand_bytes(38), padding: false)
-    assert {:error, _} = OAuth.exchange_code(code, no_match)
 
+    no_match =
+      "lollollollollollollollollollollollollollollollollollollollollollollollollollollollollollollollollollollollollollollollollollol"
+
+    assert {:error, err} = OAuth.exchange_code(code, no_match, attrs.redirect_uri)
+    assert err =~ "doesn't match"
+  end
+
+  test "verifier cannot be too short", %{user: user, app: app} do
+    assert {:ok, _code, attrs} = OAuthTest.create_code(user, app)
     verifier = "TOO_SHORT"
     challenge = OAuthTest.hash_verifier(verifier)
     {:ok, code} = OAuth.create_code(user, %{attrs | challenge: challenge})
-    assert {:error, _} = OAuth.exchange_code(code, verifier)
+    assert {:error, err} = OAuth.exchange_code(code, verifier, attrs.redirect_uri)
+    assert err =~ "cannot be less than"
+  end
 
+  test "verifier cannot be too long", %{user: user, app: app} do
+    assert {:ok, _code, attrs} = OAuthTest.create_code(user, app)
     verifier = String.duplicate("a", 129)
     challenge = OAuthTest.hash_verifier(verifier)
     {:ok, code} = OAuth.create_code(user, %{attrs | challenge: challenge})
-    assert {:error, _} = OAuth.exchange_code(code, verifier)
+    assert {:error, err} = OAuth.exchange_code(code, verifier, attrs.redirect_uri)
+    assert err =~ "cannot be more than"
   end
 end

--- a/test/teiserver/o_auth/code_test.exs
+++ b/test/teiserver/o_auth/code_test.exs
@@ -1,0 +1,30 @@
+defmodule Teiserver.OAuth.CodeTest do
+  use Teiserver.DataCase, async: true
+  alias Teiserver.OAuth
+
+  setup do
+    user = Teiserver.TeiserverTestLib.new_user()
+
+    {:ok, app} =
+      OAuth.create_application(%{
+        name: "Testing app",
+        uid: "test_app_uid",
+        owner_id: user.id,
+        scopes: ["tachyon.lobby"]
+      })
+
+    {:ok, user: user, app: app}
+  end
+
+  test "can get valid code", %{user: user, app: app} do
+    assert {:ok, code} = OAuth.create_code(user, app)
+    assert {:ok, ^code} = OAuth.get_valid_code(code.value)
+    assert {:error, :no_code} = OAuth.get_valid_code(nil)
+  end
+
+  test "cannot retrieve expired code", %{user: user, app: app} do
+    yesterday = Timex.shift(Timex.now(), days: -1)
+    assert {:ok, code} = OAuth.create_code(user, app, now: yesterday)
+    assert {:error, :expired} = OAuth.get_valid_code(code.value)
+  end
+end

--- a/test/teiserver/o_auth/code_test.exs
+++ b/test/teiserver/o_auth/code_test.exs
@@ -24,7 +24,28 @@ defmodule Teiserver.OAuth.CodeTest do
 
   test "cannot retrieve expired code", %{user: user, app: app} do
     yesterday = Timex.shift(Timex.now(), days: -1)
-    assert {:ok, code} = OAuth.create_code(user, app, now: yesterday)
+    assert {:ok, code} = OAuth.create_code(user, app, %{}, now: yesterday)
     assert {:error, :expired} = OAuth.get_valid_code(code.value)
+  end
+
+  test "can exchange valid code for token", %{user: user, app: app} do
+    assert {:ok, code} = OAuth.create_code(user, app)
+    assert {:ok, token} = OAuth.exchange_code(code)
+    assert token.scopes == code.scopes
+    assert token.owner_id == user.id
+    # the code is now consumed and not available anymore
+    assert {:error, :no_code} = OAuth.get_valid_code(code.value)
+  end
+
+  test "redirect uri must be provided and match", %{user: user, app: app} do
+    assert {:ok, code} = OAuth.create_code(user, app, %{redirect_uri: "http://127.0.0.1/foo"})
+    assert {:error, :redirect_uri_mismatch} = OAuth.exchange_code(code)
+    assert {:error, :redirect_uri_mismatch} = OAuth.exchange_code(code, "http://another.url/")
+  end
+
+  test "cannot exchange expired code for token", %{user: user, app: app} do
+    yesterday = Timex.shift(Timex.now(), days: -1)
+    assert {:ok, code} = OAuth.create_code(user, app, %{}, now: yesterday)
+    assert {:error, :expired} = OAuth.exchange_code(code)
   end
 end

--- a/test/teiserver/o_auth/code_test.exs
+++ b/test/teiserver/o_auth/code_test.exs
@@ -1,6 +1,7 @@
 defmodule Teiserver.OAuth.CodeTest do
   use Teiserver.DataCase, async: true
   alias Teiserver.OAuth
+  alias Teiserver.Test.Support.OAuth, as: OAuthTest
 
   setup do
     user = Teiserver.TeiserverTestLib.new_user()
@@ -16,52 +17,20 @@ defmodule Teiserver.OAuth.CodeTest do
     {:ok, user: user, app: app}
   end
 
-  defp generate_challenge(method \\ :S256) do
-    # A-Z,a-z,0-9 and -._~ are authorized, but can't be bothered to cover all
-    # of that. hex encoding will fit
-    verifier = Base.hex_encode32(:crypto.strong_rand_bytes(40), padding: false)
-
-    challenge =
-      case method do
-        :plain -> verifier
-        :S256 -> hash_verifier(verifier)
-      end
-
-    {verifier, challenge, method}
-  end
-
-  defp hash_verifier(verifier),
-    do: Base.url_encode64(:crypto.hash(:sha256, verifier), padding: false)
-
-  defp create_code(user, app, opts \\ []) do
-    {verifier, challenge, method} = generate_challenge()
-
-    attrs = %{
-      id: app.id,
-      scopes: app.scopes,
-      redirect_uri: "http://some.host/a/path",
-      challenge: challenge,
-      challenge_method: method
-    }
-
-    {:ok, code} = OAuth.create_code(user, attrs, opts)
-    {:ok, code, Map.put(attrs, :verifier, verifier)}
-  end
-
   test "can get valid code", %{user: user, app: app} do
-    assert {:ok, code, _} = create_code(user, app)
+    assert {:ok, code, _} = OAuthTest.create_code(user, app)
     assert {:ok, ^code} = OAuth.get_valid_code(code.value)
     assert {:error, :no_code} = OAuth.get_valid_code(nil)
   end
 
   test "cannot retrieve expired code", %{user: user, app: app} do
     yesterday = Timex.shift(Timex.now(), days: -1)
-    assert {:ok, code, _} = create_code(user, app, now: yesterday)
+    assert {:ok, code, _} = OAuthTest.create_code(user, app, now: yesterday)
     assert {:error, :expired} = OAuth.get_valid_code(code.value)
   end
 
   test "can exchange valid code for token", %{user: user, app: app} do
-    assert {:ok, code, attrs} = create_code(user, app)
+    assert {:ok, code, attrs} = OAuthTest.create_code(user, app)
     assert {:ok, token} = OAuth.exchange_code(code, attrs.verifier, attrs.redirect_uri)
     assert token.scopes == code.scopes
     assert token.owner_id == user.id
@@ -71,22 +40,22 @@ defmodule Teiserver.OAuth.CodeTest do
 
   test "cannot exchange expired code for token", %{user: user, app: app} do
     yesterday = Timex.shift(Timex.now(), days: -1)
-    assert {:ok, code, attrs} = create_code(user, app, now: yesterday)
+    assert {:ok, code, attrs} = OAuthTest.create_code(user, app, now: yesterday)
     assert {:error, :expired} = OAuth.exchange_code(code, attrs.verifier)
   end
 
   test "must use valid verifier", %{user: user, app: app} do
-    assert {:ok, code, attrs} = create_code(user, app)
+    assert {:ok, code, attrs} = OAuthTest.create_code(user, app)
     no_match = Base.hex_encode32(:crypto.strong_rand_bytes(38), padding: false)
     assert {:error, _} = OAuth.exchange_code(code, no_match)
 
     verifier = "TOO_SHORT"
-    challenge = hash_verifier(verifier)
+    challenge = OAuthTest.hash_verifier(verifier)
     {:ok, code} = OAuth.create_code(user, %{attrs | challenge: challenge})
     assert {:error, _} = OAuth.exchange_code(code, verifier)
 
     verifier = String.duplicate("a", 129)
-    challenge = hash_verifier(verifier)
+    challenge = OAuthTest.hash_verifier(verifier)
     {:ok, code} = OAuth.create_code(user, %{attrs | challenge: challenge})
     assert {:error, _} = OAuth.exchange_code(code, verifier)
   end

--- a/test/teiserver/o_auth/credential_test.exs
+++ b/test/teiserver/o_auth/credential_test.exs
@@ -33,4 +33,14 @@ defmodule Teiserver.OAuth.CredentialTest do
     # sanity check to make sure we're not storing cleartext password
     refute cred.hashed_secret =~ "very-secret"
   end
+
+  test "can get a token from credentials", %{app: app, autohost: autohost} do
+    assert {:ok, created_cred} =
+             OAuth.create_credentials(app, autohost, "some-client-id", "very-secret")
+
+    assert {:ok, token} = OAuth.get_token_from_credentials(created_cred)
+    assert token.application_id == app.id
+    assert token.owner_id == nil
+    assert token.autohost_id == autohost.id
+  end
 end

--- a/test/teiserver/o_auth/credential_test.exs
+++ b/test/teiserver/o_auth/credential_test.exs
@@ -1,0 +1,36 @@
+defmodule Teiserver.OAuth.CredentialTest do
+  use Teiserver.DataCase, async: true
+  alias Teiserver.{OAuth, Autohost}
+
+  defp setup_autohost(_context) do
+    {:ok, autohost} = Autohost.create_autohost(%{name: "testing_autohost"})
+    %{autohost: autohost}
+  end
+
+  defp setup_app(_context) do
+    user = Teiserver.TeiserverTestLib.new_user()
+
+    {:ok, app} =
+      OAuth.create_application(%{
+        name: "Testing app",
+        uid: "test_app_uid",
+        owner_id: user.id,
+        scopes: ["tachyon.lobby"]
+      })
+
+    %{user: user, app: app}
+  end
+
+  setup [:setup_autohost, :setup_app]
+
+  test "can create and retrieve credentials", %{app: app, autohost: autohost} do
+    assert {:ok, created_cred} =
+             OAuth.create_credentials(app, autohost, "some-client-id", "very-secret")
+
+    assert {:ok, cred} = OAuth.get_valid_credentials("some-client-id", "very-secret")
+    assert created_cred.id == cred.id
+    assert cred.application.uid == app.uid
+    # sanity check to make sure we're not storing cleartext password
+    refute cred.hashed_secret =~ "very-secret"
+  end
+end

--- a/test/teiserver/o_auth/token_test.exs
+++ b/test/teiserver/o_auth/token_test.exs
@@ -1,0 +1,57 @@
+defmodule Teiserver.OAuth.TokenTest do
+  use Teiserver.DataCase, async: true
+  alias Teiserver.OAuth
+
+  setup do
+    user = Teiserver.TeiserverTestLib.new_user()
+
+    {:ok, app} =
+      OAuth.create_application(%{
+        name: "Testing app",
+        uid: "test_app_uid",
+        owner_id: user.id,
+        scopes: ["tachyon.lobby"]
+      })
+
+    {:ok, user: user, app: app}
+  end
+
+  test "can create a token directly", %{user: user, app: app} do
+    assert {:ok, token} = OAuth.create_token(user, app)
+    assert token.type == :access
+    assert token.refresh_token.type == :refresh
+    assert token.scopes == app.scopes
+  end
+
+  test "can get valid token", %{user: user, app: app} do
+    assert {:ok, new_token} = OAuth.create_token(user, app)
+    assert {:ok, token} = OAuth.get_valid_token(new_token.value)
+    assert {:error, :no_token} = OAuth.get_valid_token(nil)
+    assert token.id == new_token.id
+    assert Ecto.assoc_loaded?(token.application)
+  end
+
+  test "cannot get expired token", %{user: user, app: app} do
+    yesterday = Timex.shift(Timex.now(), days: -1)
+    assert {:ok, token} = OAuth.create_token(user, app, now: yesterday)
+    assert {:error, :expired} = OAuth.get_valid_token(token.value)
+  end
+
+  test "cannot use bearer token as refresh token", %{user: user, app: app} do
+    assert {:ok, token} = OAuth.create_token(user, app)
+    assert {:error, :invalid_token} = OAuth.refresh_token(token)
+  end
+
+  test "can refresh a token", %{user: user, app: app} do
+    assert {:ok, token} = OAuth.create_token(user, app)
+    assert {:ok, new_token} = OAuth.refresh_token(token.refresh_token)
+
+    # the previous token and its refresh token should have been invalidated
+    assert {:error, :no_token} = OAuth.get_valid_token(token.value)
+    assert {:error, :no_token} = OAuth.get_valid_token(token.refresh_token.value)
+
+    # the newly created token is valid
+    assert {:ok, new_token_fresh} = OAuth.get_valid_token(new_token.value)
+    assert new_token_fresh.id == new_token.id
+  end
+end

--- a/test/teiserver/o_auth/token_test.exs
+++ b/test/teiserver/o_auth/token_test.exs
@@ -38,6 +38,12 @@ defmodule Teiserver.OAuth.TokenTest do
     assert token.scopes == app.scopes
   end
 
+  test "can create a token without refresh token", %{user: user, app: app} do
+    assert {:ok, token} = OAuth.create_token(user, app, create_refresh: false)
+    assert token.type == :access
+    assert token.refresh_token == nil
+  end
+
   test "can get valid token", %{user: user, app: app} do
     assert {:ok, new_token} = OAuth.create_token(user, app)
     assert {:ok, token} = OAuth.get_valid_token(new_token.value)

--- a/test/teiserver_web/controllers/o_auth/authorize_controller_test.exs
+++ b/test/teiserver_web/controllers/o_auth/authorize_controller_test.exs
@@ -61,6 +61,25 @@ defmodule TeiserverWeb.OAuth.AuthorizeControllerTest do
       assert code.redirect_uri == data.redirect_uri
     end
 
+    test "only include state in redirection if provided", %{conn: conn, app: app} do
+      data = %{
+        client_id: app.uid,
+        response_type: "code",
+        code_challenge: "blah",
+        code_challenge_method: "S256",
+        state: "",
+        redirect_uri: hd(app.redirect_uris)
+        # no state
+      }
+
+      resp = post(conn, ~p"/oauth/authorize", data)
+
+      assert redired = redirected_to(resp, 302)
+      parsed = URI.parse(redired)
+      query = URI.decode_query(parsed.query)
+      refute Map.has_key?(query, "state")
+    end
+
     test "must provide client_id and redirect_uri", %{conn: conn, app: app} do
       data = %{
         client_id: app.uid,

--- a/test/teiserver_web/controllers/o_auth/authorize_controller_test.exs
+++ b/test/teiserver_web/controllers/o_auth/authorize_controller_test.exs
@@ -1,0 +1,106 @@
+defmodule TeiserverWeb.OAuth.AuthorizeControllerTest do
+  use TeiserverWeb.ConnCase
+  alias Central.Helpers.GeneralTestLib
+  alias Teiserver.OAuth
+
+  setup do
+    {:ok, data} =
+      GeneralTestLib.conn_setup(Teiserver.TeiserverTestLib.player_permissions())
+      |> Teiserver.TeiserverTestLib.conn_setup()
+
+    {:ok, app} =
+      OAuth.create_application(%{
+        name: "testing app",
+        uid: "test_app_uid",
+        owner_id: data[:user].id,
+        scopes: ["tachyon.lobby"],
+        redirect_uris: ["http://127.0.0.1:6789/oauth/callback"]
+      })
+
+    {:ok, Keyword.put(data, :app, app)}
+  end
+
+  describe "authorize" do
+    test "must provide client_id", %{conn: conn} do
+      assert get(conn, ~p"/oauth/authorize").status == 400
+    end
+
+    test "must provide valid client_id", %{conn: conn} do
+      assert get(conn, ~p"/oauth/authorize?client_id=random_client").status == 400
+    end
+
+    test "get auth screen with valid client_id", %{conn: conn, app: app} do
+      redir_uri = "http://127.0.0.1/oauth/callback"
+      query = %{client_id: app.uid, redirect_uri: redir_uri}
+      resp = get(conn, ~p"/oauth/authorize?#{query}")
+      assert html_response(resp, 200) =~ app.name
+    end
+  end
+
+  describe "generate code" do
+    test "get redirected with a code", %{conn: conn, app: app} do
+      data = %{
+        client_id: app.uid,
+        response_type: "code",
+        code_challenge: "blah",
+        code_challenge_method: "S256",
+        redirect_uri: hd(app.redirect_uris),
+        state: "some random state"
+      }
+
+      resp = post(conn, ~p"/oauth/authorize", data)
+
+      assert redired = redirected_to(resp, 302)
+      parsed = URI.parse(redired)
+
+      assert URI.to_string(%{parsed | query: nil}) == hd(app.redirect_uris)
+      query = URI.decode_query(parsed.query)
+      assert query["code"] != nil
+      assert query["state"] == data[:state]
+      {:ok, code} = OAuth.get_valid_code(query["code"])
+      assert code.redirect_uri == data.redirect_uri
+    end
+
+    test "must provide client_id and redirect_uri", %{conn: conn, app: app} do
+      data = %{
+        client_id: app.uid,
+        response_type: "code",
+        code_challenge: "blah",
+        code_challenge_method: "S256",
+        redirect_uri: hd(app.redirect_uris),
+        state: "some random state"
+      }
+
+      resp = post(conn, ~p"/oauth/authorize", Map.drop(data, [:client_id]))
+      assert html_response(resp, 400) =~ "missing client_id"
+
+      resp = post(conn, ~p"/oauth/authorize", Map.drop(data, [:redirect_uri]))
+      assert html_response(resp, 400) =~ "missing redirect_uri"
+
+      resp = post(conn, ~p"/oauth/authorize", Map.drop(data, [:redirect_uri, :client_id]))
+      assert resp.status == 400
+
+      resp = post(conn, ~p"/oauth/authorize", %{data | client_id: "lolnope"})
+      assert html_response(resp, 400) =~ "invalid client_id"
+    end
+
+    test "redirected for invalid response type", %{conn: conn, app: app} do
+      data = %{
+        client_id: app.uid,
+        response_type: "lolnope",
+        code_challenge: "blah",
+        code_challenge_method: "S256",
+        redirect_uri: hd(app.redirect_uris),
+        state: "some random state"
+      }
+
+      resp = post(conn, ~p"/oauth/authorize", data)
+      assert redired = redirected_to(resp, 302)
+      parsed = URI.parse(redired).query
+      assert String.starts_with?(redired, data.redirect_uri)
+
+      assert %{"error" => "unsupported_response_type", "state" => "some random state"} =
+               URI.decode_query(parsed)
+    end
+  end
+end

--- a/test/teiserver_web/controllers/o_auth/code_controller_test.exs
+++ b/test/teiserver_web/controllers/o_auth/code_controller_test.exs
@@ -82,6 +82,22 @@ defmodule TeiserverWeb.OAuth.CodeControllerTest do
       assert description =~ "no authorization code"
     end
 
+    test "can use basic auth to exchange", %{conn: conn} = setup_data do
+      data = get_valid_data(setup_data)
+
+      client_id = data.client_id
+      data = Map.drop(data, [:client_id])
+      auth_header = Plug.BasicAuth.encode_basic_auth(client_id, "")
+
+      resp =
+        conn
+        |> put_req_header("authorization", auth_header)
+        |> post(~p"/oauth/token", data)
+
+      json_resp = json_response(resp, 200)
+      assert is_binary(json_resp["access_token"]), "has access_token"
+    end
+
     test "must provide grant_type", %{conn: conn} = setup_data do
       data = get_valid_data(setup_data) |> Map.drop([:grant_type])
       resp = post(conn, ~p"/oauth/token", data)

--- a/test/teiserver_web/controllers/o_auth/code_controller_test.exs
+++ b/test/teiserver_web/controllers/o_auth/code_controller_test.exs
@@ -299,6 +299,18 @@ defmodule TeiserverWeb.OAuth.CodeControllerTest do
       resp = post(conn, ~p"/oauth/token", data)
       assert %{"error" => "invalid_request"} = json_response(resp, 400)
     end
+
+    test "must provide valid scope", %{conn: conn} = setup_data do
+      data = %{
+        grant_type: "refresh_token",
+        client_id: setup_data[:app].uid,
+        refresh_token: setup_data[:token].refresh_token.value,
+        scope: "lolscope"
+      }
+
+      resp = post(conn, ~p"/oauth/token", data)
+      assert %{"error" => "invalid_request"} = json_response(resp, 400)
+    end
   end
 
   describe "medatata endpoint" do

--- a/test/teiserver_web/controllers/o_auth/code_controller_test.exs
+++ b/test/teiserver_web/controllers/o_auth/code_controller_test.exs
@@ -147,7 +147,7 @@ defmodule TeiserverWeb.OAuth.CodeControllerTest do
       json_resp = json_response(resp, 200)
       assert is_binary(json_resp["access_token"]), "has access_token"
       assert is_integer(json_resp["expires_in"]), "has expires_in"
-      assert is_binary(json_resp["refresh_token"]), "has refresh_token"
+      refute Map.has_key?(json_resp, "refresh_token"), "no refresh token"
       assert json_resp["token_type"] == "Bearer", "bearer token type"
     end
 
@@ -175,7 +175,7 @@ defmodule TeiserverWeb.OAuth.CodeControllerTest do
       json_resp = json_response(resp, 200)
       assert is_binary(json_resp["access_token"]), "has access_token"
       assert is_integer(json_resp["expires_in"]), "has expires_in"
-      assert is_binary(json_resp["refresh_token"]), "has refresh_token"
+      refute Map.has_key?(json_resp, "refresh_token"), "no refresh token"
       assert json_resp["token_type"] == "Bearer", "bearer token type"
     end
 

--- a/test/teiserver_web/controllers/o_auth/code_controller_test.exs
+++ b/test/teiserver_web/controllers/o_auth/code_controller_test.exs
@@ -74,10 +74,12 @@ defmodule TeiserverWeb.OAuth.CodeControllerTest do
       resp2 = post(conn, ~p"/oauth/token", data)
 
       # code is now used up and invalid
-      assert json_response(resp2, 400) == %{
-               "error_description" => "invalid request",
-               "error" => "invalid_request"
-             }
+      assert %{
+               "error" => "invalid_request",
+               "error_description" => description
+             } = json_response(resp2, 400)
+
+      assert description =~ "no authorization code"
     end
 
     test "must provide grant_type", %{conn: conn} = setup_data do
@@ -116,7 +118,11 @@ defmodule TeiserverWeb.OAuth.CodeControllerTest do
 
       data = get_valid_data(setup_data) |> Map.put(:client_id, other_app.uid)
       resp = post(conn, ~p"/oauth/token", data)
-      assert %{"error" => "invalid_request"} = json_response(resp, 400)
+
+      assert %{"error" => "invalid_request", "error_description" => description} =
+               json_response(resp, 400)
+
+      assert description =~ "code doesn't match application"
     end
 
     # Note: verifier code and redirect URI matching is tested in OAuth.exchange_code

--- a/test/teiserver_web/controllers/o_auth/code_controller_test.exs
+++ b/test/teiserver_web/controllers/o_auth/code_controller_test.exs
@@ -1,0 +1,108 @@
+defmodule TeiserverWeb.OAuth.CodeControllerTest do
+  use TeiserverWeb.ConnCase
+  alias Central.Helpers.GeneralTestLib
+  alias Teiserver.OAuth
+  alias Teiserver.Test.Support.OAuth, as: OAuthTest
+
+  defp get_valid_data(%{app: app, code: code, code_attrs: code_attrs}) do
+    %{
+      grant_type: "authorization_code",
+      code: code.value,
+      redirect_uri: code.redirect_uri,
+      client_id: app.uid,
+      code_verifier: code_attrs.verifier
+    }
+  end
+
+  defp setup_conn(_context) do
+    GeneralTestLib.conn_setup(Teiserver.TeiserverTestLib.player_permissions())
+    |> Teiserver.TeiserverTestLib.conn_setup()
+  end
+
+  defp setup_app(context) do
+    {:ok, app} =
+      OAuth.create_application(%{
+        name: "testing app",
+        uid: "test_app_uid",
+        owner_id: context[:user].id,
+        scopes: ["tachyon.lobby"],
+        redirect_uris: ["http://127.0.0.1:6789/oauth/callback"]
+      })
+
+    %{app: app}
+  end
+
+  defp setup_code(context) do
+    {:ok, code, attrs} = OAuthTest.create_code(context[:user], context[:app])
+
+    %{code: code, code_attrs: attrs}
+  end
+
+  describe "exchange code for token" do
+    setup [:setup_conn, :setup_app, :setup_code]
+
+    test "works with the right params", %{conn: conn} = setup_data do
+      data = get_valid_data(setup_data)
+
+      resp = post(conn, ~p"/oauth/token", data)
+      json_resp = json_response(resp, 200)
+      assert is_binary(json_resp["access_token"]), "has access_token"
+      assert is_integer(json_resp["expires_in"]), "has expires_in"
+      assert is_binary(json_resp["refresh_token"]), "has refresh_token"
+      assert json_resp["token_type"] == "Bearer", "bearer token type"
+
+      # within 5 seconds in case extremely slow test
+      assert_in_delta(json_resp["expires_in"], 60 * 30, 5, "valid for 30 minutes")
+
+      resp2 = post(conn, ~p"/oauth/token", data)
+
+      # code is now used up and invalid
+      assert json_response(resp2, 400) == %{
+               "error_description" => "invalid request",
+               "error" => "invalid_request"
+             }
+    end
+
+    test "must provide grant_type", %{conn: conn} = setup_data do
+      data = get_valid_data(setup_data) |> Map.drop([:grant_type])
+      resp = post(conn, ~p"/oauth/token", data)
+      assert %{"error" => "invalid_request"} = json_response(resp, 400)
+    end
+
+    test "must provide code", %{conn: conn} = setup_data do
+      data = get_valid_data(setup_data) |> Map.drop([:code])
+      resp = post(conn, ~p"/oauth/token", data)
+      assert %{"error" => "invalid_request"} = json_response(resp, 400)
+    end
+
+    test "must provide redirect_uri", %{conn: conn} = setup_data do
+      data = get_valid_data(setup_data) |> Map.drop([:redirect_uri])
+      resp = post(conn, ~p"/oauth/token", data)
+      assert %{"error" => "invalid_request"} = json_response(resp, 400)
+    end
+
+    test "must provide client_id", %{conn: conn} = setup_data do
+      data = get_valid_data(setup_data) |> Map.drop([:client_id])
+      resp = post(conn, ~p"/oauth/token", data)
+      assert %{"error" => "invalid_request"} = json_response(resp, 400)
+    end
+
+    test "client_id must match", %{conn: conn} = setup_data do
+      {:ok, other_app} =
+        OAuth.create_application(%{
+          name: "another testing app",
+          uid: "another_test_app_uid",
+          owner_id: setup_data[:user].id,
+          scopes: ["tachyon.lobby"],
+          redirect_uris: ["http://127.0.0.1:6789/oauth/callback"]
+        })
+
+      data = get_valid_data(setup_data) |> Map.put(:client_id, other_app.uid)
+      resp = post(conn, ~p"/oauth/token", data)
+      assert %{"error" => "invalid_request"} = json_response(resp, 400)
+    end
+
+    # Note: verifier code and redirect URI matching is tested in OAuth.exchange_code
+    # so they are omitted here
+  end
+end

--- a/test/teiserver_web/controllers/o_auth/code_controller_test.exs
+++ b/test/teiserver_web/controllers/o_auth/code_controller_test.exs
@@ -150,6 +150,7 @@ defmodule TeiserverWeb.OAuth.CodeControllerTest do
         client_id: credential.client_id,
         client_secret: "definitely-not-the-correct-secret"
       }
+
       resp = post(conn, ~p"/oauth/token", data)
       json_response(resp, 400)
     end
@@ -199,6 +200,27 @@ defmodule TeiserverWeb.OAuth.CodeControllerTest do
 
       resp = post(conn, ~p"/oauth/token", data)
       assert %{"error" => "invalid_request"} = json_response(resp, 400)
+    end
+  end
+
+  describe "medatata endpoint" do
+    setup :setup_conn
+
+    test "can query oauth metadata", %{conn: conn} do
+      resp = json_response(get(conn, ~p"/.well-known/oauth-authorization-server"), 200)
+
+      assert resp == %{
+               "issuer" => "https://beyondallreason.info",
+               "authorization_endpoint" => "https://beyondallreason.info/oauth/authorize",
+               "token_endpoint" => "https://beyondallreason.info/oauth/token",
+               "token_endpoint_auth_methods_supported" => ["none", "client_secret_post"],
+               "grant_types_supported" => [
+                 "authorization_code",
+                 "refresh_token",
+                 "client_credentials"
+               ],
+               "code_challenge_methods_supported" => ["S256"]
+             }
     end
   end
 end

--- a/test/teiserver_web/controllers/o_auth/code_controller_test.exs
+++ b/test/teiserver_web/controllers/o_auth/code_controller_test.exs
@@ -38,6 +38,11 @@ defmodule TeiserverWeb.OAuth.CodeControllerTest do
     %{code: code, code_attrs: attrs}
   end
 
+  defp setup_token(context) do
+    {:ok, token} = OAuth.create_token(context[:user], context[:app])
+    %{token: token}
+  end
+
   describe "exchange code for token" do
     setup [:setup_conn, :setup_app, :setup_code]
 
@@ -104,5 +109,52 @@ defmodule TeiserverWeb.OAuth.CodeControllerTest do
 
     # Note: verifier code and redirect URI matching is tested in OAuth.exchange_code
     # so they are omitted here
+  end
+
+  describe "refresh token" do
+    setup [:setup_conn, :setup_app, :setup_token]
+
+    test "works", %{conn: conn} = setup_data do
+      data = %{
+        grant_type: "refresh_token",
+        client_id: setup_data[:app].uid,
+        refresh_token: setup_data[:token].refresh_token.value
+      }
+
+      resp = post(conn, ~p"/oauth/token", data)
+      assert json_resp = json_response(resp, 200)
+      assert is_binary(json_resp["access_token"]), "has access_token"
+      assert is_integer(json_resp["expires_in"]), "has expires_in"
+      assert is_binary(json_resp["refresh_token"]), "has refresh_token"
+      assert json_resp["token_type"] == "Bearer", "bearer token type"
+
+      resp2 = post(conn, ~p"/oauth/token", data)
+
+      # refresh token is now used up and invalid
+      assert json_response(resp2, 400) == %{
+               "error_description" => "invalid request",
+               "error" => "invalid_request"
+             }
+    end
+
+    test "client_id must match", %{conn: conn} = setup_data do
+      {:ok, other_app} =
+        OAuth.create_application(%{
+          name: "another testing app",
+          uid: "another_test_app_uid",
+          owner_id: setup_data[:user].id,
+          scopes: ["tachyon.lobby"],
+          redirect_uris: ["http://127.0.0.1:6789/oauth/callback"]
+        })
+
+      data = %{
+        grant_type: "refresh_token",
+        client_id: other_app.uid,
+        refresh_token: setup_data[:token].refresh_token.value
+      }
+
+      resp = post(conn, ~p"/oauth/token", data)
+      assert %{"error" => "invalid_request"} = json_response(resp, 400)
+    end
   end
 end


### PR DESCRIPTION
This implements the two oauth flows required for running tachyon.

There's also at the time of writing, a demo server running at [https://tachyon.geekingfrog.com:4567/login](https://tachyon.geekingfrog.com:4567)

There's currently only one OAuth application registered, with the hardcoded scope `tachyon.lobby`, one redirect uri: `http://127.0.0.1/oauth2callback` and the client id is `generic_lobby`.

# The lobby flow
This is using the `authorization_code` flow.

## getting an authorization code
First, the client need to [generate a PKCE](https://www.rfc-editor.org/rfc/rfc7636#page-8) verifier and challenge.
For example:
```
challenge: "BGLMtLONQ_f6-Z6ikTk8ofWo-cWM3UUeT93LIEG33-M"
verifier: "2ENOENOGA0USUNPROMSUD9U64P604R2LVOVDG5SEL7EIGA5SL3TC2BQN0MJVVG8S"
```

Then, the client can request an authorization code with a `GET` request to the endpoint:

https://tachyon.geekingfrog.com:4567/oauth/authorize?response_type=code&code_challenge=BGLMtLONQ_f6-Z6ikTk8ofWo-cWM3UUeT93LIEG33-M&code_challenge_method=S256&client_id=generic_lobby&redirect_uri=http%3A%2F%2F127.0.0.1%2Foauth2callback

You get redirected to a login screen.
The demo server has one user with email/password: `tachyon@foo.bar` and password: `tachyonmelon`

You then should see a screen to grant access:

![2024-06-16-856x269-scrot](https://github.com/beyond-all-reason/teiserver/assets/1531763/7b045ea9-0115-48a2-8aad-790ca79d354f)

Clicking on "Let's go!" redirects to: `127.0.0.1/oauth2callback?code=<code>`

## exchanging the authorization code for an access token
You can then issue a `POST` request to

```
curl -iv https://tachyon.geekingfrog.com:4567/oauth/token \
--data-urlencode "grant_type=authorization_code" \
--data-urlencode "client_id=generic_lobby" \
--data-urlencode "code=60PKPAAVGIL8L6MCSVQK90V1GLORV22PQI6H13PIGQL21E0HFAF0====" \
--data-urlencode "code_verifier=2ENOENOGA0USUNPROMSUD9U64P604R2LVOVDG5SEL7EIGA5SL3TC2BQN0MJVVG8S" \
--data-urlencode "redirect_uri=http://localhost/oauth2callback"
```

and you get back
```json
{
  "access_token":"C45B3IG4CAHUDG1TAN03USAA55KDS2NA30VQIFLTN9FNMICPA2DG",
  "expires_in":1800,
  "refresh_token":"15IA4J2O0NCH08D6URPK6O3S38G3B7RFBFOPJVV20MNJNHJ11JIG",
  "token_type":"Bearer"
}
```

# the autohost flow

I configured one client_id/client_secret pair that can be used to retrieve an auth token:

```bash
curl -ivv "https://tachyon.geekingfrog.com:4567/oauth/token" \
--data-urlencode "grant_type=client_credentials" \
--data-urlencode "client_id=207966ee-6997-433f-a1fa-28da8f3b754e" \
--data-urlencode "client_secret=NENEGFN5MNNA6TH34P53JE88STHA5RCQJ06RKTG5HN92UMAOQ72G"
```

and this gives the same type of response.

# Testing
There are automated tests under 2 location, one for the context and one for the controllers:
```
mix test test/teiserver/o_auth/
mix test test/teiserver_web/controllers/o_auth
```

# Out of (OAuth) Scope for this PR

* Currently the only thing you can do with an auth token is refresh it. I'll implement the basic websocket connection later.
* Any CRUD operations or interface to manage applications and client credentials. For now, manually inserting things in the DB will have to do.
