### PR TITLE
Coordinator send message when avoid is triggered

### DIFF
--- a/lib/teiserver/account/libs/relationship_lib.ex
+++ b/lib/teiserver/account/libs/relationship_lib.ex
@@ -326,16 +326,16 @@ defmodule Teiserver.Account.RelationshipLib do
       |> list_userids_blocked_by_userid()
       |> Enum.count(fn uid -> Enum.member?(userid_list, uid) end)
 
-    being_blocked_percentage = being_blocked_count / userid_count
-    blocking_percentage = blocking_count / userid_count
+    being_blocked_percentage = being_blocked_count / userid_count * 100
+    blocking_percentage = blocking_count / userid_count * 100
 
     cond do
       # You are being blocked
-      being_blocked_percentage > block_percentage_needed -> :blocked
-      being_blocked_count > block_count_needed -> :blocked
+      being_blocked_percentage >= block_percentage_needed -> :blocked
+      being_blocked_count >= block_count_needed -> :blocked
       # You are blocking
-      blocking_percentage > block_percentage_needed -> :blocking
-      blocking_count > block_count_needed -> :blocking
+      blocking_percentage >= block_percentage_needed -> :blocking
+      blocking_count >= block_count_needed -> :blocking
       true -> :ok
     end
   end
@@ -375,11 +375,11 @@ defmodule Teiserver.Account.RelationshipLib do
 
     cond do
       # You are being avoided
-      being_avoided_percentage > avoid_percentage_needed -> :avoided
-      being_avoided_count > avoid_count_needed -> :avoided
+      being_avoided_percentage >= avoid_percentage_needed -> :avoided
+      being_avoided_count >= avoid_count_needed -> :avoided
       # You are avoiding
-      avoiding_percentage > avoid_percentage_needed -> :avoiding
-      avoiding_count > avoid_count_needed -> :avoiding
+      avoiding_percentage >= avoid_percentage_needed -> :avoiding
+      avoiding_count >= avoid_count_needed -> :avoiding
       true -> :ok
     end
   end

--- a/lib/teiserver/coordinator/consul_server.ex
+++ b/lib/teiserver/coordinator/consul_server.ex
@@ -935,7 +935,7 @@ defmodule Teiserver.Coordinator.ConsulServer do
     boss_avoid_status =
       state.host_bosses
       |> Stream.map(fn boss_id ->
-        Account.does_a_avoid_b?(boss_id, user.id)
+        Account.does_a_avoid_b?(boss_id, userid)
       end)
       |> Enum.any?()
 

--- a/lib/teiserver/libs/teiserver_configs.ex
+++ b/lib/teiserver/libs/teiserver_configs.ex
@@ -389,7 +389,7 @@ defmodule Teiserver.TeiserverConfigs do
       permissions: ["Admin"],
       description:
         "The percentage of users who would need to block someone to prevent them joining a lobby",
-      default: 66
+      default: 50
     })
 
     add_site_config_type(%{
@@ -399,7 +399,7 @@ defmodule Teiserver.TeiserverConfigs do
       permissions: ["Admin"],
       description:
         "The raw number of players who would need to avoid someone to prevent them becoming a player",
-      default: 4
+      default: 6
     })
 
     add_site_config_type(%{


### PR DESCRIPTION
## Changes
When avoid is triggered the coordinator will send a message. Avoid can be triggered based on percentage or raw amount.
Also fixes some bugs because a function should have used player ids but it was being sent player objects

## Other improvements
Use >= instead of > for checks to make it align with description in Admin config description.

Some default configs have been changed, but still overridable by admin:

**Block triggers**
50% or 8 players (previously 66% or 8 players)

**Avoid triggers**
50% or 6 players (previously 50% or 4 players)

I think nobody will trigger these anyway. Avoid trigger increased because otherwise I think it will trigger too easily on special event lobbies.

![Screenshot 2024-07-31 084725](https://github.com/user-attachments/assets/58157573-2591-41e6-9e2d-d039f23d65ed)
![Screenshot 2024-07-31 084800](https://github.com/user-attachments/assets/2b15a5b3-92bb-4321-b787-bf08e023d64c)
