### PR TITLE
Use same max length for `!welcome-message` and `$welcome-message`.

### DIFF
--- a/lib/teiserver/protocols/spring/spring_in.ex
+++ b/lib/teiserver/protocols/spring/spring_in.ex
@@ -1197,7 +1197,7 @@ defmodule Teiserver.Protocols.SpringIn do
               String.starts_with?(lowercase_msg, "!bset tweakunits") ->
             msg |> String.trim() |> String.slice(0..16384)
 
-          String.starts_with?(lowercase_msg, "$welcome-message") ->
+          String.starts_with?(lowercase_msg, ["$welcome-message", "!welcome-message"]) ->
             msg |> String.trim() |> String.slice(0..1024)
 
           true ->
@@ -1223,7 +1223,7 @@ defmodule Teiserver.Protocols.SpringIn do
               String.starts_with?(lowercase_msg, "!bset tweakunits") ->
             msg |> String.trim() |> String.slice(0..16384)
 
-          String.starts_with?(lowercase_msg, "$welcome-message") ->
+          String.starts_with?(lowercase_msg, ["$welcome-message", "!welcome-message"]) ->
             msg |> String.trim() |> String.slice(0..1024)
 
           true ->


### PR DESCRIPTION
Teiserver enforces a maximum message length for the `SAYBATTLE` and `SAYBATTLEEX` Spring messages. These messages are limited to 256 characters by default, but they are increased if the message begins with certain prefixes.

Currently, when these messages begin with `$welcome-message`, the limit is raised to 1024 characters.

This patch adds `!welcome-message` to the that special case check, so that both versions of the command have the same limit of 1024.