### PR TITLE
Make match open new tab on ctrl + click

### DIFF
--- a/lib/teiserver_web/live/battles/match/ratings.html.heex
+++ b/lib/teiserver_web/live/battles/match/ratings.html.heex
@@ -87,10 +87,10 @@
               log.value["uncertainty_change"] < 0 -> {"text-secondary column-delta", "arrow-down"}
               true -> {"text-secondary column-delta", "pause"}
             end %>
-          <tr phx-click={"[[\"navigate\",{\"href\":\"/battle/#{log.match_id}\",\"replace\":false}]]"}>
+          <tr>
             <%= if log.match do %>
               <td>
-                <%= live_redirect("#{log.match.map}", to: ~p"/battle/#{log.match_id}") %>
+                <%= log.match.map %>
               </td>
               <td><%= log.match.team_size * log.match.team_count %></td>
             <% else %>
@@ -127,11 +127,9 @@
 
             <%= if log.match do %>
               <td>
-                <div class="visually-hidden">
-                  <.link navigate={~p"/battle/#{log.match_id}"}>
-                    Show
+                  <.link navigate={~p"/battle/#{log.match_id}"} class="stretched-link">
+                    
                   </.link>
-                </div>
               </td>
             <% else %>
               <td>&nbsp;</td>

--- a/lib/teiserver_web/live/battles/match/ratings.html.heex
+++ b/lib/teiserver_web/live/battles/match/ratings.html.heex
@@ -127,9 +127,7 @@
 
             <%= if log.match do %>
               <td>
-                  <.link navigate={~p"/battle/#{log.match_id}"} class="stretched-link">
-                    
-                  </.link>
+                <.link navigate={~p"/battle/#{log.match_id}"} class="stretched-link"></.link>
               </td>
             <% else %>
               <td>&nbsp;</td>


### PR DESCRIPTION
## Context
Go to matches > ratings > large team
Currently if you hold ctrl + click link, it opens in same window

This PR will make it so that if you hold ctrl + click a row it will open in new tab.

## Test Steps
Go to matches > ratings > large team
Hold ctrl + click link, it should open in new tab
Clicking normally will open in same tab