### PR TITLE
Fix compiler warnings

### DIFF
--- a/lib/teiserver/helpers/styling_helpers.ex
+++ b/lib/teiserver/helpers/styling_helpers.ex
@@ -53,10 +53,10 @@ defmodule Teiserver.Helper.StylingHelper do
 
   @spec icon(atom) :: String.t()
   def icon(nil), do: nil
-  def icon(nil, _), do: nil
   def icon(atom), do: icon(atom, "solid")
 
   @spec icon(atom, String.t()) :: String.t()
+  def icon(nil, _), do: nil
   def icon(:report, fa_type), do: "fa-#{fa_type} fa-signal"
   def icon(:up, fa_type), do: "fa-#{fa_type} fa-level-up"
   def icon(:back, fa_type), do: "fa-#{fa_type} fa-arrow-left"

--- a/lib/teiserver/moderation/queries/report_group_queries.ex
+++ b/lib/teiserver/moderation/queries/report_group_queries.ex
@@ -84,8 +84,6 @@ defmodule Teiserver.Moderation.ReportGroupQueries do
       where: fragment("? ~* ?", reports.type, ^kind)
   end
 
-  defp _where(query, :has_reports_of_kind, nil), do: query
-
   @spec do_order_by(Ecto.Query.t(), list | nil) :: Ecto.Query.t()
   defp do_order_by(query, nil), do: query
 

--- a/lib/teiserver_web/controllers/admin/match_controller.ex
+++ b/lib/teiserver_web/controllers/admin/match_controller.ex
@@ -1,8 +1,7 @@
 defmodule TeiserverWeb.Admin.MatchController do
   use TeiserverWeb, :controller
 
-  alias Teiserver.{Battle, Game, Account, Telemetry}
-  alias Teiserver.Battle.{MatchLib, BalanceLib}
+  alias Teiserver.{Battle, Game, Account}
   import Teiserver.Helper.StringHelper, only: [get_hash_id: 1]
   require Logger
 

--- a/lib/teiserver_web/live/account/profile/overview.ex
+++ b/lib/teiserver_web/live/account/profile/overview.ex
@@ -59,6 +59,7 @@ defmodule TeiserverWeb.Account.ProfileLive.Overview do
     |> assign(:page_title, "#{user.name} - Achievements")
   end
 
+  @impl true
   def handle_info(%{channel: "teiserver_client_messages:" <> _, event: :connected}, socket) do
     user_id = socket.assigns.user.id
 

--- a/lib/teiserver_web/live/account/profile/overview.ex
+++ b/lib/teiserver_web/live/account/profile/overview.ex
@@ -84,6 +84,20 @@ defmodule TeiserverWeb.Account.ProfileLive.Overview do
   end
 
   @impl true
+  def handle_event("join", _params, %{assigns: assigns} = socket) do
+    current_user_id = assigns.current_user.id
+    lobby_id = assigns.client.lobby_id
+
+    with :ok <- client_connected(current_user_id),
+         :ok <- server_allows_join(lobby_id, current_user_id),
+         :ok <- join_lobby(lobby_id, current_user_id) do
+      {:noreply, put_flash(socket, :success, "Lobby joined")}
+    else
+      {:error, reason} ->
+        {:noreply, put_flash(socket, :warning, reason)}
+    end
+  end
+
   def handle_event(
         "follow-user",
         _event,
@@ -269,37 +283,6 @@ defmodule TeiserverWeb.Account.ProfileLive.Overview do
     {:noreply, socket}
   end
 
-  def get_relationships_and_permissions(%{assigns: %{current_user: nil}} = socket) do
-    socket
-    |> assign(:relationship, [])
-    |> assign(:friendship, [])
-    |> assign(:friendship_request, [])
-    |> assign(:profile_permissions, [])
-  end
-
-  def get_relationships_and_permissions(%{assigns: %{user: nil}} = socket) do
-    socket
-    |> assign(:relationship, [])
-    |> assign(:friendship, [])
-    |> assign(:friendship_request, [])
-    |> assign(:profile_permissions, [])
-  end
-
-  def handle_event("join", _params, %{assigns: assigns} = socket) do
-    user_id = assigns.user.id
-    current_user_id = assigns.current_user.id
-    lobby_id = assigns.client.lobby_id
-
-    with :ok <- client_connected(current_user_id),
-         :ok <- server_allows_join(lobby_id, current_user_id),
-         :ok <- join_lobby(lobby_id, current_user_id) do
-      {:noreply, put_flash(socket, :success, "Lobby joined")}
-    else
-      {:error, reason} ->
-        {:noreply, put_flash(socket, :warning, reason)}
-    end
-  end
-
   defp client_connected(user_id) do
     client = Account.get_client_by_id(user_id)
 
@@ -323,6 +306,22 @@ defmodule TeiserverWeb.Account.ProfileLive.Overview do
     else
       {:error, "Failed to join lobby"}
     end
+  end
+
+  def get_relationships_and_permissions(%{assigns: %{current_user: nil}} = socket) do
+    socket
+    |> assign(:relationship, [])
+    |> assign(:friendship, [])
+    |> assign(:friendship_request, [])
+    |> assign(:profile_permissions, [])
+  end
+
+  def get_relationships_and_permissions(%{assigns: %{user: nil}} = socket) do
+    socket
+    |> assign(:relationship, [])
+    |> assign(:friendship, [])
+    |> assign(:friendship_request, [])
+    |> assign(:profile_permissions, [])
   end
 
   def get_relationships_and_permissions(

--- a/lib/teiserver_web/templates/admin/user/smurf_list.html.heex
+++ b/lib/teiserver_web/templates/admin/user/smurf_list.html.heex
@@ -185,9 +185,7 @@ is_moderator = allow?(@conn, "Moderator") %>
                 </tr>
 
                 <%= for user <- @users do %>
-                  <% user_stats = @stats_map[user.id]
-                  games_allied = @games_allied[user.id]
-                  games_vs = @games_vs[user.id] %>
+                  <% user_stats = @stats_map[user.id] %>
 
                   <tr>
                     <td style={"background-color: #{user.colour}; color: #FFF;"} width="22">


### PR DESCRIPTION
Some minor changes.
Running `mix compile --all-warnings --warnings-as-errors` now passes, no more compiler warnings.