### PR TITLE
Make new login sessions replace existing sessions.

### DIFF
--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -870,8 +870,8 @@ defmodule Teiserver.CacheUser do
 
           true ->
             if Client.get_client_by_id(user.id) != nil do
-              :timer.sleep(1000)
               Client.disconnect(user.id, "Already logged in")
+              :timer.sleep(1000)
             end
 
             # Okay, we're good, what's capacity looking like?
@@ -969,8 +969,8 @@ defmodule Teiserver.CacheUser do
 
           true ->
             if Client.get_client_by_id(user.id) != nil do
-              :timer.sleep(1000)
               Client.disconnect(user.id, "Already logged in")
+              :timer.sleep(1000)
             end
 
             # Okay, we're good, what's capacity looking like?

--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -780,7 +780,7 @@ defmodule Teiserver.CacheUser do
     login_count = Teiserver.cache_get(:teiserver_login_count, userid) || 0
     rate_limit = Config.get_site_config_cache("system.Login limit count")
 
-    if login_count > rate_limit do
+    if login_count >= rate_limit do
       :block
     else
       Teiserver.cache_put(:teiserver_login_count, userid, login_count + 1)
@@ -868,18 +868,12 @@ defmodule Teiserver.CacheUser do
 
             {:error, "Unverified", user.id}
 
-          Client.get_client_by_id(user.id) != nil ->
-            Client.disconnect(user.id, "Already logged in")
-
-            if is_bot?(user) do
+          true ->
+            if Client.get_client_by_id(user.id) != nil do
               :timer.sleep(1000)
-              do_login(user, ip, lobby, lobby_hash)
-            else
-              Teiserver.cache_put(:teiserver_login_count, user.id, 10)
-              {:error, "Existing session, please retry in 20 seconds to clear the cache"}
+              Client.disconnect(user.id, "Already logged in")
             end
 
-          true ->
             # Okay, we're good, what's capacity looking like?
             cond do
               is_bot?(user) ->
@@ -973,18 +967,12 @@ defmodule Teiserver.CacheUser do
 
             {:error, "Unverified", user.id}
 
-          Client.get_client_by_id(user.id) != nil ->
-            Client.disconnect(user.id, "Already logged in")
-
-            if is_bot?(user) do
+          true ->
+            if Client.get_client_by_id(user.id) != nil do
               :timer.sleep(1000)
-              do_login(user, ip, lobby, lobby_hash)
-            else
-              Teiserver.cache_put(:teiserver_login_count, user.id, 10)
-              {:error, "Existing session, please retry in 20 seconds to clear the cache"}
+              Client.disconnect(user.id, "Already logged in")
             end
 
-          true ->
             # Okay, we're good, what's capacity looking like?
             cond do
               is_bot?(user) ->


### PR DESCRIPTION
This PR seeks to improve the user experience when reconnecting after a client crashes.

Currently, if a session already exists for a user and a client attempts to log in as the same user, the following happens:
- The login flood protection count is incremented
- The existing session is disconnected
- The new login attempt is rejected with instructions to try later

This patch changes that last point. Now, the following happens:
- The login flood protection count is incremented
- The existing session is disconnected
- The new login attempt proceeds as usual

The login attempt may still fail, for example if Teiserver's number of active sessions is at capacity; however, for typical cases the login will succeed.

(Note: most of the usual login checks occur before any existing sessions are disconnected (such as password verification). That is unchanged by this patch.)