### PR TITLE
Add UI to assign tourney winner

### DIFF
--- a/lib/teiserver/account/libs/role_lib.ex
+++ b/lib/teiserver/account/libs/role_lib.ex
@@ -45,6 +45,12 @@ defmodule Teiserver.Account.RoleLib do
       icon: "fa-solid fa-check",
       contains: ~w()
     },
+    %{
+      name: "Tournament winner",
+      colour: "#AA8833",
+      icon: "fa-solid fa-trophy",
+      contains: ~w()
+    },
 
     # Community team
     %{
@@ -250,7 +256,7 @@ defmodule Teiserver.Account.RoleLib do
 
   @spec property_roles :: [String.t()]
   def property_roles() do
-    ["Trusted", "BAR+", "Verified", "Streamer"]
+    ["Trusted", "BAR+", "Verified", "Streamer", "Tournament winner"]
   end
 
   @spec allowed_role_management(String.t()) :: [String.t()]

--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -1311,6 +1311,7 @@ defmodule Teiserver.CacheUser do
     ingame_hours = rank_time(userid)
 
     cond do
+      has_any_role?(userid, ["Tournament winner"]) -> 7
       has_any_role?(userid, ~w(Core Contributor)) -> 6
       ingame_hours > 1000 -> 5
       ingame_hours > 250 -> 4


### PR DESCRIPTION
Currently many tourney winners don't get given their tourney rank icon. In the past Teifion was doing manual SQL queries to give people the tourney rank. This PR allows us to do it via the UI.

## Test Steps
1. Login as admin and edit a user. Assign them the role of "Tournament winner". Note this is different from Tournament. Tournament role is to give access to special lobbies.
2. Launch Chobby and login as the user you assigned as tournament winner. Inside a lobby, they should have the tourney winner rank icon.

![1](https://github.com/beyond-all-reason/teiserver/assets/1305569/b76e628b-8b15-4c89-b26e-99dc03711d66)
