### PR TITLE
Add welcome text when using custom balance algo

### DIFF
--- a/lib/teiserver/coordinator/welcome_helper.ex
+++ b/lib/teiserver/coordinator/welcome_helper.ex
@@ -1,0 +1,52 @@
+defmodule Teiserver.Coordinator.WelcomeHelper do
+  alias Teiserver.Battle.BalanceLib
+  alias Teiserver.Lobby.LobbyRestrictions
+
+  # Gets welcome text when given consul_server state
+  # Includes rating restrictions text and custom balance algorithm info
+  def get_welcome_message(state) do
+    welcome_message =
+      if state.welcome_message do
+        String.split(state.welcome_message, "$$")
+      end
+
+    restrictions = LobbyRestrictions.get_lobby_restrictions_welcome_text(state)
+
+    custom_balance_welcome_message = get_custom_balance_welcome(state.balance_algorithm)
+
+    combine_welcome_message(
+      welcome_message,
+      restrictions,
+      custom_balance_welcome_message
+    )
+  end
+
+  def combine_welcome_message(welcome_text, restrictions_text, custom_balance_text) do
+    [
+      welcome_text,
+      restrictions_text,
+      custom_balance_text
+    ]
+    |> Enum.filter(fn s -> s != nil and s != [] end)
+    |> Enum.intersperse("")
+    |> List.flatten()
+  end
+
+  # Custom welcome message when using non-default balance
+  def get_custom_balance_welcome(balance_algorithm) do
+    default_algo = BalanceLib.get_default_algorithm()
+
+    cond do
+      balance_algorithm == default_algo ->
+        nil
+
+      true ->
+        [
+          "This lobby is using balance algorithm:",
+          balance_algorithm,
+          "",
+          "Use \"$explain\" after balancing to view logs."
+        ]
+    end
+  end
+end

--- a/lib/teiserver/lobby/commands/explain_command.ex
+++ b/lib/teiserver/lobby/commands/explain_command.ex
@@ -8,7 +8,7 @@ defmodule Teiserver.Lobby.Commands.ExplainCommand do
   alias Teiserver.{Account, Battle, Coordinator}
   import Teiserver.Helper.NumberHelper, only: [round: 2]
 
-  @splitter "---------------------------"
+  @splitter "------------------------------------------------------"
 
   @impl true
   @spec name() :: String.t()

--- a/lib/teiserver/lobby/libs/lobby_restrictions.ex
+++ b/lib/teiserver/lobby/libs/lobby_restrictions.ex
@@ -102,7 +102,7 @@ defmodule Teiserver.Lobby.LobbyRestrictions do
     bounds = get_rank_bounds_for_title(consul_state)
 
     [
-      @splitter,
+      "",
       "You don't meet the chevron requirements for this lobby (#{bounds}). Your chevron level is #{player_rank + 1}. Learn more about chevrons here:",
       "https://www.beyondallreason.info/guide/rating-and-lobby-balance#rank-icons"
     ]
@@ -113,7 +113,7 @@ defmodule Teiserver.Lobby.LobbyRestrictions do
     player_rating_text = player_rating |> Decimal.from_float() |> Decimal.round(2)
 
     [
-      @splitter,
+      "",
       "You don't meet the rating requirements for this lobby (#{bounds}). Your #{rating_type} match rating is #{player_rating_text}. Learn more about rating here:",
       "https://www.beyondallreason.info/guide/rating-and-lobby-balance#openskill"
     ]

--- a/test/teiserver/coordinator/welcome_helper_test.exs
+++ b/test/teiserver/coordinator/welcome_helper_test.exs
@@ -1,0 +1,22 @@
+defmodule Teiserver.Coordinator.WeclomeHelperTest do
+  use ExUnit.Case
+  alias Teiserver.Coordinator.WelcomeHelper
+
+  test 'combine welcome message' do
+    result = WelcomeHelper.combine_welcome_message([], [], [])
+    assert result == []
+
+    result = WelcomeHelper.combine_welcome_message(nil, nil, nil)
+    assert result == []
+
+    welcome_text = "Welcome Text"
+    restrictions_text = "Restrictions Text"
+    balance_text = "Balance Text"
+
+    result = WelcomeHelper.combine_welcome_message(welcome_text, nil, balance_text)
+    assert result == ["Welcome Text", "", "Balance Text"]
+
+    result = WelcomeHelper.combine_welcome_message(welcome_text, restrictions_text, balance_text)
+    assert result == ["Welcome Text", "", "Restrictions Text", "", "Balance Text"]
+  end
+end


### PR DESCRIPTION
## Context
There's currently no visual indicator when using a custom balance algorithm. Not everyone knows about `$s`. Ideally it should show in a dropdown in Chobby, but given Chobby is end of life it might not come. As a workaround show it in welcome message.

## Improvement
![Screenshot 2024-08-20 125613](https://github.com/user-attachments/assets/d1841533-e5a3-422a-91f5-a34eb9befbd8)


## Other enhancements
Minor change to remove splitter from when you don't meet rating restrictions because this should appear directly below welcome message resulting in two splitters back to back which looks weird.
![Screenshot 2024-08-20 100853](https://github.com/user-attachments/assets/22f0fc92-e671-4152-bb68-30f0e6cc83db)

Also standardise splitter for explain command

## Testing
Login as a user and boss yourself. Then change balance algo
```
$balancemode split_noobs
```

Join as another user and you will see a message about the custom balance algorithim.
