### PR TITLE
Remove vacuum FULL from daily cleanup task

### DIFF
--- a/lib/teiserver/admin/tasks/daily_cleanup_task.ex
+++ b/lib/teiserver/admin/tasks/daily_cleanup_task.ex
@@ -9,10 +9,6 @@ defmodule Teiserver.Admin.DailyCleanupTask do
   @spec perform(any) :: :ok
   def perform(_) do
     if Config.get_site_config_cache("system.Use geoip") do
-      Ecto.Adapters.SQL.query!(Repo, "VACUUM FULL;", [])
-
-      :timer.sleep(1000)
-
       Ecto.Adapters.SQL.query!(Repo, "VACUUM ANALYZE;", [])
     end
 


### PR DESCRIPTION
Only keep the daily vacuum analyze query. This one can be run concurrently with other read/write operation.
The cost is that some deleted rows would still occupy space on disk, but hopefully it won't cause logging and disconnection issue.

This is a bit of a stopgap measure until we figure out the true cause of the morning disconnections.