### PR TITLE
Defaults cache lists to empty lists

### DIFF
--- a/lib/teiserver/chat/chat_room_cache.ex
+++ b/lib/teiserver/chat/chat_room_cache.ex
@@ -144,6 +144,8 @@ defmodule Teiserver.Room do
     Teiserver.cache_put(:rooms, room.name, room)
 
     Teiserver.cache_update(:lists, :rooms, fn value ->
+      value = value || []
+
       new_value =
         [room.name | value]
         |> Enum.uniq()
@@ -155,7 +157,7 @@ defmodule Teiserver.Room do
   end
 
   def list_rooms() do
-    Teiserver.cache_get(:lists, :rooms)
+    (Teiserver.cache_get(:lists, :rooms) || [])
     |> Enum.map(fn room_name -> Teiserver.cache_get(:rooms, room_name) end)
   end
 

--- a/lib/teiserver/data/matchmaking.ex
+++ b/lib/teiserver/data/matchmaking.ex
@@ -176,6 +176,8 @@ defmodule Teiserver.Data.Matchmaking do
 
   def add_queue(queue) do
     Teiserver.cache_update(:lists, :queues, fn value ->
+      value = value || []
+
       new_value =
         [queue.id | value]
         |> Enum.uniq()

--- a/lib/teiserver/game/libs/lobby_policy_lib.ex
+++ b/lib/teiserver/game/libs/lobby_policy_lib.ex
@@ -238,6 +238,8 @@ defmodule Teiserver.Game.LobbyPolicyLib do
 
   defp cache_updated_lobby_policy(lobby_policy) do
     Teiserver.cache_update(:lists, :lobby_policies, fn value ->
+      value = value || []
+
       new_value =
         [lobby_policy.id | value]
         |> Enum.uniq()
@@ -261,7 +263,7 @@ defmodule Teiserver.Game.LobbyPolicyLib do
 
   @spec list_cached_lobby_policies() :: list()
   def list_cached_lobby_policies() do
-    Teiserver.cache_get(:lists, :lobby_policies)
+    (Teiserver.cache_get(:lists, :lobby_policies) || [])
     |> Enum.map(fn id ->
       get_cached_lobby_policy(id)
     end)


### PR DESCRIPTION
Because the `:lists` cache has an expiry time of 1 minutes, if there's no activity for a given list after a minute, retrieving the list would return `nil` and that causes problem when the code expects `[]`.