### PR TITLE
Tachyon dev conveniences

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -129,6 +129,7 @@ config :teiserver, Oban,
        # 1:07 am
        {"7 1 * * *", Teiserver.Account.Tasks.DailyCleanupTask},
        {"22 1 * * *", Teiserver.Telemetry.EventCleanupTask},
+       {"7 1 * * *", Teiserver.OAuth.Tasks.Cleanup},
 
        # At 17 minutes past every hour
        {"17 * * * *", Teiserver.Battle.Tasks.CleanupTask},

--- a/lib/teiserver/account/libs/user_lib.ex
+++ b/lib/teiserver/account/libs/user_lib.ex
@@ -85,7 +85,7 @@ defmodule Teiserver.Account.UserLib do
     |> Repo.one!()
   end
 
-  @spec get_user(non_neg_integer(), list) :: User.t() | nil
+  @spec get_user(non_neg_integer() | nil, list) :: User.t() | nil
   def get_user(user_id, args \\ []) do
     (args ++ [id: user_id])
     |> UserQueries.query_users()

--- a/lib/teiserver/mix_tasks/fake_data.ex
+++ b/lib/teiserver/mix_tasks/fake_data.ex
@@ -34,6 +34,8 @@ defmodule Mix.Tasks.Teiserver.Fakedata do
       make_moderation()
       make_one_time_code()
 
+      make_lobby_app()
+
       # Add fake playtime data to all our non-bot users
       Mix.Task.run("teiserver.fake_playtime")
 
@@ -424,6 +426,21 @@ defmodule Mix.Tasks.Teiserver.Fakedata do
         purpose: "one_time_login",
         expires: Timex.now() |> Timex.shift(hours: 24),
         user_id: root_user.id
+      })
+  end
+
+  # Create the oauth application for the new lobby
+  defp make_lobby_app() do
+    root_user = Account.get_user_by_email("root@localhost")
+
+    {:ok, _app} =
+      Teiserver.OAuth.create_application(%{
+        name: "generic lobby client",
+        owner_id: root_user.id,
+        uid: "generic_lobby",
+        scopes: ["tachyon.lobby"],
+        redirect_uris: ["http://localhost/oauth2callback"],
+        description: "new and shiny client!"
       })
   end
 

--- a/lib/teiserver/mix_tasks/gen_token.ex
+++ b/lib/teiserver/mix_tasks/gen_token.ex
@@ -1,0 +1,42 @@
+defmodule Mix.Tasks.Teiserver.GenToken do
+  @usage_str "Usage: `mix teiserver.gen_token --user <username/email> [--app <app_uid>]`"
+
+  @moduledoc """
+  Creates an oauth token for the given username or email.
+  This is a convenience task to help developping anything requiring an
+  oauth token like tachyon.
+
+  #{@usage_str}
+  """
+
+  @shortdoc "generate an oauth token for testing"
+
+  use Mix.Task
+
+  @impl Mix.Task
+  def run(args) do
+    shell = Mix.shell()
+    shell.info("raw args: #{inspect(args)}")
+    {parsed, _, _errors} = OptionParser.parse(args, strict: [user: :string, app: :string])
+    shell.info("parsed args: #{inspect(parsed)}")
+
+    Mix.Task.run("ecto.setup")
+
+    case parsed[:user] do
+      nil ->
+        shell.error("Missing username or email. #{@usage_str}")
+        exit({:shutdown, 1})
+
+      user ->
+        case Teiserver.OAuth.Task.GenToken.create_token(user, parsed[:app]) do
+          {:ok, token} ->
+            shell.info("Generated token (id=#{token.id}) - #{token.value}")
+            :ok
+
+          {:error, msg} ->
+            shell.error("#{msg} -- #{@usage_str}")
+            exit({:shutdown, 1})
+        end
+    end
+  end
+end

--- a/lib/teiserver/o_auth.ex
+++ b/lib/teiserver/o_auth.ex
@@ -415,6 +415,16 @@ defmodule Teiserver.OAuth do
     )
   end
 
+  @doc """
+  Delete all expired oauth code.
+  """
+  @spec delete_expired_codes(DateTime.t() | nil) :: non_neg_integer()
+  def delete_expired_codes(now \\ nil) do
+    now = now || DateTime.utc_now()
+    {count, _} = CodeQueries.base_query() |> CodeQueries.expired(now) |> Repo.delete_all()
+    count
+  end
+
   defp check_expiry(obj, now) do
     if Timex.after?(now, Map.fetch!(obj, :expires_at)) do
       {:error, :expired}

--- a/lib/teiserver/o_auth.ex
+++ b/lib/teiserver/o_auth.ex
@@ -425,6 +425,16 @@ defmodule Teiserver.OAuth do
     count
   end
 
+  @doc """
+  Delete all expired oauth tokens (access and refresh)
+  """
+  @spec delete_expired_tokens(DateTime.t() | nil) :: non_neg_integer()
+  def delete_expired_tokens(now \\ nil) do
+    now = now || DateTime.utc_now()
+    {count, _} = TokenQueries.base_query() |> TokenQueries.expired(now) |> Repo.delete_all()
+    count
+  end
+
   defp check_expiry(obj, now) do
     if Timex.after?(now, Map.fetch!(obj, :expires_at)) do
       {:error, :expired}

--- a/lib/teiserver/o_auth/queries/code_query.ex
+++ b/lib/teiserver/o_auth/queries/code_query.ex
@@ -35,6 +35,13 @@ defmodule Teiserver.OAuth.CodeQueries do
       where: code.expires_at > ^as_at
   end
 
+  def expired(query, as_at \\ nil) do
+    as_at = as_at || DateTime.utc_now()
+
+    from [code: code] in query,
+      where: code.expires_at <= ^as_at
+  end
+
   @spec count_per_apps([Application.id()], DateTime.t() | nil) :: %{
           Application.id() => non_neg_integer()
         }

--- a/lib/teiserver/o_auth/queries/token_query.ex
+++ b/lib/teiserver/o_auth/queries/token_query.ex
@@ -37,6 +37,13 @@ defmodule Teiserver.OAuth.TokenQueries do
       where: token.expires_at > ^as_at
   end
 
+  def expired(query, as_at \\ nil) do
+    as_at = as_at || DateTime.utc_now()
+
+    from [token: token] in query,
+      where: token.expires_at <= ^as_at
+  end
+
   @doc """
   given a refresh token, deletes it and its potential associated token
   """

--- a/lib/teiserver/o_auth/tasks/cleanup.ex
+++ b/lib/teiserver/o_auth/tasks/cleanup.ex
@@ -1,0 +1,13 @@
+defmodule Teiserver.OAuth.Tasks.Cleanup do
+  use Oban.Worker, queue: :cleanup
+  require Logger
+
+  @impl Oban.Worker
+  def perform(_) do
+    code_count = Teiserver.OAuth.delete_expired_codes()
+    Logger.info("Deleted #{code_count} expired oauth codes")
+
+    token_count = Teiserver.OAuth.delete_expired_tokens()
+    Logger.info("Deleted #{token_count} expired oauth tokens")
+  end
+end

--- a/lib/teiserver/o_auth/tasks/gen_token.ex
+++ b/lib/teiserver/o_auth/tasks/gen_token.ex
@@ -1,0 +1,63 @@
+defmodule Teiserver.OAuth.Task.GenToken do
+  @moduledoc """
+  Generates a token for the given user. This is for a convenience task to ease
+  the development of anything requiring OAuth tokens like tachyon protocol.
+  """
+
+  alias Teiserver.OAuth.{ApplicationQueries, Token}
+
+  @spec create_token(String.t(), String.t() | nil) :: {:ok, Token.t()} | {:error, term()}
+  def create_token(username_or_email, app_uid \\ nil) do
+    with {:ok, user} <- get_user(username_or_email),
+         {:ok, app} <- get_app(app_uid) do
+      token_attr = %{
+        value: Base.hex_encode32(:crypto.strong_rand_bytes(32), padding: false),
+        owner_id: user.id,
+        application_id: app.id,
+        scopes: app.scopes,
+        expires_at: Timex.add(DateTime.utc_now(), Timex.Duration.from_days(1)),
+        type: :access,
+        refresh_token: nil
+      }
+
+      %Token{}
+      |> Token.changeset(token_attr)
+      |> Teiserver.Repo.insert()
+    else
+      {:error, msg} -> {:error, msg}
+    end
+  end
+
+  defp get_user(username_or_email) do
+    user =
+      if String.contains?(username_or_email, "@") do
+        Teiserver.Account.UserCacheLib.get_user_by_email(username_or_email)
+      else
+        Teiserver.Account.UserCacheLib.get_user_by_name(username_or_email)
+      end
+
+    if is_nil(user) do
+      {:error, "No user found for username or email #{username_or_email}"}
+    else
+      {:ok, user}
+    end
+  end
+
+  defp get_app(app_uid) do
+    apps =
+      ApplicationQueries.list_applications()
+      |> Enum.filter(fn app -> is_nil(app_uid) or app.uid == app_uid end)
+
+    case apps do
+      [app] ->
+        {:ok, app}
+
+      [] ->
+        {:error, "no oauth application found, need to create one first"}
+
+      apps ->
+        uids = Enum.map(apps, & &1.uid)
+        {:error, "more than one oauth application found #{inspect(uids)}"}
+    end
+  end
+end

--- a/test/teiserver/o_auth/gen_token_test.exs
+++ b/test/teiserver/o_auth/gen_token_test.exs
@@ -1,0 +1,44 @@
+defmodule Teiserver.OAuth.GenTokenTest do
+  use Teiserver.DataCase, async: true
+  alias Teiserver.OAuthFixtures
+  alias Teiserver.OAuth.Task.GenToken
+  alias Teiserver.OAuth.{Token, TokenQueries}
+
+  test "no user fails" do
+    assert {:error, _} = GenToken.create_token("oops", nil)
+  end
+
+  test "works with valid username" do
+    user = Teiserver.TeiserverTestLib.new_user()
+    OAuthFixtures.app_attrs(user.id) |> OAuthFixtures.create_app()
+    assert {:ok, tok} = GenToken.create_token(user.name)
+    assert %Token{} = TokenQueries.get_token(tok.value)
+  end
+
+  test "works with valid email" do
+    user = Teiserver.TeiserverTestLib.new_user()
+    OAuthFixtures.app_attrs(user.id) |> OAuthFixtures.create_app()
+    assert {:ok, tok} = GenToken.create_token(user.email)
+    assert %Token{} = TokenQueries.get_token(tok.value)
+  end
+
+  test "must have one oauth app in the DB" do
+    user = Teiserver.TeiserverTestLib.new_user()
+    assert {:error, _} = GenToken.create_token(user.email)
+  end
+
+  test "must specify an app uid if several oauth app in DB" do
+    user = Teiserver.TeiserverTestLib.new_user()
+    OAuthFixtures.app_attrs(user.id) |> OAuthFixtures.create_app()
+    OAuthFixtures.app_attrs(user.id) |> Map.put(:uid, "other_uid") |> OAuthFixtures.create_app()
+    assert {:error, _} = GenToken.create_token(user.email)
+  end
+
+  test "can select an oauth app with uid" do
+    user = Teiserver.TeiserverTestLib.new_user()
+    app = OAuthFixtures.app_attrs(user.id) |> OAuthFixtures.create_app()
+    OAuthFixtures.app_attrs(user.id) |> Map.put(:uid, "other_uid") |> OAuthFixtures.create_app()
+    assert {:ok, tok} = GenToken.create_token(user.email, app.uid)
+    assert %Token{} = TokenQueries.get_token(tok.value)
+  end
+end


### PR DESCRIPTION
Some utilities to tie up some lose ends with oauth stuff and make developing tachyon easier.
* a mix task to generate an oauth token for a given user
* extend fakedata to seed a basic oauth application
* a cleanup task to delete from DB the expired codes and tokens 