### PR TITLE
Clear cache users between tests

### DIFF
--- a/lib/teiserver/libs/test_lib.ex
+++ b/lib/teiserver/libs/test_lib.ex
@@ -660,7 +660,12 @@ defmodule Teiserver.TeiserverTestLib do
       :telemetry_simple_client_event_types_cache,
       :telemetry_simple_lobby_event_types_cache,
       :telemetry_simple_match_event_types_cache,
-      :telemetry_simple_server_event_types_cache
+      :telemetry_simple_server_event_types_cache,
+      :users,
+      :users_lookup_id_with_discord,
+      :users_lookup_id_with_email,
+      :users_lookup_id_with_name,
+      :users_lookup_name_with_id
     ]
 
     Enum.each(cache_list, fn cache ->

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -37,6 +37,7 @@ defmodule Teiserver.DataCase do
 
   setup tags do
     setup_sandbox(tags)
+    on_exit(&Teiserver.TeiserverTestLib.clear_all_con_caches/0)
     :ok
   end
 

--- a/test/teiserver/caches_test.exs
+++ b/test/teiserver/caches_test.exs
@@ -1,0 +1,25 @@
+defmodule Teiserver.CachesTest do
+  use Teiserver.DataCase, async: false
+
+  # This module is merely here to check that
+  # Teiserver.TeiserverTestLib.clear_all_con_caches does indeed clear the advertised
+  # cache across tests.
+  # because all queries rely heavily on caches, it's important to clear them between
+  # tests so as not to pollute other tests
+
+  test "Clear user caches 1" do
+    name = "ClearDbEachTestUser"
+    assert is_nil(Teiserver.CacheUser.get_user_by_name(name))
+    user = Teiserver.TeiserverTestLib.new_user(name)
+    result = Teiserver.CacheUser.get_user_by_id(user.id)
+    assert result[:name] == name
+  end
+
+  test "Clear user caches 2" do
+    name = "ClearDbEachTestUser"
+    assert is_nil(Teiserver.CacheUser.get_user_by_name(name))
+    user = Teiserver.TeiserverTestLib.new_user(name)
+    result = Teiserver.CacheUser.get_user_by_id(user.id)
+    assert result[:name] == name
+  end
+end


### PR DESCRIPTION
This must be done for data cases as well as server cases. Because most of the querying logic rely under the hood on the caches, when someone creates a user, it won't be persisted to the DB after the test, but the cache will not be rolled back.