### PR TITLE
Allow Tester role to use $balancemode in unbossed lobby

### DIFF
--- a/lib/teiserver/coordinator/consul_server.ex
+++ b/lib/teiserver/coordinator/consul_server.ex
@@ -27,6 +27,8 @@ defmodule Teiserver.Coordinator.ConsulServer do
 
   @always_allow ~w(status s y n follow joinq leaveq splitlobby afks roll players password? newlobby jazlobby tournament)
   @boss_commands ~w(balancemode gatekeeper welcome-message meme reset-approval rename minchevlevel maxchevlevel resetchevlevels resetratinglevels minratinglevel maxratinglevel setratinglevels)
+  # A tester can use these commands when there is no boss
+  @tester_commands ~w(balancemode)
   @vip_boss_commands ~w(shuffle)
   @host_commands ~w(specunready makeready settag speclock forceplay lobbyban lobbybanmult unban forcespec forceplay lock unlock makebalance)
 
@@ -1013,6 +1015,7 @@ defmodule Teiserver.Coordinator.ConsulServer do
     is_host = senderid == state.host_id
     is_boss = Enum.member?(state.host_bosses, senderid)
     is_vip = Enum.member?(user.roles, "VIP")
+    is_tester = Enum.member?(user.roles, "Tester")
 
     cond do
       client == nil ->
@@ -1031,6 +1034,9 @@ defmodule Teiserver.Coordinator.ConsulServer do
         true
 
       Enum.member?(@boss_commands, cmd.command) and (is_host or is_boss) ->
+        true
+
+      Enum.member?(@tester_commands, cmd.command) and length(state.host_bosses) == 0 and is_tester ->
         true
 
       Enum.member?(@vip_boss_commands, cmd.command) and (is_vip and is_boss) ->


### PR DESCRIPTION
## Context
In discussions with Sun_Tzu, they mentioned it was difficult to test a new balance algorithm as it requires boss and getting people to vote you boss is nearly impossible. https://discord.com/channels/549281623154229250/1245516077547389009/1260223439067811980

As a short term solution, and to enable us to test balance algorithm this PR will enable someone with Tester role to use `$balancemode` without being boss. However, they can only do this in a non-bossed lobby. It will automatically succeed and not trigger a vote

## Test Steps
1. Launch Lobby and run `$balancemode split_one_chevs`. It should fail
2. Change this user to have Tester role. Login to Chobby again and retry the command. It should succeed.
3. Add another user to the lobby and make that user boss. Try the command again and it should fail.

## Results
![1](https://github.com/beyond-all-reason/teiserver/assets/1305569/fdff5f78-9d6a-4980-82be-079c7ce3bdc7)
![2](https://github.com/beyond-all-reason/teiserver/assets/1305569/2339c460-a06d-4894-bdb3-f9a6626760b0)
