### PR TITLE
Fix gatekeeper friends - friends don't need password to join

### DIFF
--- a/lib/teiserver/coordinator/consul_server.ex
+++ b/lib/teiserver/coordinator/consul_server.ex
@@ -977,7 +977,7 @@ defmodule Teiserver.Coordinator.ConsulServer do
       Enum.member?(state.approved_users, userid) ->
         {true, :override_approve}
 
-      state.gatekeeper == "friends" ->
+      state.gatekeeper == :friends ->
         if is_on_friendlist?(userid, state, :all) do
           {true, :allow_friends}
         else


### PR DESCRIPTION
A simple fix to https://github.com/beyond-all-reason/teiserver/pull/285. Tested and works.