### PR TITLE
$playerlimit as Admin only command

### DIFF
--- a/lib/teiserver/coordinator/consul_commands.ex
+++ b/lib/teiserver/coordinator/consul_commands.ex
@@ -1630,27 +1630,6 @@ defmodule Teiserver.Coordinator.ConsulCommands do
 
   #################### Moderator only
   # ----------------- General commands
-  def handle_command(
-        %{command: "playerlimit", remaining: value_str, senderid: senderid} = cmd,
-        state
-      ) do
-    case Integer.parse(value_str) do
-      {new_limit, _} ->
-        ConsulServer.say_command(cmd, state)
-        %{state | player_limit: abs(new_limit)}
-
-      _ ->
-        ChatLib.sayprivateex(
-          state.coordinator_id,
-          senderid,
-          "Unable to convert #{value_str} into an integer",
-          state.lobby_id
-        )
-
-        state
-    end
-  end
-
   def handle_command(%{command: "makeready", remaining: ""} = cmd, state) do
     battle = Lobby.get_lobby(state.lobby_id)
 
@@ -2057,6 +2036,29 @@ defmodule Teiserver.Coordinator.ConsulCommands do
 
     ConsulServer.empty_state(state.lobby_id)
     |> ConsulServer.broadcast_update("reset")
+  end
+
+  #################### Admin only
+  # ----------------- General commands
+  def handle_command(
+        %{command: "playerlimit", remaining: value_str, senderid: senderid} = cmd,
+        state
+      ) do
+    case Integer.parse(value_str) do
+      {new_limit, _} ->
+        ConsulServer.say_command(cmd, state)
+        %{state | player_limit: abs(new_limit)}
+
+      _ ->
+        ChatLib.sayprivateex(
+          state.coordinator_id,
+          senderid,
+          "Unable to convert #{value_str} into an integer",
+          state.lobby_id
+        )
+
+        state
+    end
   end
 
   #################### Internal commands

--- a/lib/teiserver/coordinator/consul_server.ex
+++ b/lib/teiserver/coordinator/consul_server.ex
@@ -29,6 +29,7 @@ defmodule Teiserver.Coordinator.ConsulServer do
   @boss_commands ~w(balancemode gatekeeper welcome-message meme reset-approval rename minchevlevel maxchevlevel resetchevlevels resetratinglevels minratinglevel maxratinglevel setratinglevels)
   @vip_boss_commands ~w(shuffle)
   @host_commands ~w(specunready makeready settag speclock forceplay lobbyban lobbybanmult unban forcespec forceplay lock unlock makebalance set-config-teaser)
+  @admin_commands ~w(playerlimit)
 
   # @handled_by_lobby ~w(explain)
   @default_balance_algorithm "loser_picks"
@@ -1010,6 +1011,7 @@ defmodule Teiserver.Coordinator.ConsulServer do
     is_host = senderid == state.host_id
     is_boss = Enum.member?(state.host_bosses, senderid)
     is_vip = Enum.member?(user.roles, "VIP")
+    is_admin = Enum.member?(user.roles, "Admin")
 
     cond do
       client == nil ->
@@ -1021,7 +1023,12 @@ defmodule Teiserver.Coordinator.ConsulServer do
       Enum.member?(@always_allow, cmd.command) ->
         true
 
-      client.moderator == true ->
+      # Allow all commands for Admins
+      is_admin ->
+        true
+
+      # Allow all except Admin only commands for moderators
+      client.moderator and not Enum.member?(@admin_commands, cmd.command) ->
         true
 
       Enum.member?(@host_commands, cmd.command) and is_host ->

--- a/lib/teiserver/coordinator/consul_server.ex
+++ b/lib/teiserver/coordinator/consul_server.ex
@@ -1011,7 +1011,7 @@ defmodule Teiserver.Coordinator.ConsulServer do
     is_host = senderid == state.host_id
     is_boss = Enum.member?(state.host_bosses, senderid)
     is_vip = Enum.member?(user.roles, "VIP")
-    is_admin = Enum.member?(user.roles, "Admin")
+    is_admin = CacheUser.is_admin?(user.roles)
 
     cond do
       client == nil ->

--- a/lib/teiserver/coordinator/coordinator_lib.ex
+++ b/lib/teiserver/coordinator/coordinator_lib.ex
@@ -251,7 +251,7 @@ Multiple locks can be engaged at the same time
       :everybody -> true
       :host -> CacheUser.is_moderator?(user) or host
       :moderator -> CacheUser.is_moderator?(user)
-      :admin -> CacheUser.has_any_role?(user, "Admin")
+      :admin -> CacheUser.is_admin?(user)
       _ -> false
     end
   end

--- a/lib/teiserver/coordinator/coordinator_lib.ex
+++ b/lib/teiserver/coordinator/coordinator_lib.ex
@@ -126,7 +126,6 @@ Multiple locks can be engaged at the same time
       {"success", [],
        "Sends a \"!y\" message from every player to the game host to make a vote pass.",
        :moderator},
-      {"playerlimit", ["limit"], "Sets a new player limit for this specific host.", :moderator},
       {"check", ["user"],
        "Performs a smurf check against the user mentioned and sends you the result.", :moderator},
       {"pull", ["user"], "Pulls a given user into the battle.", :moderator},
@@ -138,7 +137,10 @@ Multiple locks can be engaged at the same time
       {"reset", [], "Resets the coordinator bot for this lobby to the default.", :moderator},
       {"specafk", [],
        "Everybody is sent a message asking them to confirm they are not afk. If they don't respond within 40 seconds they are moved to spectators. Requires boss privileges.",
-       :moderator}
+       :moderator},
+
+      # --- :admin only ---
+      {"playerlimit", ["limit"], "Sets a new player limit for this specific host.", :admin}
     ]
 
     # $command - Coordinator command
@@ -249,6 +251,7 @@ Multiple locks can be engaged at the same time
       :everybody -> true
       :host -> CacheUser.is_moderator?(user) or host
       :moderator -> CacheUser.is_moderator?(user)
+      :admin -> CacheUser.has_any_role?(user, "Admin")
       _ -> false
     end
   end

--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -1268,28 +1268,34 @@ defmodule Teiserver.CacheUser do
   end
 
   @spec is_bot?(T.userid() | T.user()) :: boolean()
-  def is_bot?(nil), do: true
+  def is_bot?(nil), do: false
   def is_bot?(userid) when is_integer(userid), do: is_bot?(get_user_by_id(userid))
   def is_bot?(%{roles: roles}), do: Enum.member?(roles, "Bot")
   def is_bot?(_), do: false
 
   @spec is_moderator?(T.userid() | T.user()) :: boolean()
-  def is_moderator?(nil), do: true
+  def is_moderator?(nil), do: false
   def is_moderator?(userid) when is_integer(userid), do: is_moderator?(get_user_by_id(userid))
   def is_moderator?(%{roles: roles}), do: Enum.member?(roles, "Moderator")
   def is_moderator?(_), do: false
 
   @spec is_contributor?(T.userid() | T.user()) :: boolean()
-  def is_contributor?(nil), do: true
+  def is_contributor?(nil), do: false
   def is_contributor?(userid) when is_integer(userid), do: is_contributor?(get_user_by_id(userid))
   def is_contributor?(%{roles: roles}), do: Enum.member?(roles, "Contributor")
   def is_contributor?(_), do: false
 
   @spec is_verified?(T.userid() | T.user()) :: boolean()
-  def is_verified?(nil), do: true
+  def is_verified?(nil), do: false
   def is_verified?(userid) when is_integer(userid), do: is_verified?(get_user_by_id(userid))
   def is_verified?(%{roles: roles}), do: Enum.member?(roles, "Verified")
   def is_verified?(_), do: false
+
+  @spec is_admin?(T.userid() | T.user()) :: boolean()
+  def is_admin?(nil), do: false
+  def is_admin?(userid) when is_integer(userid), do: is_admin?(get_user_by_id(userid))
+  def is_admin?(%{roles: roles}), do: Enum.member?(roles, "Admin")
+  def is_admin?(_), do: false
 
   @spec rank_time(T.userid()) :: non_neg_integer()
   def rank_time(userid) do

--- a/test/teiserver/coordinator/consul_commands_test.exs
+++ b/test/teiserver/coordinator/consul_commands_test.exs
@@ -20,7 +20,8 @@ defmodule Teiserver.Coordinator.ConsulCommandsTest do
     %{socket: psocket, user: player} = tachyon_auth_setup()
 
     # User needs to be a moderator (at this time) to start/stop Coordinator mode
-    CacheUser.update_user(%{host | roles: ["Moderator"]})
+    # Admin role (contains Moderator) used for playerlimit test
+    CacheUser.update_user(%{host | roles: ["Admin"]})
     ClientLib.refresh_client(host.id)
 
     lobby_data = %{


### PR DESCRIPTION
`$playerlimit <number>` - sets maximum player count limit for current host only, used to change the default 16 player limit.

This PR makes `$playerlimit` command Admin only, first of its type.