### PR TITLE
Add brute force balance algo

### DIFF
--- a/lib/teiserver/battle/balance/brute_force.ex
+++ b/lib/teiserver/battle/balance/brute_force.ex
@@ -1,0 +1,251 @@
+defmodule Teiserver.Battle.Balance.BruteForce do
+  @moduledoc """
+  Algorithm idea by Suuwassea
+  Adjusted by jauggy
+
+  Overview:
+  Go through every possible combination and pick the best one. Ideal for keeping parties together.
+  The best combination will have the lowest score.
+  Score = difference in team rating + broken party penalty
+  broken party penalty = num broken parties * broken party multiplier
+
+  Only use for games with two teams and <=16 players
+  """
+  alias Teiserver.Battle.Balance.BalanceTypes, as: BT
+  alias Teiserver.Battle.Balance.BruteForceTypes, as: BF
+  import Teiserver.Helper.NumberHelper, only: [format: 1]
+  require Integer
+
+  @broken_party_multiplier 3
+  @splitter "------------------------------------------------------"
+
+  @doc """
+  Main entry point used by balance_lib
+  """
+  @spec perform([BT.expanded_group()], non_neg_integer(), list()) :: any()
+  def perform(expanded_group, team_count, opts \\ []) do
+    input_data = %{
+      players: flatten_members(expanded_group),
+      parties: get_parties(expanded_group)
+    }
+
+    case should_use_algo?(input_data, team_count) do
+      :ok ->
+        potential_teams = potential_teams(length(input_data.players))
+        best_combo = get_best_combo(potential_teams, input_data.players, input_data.parties)
+        standardise_result(best_combo, input_data.players, input_data.parties)
+
+      {:error, message} ->
+        # Call another balancer
+        result = Teiserver.Battle.Balance.LoserPicks.perform(expanded_group, team_count, opts)
+
+        new_logs =
+          ["#{message} Will use another balance algorithm instead.", @splitter, result.logs]
+          |> List.flatten()
+
+        Map.put(result, :logs, new_logs)
+    end
+  end
+
+  @doc """
+  Use this algo if two teams and <=16 players
+  """
+  @spec should_use_algo?(BF.input_data(), integer()) :: :ok | {:error, String.t()}
+  def should_use_algo?(input_data, team_count) do
+    num_players = length(input_data[:players])
+
+    cond do
+      team_count != 2 -> {:error, "Team count doesn't equal two."}
+      num_players > 16 -> {:error, "Number of players greater than 16."}
+      Integer.is_odd(num_players) -> {:error, "Odd number of players."}
+      true -> :ok
+    end
+  end
+
+  @doc """
+  Converts the input to a simple list of players
+  """
+  @spec flatten_members([BT.expanded_group()]) :: any()
+  def flatten_members(expanded_group) do
+    for %{
+          members: members,
+          ratings: ratings,
+          ranks: ranks,
+          names: names,
+          uncertainties: uncertainties
+        } <- expanded_group,
+        # Zipping will create binary tuples from 2 lists
+        {id, rating, _rank, name, _uncertainty} <-
+          Enum.zip([members, ratings, ranks, names, uncertainties]),
+        # Create result value
+        do: %{
+          rating: rating,
+          name: name,
+          id: id
+        }
+  end
+
+  @spec get_parties([BT.expanded_group()]) :: [String.t()]
+  def get_parties(expanded_group) do
+    Enum.filter(expanded_group, fn x ->
+      x[:count] >= 2
+    end)
+    |> Enum.map(fn y ->
+      y[:names]
+    end)
+  end
+
+  @spec potential_teams(integer()) :: any()
+  def potential_teams(num_players) do
+    Teiserver.Helper.CombinationsHelper.get_combinations(num_players)
+  end
+
+  @spec get_best_combo([integer()], [BF.player()], [String.t()]) :: BF.combo_result()
+  def get_best_combo(combos, players, parties) do
+    Enum.map(combos, fn x ->
+      get_players_from_indexes(x, players)
+    end)
+    |> Enum.map(fn team ->
+      result = score_combo(team, players, parties)
+      Map.put(result, :team, team)
+    end)
+    |> Enum.min_by(fn z ->
+      z.score
+    end)
+  end
+
+  @spec score_combo([BF.player()], [BF.player()], [String.t()]) :: any()
+  def score_combo(first_team, all_players, parties) do
+    first_team_rating = get_team_rating(first_team)
+    both_team_rating = get_team_rating(all_players)
+
+    rating_diff_penalty = abs(both_team_rating - first_team_rating * 2)
+    broken_party_penalty = count_broken_parties(first_team, parties) * @broken_party_multiplier
+
+    score = rating_diff_penalty + broken_party_penalty
+
+    %{
+      score: score,
+      rating_diff_penalty: rating_diff_penalty,
+      broken_party_penalty: broken_party_penalty
+    }
+  end
+
+  def get_players_from_indexes(player_indexes, players) do
+    players = Enum.with_index(players)
+
+    Enum.filter(players, fn {_player, index} ->
+      Enum.member?(player_indexes, index)
+    end)
+    |> Enum.map(fn {player, _index} ->
+      player
+    end)
+  end
+
+  def count_broken_parties(first_team, parties) do
+    Enum.count(parties, fn party ->
+      is_party_broken?(first_team, party)
+    end)
+  end
+
+  @spec is_party_broken?([BF.player()], [String.t()]) :: any()
+  def is_party_broken?(team, party) do
+    count =
+      Enum.count(party, fn x ->
+        Enum.any?(team, fn y ->
+          y.name == x
+        end)
+      end)
+
+    cond do
+      # Nobody from this party is on this team. Therefore unbroken.
+      count == 0 -> false
+      # Everyone from this party is on this team. Therefore unbroken.
+      count == length(party) -> false
+      # Otherwise, this party is broken.
+      true -> true
+    end
+  end
+
+  defp get_team_rating(players) do
+    Enum.reduce(players, 0, fn x, acc ->
+      acc + x.rating
+    end)
+  end
+
+  @spec standardise_result(BF.combo_result(), [BF.player()], [String.t()]) :: any()
+  def standardise_result(best_combo, all_players, parties) do
+    first_team = best_combo.team
+
+    second_team =
+      all_players
+      |> Enum.filter(fn x ->
+        !Enum.any?(first_team, fn y ->
+          y.id == x.id
+        end)
+      end)
+
+    team_groups = %{
+      1 => standardise_team_groups(first_team),
+      2 => standardise_team_groups(second_team)
+    }
+
+    team_players = %{
+      1 => standardise_team_players(first_team),
+      2 => standardise_team_players(second_team)
+    }
+
+    logs = [
+      "Algorithm: brute_force",
+      @splitter,
+      "Parties: #{log_parties(parties)}",
+      "Team rating diff penalty: #{format(best_combo.rating_diff_penalty)}",
+      "Broken party penalty: #{best_combo.broken_party_penalty}",
+      "Score: #{format(best_combo.score)} (lower is better)",
+      "Team 1: #{log_team(first_team)}",
+      "Team 2: #{log_team(second_team)}"
+    ]
+
+    %{
+      team_groups: team_groups,
+      team_players: team_players,
+      logs: logs
+    }
+  end
+
+  @spec log_parties([[String.t()]]) :: String.t()
+  def log_parties(parties) do
+    Enum.map(parties, fn party ->
+      "[#{Enum.join(party, ", ")}]"
+    end)
+    |> Enum.join(", ")
+  end
+
+  @spec log_team([BF.player()]) :: String.t()
+  defp log_team(team) do
+    Enum.map(team, fn x ->
+      x.name
+    end)
+    |> Enum.join(", ")
+  end
+
+  @spec standardise_team_groups([BF.player()]) :: any()
+  defp standardise_team_groups(team) do
+    team
+    |> Enum.map(fn x ->
+      %{
+        members: [x.id],
+        count: 1,
+        group_rating: x.rating,
+        ratings: [x.rating]
+      }
+    end)
+  end
+
+  defp standardise_team_players(team) do
+    team
+    |> Enum.map(fn x ->
+      x.id
+    end)
+  end
+end

--- a/lib/teiserver/battle/balance/brute_force_types.ex
+++ b/lib/teiserver/battle/balance/brute_force_types.ex
@@ -1,0 +1,24 @@
+defmodule Teiserver.Battle.Balance.BruteForceTypes do
+  @moduledoc false
+
+  @type player :: %{
+          rating: float(),
+          id: any(),
+          name: String.t()
+        }
+  @type team :: %{
+          players: [player],
+          id: integer()
+        }
+  @type input_data :: %{
+          players: [player],
+          parties: [String.t()]
+        }
+
+  @type combo_result :: %{
+          broken_party_penalty: number(),
+          rating_diff_penalty: number(),
+          score: number(),
+          team: [player()]
+        }
+end

--- a/lib/teiserver/battle/libs/balance_lib.ex
+++ b/lib/teiserver/battle/libs/balance_lib.ex
@@ -66,7 +66,9 @@ defmodule Teiserver.Battle.BalanceLib do
     if(is_moderator) do
       Teiserver.Battle.BalanceLib.algorithm_modules() |> Map.keys()
     else
-      Teiserver.Battle.BalanceLib.algorithm_modules() |> Map.delete("force_party") |> Map.keys()
+      Teiserver.Battle.BalanceLib.algorithm_modules()
+      |> Map.drop(["force_party", "brute_force"])
+      |> Map.keys()
     end
   end
 

--- a/lib/teiserver/battle/libs/balance_lib.ex
+++ b/lib/teiserver/battle/libs/balance_lib.ex
@@ -53,7 +53,8 @@ defmodule Teiserver.Battle.BalanceLib do
       "loser_picks" => Teiserver.Battle.Balance.LoserPicks,
       "force_party" => Teiserver.Battle.Balance.ForceParty,
       "cheeky_switcher_smart" => Teiserver.Battle.Balance.CheekySwitcherSmart,
-      "split_one_chevs" => Teiserver.Battle.Balance.SplitOneChevs
+      "split_one_chevs" => Teiserver.Battle.Balance.SplitOneChevs,
+      "brute_force" => Teiserver.Battle.Balance.BruteForce
     }
   end
 

--- a/lib/teiserver/helpers/combinations_helper.ex
+++ b/lib/teiserver/helpers/combinations_helper.ex
@@ -1,0 +1,30 @@
+defmodule Teiserver.Helper.CombinationsHelper do
+  # This module to help get combinations taken from Elixir Forums:
+  # https://elixirforum.com/t/create-all-possible-teams-from-a-list-of-players/64892/5?u=joshua.aug
+  require Integer
+
+  defp n_comb(0, _list), do: [[]]
+  defp n_comb(_, []), do: []
+
+  defp n_comb(n, [h | t]) do
+    list = for l <- n_comb(n - 1, t), do: [h | l]
+    list ++ n_comb(n, t)
+  end
+
+  def n_comb(list) when is_list(list) do
+    n = trunc(length(list) / 2)
+
+    for i <- n_comb(n - 1, tl(list)),
+        do: [hd(list) | i]
+  end
+
+  # Returns a list of possible combinations of a single team using indexes starting at zero
+  # but doesn't include duplicates. Assumes we need exactly two teams of equal size.
+  # E.g. for a 4 player lobby, Team1: [0,1] is a duplicate of Team1: [2,3]
+  # since Team1 and Team2 are just swapped
+  def get_combinations(num_players) when is_integer(num_players) do
+    last = trunc(num_players) - 1
+
+    0..last |> Enum.to_list() |> n_comb()
+  end
+end

--- a/lib/teiserver_web/live/battles/match/show.html.heex
+++ b/lib/teiserver_web/live/battles/match/show.html.heex
@@ -312,6 +312,10 @@
               <td>Deviation</td>
               <td><%= @past_balance.deviation %></td>
             </tr>
+            <tr>
+              <td>Time Taken (ms)</td>
+              <td><%= @past_balance.time_taken / 1000 %></td>
+            </tr>
           </tbody>
         </table>
 
@@ -333,6 +337,10 @@
             <tr>
               <td>Deviation</td>
               <td><%= @new_balance.deviation %></td>
+            </tr>
+            <tr>
+              <td>Time Taken (ms)</td>
+              <td><%= @new_balance.time_taken / 1000 %></td>
             </tr>
           </tbody>
         </table>

--- a/test/teiserver/battle/balance_lib_internal_test.exs
+++ b/test/teiserver/battle/balance_lib_internal_test.exs
@@ -117,6 +117,23 @@ defmodule Teiserver.Battle.BalanceLibInternalTest do
     assert BalanceLib.balanced_teams_has_parties?(team_groups)
   end
 
+  test "Allowed algorithms" do
+    is_moderator = true
+    result = BalanceLib.get_allowed_algorithms(is_moderator)
+
+    assert result == [
+             "brute_force",
+             "cheeky_switcher_smart",
+             "force_party",
+             "loser_picks",
+             "split_one_chevs"
+           ]
+
+    is_moderator = false
+    result = BalanceLib.get_allowed_algorithms(is_moderator)
+    assert result == ["cheeky_switcher_smart", "loser_picks", "split_one_chevs"]
+  end
+
   defp create_test_users do
     Enum.map(1..5, fn k ->
       Teiserver.TeiserverTestLib.new_user("User_#{k}")

--- a/test/teiserver/battle/brute_force_internal_test.exs
+++ b/test/teiserver/battle/brute_force_internal_test.exs
@@ -1,0 +1,264 @@
+defmodule Teiserver.Battle.BruteForceInternalTest do
+  @moduledoc """
+  Can run all balance tests via
+  mix test --only balance_test
+  """
+  use Teiserver.DataCase, async: true
+  @moduletag :balance_test
+  alias Teiserver.Battle.BalanceLib
+  alias Teiserver.Battle.Balance.BruteForce
+  alias Teiserver.Helper.CombinationsHelper
+
+  test "combinations helper module" do
+    combos = CombinationsHelper.get_combinations(4)
+    assert combos == [[0, 1], [0, 2], [0, 3]]
+
+    combos = CombinationsHelper.get_combinations(12)
+    assert length(combos) == 462
+  end
+
+  test "check for broken party" do
+    party = ["kyutoryu", "fbots1998"]
+
+    first_team = [
+      %{name: "kyutoryu", rating: 12.25},
+      %{name: "fbots1998", rating: 13.98},
+      %{name: "Dixinormus", rating: 18.28},
+      %{name: "HungDaddy", rating: 2.8}
+    ]
+
+    second_team = [
+      %{name: "A", rating: 12.25},
+      %{name: "fbots1998", rating: 13.98},
+      %{name: "Dixinormus", rating: 18.28},
+      %{name: "HungDaddy", rating: 2.8}
+    ]
+
+    third_team = [
+      %{name: "A", rating: 12.25},
+      %{name: "B", rating: 13.98},
+      %{name: "Dixinormus", rating: 18.28},
+      %{name: "HungDaddy", rating: 2.8}
+    ]
+
+    result = BruteForce.is_party_broken?(first_team, party)
+    refute result
+
+    result = BruteForce.is_party_broken?(second_team, party)
+    assert result
+
+    result = BruteForce.is_party_broken?(third_team, party)
+    refute result
+  end
+
+  test "log parties" do
+    parties = [["kyutoryu", "fbots1998"], ["Dix", "Dixinormus"]]
+    result = BruteForce.log_parties(parties)
+
+    assert result == "[kyutoryu, fbots1998], [Dix, Dixinormus]"
+  end
+
+  test "check for broken party with parties list" do
+    parties = [["kyutoryu", "fbots1998"], ["Dix", "Dixinormus"]]
+
+    first_team = [
+      %{name: "kyutoryu", rating: 12.25},
+      %{name: "fbots1998", rating: 13.98},
+      %{name: "Dixinormus", rating: 18.28},
+      %{name: "HungDaddy", rating: 2.8}
+    ]
+
+    result = BruteForce.count_broken_parties(first_team, parties)
+    assert result = 1
+
+    parties = [["kyutoryu", "fbots1998", "A"], ["Dix", "Dixinormus"]]
+    result = BruteForce.count_broken_parties(first_team, parties)
+    assert result = 2
+
+    parties = [["A", "B", "C"], ["HungDaddy", "fbots1998"]]
+    result = BruteForce.count_broken_parties(first_team, parties)
+    assert result = 0
+  end
+
+  test "can get all combos" do
+    input = %{
+      parties: [["kyutoryu", "fbots1998"]],
+      players: [
+        %{name: "kyutoryu", rating: 12.25, id: 1},
+        %{name: "fbots1998", rating: 13.98, id: 2},
+        %{name: "Dixinormus", rating: 18.28, id: 3},
+        %{name: "HungDaddy", rating: 2.8, id: 4},
+        %{name: "SLOPPYGAGGER", rating: 8.89, id: 5},
+        %{name: "jauggy", rating: 20.49, id: 6},
+        %{name: "reddragon2010", rating: 18.4, id: 7},
+        %{name: "Aposis", rating: 20.42, id: 8},
+        %{name: "MaTThiuS_82", rating: 8.26, id: 9},
+        %{name: "Noody", rating: 17.64, id: 10},
+        %{name: "[DTG]BamBin0", rating: 20.06, id: 11},
+        %{name: "barmalev", rating: 3.58, id: 12}
+      ]
+    }
+
+    combos = BruteForce.potential_teams(length(input.players))
+    assert length(combos) == 462
+    first_combo = combos |> Enum.at(0)
+    assert first_combo == [0, 1, 2, 3, 4, 5]
+
+    first_potential_team = BruteForce.get_players_from_indexes(first_combo, input.players)
+
+    assert first_potential_team == [
+             %{name: "kyutoryu", rating: 12.25, id: 1},
+             %{name: "fbots1998", rating: 13.98, id: 2},
+             %{name: "Dixinormus", rating: 18.28, id: 3},
+             %{name: "HungDaddy", rating: 2.8, id: 4},
+             %{name: "SLOPPYGAGGER", rating: 8.89, id: 5},
+             %{name: "jauggy", rating: 20.49, id: 6}
+           ]
+
+    result = BruteForce.score_combo(first_potential_team, input.players, input.parties)
+
+    assert result == %{
+             broken_party_penalty: 0,
+             rating_diff_penalty: 11.670000000000044,
+             score: 11.670000000000044
+           }
+
+    best_combo = BruteForce.get_best_combo(combos, input.players, input.parties)
+
+    assert best_combo == %{
+             broken_party_penalty: 0,
+             rating_diff_penalty: 0.5100000000000477,
+             score: 0.5100000000000477,
+             team: [
+               %{name: "kyutoryu", rating: 12.25, id: 1},
+               %{name: "fbots1998", rating: 13.98, id: 2},
+               %{name: "SLOPPYGAGGER", rating: 8.89, id: 5},
+               %{name: "jauggy", rating: 20.49, id: 6},
+               %{name: "reddragon2010", rating: 18.4, id: 7},
+               %{name: "MaTThiuS_82", rating: 8.26, id: 9}
+             ]
+           }
+
+    result =
+      BruteForce.standardise_result(best_combo, input.players, input.parties) |> Map.drop([:logs])
+
+    assert result == %{
+             team_groups: %{
+               1 => [
+                 %{count: 1, group_rating: 12.25, members: [1], ratings: [12.25]},
+                 %{count: 1, group_rating: 13.98, members: [2], ratings: [13.98]},
+                 %{count: 1, group_rating: 8.89, members: [5], ratings: [8.89]},
+                 %{count: 1, group_rating: 20.49, members: [6], ratings: [20.49]},
+                 %{count: 1, group_rating: 18.4, members: [7], ratings: [18.4]},
+                 %{count: 1, group_rating: 8.26, members: [9], ratings: [8.26]}
+               ],
+               2 => [
+                 %{count: 1, group_rating: 18.28, members: [3], ratings: [18.28]},
+                 %{count: 1, group_rating: 2.8, members: [4], ratings: [2.8]},
+                 %{count: 1, group_rating: 20.42, members: [8], ratings: [20.42]},
+                 %{count: 1, group_rating: 17.64, members: [10], ratings: [17.64]},
+                 %{count: 1, group_rating: 20.06, members: [11], ratings: [20.06]},
+                 %{count: 1, group_rating: 3.58, members: [12], ratings: [3.58]}
+               ]
+             },
+             team_players: %{1 => [1, 2, 5, 6, 7, 9], 2 => [3, 4, 8, 10, 11, 12]}
+           }
+  end
+
+  test "can process expanded_group" do
+    # https://server5.beyondallreason.info/battle/2092529/players
+    expanded_group = [
+      %{
+        count: 2,
+        members: ["kyutoryu", "fbots1998"],
+        ratings: [12.25, 13.98],
+        names: ["kyutoryu", "fbots1998"],
+        uncertainties: [0, 1],
+        ranks: [1, 1]
+      },
+      %{
+        count: 1,
+        members: ["Dixinormus"],
+        ratings: [18.28],
+        names: ["Dixinormus"],
+        uncertainties: [2, 1],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["HungDaddy"],
+        ratings: [2.8],
+        names: ["HungDaddy"],
+        uncertainties: [2, 1],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["SLOPPYGAGGER"],
+        ratings: [8.89],
+        names: ["SLOPPYGAGGER"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["jauggy"],
+        ratings: [20.49],
+        names: ["jauggy"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["reddragon2010"],
+        ratings: [18.4],
+        names: ["reddragon2010"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["Aposis"],
+        ratings: [20.42],
+        names: ["Aposis"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["MaTThiuS_82"],
+        ratings: [8.26],
+        names: ["MaTThiuS_82"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["Noody"],
+        ratings: [17.64],
+        names: ["Noody"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["[DTG]BamBin0"],
+        ratings: [20.06],
+        names: ["[DTG]BamBin0"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["barmalev"],
+        ratings: [3.58],
+        names: ["barmalev"],
+        uncertainties: [3],
+        ranks: [2]
+      }
+    ]
+
+    parties = BruteForce.get_parties(expanded_group)
+    assert parties == [["kyutoryu", "fbots1998"]]
+  end
+end

--- a/test/teiserver/battle/brute_force_internal_test.exs
+++ b/test/teiserver/battle/brute_force_internal_test.exs
@@ -5,7 +5,6 @@ defmodule Teiserver.Battle.BruteForceInternalTest do
   """
   use Teiserver.DataCase, async: true
   @moduletag :balance_test
-  alias Teiserver.Battle.BalanceLib
   alias Teiserver.Battle.Balance.BruteForce
   alias Teiserver.Helper.CombinationsHelper
 
@@ -69,15 +68,15 @@ defmodule Teiserver.Battle.BruteForceInternalTest do
     ]
 
     result = BruteForce.count_broken_parties(first_team, parties)
-    assert result = 1
+    assert result == 1
 
     parties = [["kyutoryu", "fbots1998", "A"], ["Dix", "Dixinormus"]]
     result = BruteForce.count_broken_parties(first_team, parties)
-    assert result = 2
+    assert result == 2
 
     parties = [["A", "B", "C"], ["HungDaddy", "fbots1998"]]
     result = BruteForce.count_broken_parties(first_team, parties)
-    assert result = 0
+    assert result == 0
   end
 
   test "can get all combos" do

--- a/test/teiserver/battle/brute_force_test.exs
+++ b/test/teiserver/battle/brute_force_test.exs
@@ -1,0 +1,139 @@
+defmodule Teiserver.Battle.BruteForceTest do
+  @moduledoc """
+  Can run all balance tests via
+  mix test --only balance_test
+  """
+  use Teiserver.DataCase, async: true
+  @moduletag :balance_test
+  alias Teiserver.Battle.BalanceLib
+  alias Teiserver.Battle.Balance.BruteForce
+  alias Teiserver.Helper.CombinationsHelper
+
+  test "can process expanded_group" do
+    # https://server5.beyondallreason.info/battle/2092529/players
+    expanded_group = [
+      %{
+        count: 2,
+        members: ["kyutoryu", "fbots1998"],
+        ratings: [12.25, 13.98],
+        names: ["kyutoryu", "fbots1998"],
+        uncertainties: [0, 1],
+        ranks: [1, 1]
+      },
+      %{
+        count: 1,
+        members: ["Dixinormus"],
+        ratings: [18.28],
+        names: ["Dixinormus"],
+        uncertainties: [2, 1],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["HungDaddy"],
+        ratings: [2.8],
+        names: ["HungDaddy"],
+        uncertainties: [2, 1],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["SLOPPYGAGGER"],
+        ratings: [8.89],
+        names: ["SLOPPYGAGGER"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["jauggy"],
+        ratings: [20.49],
+        names: ["jauggy"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["reddragon2010"],
+        ratings: [18.4],
+        names: ["reddragon2010"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["Aposis"],
+        ratings: [20.42],
+        names: ["Aposis"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["MaTThiuS_82"],
+        ratings: [8.26],
+        names: ["MaTThiuS_82"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["Noody"],
+        ratings: [17.64],
+        names: ["Noody"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["[DTG]BamBin0"],
+        ratings: [20.06],
+        names: ["[DTG]BamBin0"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["barmalev"],
+        ratings: [3.58],
+        names: ["barmalev"],
+        uncertainties: [3],
+        ranks: [2]
+      }
+    ]
+
+    result = BruteForce.perform(expanded_group, 2) |> Map.drop([:logs])
+
+    assert result == %{
+             team_groups: %{
+               1 => [
+                 %{count: 1, group_rating: 12.25, members: ["kyutoryu"], ratings: [12.25]},
+                 %{count: 1, group_rating: 13.98, members: ["fbots1998"], ratings: [13.98]},
+                 %{count: 1, group_rating: 8.89, members: ["SLOPPYGAGGER"], ratings: [8.89]},
+                 %{count: 1, group_rating: 20.49, members: ["jauggy"], ratings: [20.49]},
+                 %{count: 1, group_rating: 18.4, members: ["reddragon2010"], ratings: [18.4]},
+                 %{count: 1, group_rating: 8.26, members: ["MaTThiuS_82"], ratings: [8.26]}
+               ],
+               2 => [
+                 %{count: 1, group_rating: 18.28, members: ["Dixinormus"], ratings: [18.28]},
+                 %{count: 1, group_rating: 2.8, members: ["HungDaddy"], ratings: [2.8]},
+                 %{count: 1, group_rating: 20.42, members: ["Aposis"], ratings: [20.42]},
+                 %{count: 1, group_rating: 17.64, members: ["Noody"], ratings: [17.64]},
+                 %{count: 1, group_rating: 20.06, members: ["[DTG]BamBin0"], ratings: [20.06]},
+                 %{count: 1, group_rating: 3.58, members: ["barmalev"], ratings: [3.58]}
+               ]
+             },
+             team_players: %{
+               1 => [
+                 "kyutoryu",
+                 "fbots1998",
+                 "SLOPPYGAGGER",
+                 "jauggy",
+                 "reddragon2010",
+                 "MaTThiuS_82"
+               ],
+               2 => ["Dixinormus", "HungDaddy", "Aposis", "Noody", "[DTG]BamBin0", "barmalev"]
+             }
+           }
+  end
+end

--- a/test/teiserver/battle/brute_force_test.exs
+++ b/test/teiserver/battle/brute_force_test.exs
@@ -5,9 +5,7 @@ defmodule Teiserver.Battle.BruteForceTest do
   """
   use Teiserver.DataCase, async: true
   @moduletag :balance_test
-  alias Teiserver.Battle.BalanceLib
   alias Teiserver.Battle.Balance.BruteForce
-  alias Teiserver.Helper.CombinationsHelper
 
   test "can process expanded_group" do
     # https://server5.beyondallreason.info/battle/2092529/players


### PR DESCRIPTION
## Context
Many people want a balance algorithm that keeps parties together more often. This algorithm goes through every possible combination and picks the best combination. The original idea was from Suuwassea here: https://discord.com/channels/549281623154229250/855772061095559179/1235344149713260584

## Conditions the algorithm will run
1. Team count must equal 2
2. Player count must be <= 16
3. Even number of players

If any of these conditions aren't met, the default balancer will be called instead

## Scoring each combination
Each combination will be given a score as follows:
```
    score = rating_diff_penalty + broken_party_penalty
```
rating_diff_penalty  is just the difference in team ratings
broken_party_penalty is the number of broken parties * broken_party_multiplier
broken_party_multiplier = 3

Pick the combination that scores the lowest.

## Test Steps
Go to to any match on integration server. Preferably find one where parties got split e.g.
https://server5.beyondallreason.info/battle/2092529/players
You can see the parties as they are represented by same coloured dice in the player list. In this case kyutoryu and fbots1998 got split.

Go to balance tab and check brute_force algo. You should see broken party penalty of 0 meaning parties weren't split.

![1](https://github.com/user-attachments/assets/1e8d700c-261a-42e5-b6a5-ab67364780e3)
![2](https://github.com/user-attachments/assets/a58761ec-1584-4ee6-8712-a2a5005bf5a9)

In lobby if you do
```
$balancemode x
```
It will give you a warning and tell you the allowed balance algo. brute_force will not be listed as I have restricted it to mod only.
