### PR TITLE
Add "$set-config-teaser" Host-command. (Prerequisite to fixing #371)

### DIFF
--- a/lib/teiserver/coordinator/consul_commands.ex
+++ b/lib/teiserver/coordinator/consul_commands.ex
@@ -1515,8 +1515,8 @@ defmodule Teiserver.Coordinator.ConsulCommands do
     new_teaser = String.trim(new_teaser)
 
     new_teaser =
-      case Regex.run(~r/^[a-zA-Z0-9_\-\[\] \<\>\+\|:]+$/, new_teaser) do
-        [s] -> s
+      case chars_valid_for_lobby_name?(new_teaser) do
+        true -> new_teaser
         _ -> ""
       end
 
@@ -1529,8 +1529,8 @@ defmodule Teiserver.Coordinator.ConsulCommands do
     new_name = String.trim(new_name)
 
     stripped_name =
-      case Regex.run(~r/^[a-zA-Z0-9_\-\[\] \<\>\+\|:]+$/, new_name) do
-        [s] -> s
+      case chars_valid_for_lobby_name?(new_name) do
+        true -> new_name
         _ -> ""
       end
 
@@ -2130,6 +2130,14 @@ defmodule Teiserver.Coordinator.ConsulCommands do
 
       false ->
         -1
+    end
+  end
+
+  @spec chars_valid_for_lobby_name?(String.t()) :: boolean()
+  defp chars_valid_for_lobby_name?(string) do
+    case Regex.run(~r/^[a-zA-Z0-9_\-\[\] \<\>\+\|:]+$/, string) do
+      [_] -> true
+      _ -> false
     end
   end
 

--- a/lib/teiserver/coordinator/consul_server.ex
+++ b/lib/teiserver/coordinator/consul_server.ex
@@ -18,7 +18,7 @@ defmodule Teiserver.Coordinator.ConsulServer do
     Communication
   }
 
-  alias Teiserver.Lobby.{ChatLib, LobbyRestrictions}
+  alias Teiserver.Lobby.{ChatLib, LobbyRestrictions, LobbyLib}
   import Teiserver.Helper.NumberHelper, only: [int_parse: 1]
   alias Phoenix.PubSub
   alias Teiserver.Battle.BalanceLib
@@ -28,7 +28,7 @@ defmodule Teiserver.Coordinator.ConsulServer do
   @always_allow ~w(status s y n follow joinq leaveq splitlobby afks roll players password? newlobby jazlobby tournament)
   @boss_commands ~w(balancemode gatekeeper welcome-message meme reset-approval rename minchevlevel maxchevlevel resetchevlevels resetratinglevels minratinglevel maxratinglevel setratinglevels)
   @vip_boss_commands ~w(shuffle)
-  @host_commands ~w(specunready makeready settag speclock forceplay lobbyban lobbybanmult unban forcespec forceplay lock unlock makebalance)
+  @host_commands ~w(specunready makeready settag speclock forceplay lobbyban lobbybanmult unban forcespec forceplay lock unlock makebalance set-config-teaser)
 
   # @handled_by_lobby ~w(explain)
   @default_balance_algorithm "loser_picks"
@@ -396,10 +396,7 @@ defmodule Teiserver.Coordinator.ConsulServer do
         })
 
       # Remove filters from lobby name
-      lobby = Lobby.get_lobby(state.lobby_id)
-      old_name = lobby.name
-      new_name = String.split(old_name, "|", trim: true) |> Enum.at(0)
-      Battle.rename_lobby(state.lobby_id, new_name, nil)
+      LobbyLib.cast_lobby(state.lobby_id, :refresh_name)
 
       {:noreply, new_state}
     else

--- a/lib/teiserver/lobby.ex
+++ b/lib/teiserver/lobby.ex
@@ -85,6 +85,7 @@ defmodule Teiserver.Lobby do
         player_rename: false,
         base_name: lobby.name,
         display_name: lobby.name,
+        teaser: "",
 
         # Used to indicate the lobby is subject to a lobby policy
         lobby_policy_id: nil,

--- a/lib/teiserver/lobby/schemas/lobby_struct.ex
+++ b/lib/teiserver/lobby/schemas/lobby_struct.ex
@@ -30,6 +30,7 @@ defmodule Teiserver.Lobby.LobbyStruct do
 
     # Basic variables
     base_name: nil,
+    teaser: "",
     rename_type: nil,
     password: nil,
     locked: nil,

--- a/lib/teiserver/lobby/servers/lobby_server.ex
+++ b/lib/teiserver/lobby/servers/lobby_server.ex
@@ -545,6 +545,7 @@ defmodule Teiserver.Battle.LobbyServer do
       cond do
         state.lobby.teaser == "" ->
           ""
+
         true ->
           " " <> state.lobby.teaser
       end

--- a/lib/teiserver/lobby/servers/lobby_server.ex
+++ b/lib/teiserver/lobby/servers/lobby_server.ex
@@ -541,9 +541,17 @@ defmodule Teiserver.Battle.LobbyServer do
   defp generate_name(state) do
     consul_state = Coordinator.call_consul(state.id, :get_consul_state)
 
+    teaser =
+      cond do
+        state.lobby.teaser == "" ->
+          ""
+        true ->
+          " " <> state.lobby.teaser
+      end
+
     parts =
       [
-        "",
+        teaser,
         LobbyRestrictions.get_rank_bounds_for_title(consul_state),
         # Rating stuff here
         LobbyRestrictions.get_rating_bounds_for_title(consul_state)

--- a/test/teiserver/battle/lobby_server_test.exs
+++ b/test/teiserver/battle/lobby_server_test.exs
@@ -77,6 +77,7 @@ defmodule Teiserver.Battle.LobbyServerTest do
       game_hash: "string_of_characters",
       map_hash: "string_of_characters",
       map_name: "koom valley",
+      teaser: "",
       game_name: "BAR",
       engine_name: "spring-105",
       engine_version: "105.1.2.3",


### PR DESCRIPTION
This command allows Hosts to specify a string that can be used to quickly describe a lobby's currently-configured settings.

The teaser is currently used in the title of a lobby, similar to the existing behavior but without using the "$rename" command. This gives the benefit of not potentially overriding a custom player-set lobby name.

____

This PR is a complement to https://github.com/beyond-all-reason/spads_config_bar/pull/136 , and implements the Teiserver-side command used in that PR. Since BarManager's rename functionality is currently broken, it does not particularly matter which of these two PRs is merged first (no harm will be done if BarManager is using a non-existent command).

This PR specifically **does not** update the `$rename` command, as that would impact player-set lobby names for any SPADS instances that still use the old BarManager code. Once the new plugin code is running on all servers, I can submit a very short PR to update `$rename` and fix #371.