### PR TITLE
Add command to initiate a vote for boss-restricted $-commands.

### DIFF
--- a/lib/teiserver/coordinator/coordinator_lib.ex
+++ b/lib/teiserver/coordinator/coordinator_lib.ex
@@ -30,6 +30,9 @@ defmodule Teiserver.Coordinator.CoordinatorLib do
        "Causes a \"vote\" to start where other players can elect to join you in splitting the lobby, follow someone
 of their choosing or remain in place. After 60 seconds, if at least the minimum number of players agreed to split, you are moved to a new (empty) lobby and those that voted yes
 or are following someone that voted yes are also moved to that lobby.", :everybody},
+      {"cv", ["command", "[parameters]"],
+       "Causes a \"vote\" to start on whether to run \"$command [parameters]\", without requiring boss privileges. Votes can only be started for certain commands.",
+       :everybody},
       {"roll", ["range"], "Rolls a random number based on the range format.
 - Dice format: nDs, where n is number of dice and s is sides of die. E.g. 4D6 - 4 dice with 6 sides are rolled
 - Max format: N, where N is a number and an integer between 1 and N is returned

--- a/lib/teiserver/lobby/schemas/lobby_struct.ex
+++ b/lib/teiserver/lobby/schemas/lobby_struct.ex
@@ -83,6 +83,7 @@ defmodule Teiserver.Lobby.LobbyStruct do
     last_queue_state: [],
     balance_result: nil,
     showmatch: true,
+    cmd_voting: nil,
 
     # Stuff from the consul that needs to move out of the lobby state itself
     split: nil,


### PR DESCRIPTION
**Note: This PR should be considered a proof-of-concept/work-in-progress, and is submitted to request feedback/review.** This is the first non-trivial Teiserver change that I've written, and I am not experienced with Elixir; so I'm not confident that I'm following the idiomatic patterns for the language.

Currently, a boss is often democratically elected in order to make a relatively-minor settings change, rather than for lobby management reasons. However, this is not-uncommonly subject to abuse; a player may lie (or just not tell the whole truth) to be voted as boss, and then they may take actions other than what the rest of the lobby expects.

This PR seeks to provide an alternative way for a democratic lobby to change certain settings, without electing a boss. It does so by making the following changes:
- Add "$cv <...>" command to allow voting on whether to run a whitelisted $-command, without using boss privileges.
- Add "$ev" command to cancel a running vote.
- Extend "$y" and "$n" (currently used for "$splitlobby") to also update votes for "$cv".

The general flow of these commands is as follows:
1. A player runs a $cv command to change a setting. For example: $cv minratinglevel 1
2. Over the next 30 seconds, players may say "$y" or "$n" to place their votes
3. After 30 seconds, if the number of $y votes is higher than the number of $n votes, then the command executes as if the Coordinator had run it.

Some restrictions have been created for the above commands:
- $cv can only be used with commands that have been whitelisted for voting.
- $cv cannot be run by spectators
- $cv cannot be run by players when a boss is present
- $ev can only be run by the player who ran $cv (or privileged users)

The following commands are currently whitelisted for voting:
- welcome-message
- rename
- minratinglevel
- maxratinglevel
- setratinglevels
- resetratinglevels
- minchevlevel
- maxchevlevel
- resetchevlevels

The patch was tested in my local dev environment, but I plan to do additional polishing/testing. I am submitting this PR now for  early feedback, particularly regarding any preferred ways to implement this feature, so that less work is wasted if a change in approach is needed.