### PR TITLE
Add balancealgorithm command

### DIFF
--- a/lib/teiserver/coordinator/consul_commands.ex
+++ b/lib/teiserver/coordinator/consul_commands.ex
@@ -629,7 +629,18 @@ defmodule Teiserver.Coordinator.ConsulCommands do
   end
 
   #################### Boss
+  # balancemode is deprecated. Use balancealgorithm instead, which is also a SPADS command
   def handle_command(%{command: "balancemode", remaining: remaining, senderid: senderid}, state) do
+    handle_command(
+      %{command: "balancealgorithm", remaining: remaining, senderid: senderid},
+      state
+    )
+  end
+
+  def handle_command(
+        %{command: "balancealgorithm", remaining: remaining, senderid: senderid},
+        state
+      ) do
     remaining =
       remaining
       |> String.downcase()
@@ -642,17 +653,16 @@ defmodule Teiserver.Coordinator.ConsulCommands do
     if Enum.member?(allowed_choices, remaining) do
       ChatLib.say(
         state.coordinator_id,
-        "Balance mode set to #{remaining}",
+        "Balance algorithm set to #{remaining}",
         state.lobby_id
       )
 
       Coordinator.cast_balancer(state.lobby_id, {:set_algorithm, remaining})
       %{state | balance_algorithm: remaining}
     else
-      Lobby.sayprivateex(
+      ChatLib.say(
         state.coordinator_id,
-        senderid,
-        "No balancemode of #{remaining}, options are: #{allowed_choices |> Enum.join(", ")}",
+        "No balance algorithm of #{remaining}. Options are: #{allowed_choices |> Enum.join(", ")}",
         state.lobby_id
       )
 

--- a/lib/teiserver/coordinator/consul_server.ex
+++ b/lib/teiserver/coordinator/consul_server.ex
@@ -26,7 +26,7 @@ defmodule Teiserver.Coordinator.ConsulServer do
   alias Teiserver.Coordinator.{ConsulCommands, CoordinatorLib, SpadsParser, CoordinatorCommands}
 
   @always_allow ~w(status s y n follow joinq leaveq splitlobby afks roll players password? newlobby jazlobby tournament)
-  @boss_commands ~w(balancemode gatekeeper welcome-message meme reset-approval rename minchevlevel maxchevlevel resetchevlevels resetratinglevels minratinglevel maxratinglevel setratinglevels)
+  @boss_commands ~w(balancemode balancealgorithm gatekeeper welcome-message meme reset-approval rename minchevlevel maxchevlevel resetchevlevels resetratinglevels minratinglevel maxratinglevel setratinglevels)
   @vip_boss_commands ~w(shuffle)
   @host_commands ~w(specunready makeready settag speclock forceplay lobbyban lobbybanmult unban forcespec forceplay lock unlock makebalance set-config-teaser)
   @admin_commands ~w(playerlimit)


### PR DESCRIPTION
## Context
Currently SPADS has a command balancealgorithm. It is calling teiserver command balancemode. For consistency we should add a teiserver command called `balancealgorithm`. This PR adds balancealgorithm command that does exactly the same as balancemode but it can be called by SPADS one to one.

## Other enhancements
When you give an invalid command parameter via `!balancealgorithm blah`, the error isn't displayed in lobby. So Lobby.sayprivateex has changed to ChatLib.say

For example currently in production if I use `!balancealgorithm split_one_chevs` no error is visible (but it should show that it is not a valid balance algo).

![1](https://github.com/user-attachments/assets/2303a1a2-c4f6-489b-8787-ee57fc7102c4)



## Test Steps
Set yourself as boss. Then run these commands
```
$balancealgorithm split_noobs
$balancemode loser_picks
$balancealgorithm x
```