### PR TITLE
Script to update permissions after role_lib.ex changed

### DIFF
--- a/lib/teiserver/account/libs/role_lib.ex
+++ b/lib/teiserver/account/libs/role_lib.ex
@@ -1,6 +1,11 @@
 defmodule Teiserver.Account.RoleLib do
   @moduledoc """
   A library with all the hard-coded data regarding user roles.
+
+  If you update this file, please run:
+  mix teiserver.update_user_permissions
+
+  to update permissions in the database of each user
   """
 
   @role_defaults %{

--- a/lib/teiserver/mix_tasks/update_user_permissions.ex
+++ b/lib/teiserver/mix_tasks/update_user_permissions.ex
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.Teiserver.UpdateUserPermissions do
 
   use Mix.Task
   require Logger
-  alias Teiserver.{Account, CacheUser}
+  alias Teiserver.Account
   alias Teiserver.Repo
   alias Teiserver.Account.RoleLib
 
@@ -40,15 +40,11 @@ defmodule Mix.Tasks.Teiserver.UpdateUserPermissions do
       select id from account_users
     """
 
-    case Ecto.Adapters.SQL.query(Repo, query, []) do
-      {:ok, results} ->
-        results.rows
-        |> Enum.map(fn [userid] ->
-          userid
-        end)
+    results = Ecto.Adapters.SQL.query!(Repo, query, [])
 
-      {a, b} ->
-        raise "ERR: #{a}, #{b}"
-    end
+    results.rows
+    |> Enum.map(fn [userid] ->
+      userid
+    end)
   end
 end

--- a/lib/teiserver/mix_tasks/update_user_permissions.ex
+++ b/lib/teiserver/mix_tasks/update_user_permissions.ex
@@ -1,0 +1,54 @@
+defmodule Mix.Tasks.Teiserver.UpdateUserPermissions do
+  @moduledoc """
+  If you make changes to role_lib.ex then run this task to update user permissions
+  mix teiserver.update_user_permissions
+  """
+
+  use Mix.Task
+  require Logger
+  alias Teiserver.{Account, CacheUser}
+  alias Teiserver.Repo
+  alias Teiserver.Account.RoleLib
+
+  def run(_args) do
+    Application.ensure_all_started(:teiserver)
+    user_ids = get_user_ids()
+
+    Enum.each(user_ids, fn user_id ->
+      user = Account.get_user!(user_id)
+      roles = user.roles
+
+      permissions =
+        roles
+        |> Enum.map(fn role_name ->
+          role_def = RoleLib.role_data(role_name)
+          [role_name | role_def.contains]
+        end)
+        |> List.flatten()
+        |> Enum.uniq()
+
+      user_params = %{
+        "permissions" => permissions
+      }
+
+      Account.server_update_user(user, user_params)
+    end)
+  end
+
+  defp get_user_ids() do
+    query = """
+      select id from account_users
+    """
+
+    case Ecto.Adapters.SQL.query(Repo, query, []) do
+      {:ok, results} ->
+        results.rows
+        |> Enum.map(fn [userid] ->
+          userid
+        end)
+
+      {a, b} ->
+        raise "ERR: #{a}, #{b}"
+    end
+  end
+end


### PR DESCRIPTION
## Context
After changing role_lib, permissions in the database need to be updated. Recently Blog Helper role was added and permissions are now not correct. 
Fix #395 
## Test
```
mix teiserver.update_user_permissions
```

This will now update everyone's permissions. 

Now to check run the query below on the db. It will show you the permissions of users. Ensure contributors have "Blog Helper"
```
select id, name, permissions, roles  from account_users au 
where 'Contributor'=ANY(au.roles)
```

