### PR TITLE
Turn off boss blocks after playercount + queue size threshold reached

### DIFF
--- a/lib/teiserver/libs/teiserver_configs.ex
+++ b/lib/teiserver/libs/teiserver_configs.ex
@@ -413,6 +413,15 @@ defmodule Teiserver.TeiserverConfigs do
     })
 
     add_site_config_type(%{
+      key: "lobby.Boss blocks turn off threshold",
+      section: "Lobbies",
+      type: "integer",
+      permissions: ["Admin"],
+      description: "Turn off boss blocks when players plus queue size is at least this number",
+      default: 16
+    })
+
+    add_site_config_type(%{
       key: "lobby.Small team game limit",
       section: "Lobbies",
       type: "integer",


### PR DESCRIPTION
## Context
Some people want boss blocks off. Some people want them on. This is a compromise. It will guarantee your boss blocks work for your very first match, but not guaranteed afterwards if you lobby gets popular.

## Feature
Once a certain player count + queue size is reached (set to 16) then boss blocks are turned off. If you start a lobby from scratch, you might have to wait a long time for it to fill, so it's good to guarantee you won't have to play with your avoid list for your first match. However, after the first match, it will no longer be guaranteed since your lobby might hit these thresholds.

The reason we consider queue size is so that if you set it to 7v7 you can still hit the threshold if there's two people on your queue.

## Other enhancements
There was a check after a match to recheck blocks/avoids. This has been removed. 
```
      send(self(), :recheck_membership)
```
So once a user makes it as a player, even if the lobby falls below the threshold, they are safe.

## Test Steps
Requires 2 players.
Have player 1 join a lobby and boss themselves.  Have player 2 try and join the lobby. Have player 1 block player 2 then have player 2 try and leave and join the lobby; they will be blocked.

Now go to admin site config > Lobbies . Change the setting below to 0
![1](https://github.com/user-attachments/assets/2414c156-b10f-470d-8460-8da4421f4b46)

Now have player 2 try and join again. They may still get blocked due to hitting the player count trigger block; but they will not receive the boss block message.