### PR TITLE
Fix stretched-link taking up whole screen on ratings page

### DIFF
--- a/lib/teiserver_web/live/battles/match/ratings.html.heex
+++ b/lib/teiserver_web/live/battles/match/ratings.html.heex
@@ -87,10 +87,10 @@
               log.value["uncertainty_change"] < 0 -> {"text-secondary column-delta", "arrow-down"}
               true -> {"text-secondary column-delta", "pause"}
             end %>
-          <tr phx-click={"[[\"navigate\",{\"href\":\"/battle/#{log.match_id}\",\"replace\":false}]]"}>
+          <tr class="position-relative">
             <%= if log.match do %>
               <td>
-                <%= live_redirect("#{log.match.map}", to: ~p"/battle/#{log.match_id}") %>
+                <%= log.match.map %>
               </td>
               <td><%= log.match.team_size * log.match.team_count %></td>
             <% else %>
@@ -127,11 +127,7 @@
 
             <%= if log.match do %>
               <td>
-                <div class="visually-hidden">
-                  <.link navigate={~p"/battle/#{log.match_id}"}>
-                    Show
-                  </.link>
-                </div>
+                <.link navigate={~p"/battle/#{log.match_id}"} class="stretched-link"></.link>
               </td>
             <% else %>
               <td>&nbsp;</td>


### PR DESCRIPTION
This fixes a bug where stretched-link class took up the whole screen. We use position-relative to limit it to one row.

## Test Steps
Go to a ratings page to view matches. Test that links open for each row and that the match id is different.