### PR TITLE
Fb ext ring originator

### DIFF
--- a/lib/teiserver/protocols/spring/spring_in.ex
+++ b/lib/teiserver/protocols/spring/spring_in.ex
@@ -1366,10 +1366,11 @@ defmodule Teiserver.Protocols.SpringIn do
     userid = CacheUser.get_userid(data)
 
     case String.split(data) do
-      [_, originator] ->
+      [sender, originator] ->
+        userid = CacheUser.get_userid(sender)
         client = Client.get_client_by_id(state.userid)
 
-        if client != nil and not CacheUser.is_bot?(state.userid) do
+        if client != nil and CacheUser.is_bot?(state.userid) do
           originator_id = CacheUser.get_userid(originator)
           CacheUser.ring(userid, originator_id)
         end

--- a/lib/teiserver/protocols/spring/spring_in.ex
+++ b/lib/teiserver/protocols/spring/spring_in.ex
@@ -1363,29 +1363,22 @@ defmodule Teiserver.Protocols.SpringIn do
   # extended to accept originator as a second argument (only allowed when sent by bots)
   # this allows spads to inform clients who originally rang them with spads-command !ring
   defp do_handle("RING", data, _msg_id, state) do
-    case Regex.run(~r/(\S+) (\S+)/, data) do
-      [_, _, originator] ->
+    userid = CacheUser.get_userid(data)
+
+    case String.split(data) do
+      [_, originator] ->
         client = Client.get_client_by_id(state.userid)
 
-        cond do
-          client == nil ->
-            {:failure, "No client"}
-
-          not CacheUser.is_bot?(state.userid) ->
-            {:failure, "Not a bot"}
-
-          true ->
-            userid = CacheUser.get_userid(data)
-            originatorid = CacheUser.get_userid(originator)
-            CacheUser.ring(userid, originatorid)
-            state
+        if client != nil and not CacheUser.is_bot?(state.userid) do
+          originator_id = CacheUser.get_userid(originator)
+          CacheUser.ring(userid, originator_id)
         end
 
       _ ->
-        userid = CacheUser.get_userid(data)
         CacheUser.ring(userid, state.userid)
-        state
     end
+
+    state
   end
 
   # Not handled catcher

--- a/lib/teiserver/protocols/spring/spring_in.ex
+++ b/lib/teiserver/protocols/spring/spring_in.ex
@@ -1366,11 +1366,10 @@ defmodule Teiserver.Protocols.SpringIn do
     userid = CacheUser.get_userid(data)
 
     case String.split(data) do
-      [sender, originator] ->
-        userid = CacheUser.get_userid(sender)
+      [_, originator] ->
         client = Client.get_client_by_id(state.userid)
 
-        if client != nil and CacheUser.is_bot?(state.userid) do
+        if client != nil and not CacheUser.is_bot?(state.userid) do
           originator_id = CacheUser.get_userid(originator)
           CacheUser.ring(userid, originator_id)
         end

--- a/lib/teiserver/protocols/spring/spring_out.ex
+++ b/lib/teiserver/protocols/spring/spring_out.ex
@@ -73,7 +73,7 @@ defmodule Teiserver.Protocols.SpringOut do
   end
 
   defp do_reply(:protocol_extensions, nil) do
-    "@PROTOCOL_EXTENSIONS@ {\"ring:originator\":1}\n"
+    "SERVERMSG @PROTOCOL_EXTENSIONS@ {\"ring:originator\":1}\n"
   end
 
   defp do_reply(:motd, nil) do

--- a/lib/teiserver/protocols/spring/spring_out.ex
+++ b/lib/teiserver/protocols/spring/spring_out.ex
@@ -73,7 +73,7 @@ defmodule Teiserver.Protocols.SpringOut do
   end
 
   defp do_reply(:protocol_extensions, nil) do
-    "SERVERMSG @PROTOCOL_EXTENSIONS@ {\"ring:originator\":1}\n"
+    "@PROTOCOL_EXTENSIONS@ {\"ring:originator\":1}\n"
   end
 
   defp do_reply(:motd, nil) do

--- a/lib/teiserver/protocols/spring/spring_out.ex
+++ b/lib/teiserver/protocols/spring/spring_out.ex
@@ -72,6 +72,10 @@ defmodule Teiserver.Protocols.SpringOut do
     "DENIED #{reason}\n"
   end
 
+  defp do_reply(:protocol_extensions, nil) do
+    "@PROTOCOL_EXTENSIONS@ {\"ring:originator\":1}\n"
+  end
+
   defp do_reply(:motd, nil) do
     @motd
     |> String.split("\n")
@@ -681,6 +685,7 @@ defmodule Teiserver.Protocols.SpringOut do
       })
 
     reply(:login_accepted, user.name, nil, state)
+    reply(:protocol_extensions, nil, nil, state)
     reply(:motd, nil, nil, state)
 
     # Login the client


### PR DESCRIPTION
Fix RING

1. Spads needs prefix "@PROTOCOL_EXTENSIONS@ " being sent as a SERVERMSG command
2. testing for bot account had wrong expression
3. RING couldn't be sent, because it tried to read userID from the array "userID, originatorID"
