### PR TITLE
Blog Helper + Permission improvements + Toggle contributor icon

### DIFF
--- a/lib/teiserver/account.ex
+++ b/lib/teiserver/account.ex
@@ -2152,4 +2152,17 @@ defmodule Teiserver.Account do
 
   @spec call_party(T.party_id(), any) :: any | nil
   defdelegate call_party(party_id, msg), to: PartyLib
+
+  @spec hide_contributor_rank?(T.userid()) :: boolean()
+  def hide_contributor_rank?(userid) do
+    stats_data = get_user_stat_data(userid)
+    Map.get(stats_data, "hide_contributor_rank", false)
+  end
+
+  @spec set_hide_contributor_rank(T.userid(), boolean()) :: any()
+  def set_hide_contributor_rank(userid, boolean_value) do
+    update_user_stat(userid, %{
+      "hide_contributor_rank" => boolean_value
+    })
+  end
 end

--- a/lib/teiserver/account/libs/role_lib.ex
+++ b/lib/teiserver/account/libs/role_lib.ex
@@ -81,6 +81,13 @@ defmodule Teiserver.Account.RoleLib do
       contains: ["Community team"],
       badge: true
     },
+    %{
+      name: "Blog helper",
+      colour: "#66AA66",
+      icon: "fa-solid fa-blog",
+      contains: [],
+      badge: true
+    },
 
     # Privileged
     %{name: "VIP", colour: "#AA8833", icon: "fa-solid fa-sparkles", contains: ["BAR+"]},
@@ -97,10 +104,17 @@ defmodule Teiserver.Account.RoleLib do
 
     # Contributor/Staff
     %{
+      name: "Tester",
+      colour: "#00AAAA",
+      icon: "fa-solid fa-vial",
+      contains: ~w(),
+      badge: true
+    },
+    %{
       name: "Contributor",
       colour: "#66AA66",
       icon: "fa-solid fa-code-commit",
-      contains: ["Trusted", "BAR+"],
+      contains: ["Trusted", "BAR+", "Tester", "Blog helper"],
       badge: true
     },
     %{name: "Engine", colour: "#007700", icon: "fa-solid fa-engine", contains: ~w(Contributor)},
@@ -123,13 +137,6 @@ defmodule Teiserver.Account.RoleLib do
       colour: "#007700",
       icon: "fa-solid fa-download",
       contains: ~w(Contributor)
-    },
-    %{
-      name: "Tester",
-      colour: "#00AAAA",
-      icon: "fa-solid fa-vial",
-      contains: ~w(Contributor),
-      badge: true
     },
     %{
       name: "Core",
@@ -246,7 +253,7 @@ defmodule Teiserver.Account.RoleLib do
 
   @spec community_roles :: [String.t()]
   def community_roles() do
-    ["Mentor", "Academy manager", "Promo team", "Community team"]
+    ["Mentor", "Academy manager", "Promo team", "Community team", "Blog helper"]
   end
 
   @spec privileged_roles :: [String.t()]

--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -1316,7 +1316,7 @@ defmodule Teiserver.CacheUser do
     # https://www.beyondallreason.info/guide/rating-and-lobby-balance#rank-icons
     cond do
       has_any_role?(userid, ["Tournament winner"]) -> 7
-      has_any_role?(userid, ~w(Core Contributor)) -> 6
+      has_any_role?(userid, ~w(Core Contributor)) and !Account.hide_contributor_rank?(userid) -> 6
       ingame_hours >= 1000 -> 5
       ingame_hours >= 250 -> 4
       ingame_hours >= 100 -> 3

--- a/lib/teiserver_web/live/account/profile/contributor.html.heex
+++ b/lib/teiserver_web/live/account/profile/contributor.html.heex
@@ -61,4 +61,25 @@
       <% end %>
     </div>
   </div>
+  <div class="row mt-3 mb-3">
+    <div class="col">
+        <form>
+          <h4>Contributor Rank Icon</h4>
+          <div class="form-check">
+              <input
+                name={"hide-rank-icon"}
+                id={"hide-rank-icon"}
+                class="form-check-input"
+                type="checkbox"
+                value="true"
+                checked={@hide_contributor_rank}
+                phx-change="toggle-hide-contributor-rank"
+                />
+              <label class="form-check-label" for={"hide-rank-icon"}>
+              Hide contributor rank icon
+              </label>
+          </div>
+        </form>
+    </div>
+  </div>
 </div>

--- a/lib/teiserver_web/live/account/profile/contributor.html.heex
+++ b/lib/teiserver_web/live/account/profile/contributor.html.heex
@@ -63,23 +63,23 @@
   </div>
   <div class="row mt-3 mb-3">
     <div class="col">
-        <form>
-          <h4>Contributor Rank Icon</h4>
-          <div class="form-check">
-              <input
-                name={"hide-rank-icon"}
-                id={"hide-rank-icon"}
-                class="form-check-input"
-                type="checkbox"
-                value="true"
-                checked={@hide_contributor_rank}
-                phx-change="toggle-hide-contributor-rank"
-                />
-              <label class="form-check-label" for={"hide-rank-icon"}>
-              Hide contributor rank icon
-              </label>
-          </div>
-        </form>
+      <form>
+        <h4>Contributor Rank Icon</h4>
+        <div class="form-check">
+          <input
+            name="hide-rank-icon"
+            id="hide-rank-icon"
+            class="form-check-input"
+            type="checkbox"
+            value="true"
+            checked={@hide_contributor_rank}
+            phx-change="toggle-hide-contributor-rank"
+          />
+          <label class="form-check-label" for="hide-rank-icon">
+            Hide contributor rank icon
+          </label>
+        </div>
+      </form>
     </div>
   </div>
 </div>

--- a/lib/teiserver_web/live/battles/match/show.ex
+++ b/lib/teiserver_web/live/battles/match/show.ex
@@ -57,7 +57,7 @@ defmodule TeiserverWeb.Battle.MatchLive.Show do
     # Restrict the balance tab to certain roles.
     # Note that Staff roles like "Tester" also contain Contributor role.
     socket
-    |> mount_require_any(["Reviewer", "Contributor"])
+    |> mount_require_any(["Reviewer", "Tester"])
     |> assign(:page_title, "#{match_name} - Balance")
   end
 

--- a/lib/teiserver_web/live/battles/match/show.ex
+++ b/lib/teiserver_web/live/battles/match/show.ex
@@ -55,7 +55,7 @@ defmodule TeiserverWeb.Battle.MatchLive.Show do
 
   defp apply_action(%{assigns: %{match_name: match_name}} = socket, :balance, _params) do
     # Restrict the balance tab to certain roles.
-    # Note that Staff roles like "Tester" also contain Contributor role.
+    # Note that Staff roles like Contributor will inherit Tester permissions
     socket
     |> mount_require_any(["Reviewer", "Tester"])
     |> assign(:page_title, "#{match_name} - Balance")

--- a/lib/teiserver_web/live/battles/match/show.html.heex
+++ b/lib/teiserver_web/live/battles/match/show.html.heex
@@ -41,7 +41,7 @@
         </.tab_nav>
       <% end %>
 
-      <%= if @rating_logs != %{} and allow_any?(@current_user, ["Overwatch", "Contributor"]) do %>
+      <%= if @rating_logs != %{} and allow_any?(@current_user, ["Overwatch", "Tester"]) do %>
         <.tab_nav url={~p"/battle/#{@match.id}/balance"} selected={@tab == :balance}>
           <Fontawesome.icon icon="fa-solid fa-scale-balanced" style="solid" /> Balance
         </.tab_nav>
@@ -282,7 +282,7 @@
       </div>
     <% end %>
 
-    <%= if allow_any?(@current_user, ["Overwatch", "Contributor"]) do %>
+    <%= if allow_any?(@current_user, ["Overwatch", "Tester"]) do %>
       <div :if={@tab == :balance} class="p-4">
         <form method="post" class="">
           <.input

--- a/lib/teiserver_web/live/microblog/admin/post/index.ex
+++ b/lib/teiserver_web/live/microblog/admin/post/index.ex
@@ -11,7 +11,7 @@ defmodule TeiserverWeb.Microblog.Admin.PostLive.Index do
 
   @impl true
   def handle_params(params, _url, socket) do
-    case allow?(socket.assigns[:current_user], "Contributor") do
+    case allow?(socket.assigns[:current_user], "Blog helper") do
       true ->
         {:noreply, apply_action(socket, socket.assigns.live_action, params)}
 

--- a/lib/teiserver_web/live/microblog/admin/post/show.ex
+++ b/lib/teiserver_web/live/microblog/admin/post/show.ex
@@ -10,7 +10,7 @@ defmodule TeiserverWeb.Microblog.Admin.PostLive.Show do
 
   @impl true
   def handle_params(%{"id" => id}, _url, socket) do
-    if allow?(socket.assigns[:current_user], "Contributor") do
+    if allow?(socket.assigns[:current_user], "Blog helper") do
       post = Microblog.get_post!(id, preload: [:tags])
 
       if post.poster_id == socket.assigns.current_user.id or

--- a/lib/teiserver_web/live/microblog/blog/index.html.heex
+++ b/lib/teiserver_web/live/microblog/blog/index.html.heex
@@ -30,7 +30,7 @@
       </a>
 
       <a
-        :if={allow?(@current_user, "Contributor")}
+        :if={allow?(@current_user, "Blog helper")}
         href={~p"/microblog/admin/posts"}
         class="btn btn-primary btn-sm mx-1"
       >

--- a/lib/teiserver_web/live/microblog/microblog_components.ex
+++ b/lib/teiserver_web/live/microblog/microblog_components.ex
@@ -35,7 +35,7 @@ defmodule TeiserverWeb.MicroblogComponents do
       </.sub_menu_button>
 
       <.sub_menu_button
-        :if={allow?(@current_user, "Contributor")}
+        :if={allow?(@current_user, "Blog helper")}
         bsname={@view_colour}
         icon={Teiserver.Microblog.PostLib.icon()}
         active={@active == "posts"}

--- a/lib/teiserver_web/router.ex
+++ b/lib/teiserver_web/router.ex
@@ -106,7 +106,7 @@ defmodule TeiserverWeb.Router do
     live_session :microblog_admin,
       on_mount: [
         {Teiserver.Account.AuthPlug, :ensure_authenticated},
-        {Teiserver.Account.AuthPlug, {:authorise, "Contributor"}}
+        {Teiserver.Account.AuthPlug, {:authorise, "Blog helper"}}
       ] do
       live "/admin/posts", Admin.PostLive.Index, :index
       live "/admin/posts/:id", Admin.PostLive.Show, :show


### PR DESCRIPTION
## Improvements
1. Contributors can now toggle whether or not they want to show their contributor icon in game. The checkbox is accessible on Contributor page and saves immediately on change.
2. Contributor will now inherit permissions from Tester and Tester will no longer inherit permission from Contributor. Previously Tester would inherit permissions from Contributor, making the Tester potentially more powerful which doesn't make sense. 
3. Added a Blog helper role to coincide with this discord post: https://discord.com/channels/549281623154229250/1243869733988864042/1243869733988864042
The name could be changed to something else but it was called "Blog helper" in the discord post.
4. Posting to blog now requires "Blog helper" permission. Contributors will inherit this permission. Since Tester no longer inherits from Contributor, a Tester can no longer post to blog.

## Other Thoughts
The UI for toggling rank icon is very bare bones (there's no submit button - you just have to toggle it). I am not wanting to do more in this ticket but could be improved in the future.

## Test Steps
### Testing contributor rank toggle
Login as a user with Contributor role. Go to my account > Contributor. Tick the checkbox to disable showing rank icon. It will auto save on toggle. Now login to Chobby. Your rank icon will be like a regular user. 

### Testing Blog helper role
Give someone Blog helper role (remove Contributor role if needed). They should be able to create a blog post. Access via Blog > Blog Admin

### Testing Tester role reduced permissions
Remove Blog helper role and give that user Tester role. Try relogin and on the blog page they shouldn't have permission to create a blog post. They still might see a preferences button but this button was already exposed to regular users.