### PR TITLE
Bugfix: Allow hosts to rename lobbies with equal priority to players.

### DIFF
--- a/lib/teiserver/coordinator/consul_commands.ex
+++ b/lib/teiserver/coordinator/consul_commands.ex
@@ -1618,9 +1618,6 @@ defmodule Teiserver.Coordinator.ConsulCommands do
 
         state
 
-      lobby.player_rename ->
-        state
-
       true ->
         Battle.rename_lobby(state.lobby_id, new_name, nil)
 
@@ -2053,8 +2050,6 @@ defmodule Teiserver.Coordinator.ConsulCommands do
   end
 
   def handle_command(%{command: "reset"} = _cmd, state) do
-    Battle.update_lobby_values(state.lobby_id, %{player_rename: false})
-
     ConsulServer.empty_state(state.lobby_id)
     |> ConsulServer.broadcast_update("reset")
   end

--- a/lib/teiserver/lobby.ex
+++ b/lib/teiserver/lobby.ex
@@ -81,8 +81,6 @@ defmodule Teiserver.Lobby do
         match_id: nil,
 
         # Rename flags
-        # consul rename means it was renamed by a player and overrides spads
-        player_rename: false,
         base_name: lobby.name,
         display_name: lobby.name,
         teaser: "",
@@ -763,10 +761,6 @@ defmodule Teiserver.Lobby do
     cond do
       CacheUser.is_moderator?(changer.userid) == true ->
         true
-
-      # If the battle has been renamed by the consul then we'll keep it renamed as such
-      battle.player_rename == true and cmd == :update_lobby_title ->
-        false
 
       # Basic stuff
       battle.founder_id == changer.userid ->

--- a/lib/teiserver/lobby/servers/lobby_server.ex
+++ b/lib/teiserver/lobby/servers/lobby_server.ex
@@ -213,7 +213,6 @@ defmodule Teiserver.Battle.LobbyServer do
   end
 
   def handle_cast({:rename_lobby, new_base_name, renamer_id}, state) do
-
     Telemetry.log_complex_lobby_event(renamer_id, state.match_id, "command.rename", %{
       name: new_base_name
     })

--- a/lib/teiserver/lobby/servers/lobby_server.ex
+++ b/lib/teiserver/lobby/servers/lobby_server.ex
@@ -213,20 +213,16 @@ defmodule Teiserver.Battle.LobbyServer do
   end
 
   def handle_cast({:rename_lobby, new_base_name, renamer_id}, state) do
-    player_rename = not Account.has_any_role?(renamer_id, "bot")
 
-    if player_rename do
-      Telemetry.log_complex_lobby_event(renamer_id, state.match_id, "command.rename", %{
-        name: new_base_name
-      })
-    end
+    Telemetry.log_complex_lobby_event(renamer_id, state.match_id, "command.rename", %{
+      name: new_base_name
+    })
 
     new_name = generate_name(%{state | lobby: %{state.lobby | base_name: new_base_name}})
 
     new_state =
       do_update_values(state, %{
         base_name: new_base_name,
-        player_rename: player_rename,
         name: new_name
       })
 


### PR DESCRIPTION
### **This PR should only be deployed after all SPADS instances are running the new code from https://github.com/beyond-all-reason/spads_config_bar/pull/136 !**
_(Otherwise, any non-updated SPADS instances will regularly set the lobby name back to the default)_

Background and summary:
With the new "!rename" command added to the BarManager SPADS plugin, a host may attempt to rename its lobby at the request of a player. Furthermore, BarManager no longer automatically changes lobby names (instead, it only updates the lobby's Teaser).

However, after the very first rename for a lobby (starting from initial creation), Teiserver currently forbids any further renames originating from the host. This PR removes that restriction, allowing "!rename" to function as expected.