### PR TITLE
More lobby tips

### DIFF
--- a/lib/teiserver/lobby/libs/lobby_restrictions.ex
+++ b/lib/teiserver/lobby/libs/lobby_restrictions.ex
@@ -199,17 +199,7 @@ defmodule Teiserver.Lobby.LobbyRestrictions do
   end
 
   defp get_tips(name) do
-    tips =
-      case is_noob_title?(name) do
-        true -> get_noob_looby_tips()
-        false -> []
-      end
-
-    tips =
-      case is_rotato_title?(name) do
-        true -> tips ++ get_rotato_tips()
-        false -> tips
-      end
+    tips = [] ++ get_noob_looby_tips(name) ++ get_rotato_tips(name)
 
     case length(tips) do
       0 -> nil
@@ -217,31 +207,43 @@ defmodule Teiserver.Lobby.LobbyRestrictions do
     end
   end
 
-  defp get_noob_looby_tips() do
-    [
-      @splitter,
-      "Useful commands for Noob lobbies",
-      @splitter,
-      "To restrict this lobby to players who are new, use either:",
-      "$maxchevlevel <chevlevel>",
-      "$maxratinglevel <rating>",
-      "",
-      "To ensure new players are distributed evenly across teams:",
-      "$balancemode split_one_chevs",
-      ""
-    ]
+  defp get_noob_looby_tips(lobby_title) do
+    case is_noob_title?(lobby_title) do
+      true ->
+        [
+          @splitter,
+          "Useful commands for Noob lobbies",
+          @splitter,
+          "To restrict this lobby to players who are new, use either:",
+          "$maxchevlevel <chevlevel>",
+          "$maxratinglevel <rating>",
+          "",
+          "To ensure new players are distributed evenly across teams:",
+          "$balancemode split_one_chevs",
+          ""
+        ]
+
+      false ->
+        []
+    end
   end
 
-  defp get_rotato_tips() do
-    [
-      # Temporary tips until this is part of Chobby UI
-      @splitter,
-      "Useful commands for map rotation",
-      @splitter,
-      "To turn on/off auto map rotation at end of each match:",
-      "!rotationEndGame <(random|off)>",
-      ""
-    ]
+  defp get_rotato_tips(lobby_title) do
+    case is_rotato_title?(lobby_title) do
+      true ->
+        [
+          # Temporary tips until this is part of Chobby UI
+          @splitter,
+          "Useful commands for map rotation",
+          @splitter,
+          "To turn on/off auto map rotation at end of each match:",
+          "!rotationEndGame <(random|off)>",
+          ""
+        ]
+
+      false ->
+        []
+    end
   end
 
   # Check if lobby has restrictions for playing
@@ -291,37 +293,16 @@ defmodule Teiserver.Lobby.LobbyRestrictions do
   """
   @spec is_noob_title?(String.t()) :: boolean()
   def is_noob_title?(title) do
-    title =
-      title
-      |> String.downcase()
+    anti_noob_regex = ~r/no (noob|newb|nub)/i
+    noob_regex = ~r/\b(noob|newb|nub(s|\b))/i
 
-    anti_noob_regex = ~r/no (noob|newb|nub)/
-    noob_regex = ~r/\b(noob|newb|nub(s|\b))/
-
-    noob_matches =
-      Regex.scan(noob_regex, title)
-      |> Enum.count()
-
-    anti_noob_matches =
-      Regex.scan(anti_noob_regex, title)
-      |> Enum.count()
-
-    # Returns true if both critera met
-    noob_matches > 0 && anti_noob_matches == 0
+    Regex.match?(noob_regex, title) && !Regex.match?(anti_noob_regex, title)
   end
 
   @spec is_rotato_title?(String.t()) :: boolean()
   def is_rotato_title?(title) do
-    title =
-      title
-      |> String.downcase()
+    regex = ~r/\b(rotat)/i
 
-    regex = ~r/\b(rotat)/
-
-    matches =
-      Regex.scan(regex, title)
-      |> Enum.count()
-
-    matches > 0
+    Regex.match?(regex, title)
   end
 end

--- a/lib/teiserver/lobby/libs/lobby_restrictions.ex
+++ b/lib/teiserver/lobby/libs/lobby_restrictions.ex
@@ -215,11 +215,11 @@ defmodule Teiserver.Lobby.LobbyRestrictions do
           "Useful commands for Noob lobbies",
           @splitter,
           "To restrict this lobby to players who are new, use either:",
-          "$maxchevlevel <chevlevel>",
-          "$maxratinglevel <rating>",
+          "!maxchevlevel <chevlevel>",
+          "!maxratinglevel <rating>",
           "",
           "To ensure new players are distributed evenly across teams:",
-          "$balancemode split_one_chevs",
+          "!balancealgorithm split_one_chevs",
           ""
         ]
 

--- a/lib/teiserver/lobby/libs/lobby_restrictions.ex
+++ b/lib/teiserver/lobby/libs/lobby_restrictions.ex
@@ -9,7 +9,7 @@ defmodule Teiserver.Lobby.LobbyRestrictions do
 
   @rank_upper_bound 1000
   @rating_upper_bound 1000
-  @splitter "---------------------------"
+  @splitter "------------------------------------------------------"
   @spec rank_upper_bound() :: number
   def rank_upper_bound, do: @rank_upper_bound
   def rating_upper_bound, do: @rating_upper_bound
@@ -193,23 +193,54 @@ defmodule Teiserver.Lobby.LobbyRestrictions do
         {:error,
          "* You cannot declare a lobby to be all welcome if there are player restrictions"}
 
-      is_noob_title?(name) ->
-        {:ok, get_noob_looby_tips()}
-
       true ->
-        {:ok, nil}
+        {:ok, get_tips(name)}
+    end
+  end
+
+  defp get_tips(name) do
+    tips =
+      case is_noob_title?(name) do
+        true -> get_noob_looby_tips()
+        false -> []
+      end
+
+    tips =
+      case is_rotato_title?(name) do
+        true -> tips ++ get_rotato_tips()
+        false -> tips
+      end
+
+    case length(tips) do
+      0 -> nil
+      _ -> tips
     end
   end
 
   defp get_noob_looby_tips() do
     [
       @splitter,
-      "Noob lobby tips",
+      "Useful commands for Noob lobbies",
       @splitter,
-      "To restrict this lobby to players who are new, use command:",
+      "To restrict this lobby to players who are new, use either:",
       "$maxchevlevel <chevlevel>",
-      "To ensure new players are distributed evenly across teams, use command:",
-      "$balancemode split_one_chevs"
+      "$maxratinglevel <rating>",
+      "",
+      "To ensure new players are distributed evenly across teams:",
+      "$balancemode split_one_chevs",
+      ""
+    ]
+  end
+
+  defp get_rotato_tips() do
+    [
+      # Temporary tips until this is part of Chobby UI
+      @splitter,
+      "Useful commands for map rotation",
+      @splitter,
+      "To turn on/off auto map rotation at end of each match:",
+      "!rotationEndGame <(random|off)>",
+      ""
     ]
   end
 
@@ -277,5 +308,20 @@ defmodule Teiserver.Lobby.LobbyRestrictions do
 
     # Returns true if both critera met
     noob_matches > 0 && anti_noob_matches == 0
+  end
+
+  @spec is_rotato_title?(String.t()) :: boolean()
+  def is_rotato_title?(title) do
+    title =
+      title
+      |> String.downcase()
+
+    regex = ~r/\b(rotat)/
+
+    matches =
+      Regex.scan(regex, title)
+      |> Enum.count()
+
+    matches > 0
   end
 end


### PR DESCRIPTION
## Purpose
Add more lobby tips that will trigger on certain lobby titles. In the future these tips can be removed if we can incorporate it as part of Chobby UI.

![Screenshot 2024-07-10 180216](https://github.com/beyond-all-reason/teiserver/assets/1305569/ace9e866-5b4d-4f7a-8e9c-8a49261d3279)

## Test Steps
In a new lobby boss yourself then rename the lobby to contain noob or rotato (or both) e.g.
```
$rename Noob Rotato
```
Or 
```
$rename Noob
$rename Rotato
```
