### PR TITLE
Display *all* the friends (and avoid and other)

### DIFF
--- a/lib/teiserver_web/controllers/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/admin/user_controller.ex
@@ -972,7 +972,7 @@ defmodule TeiserverWeb.Admin.UserController do
       |> Enum.uniq()
 
     lookup =
-      Account.list_users(search: [id_in: user_ids])
+      Account.list_users(search: [id_in: user_ids], limit: :infinity)
       |> Map.new(fn u -> {u.id, u} end)
 
     conn


### PR DESCRIPTION
something I missed for https://github.com/beyond-all-reason/teiserver/pull/408 is that the [default user query](https://github.com/geekingfrog/teiserver/blob/348972752fe01e876adefa723c16fbff29054c49/lib/teiserver/account/queries/user_queries.ex#L18) has a limit of 50. So for people like Lexon with a ton of friends, that page would only show up to 50 users total.