### PR TITLE
Save first_ip at registration time.

### DIFF
--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -335,6 +335,7 @@ defmodule Teiserver.CacheUser do
     case Account.script_create_user(params) do
       {:ok, user} ->
         Account.update_user_stat(user.id, %{
+          "first_ip" => ip,
           "country" => Teiserver.Geoip.get_flag(ip),
           "verification_code" => (:rand.uniform(899_999) + 100_000) |> to_string
         })

--- a/lib/teiserver_web/controllers/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/admin/user_controller.ex
@@ -1092,6 +1092,7 @@ defmodule TeiserverWeb.Admin.UserController do
         Account.update_cache_user(user.id, new_user)
 
         Account.delete_user_stat_keys(user.id, [
+          "first_ip",
           "country",
           "last_ip"
         ])


### PR DESCRIPTION
Currently, only the most-recently-used IP address ("last_ip") for each account is stored in the database. This 2-line PR saves the IP used when an account was registered ("first_ip") as well, accessible to Admins and Moderators.