### PR TITLE
Make web-based lobby chat read-only for non-Admin/Moderator users.

### DIFF
--- a/lib/teiserver_web/live/battles/lobbies/chat.ex
+++ b/lib/teiserver_web/live/battles/lobbies/chat.ex
@@ -61,10 +61,8 @@ defmodule TeiserverWeb.Battle.LobbyLive.Chat do
 
       true ->
         allowed_to_send =
-          CacheUser.has_any_role?(current_user.id, [
-            "Admin",
-            "Moderator"
-          ]) and not CacheUser.has_mute?(current_user.id)
+          CacheUser.allow?(current_user.id, "Moderator") and
+            not CacheUser.has_mute?(current_user.id)
 
         :timer.send_interval(10_000, :tick)
 

--- a/lib/teiserver_web/live/battles/lobbies/chat.ex
+++ b/lib/teiserver_web/live/battles/lobbies/chat.ex
@@ -60,7 +60,11 @@ defmodule TeiserverWeb.Battle.LobbyLive.Chat do
         index_redirect(socket)
 
       true ->
-        allowed_to_send = not CacheUser.has_mute?(current_user.id)
+        allowed_to_send =
+          CacheUser.has_any_role?(current_user.id, [
+            "Admin",
+            "Moderator"
+          ]) and not CacheUser.has_mute?(current_user.id)
 
         :timer.send_interval(10_000, :tick)
 


### PR DESCRIPTION
Currently, any non-Muted user is allowed to read and send lobby chat messages via the website.

However, the use-case for this feature is not very strong for the typical player, and we occasionally see it abused by players who have been kickbanned from the lobby (to flame anyone involved in the kickban).

Therefore, this patch restricts web-based chat such that only users with either the "Admin" or "Moderator" roles are able to send messages.
____

Implements #399.

Screenshots from local testing:

- Users with `Admin`/`Moderator` roles can chat:
![2024-08-04 17_09_13](https://github.com/user-attachments/assets/46574510-0980-4ebd-8426-dcfa42b65f5c)
- Users without those roles can only read chat:
![2024-08-04 17_09_23](https://github.com/user-attachments/assets/07075131-8b36-439e-bb7d-9defe6033ac8)

To test:

1. Log in as an `Admin`/`Moderator` user
2. Browse to <TEISERVER_HOSTNAME>/battle/lobbies and click "CHAT" for any lobby
3. Observe that the chat bar and Send button are shown
4. Repeat steps 1-3 with a non-`Admin`/`Moderator` user, and observe that the chat bar and Send button are not shown