### PR TITLE
Fix balance rating bug

### DIFF
--- a/lib/teiserver/battle/libs/balance_lib.ex
+++ b/lib/teiserver/battle/libs/balance_lib.ex
@@ -621,8 +621,7 @@ defmodule Teiserver.Battle.BalanceLib do
     # which has an expiry of 60s
     # See application.ex for cache settings
     rating_type_id = MatchRatingLib.rating_type_name_lookup()[rating_type]
-    {skill, uncertainty} = get_user_rating_value_uncertainty_pair(userid, rating_type_id)
-    rating = calculate_rating_value(skill, uncertainty)
+    {rating, uncertainty} = get_user_rating_value_uncertainty_pair(userid, rating_type_id)
     rating = fuzz_rating(rating, fuzz_multiplier)
 
     # Get stats data

--- a/lib/teiserver_web/live/battles/match/show.ex
+++ b/lib/teiserver_web/live/battles/match/show.ex
@@ -207,6 +207,9 @@ defmodule TeiserverWeb.Battle.MatchLive.Show do
   end
 
   defp generate_new_balance_data(match, algorithm) do
+    # For the section "If balance we made using current ratings", do not fuzz ratings
+    # This means the rating used is exactly equal to what is stored in database
+    fuzz_multiplier = 0
     rating_type = MatchLib.game_type(match.team_size, match.team_count)
 
     partied_players =
@@ -221,13 +224,13 @@ defmodule TeiserverWeb.Battle.MatchLive.Show do
         {nil, player_id_list} ->
           player_id_list
           |> Enum.map(fn userid ->
-            %{userid => BalanceLib.get_user_rating_rank(userid, rating_type)}
+            %{userid => BalanceLib.get_user_rating_rank(userid, rating_type, fuzz_multiplier)}
           end)
 
         {_party_id, player_id_list} ->
           player_id_list
           |> Map.new(fn userid ->
-            {userid, BalanceLib.get_user_rating_rank(userid, rating_type)}
+            {userid, BalanceLib.get_user_rating_rank(userid, rating_type, fuzz_multiplier)}
           end)
       end)
       |> List.flatten()


### PR DESCRIPTION
## Bug
Currently the balancer is using 
```
rating = skill - 2* uncertainty
```
It should be using
```
rating = skill - uncertainty
```

Bug was introduced in this PR: https://github.com/beyond-all-reason/teiserver/pull/328/files#r1716189573

See https://discord.com/channels/549281623154229250/1245516077547389009/1271838783750406155
Notice the rating in chobby and the rating in $explain is different. $explain rating is less than rating in chobby by roughly sigma.

The server update was done on 1 August so this bug has been here for about two weeks.

## Other enhancements
For the balance tab on the website, I have removed the fuzz multiplier for the bottom section so we can debug this easier. Fuzz multiplier still gets applied in game though for teifion's algo.

## Testing the fix
You can test this fix by first logging in as a user (like root) and checking their current ratings. The rating buttons small team and large team have their current ratings in the button.
![1](https://github.com/user-attachments/assets/72edcec1-d5c4-4504-ae89-140804e22bbf)

Now select their latest match and go to balance tab. Check the rating used in the bottom section is exactly equal to their current rating.

![2](https://github.com/user-attachments/assets/658efcc2-23e5-4068-9e7e-83582bb963a7)
