### PR TITLE
Add restriction to number of symbols allowed in a username.

### DIFF
--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -96,7 +96,13 @@ defmodule Teiserver.CacheUser do
 
   @spec check_symbol_limit(String.t()) :: Boolean.t()
   def check_symbol_limit(name) do
-    name |> String.replace(~r/[[:alnum:]]/, "") |> String.graphemes |> Enum.frequencies |> Enum.filter(fn {_, val} -> (val > 2) end) |> Enum.count() |> Kernel.>(0)
+    name
+    |> String.replace(~r/[[:alnum:]]/, "")
+    |> String.graphemes()
+    |> Enum.frequencies()
+    |> Enum.filter(fn {_, val} -> val > 2 end)
+    |> Enum.count()
+    |> Kernel.>(0)
   end
 
   @spec encrypt_password(any) :: binary | {binary, binary, {any, any, any, any, any}}

--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -94,6 +94,11 @@ defmodule Teiserver.CacheUser do
     |> Regex.replace(name, "")
   end
 
+  @spec check_symbol_limit(String.t()) :: Boolean.t()
+  def check_symbol_limit(name) do
+    name |> String.replace(~r/[[:alnum:]]/, "") |> String.graphemes |> Enum.frequencies |> Enum.filter(fn {_, val} -> (val > 2) end) |> Enum.count() |> Kernel.>(0)
+  end
+
   @spec encrypt_password(any) :: binary | {binary, binary, {any, any, any, any, any}}
   def encrypt_password(password) do
     Argon2.hash_pwd_salt(password)
@@ -184,6 +189,9 @@ defmodule Teiserver.CacheUser do
       clean_name(name) != name ->
         {:failure, "Invalid characters in name (only a-z, A-Z, 0-9, [, ] and _ allowed)"}
 
+      check_symbol_limit(name) ->
+        {:error, "Too many repeated symbols in name"}
+
       get_user_by_name(name) ->
         {:failure, "Username already taken"}
 
@@ -229,6 +237,9 @@ defmodule Teiserver.CacheUser do
 
       clean_name(name) != name ->
         {:error, "Invalid characters in name (only a-z, A-Z, 0-9, [, ] and _ allowed)"}
+
+      check_symbol_limit(name) ->
+        {:error, "Too many repeated symbols in name"}
 
       get_user_by_name(name) ->
         {:error, "Username already taken"}
@@ -431,6 +442,9 @@ defmodule Teiserver.CacheUser do
 
       clean_name(new_name) != new_name ->
         {:error, "Invalid characters in name (only a-z, A-Z, 0-9, [, ] allowed)"}
+
+      check_symbol_limit(new_name) ->
+        {:error, "Too many repeated symbols in name"}
 
       get_user_by_name(new_name) &&
           get_user_by_name(new_name).name |> String.downcase() == String.downcase(new_name) ->

--- a/test/teiserver/data/user_test.exs
+++ b/test/teiserver/data/user_test.exs
@@ -133,4 +133,24 @@ defmodule Teiserver.Data.UserTest do
       assert result == expected, message: "Bad result for email '#{value}'"
     end
   end
+
+  test "username symbol restrictions" do
+    data = [
+      {"abc123", false},
+      {"[abc]_123", false},
+      {"a_b_c[[123]]", false},
+      {"[[__]]", false},
+      {"___", true},
+      {"[[[", true},
+      {"]]]", true},
+      {"_abc_123_", true},
+      {"[]_[]_[]_", true},
+      {"[[[abc123]]]", true}
+    ]
+
+    for {value, expected} <- data do
+      result = CacheUser.check_symbol_limit(value)
+      assert result == expected, message: "Bad result for username '#{value}'"
+    end
+  end
 end


### PR DESCRIPTION
Adds an additional check at registration/rename time, which considers how many times each non-alphanumeric character appears in a requested username.

If any individual symbol appears three or more times, then the new username is rejected (and registration / renaming fails).

This patch is intended to restrict unpronounceable "meme names", such as:
- `___`
- `____`
- `_____`
- `[]]][[[]`
... while still allowing names such as:
- `[[CLAN]]First_Middle_Last`

These kinds of names have exceptionally poor recognizability, and if more than one player in a lobby uses these names then it becomes more difficult to 1) discuss and coordinate with them, or 2) identify misbehaving players for reporting/kickbanning.

Notably, all-symbol names with few repeats are still allowed, such as:
- `__`
- `[[]]`
... however, those names are short enough that I suspect identifying them will be less of an issue. If needed, a future patch could also add a requirement to use at least one alphanumeric character in usernames -- but I believe this change alone is sufficient to prevent confusion.