### PR TITLE
Remove teaser if lobby title too long

### DIFF
--- a/lib/teiserver/lobby/servers/lobby_server.ex
+++ b/lib/teiserver/lobby/servers/lobby_server.ex
@@ -545,17 +545,34 @@ defmodule Teiserver.Battle.LobbyServer do
           " " <> state.lobby.teaser
       end
 
+    generate_short_name(
+      state.lobby.base_name,
+      teaser,
+      LobbyRestrictions.get_rank_bounds_for_title(consul_state),
+      LobbyRestrictions.get_rating_bounds_for_title(consul_state)
+    )
+  end
+
+  def generate_short_name(base_name, teaser, rank_bounds, rating_bounds) do
     parts =
       [
         teaser,
-        LobbyRestrictions.get_rank_bounds_for_title(consul_state),
+        rank_bounds,
         # Rating stuff here
-        LobbyRestrictions.get_rating_bounds_for_title(consul_state)
+        rating_bounds
       ]
       |> Enum.reject(&(&1 == nil))
       |> Enum.join(" | ")
 
-    "#{state.lobby.base_name}#{parts}"
+    long_name = "#{base_name}#{parts}"
+
+    max_char_count = 50
+
+    if teaser != "" and String.length(long_name) > max_char_count do
+      generate_short_name(base_name, "", rank_bounds, rating_bounds)
+    else
+      long_name
+    end
   end
 
   @spec do_update_values(map, map) :: map

--- a/test/teiserver/battle/lobby_server_test.exs
+++ b/test/teiserver/battle/lobby_server_test.exs
@@ -4,6 +4,7 @@ defmodule Teiserver.Battle.LobbyServerTest do
   use Teiserver.DataCase, async: false
   alias Teiserver.Lobby.LobbyLib
   alias Teiserver.Coordinator
+  alias Teiserver.Battle.LobbyServer
 
   test "server test" do
     host = Teiserver.TeiserverTestLib.new_user()
@@ -124,5 +125,39 @@ defmodule Teiserver.Battle.LobbyServerTest do
 
     LobbyLib.stop_lobby_server(lobby_id)
     assert LobbyLib.lobby_exists?(lobby_id) == false
+  end
+
+  test "generate short name" do
+    # Teasers are given from SPADS
+    # See https://github.com/beyond-all-reason/spads_config_bar/pull/136/files
+    name =
+      LobbyServer.generate_short_name(
+        "All That Glitters",
+        " | Team 8 v 8",
+        "Min chev: 4",
+        "Max rating: 20"
+      )
+
+    assert name == "All That Glitters | Min chev: 4 | Max rating: 20"
+
+    name =
+      LobbyServer.generate_short_name(
+        "All That Glitters",
+        " | Team 8 v 8",
+        nil,
+        nil
+      )
+
+    assert name == "All That Glitters | Team 8 v 8"
+
+    name =
+      LobbyServer.generate_short_name(
+        "All That Glitters",
+        "",
+        nil,
+        "Max rating: 20"
+      )
+
+    assert name == "All That Glitters | Max rating: 20"
   end
 end


### PR DESCRIPTION
Fix #391 

The teaser is the part of the title between the base name and rating restrictions. Remove if it too long.
Teasers are given by SPADS.