### PR TITLE
Better rating logs

### DIFF
--- a/lib/teiserver/game/libs/match_rating_lib.ex
+++ b/lib/teiserver/game/libs/match_rating_lib.ex
@@ -103,16 +103,9 @@ defmodule Teiserver.Game.MatchRatingLib do
     end
   end
 
-  @spec do_rate_match(Teiserver.Battle.Match.t()) :: :ok
-  defp do_rate_match(match) do
-    if(Map.has_key?(match, :team_count)) do
-      do_rate_match(match, [])
-    else
-      :ok
-    end
-  end
-
   @spec do_rate_match(Teiserver.Battle.Match.t(), any()) :: :ok
+  defp do_rate_match(match, opts \\ [])
+
   # The algorithm has not been implemented for FFA correctly so we have a clause for
   # 2 teams (correctly implemented) and a special for 3+ teams
   defp do_rate_match(%{team_count: 2} = match, opts) do
@@ -459,7 +452,6 @@ defmodule Teiserver.Game.MatchRatingLib do
     #       end)
     #   end)
     #   |> List.flatten
-
 
     save_rating_logs(match.id, win_ratings, loss_ratings, override?)
 

--- a/lib/teiserver/mix_tasks/rerate_my_matches.ex
+++ b/lib/teiserver/mix_tasks/rerate_my_matches.ex
@@ -1,0 +1,47 @@
+defmodule Mix.Tasks.Teiserver.RerateMyMatches do
+  @moduledoc """
+  Re rates matches belonging to one user
+
+  If you want to run this task invidually, use:
+  mix teiserver.rerate_my_matches <username>
+  """
+  use Mix.Task
+  alias Teiserver.Repo
+  require Logger
+
+  def run(args) do
+    Application.ensure_all_started(:teiserver)
+
+    username = Enum.at(args, 0)
+
+    case username do
+      nil ->
+        Logger.info("Username parameter cannot be empty")
+
+      _ ->
+        match_ids = get_match_ids(username)
+        Teiserver.Game.MatchRatingLib.re_rate_specific_matches(match_ids)
+        Logger.info("Finished rerating matches of #{username}")
+    end
+  end
+
+  defp get_match_ids(username) do
+    query = """
+    SELECT tbmm.match_id
+    FROM teiserver_battle_match_memberships tbmm
+    INNER JOIN teiserver_battle_matches tbm ON tbm.id = tbmm.match_id
+    WHERE user_id = (
+    SELECT id FROM account_users au WHERE name = $1
+    )
+    """
+
+    case Ecto.Adapters.SQL.query(Repo, query, [username]) do
+      {:ok, results} ->
+        results.rows
+        |> List.flatten()
+
+      {a, b} ->
+        raise "ERR: #{a}, #{b}"
+    end
+  end
+end


### PR DESCRIPTION
## Context
The purpose of this PR is to add more information into rating logs (`teiserver_game_rating_logs `) so that we can run balance algorithms using past information. Currently we store the following information in rating logs:
- skill
- uncertainty

My split_one_chevs algo also looks at rank, and Marek's algo looks at playtime. 
https://discord.com/channels/549281623154229250/1262186207673192530/1263880002563346463

When we run a balance algorithm on a past match, it should ideally pull information from the rating logs table to get data at the time of the match.

## Improvements
This PR will add the following information to rating logs whenever a match is rated
- rank
- play_hours
- spectator_hours

## Testing locally
Run the following task replacing <username> with the username of a user.
```
mix teiserver.rerate_my_matches <username>
```

This will re-rate all the matches of a single user.

Open up some sort of database viewer and check that the rating logs have new information (replace 'spadsbot' with the name of the user you want to look at)
```
SELECT tgrl.value
FROM teiserver_battle_match_memberships tbmm
INNER JOIN teiserver_battle_matches tbm ON tbm.id = tbmm.match_id
	AND user_id = (
		SELECT id
		FROM account_users au
		WHERE name = 'spadsbot'
		)
INNER JOIN teiserver_game_rating_logs tgrl ON tgrl.match_id = tbmm.match_id
``` 

Check that the value column has new fields (rank, play_hours, spectator_hours) e.g.
```
{"rank": 2, "skill": 24.46916062276121, "play_hours": 76, "uncertainty": 7.18185060647911, "rating_value": 17.2873100162821, "skill_change": 0.6665220793110613, "spectator_hours": 0, "uncertainty_change": -0.04568334603121116, "rating_value_change": 0.7122054253422725}
```

Login to the website and select a match. View the balance tab. Change the dropdown to split_one_chevs and ensure it doesn't crash. It will pull past data from the `teiserver_game_rating_logs ` table if possible