### PR TITLE
Hijacked lobbies don't apply boss blocks

### DIFF
--- a/lib/teiserver/account/libs/relationship_lib.ex
+++ b/lib/teiserver/account/libs/relationship_lib.ex
@@ -331,11 +331,11 @@ defmodule Teiserver.Account.RelationshipLib do
 
     cond do
       # You are being blocked
-      being_blocked_percentage > block_percentage_needed -> :blocked
-      being_blocked_count > block_count_needed -> :blocked
+      being_blocked_percentage >= block_percentage_needed -> :blocked
+      being_blocked_count >= block_count_needed -> :blocked
       # You are blocking
-      blocking_percentage > block_percentage_needed -> :blocking
-      blocking_count > block_count_needed -> :blocking
+      blocking_percentage >= block_percentage_needed -> :blocking
+      blocking_count >= block_count_needed -> :blocking
       true -> :ok
     end
   end
@@ -375,11 +375,11 @@ defmodule Teiserver.Account.RelationshipLib do
 
     cond do
       # You are being avoided
-      being_avoided_percentage > avoid_percentage_needed -> :avoided
-      being_avoided_count > avoid_count_needed -> :avoided
+      being_avoided_percentage >= avoid_percentage_needed -> :avoided
+      being_avoided_count >= avoid_count_needed -> :avoided
       # You are avoiding
-      avoiding_percentage > avoid_percentage_needed -> :avoiding
-      avoiding_count > avoid_count_needed -> :avoiding
+      avoiding_percentage >= avoid_percentage_needed -> :avoiding
+      avoiding_count >= avoid_count_needed -> :avoiding
       true -> :ok
     end
   end

--- a/lib/teiserver/account/libs/relationship_lib.ex
+++ b/lib/teiserver/account/libs/relationship_lib.ex
@@ -326,8 +326,8 @@ defmodule Teiserver.Account.RelationshipLib do
       |> list_userids_blocked_by_userid()
       |> Enum.count(fn uid -> Enum.member?(userid_list, uid) end)
 
-    being_blocked_percentage = being_blocked_count / userid_count
-    blocking_percentage = blocking_count / userid_count
+    being_blocked_percentage = being_blocked_count / userid_count * 100
+    blocking_percentage = blocking_count / userid_count * 100
 
     cond do
       # You are being blocked

--- a/lib/teiserver/libs/teiserver_configs.ex
+++ b/lib/teiserver/libs/teiserver_configs.ex
@@ -389,7 +389,7 @@ defmodule Teiserver.TeiserverConfigs do
       permissions: ["Admin"],
       description:
         "The percentage of users who would need to block someone to prevent them joining a lobby",
-      default: 66
+      default: 50
     })
 
     add_site_config_type(%{
@@ -419,6 +419,16 @@ defmodule Teiserver.TeiserverConfigs do
       permissions: ["Admin"],
       description: "Maximum team size to be considered as a small team game",
       default: 5
+    })
+
+    add_site_config_type(%{
+      key: "lobby.Max lobby members to gain Founder Boss",
+      section: "Lobbies",
+      type: "integer",
+      permissions: ["Admin"],
+      description:
+        "You will become Founder Boss if bossed when the lobby has this number of members or less.",
+      default: 2
     })
   end
 


### PR DESCRIPTION
## Context
Read discord here: https://discord.com/channels/549281623154229250/1258164084327579678

Currently someone who is boss of lobby will prevent any users on their blocklist from joining. For the OP lobby, this might be the only lobby they can actually join due to not many lobbies available for people at this skill level. Many people vote bosses for trivial things like rename/setting rating restrictions. If these commands were voteable, it's likely a boss would not be needed at all

## Improvement Overview
This PR will differentiate between voted bosses and bosses who create a lobby from scratch. The OP lobby is usually one that is created by hijacking an existing lobby and voting up a boss. After this PR, the voted boss will not have their blocklist applied.

If you create a lobby from scratch, you will gain the label of "Founder boss" (couldn't think of a better name and am happy to change it). As founder boss, your blocklist will be applied to players who try and join. This makes the blocklist not completely useless and also creating a lobby from scratch requires a large wait time (up to an hour) and this guarantees a good first game with the price of having to wait a long time.

## Other Details
1. The max members in lobby to gain founder boss is two i.e. if you are bossed while there are two or fewer members in the lobby you will gain founder boss. This is just for the use case if you are typing in the boss command and someone randomly joins. Or maybe you and a friend want founder boss. An admin can change the threshold to another number via the website.
2.  When determining if someone is blocked from a lobby, there is also a check to see if players are blocking. Previously this would include spectators but now it only includes players. This is relevant for OP lobby which has many random specs. 
3. Due to the changes in boss blocks, it's much harder to get blocked now, so in compensation the default percentage to trigger players blocking has been reduced from 66% to 50%. This means that if there are 10 players in a lobby, 5 will need to be blocking you for you to get blocked. This is still extremely high and it is unlikely that even the most toxic player will trigger it. It is still overridable by the Admin.
4. Some checks have been modified to use `>=` instead of `>` to make it consistent with the wording in the site admin config. For example the admin config has config that says: "_The raw number of players who would need to avoid someone to prevent them becoming a player_". If you set the number to 4 you expect you need 4 or more to trigger not greater than 4.

## Local dev tests
### Testing avoidance
1. Login as user1 and enter a lobby. Login as user2 and enter a lobby. Have user1 right click user2 and ignore them. Right click again and avoid them. Have user1 become a player. Have user2 try to become a player. They will get a message they are being avoided. (Avoidance is checked whenever you go from spectator to player.)

### Testing normal blocks
1. Following up from the previous test, have user1 right click user2 and now block them. Have user2 leave the lobby then try and join. They will get an error message that they are being blocked by too many players.

### Testing founder boss blocks
1. Have user1 boss themselves. Check `$status` and ensure user1 is listed as founder boss. Now have user2 try and join the lobby. They will get a message that they are being blocked by the founder boss.

### Testing normal boss blocks
1. Login to the website as administrator. Go to Admin > Site Config > Max lobby members to gain Founder Boss
2. Set the number to 0
3. Have user1 unboss then boss again. Run `$status` and they should be listed as boss but not founder boss.
5. Have user2 try and join the lobby again. They will get an error message, but it should not mention founder boss.
6. Login to the website as administrator.  Go to Admin > Site Config > Block percentage to prevent join
7. Set to 101
8. Have user2 try and join the lobby again. They should be able to enter.

## Screenshots
Result of $status when there is founder boss
![5](https://github.com/user-attachments/assets/e71cdbb7-b5a5-4642-9dd9-e9e77bcf6927)

Getting blocked by founder boss
![2](https://github.com/user-attachments/assets/680c9fd3-b4f0-4487-af56-6cf18f8acad2)

Result of $status when there is a normal boss
![4](https://github.com/user-attachments/assets/9c4c3235-25bc-474a-9b04-b7132c14d818)

Making it through even though the (normal) boss has blocked you
![4](https://github.com/user-attachments/assets/fc392a7e-a639-49db-a72b-699f0ebc12cd)
