### PR TITLE
Boss blocks applied only on custom preset

### DIFF
--- a/lib/teiserver/account/libs/relationship_lib.ex
+++ b/lib/teiserver/account/libs/relationship_lib.ex
@@ -326,16 +326,16 @@ defmodule Teiserver.Account.RelationshipLib do
       |> list_userids_blocked_by_userid()
       |> Enum.count(fn uid -> Enum.member?(userid_list, uid) end)
 
-    being_blocked_percentage = being_blocked_count / userid_count
-    blocking_percentage = blocking_count / userid_count
+    being_blocked_percentage = being_blocked_count / userid_count * 100
+    blocking_percentage = blocking_count / userid_count * 100
 
     cond do
       # You are being blocked
-      being_blocked_percentage > block_percentage_needed -> :blocked
-      being_blocked_count > block_count_needed -> :blocked
+      being_blocked_percentage >= block_percentage_needed -> :blocked
+      being_blocked_count >= block_count_needed -> :blocked
       # You are blocking
-      blocking_percentage > block_percentage_needed -> :blocking
-      blocking_count > block_count_needed -> :blocking
+      blocking_percentage >= block_percentage_needed -> :blocking
+      blocking_count >= block_count_needed -> :blocking
       true -> :ok
     end
   end
@@ -375,11 +375,11 @@ defmodule Teiserver.Account.RelationshipLib do
 
     cond do
       # You are being avoided
-      being_avoided_percentage > avoid_percentage_needed -> :avoided
-      being_avoided_count > avoid_count_needed -> :avoided
+      being_avoided_percentage >= avoid_percentage_needed -> :avoided
+      being_avoided_count >= avoid_count_needed -> :avoided
       # You are avoiding
-      avoiding_percentage > avoid_percentage_needed -> :avoiding
-      avoiding_count > avoid_count_needed -> :avoiding
+      avoiding_percentage >= avoid_percentage_needed -> :avoiding
+      avoiding_count >= avoid_count_needed -> :avoiding
       true -> :ok
     end
   end

--- a/lib/teiserver/coordinator/consul_commands.ex
+++ b/lib/teiserver/coordinator/consul_commands.ex
@@ -62,15 +62,16 @@ defmodule Teiserver.Coordinator.ConsulCommands do
         [] ->
           "Nobody is bossed"
 
-        [boss_id] ->
-          "Host boss is: #{CacheUser.get_username(boss_id)}"
-
         boss_ids ->
           boss_names =
             boss_ids
             |> Enum.map_join(", ", fn b -> CacheUser.get_username(b) end)
 
-          "Host bosses are: #{boss_names}"
+          if state.host_preset != nil && Regex.match?(~r/custom/i, state.host_preset) do
+            "Boss: #{boss_names} (Custom preset: No votes allowed)"
+          else
+            "Boss: #{boss_names}"
+          end
       end
 
     tourney_mode =

--- a/lib/teiserver/coordinator/consul_server.ex
+++ b/lib/teiserver/coordinator/consul_server.ex
@@ -864,7 +864,7 @@ defmodule Teiserver.Coordinator.ConsulServer do
       boss_avoid_status == true ->
         match_id = Battle.get_lobby_match_id(state.lobby_id)
         Telemetry.log_simple_lobby_event(user.id, match_id, "play_refused.boss_avoided")
-        msg = "You are avoided by the founder boss of this lobby"
+        msg = "You are avoided by the boss of this lobby"
         CacheUser.send_direct_message(get_coordinator_userid(), userid, msg)
         false
 

--- a/lib/teiserver/coordinator/consul_server.ex
+++ b/lib/teiserver/coordinator/consul_server.ex
@@ -806,17 +806,23 @@ defmodule Teiserver.Coordinator.ConsulServer do
 
   @spec user_allowed_to_play?(T.user(), T.client(), map()) :: boolean()
   defp user_allowed_to_play?(user, client, state) do
-    player_list = list_players(state)
+    player_ids = list_player_ids(state)
     userid = user.id
 
-    avoid_status = Account.check_avoid_status(user.id, player_list)
+    avoid_status = Account.check_avoid_status(user.id, player_ids)
 
     boss_avoid_status =
-      state.host_bosses
-      |> Stream.map(fn boss_id ->
-        Account.does_a_avoid_b?(boss_id, user.id)
-      end)
-      |> Enum.any?()
+      case is_custom_preset?(state) do
+        true ->
+          state.host_bosses
+          |> Stream.map(fn boss_id ->
+            Account.does_a_avoid_b?(boss_id, user.id)
+          end)
+          |> Enum.any?()
+
+        false ->
+          false
+      end
 
     rating_check_result = LobbyRestrictions.check_rating_to_play(userid, state)
 
@@ -844,20 +850,33 @@ defmodule Teiserver.Coordinator.ConsulServer do
       avoid_status == :avoiding ->
         match_id = Battle.get_lobby_match_id(state.lobby_id)
         Telemetry.log_simple_lobby_event(user.id, match_id, "play_refused.avoiding")
+        msg = "You are avoiding too many players in this lobby"
+        CacheUser.send_direct_message(get_coordinator_userid(), userid, msg)
         false
 
       avoid_status == :avoided ->
         match_id = Battle.get_lobby_match_id(state.lobby_id)
         Telemetry.log_simple_lobby_event(user.id, match_id, "play_refused.avoided")
+        msg = "You are avoided by too many players in this lobby"
+        CacheUser.send_direct_message(get_coordinator_userid(), userid, msg)
         false
 
       boss_avoid_status == true ->
         match_id = Battle.get_lobby_match_id(state.lobby_id)
         Telemetry.log_simple_lobby_event(user.id, match_id, "play_refused.boss_avoided")
+        msg = "You are avoided by the founder boss of this lobby"
+        CacheUser.send_direct_message(get_coordinator_userid(), userid, msg)
         false
 
       true ->
         true
+    end
+  end
+
+  defp is_custom_preset?(state) do
+    case state.host_preset do
+      nil -> false
+      _ -> Regex.match?(~r/custom/i, state.host_preset)
     end
   end
 
@@ -925,17 +944,22 @@ defmodule Teiserver.Coordinator.ConsulServer do
     end
 
     # Blocking using relationships
-    member_list = Battle.get_lobby_member_list(state.lobby_id)
+    player_ids = list_player_ids(state)
     match_id = Battle.get_lobby_match_id(state.lobby_id)
-
-    block_status = Account.check_block_status(userid, member_list)
+    block_status = Account.check_block_status(userid, player_ids)
 
     boss_avoid_status =
-      state.host_bosses
-      |> Stream.map(fn boss_id ->
-        Account.does_a_avoid_b?(boss_id, userid)
-      end)
-      |> Enum.any?()
+      case is_custom_preset?(state) do
+        true ->
+          state.host_bosses
+          |> Stream.map(fn boss_id ->
+            Account.does_a_avoid_b?(boss_id, userid)
+          end)
+          |> Enum.any?()
+
+        false ->
+          false
+      end
 
     cond do
       client == nil ->
@@ -1233,6 +1257,14 @@ defmodule Teiserver.Coordinator.ConsulServer do
 
   def get_max_player_count(state) do
     min(state.host_teamcount * state.host_teamsize, state.player_limit)
+  end
+
+  @spec list_player_ids(map()) :: [T.userid()]
+  def list_player_ids(state) do
+    list_players(state)
+    |> Enum.map(fn x ->
+      x[:userid]
+    end)
   end
 
   @spec list_players(map()) :: [T.client()]

--- a/lib/teiserver/libs/teiserver_configs.ex
+++ b/lib/teiserver/libs/teiserver_configs.ex
@@ -389,7 +389,7 @@ defmodule Teiserver.TeiserverConfigs do
       permissions: ["Admin"],
       description:
         "The percentage of users who would need to block someone to prevent them joining a lobby",
-      default: 66
+      default: 50
     })
 
     add_site_config_type(%{
@@ -399,7 +399,7 @@ defmodule Teiserver.TeiserverConfigs do
       permissions: ["Admin"],
       description:
         "The raw number of players who would need to avoid someone to prevent them becoming a player",
-      default: 4
+      default: 8
     })
 
     add_site_config_type(%{

--- a/test/teiserver/coordinator/spads_parser_test.exs
+++ b/test/teiserver/coordinator/spads_parser_test.exs
@@ -42,4 +42,26 @@ defmodule Teiserver.Coordinator.SpadsParserTest do
     {:host_update, host_data} = result
     assert host_data.host_bosses == []
   end
+
+  test "parsing changes to presets" do
+    state = %{host_bosses: []}
+
+    message =
+      "* BarManager|{\"BattleStateChanged\": {\"locked\": \"unlocked\", \"autoBalance\": \"advanced\", \"teamSize\": \"6\", \"nbTeams\": \"2\", \"balanceMode\": \"clan;skill\", \"preset\": \"default\"}}"
+
+    bar_manager_state = SpadsParser.parse_barmanager_state(message)
+    assert bar_manager_state == {:ok, %{preset: "default"}}
+
+    result = SpadsParser.handle_in(message, %{host_bosses: []})
+    assert result == {:host_update, %{host_preset: "default"}}
+  end
+
+  test "bad string" do
+    state = %{host_bosses: []}
+
+    message = "blah"
+
+    result = SpadsParser.handle_in(message, %{host_bosses: []})
+    assert result == nil
+  end
 end

--- a/test/teiserver/coordinator/spads_parser_test.exs
+++ b/test/teiserver/coordinator/spads_parser_test.exs
@@ -44,8 +44,6 @@ defmodule Teiserver.Coordinator.SpadsParserTest do
   end
 
   test "parsing changes to presets" do
-    state = %{host_bosses: []}
-
     message =
       "* BarManager|{\"BattleStateChanged\": {\"locked\": \"unlocked\", \"autoBalance\": \"advanced\", \"teamSize\": \"6\", \"nbTeams\": \"2\", \"balanceMode\": \"clan;skill\", \"preset\": \"default\"}}"
 
@@ -57,8 +55,6 @@ defmodule Teiserver.Coordinator.SpadsParserTest do
   end
 
   test "bad string" do
-    state = %{host_bosses: []}
-
     message = "blah"
 
     result = SpadsParser.handle_in(message, %{host_bosses: []})


### PR DESCRIPTION
## Context
Initial PR here: https://github.com/beyond-all-reason/teiserver/pull/364
This PR is based on feedback by Lexon

## Improvements
Boss blocks are only applied when you have custom preset

## Other changes
When there is an avoid check, either raw count or percentage is checked. The default raw count for avoid to trigger used to be 4. This is very low for the custom big battle events. This has been raised to 8 but is still overridable by Admin.

When there is a block check, the default percentage has been reduced from 66 to 50 since you're less likely to get blocked now. Can be overrided by admin. So far nobody has even triggered this.

Equality checks use >= instead of > to match what is written in the Admin Config portal. For example the Admin config has config that says: "The raw number of players who would need to avoid someone to prevent them becoming a player". If you set the number to 4 you expect you need 4 or more to trigger not greater than 4.

If avoided, a Coordinator message will appear.

## Test Steps
Boss yourself and do `$status`. It should show you as boss. 
Change to custom preset and run `$status` it will say that no votes are allowed next to your boss status.

Login as a second user, have them try and enter your lobby. It should work. 

Have the boss user block the second user. The second user should not be allowed to play. If the second user leaves then joins they will be blocked.

Have the boss change from custom preset to something else. Now have the second user try to join. They will not receive the boss blocked message. They may receive a different boss block message since 100% of people in the lobby are blocking them.

Go to Admin > Site Config and change the blocking and avoiding thresholds to 0 for percentage. The second user should now be able to enter.
