### PR TITLE
default balance algo determine whether to pick loser_picks or split_noobs depending on circumstances

### DIFF
--- a/lib/teiserver/battle/balance/default_balance.ex
+++ b/lib/teiserver/battle/balance/default_balance.ex
@@ -1,0 +1,81 @@
+defmodule Teiserver.Battle.Balance.DefaultBalance do
+  @moduledoc """
+  This will call other balancers depending on circumstances
+  """
+  alias Teiserver.Battle.Balance.SplitNoobs
+  alias Teiserver.Battle.Balance.LoserPicks
+  alias Teiserver.Battle.Balance.SplitNoobsTypes, as: SN
+  alias Teiserver.Battle.Balance.BalanceTypes, as: BT
+
+  @doc """
+  Main entry point used by balance_lib
+  """
+  @spec perform([BT.expanded_group()], non_neg_integer(), list()) :: any()
+  def perform(expanded_group, team_count, opts \\ []) do
+    case should_use_algo(expanded_group, team_count) do
+      "split_noobs" ->
+        SplitNoobs.perform(expanded_group, team_count, opts)
+
+      _ ->
+        LoserPicks.perform(expanded_group, team_count, opts)
+    end
+  end
+
+  @spec should_use_algo([BT.expanded_group()], integer()) ::
+          String.t()
+  def should_use_algo(expanded_group, team_count) do
+    cond do
+      team_count != 2 ->
+        "loser_picks"
+
+      true ->
+        players = flatten_members(expanded_group)
+        has_noobs? = has_noobs?(players)
+
+        cond do
+          has_noobs? -> "split_noobs"
+          true -> "loser_picks"
+        end
+    end
+  end
+
+  @doc """
+  Converts the input to a simple list of players
+  """
+  @spec flatten_members([BT.expanded_group()]) :: any()
+  def flatten_members(expanded_group) do
+    for %{
+          members: members,
+          ratings: ratings,
+          ranks: ranks,
+          names: names,
+          uncertainties: uncertainties,
+          count: count
+        } <- expanded_group,
+        # Zipping will create binary tuples from 2 lists
+        {id, rating, rank, name, uncertainty} <-
+          Enum.zip([members, ratings, ranks, names, uncertainties]),
+        # Create result value
+        do: %{
+          rating: rating,
+          name: name,
+          id: id,
+          uncertainty: uncertainty,
+          rank: rank,
+          in_party?:
+            cond do
+              count <= 1 -> false
+              true -> true
+            end
+        }
+  end
+
+  # Returns noobs that are not part of a party
+  # Noobs have high uncertainty or 0 match rating
+  @spec has_noobs?([SN.player()]) :: any()
+  def has_noobs?(players) do
+    Enum.any?(players, fn x ->
+      SplitNoobs.is_newish_player?(x.rank, x.uncertainty)
+    end)
+  end
+end

--- a/lib/teiserver/battle/balance/default_balance.ex
+++ b/lib/teiserver/battle/balance/default_balance.ex
@@ -70,8 +70,6 @@ defmodule Teiserver.Battle.Balance.DefaultBalance do
         }
   end
 
-  # Returns noobs that are not part of a party
-  # Noobs have high uncertainty or 0 match rating
   @spec has_noobs?([SN.player()]) :: any()
   def has_noobs?(players) do
     Enum.any?(players, fn x ->

--- a/lib/teiserver/battle/balance/default_balance_types.ex
+++ b/lib/teiserver/battle/balance/default_balance_types.ex
@@ -1,0 +1,8 @@
+defmodule Teiserver.Battle.Balance.DefaultBalanceTypes do
+  @moduledoc false
+
+  @type player :: %{
+          rank: number(),
+          uncertainty: number()
+        }
+end

--- a/lib/teiserver/battle/balance/loser_picks.ex
+++ b/lib/teiserver/battle/balance/loser_picks.ex
@@ -20,6 +20,7 @@ defmodule Teiserver.Battle.Balance.LoserPicks do
   alias Teiserver.Battle.Balance.BalanceTypes, as: BT
   import Teiserver.Helper.NumberHelper, only: [round: 2]
 
+  @splitter "------------------------------------------------------"
   @type algorithm_state :: %{
           teams: map,
           logs: list,
@@ -81,9 +82,11 @@ defmodule Teiserver.Battle.Balance.LoserPicks do
 
     max_teamsize = (total_members / Enum.count(teams)) |> :math.ceil() |> round()
 
+    intial_logs = [@splitter, "Algorithm: loser_picks", @splitter]
+
     state = %{
       teams: teams,
-      logs: group_logs,
+      logs: intial_logs ++ group_logs,
       solo_players: solo_players,
       group_pairs: group_pairs,
       max_teamsize: max_teamsize,

--- a/lib/teiserver/battle/balance/split_noobs.ex
+++ b/lib/teiserver/battle/balance/split_noobs.ex
@@ -319,11 +319,7 @@ defmodule Teiserver.Battle.Balance.SplitNoobs do
           id: id,
           uncertainty: uncertainty,
           rank: rank,
-          in_party?:
-            cond do
-              count <= 1 -> false
-              true -> true
-            end
+          in_party?: count > 1
         }
   end
 

--- a/lib/teiserver/battle/libs/balance_lib.ex
+++ b/lib/teiserver/battle/libs/balance_lib.ex
@@ -27,7 +27,7 @@ defmodule Teiserver.Battle.BalanceLib do
   # which one will get to pick first
   @shuffle_first_pick true
 
-  @default_balance_algorithm "loser_picks"
+  @default_balance_algorithm "default"
 
   @spec defaults() :: map()
   def defaults() do
@@ -53,7 +53,8 @@ defmodule Teiserver.Battle.BalanceLib do
       "loser_picks" => Teiserver.Battle.Balance.LoserPicks,
       "force_party" => Teiserver.Battle.Balance.ForceParty,
       "brute_force" => Teiserver.Battle.Balance.BruteForce,
-      "split_noobs" => Teiserver.Battle.Balance.SplitNoobs
+      "split_noobs" => Teiserver.Battle.Balance.SplitNoobs,
+      "default" => Teiserver.Battle.Balance.DefaultBalance
     }
   end
 
@@ -65,7 +66,7 @@ defmodule Teiserver.Battle.BalanceLib do
     if(is_moderator) do
       Teiserver.Battle.BalanceLib.algorithm_modules() |> Map.keys()
     else
-      mod_only = ["force_party", "brute_force"]
+      mod_only = ["force_party", "brute_force", "loser_picks"]
       Teiserver.Battle.BalanceLib.algorithm_modules() |> Map.drop(mod_only) |> Map.keys()
     end
   end

--- a/lib/teiserver/battle/libs/balance_lib.ex
+++ b/lib/teiserver/battle/libs/balance_lib.ex
@@ -27,8 +27,6 @@ defmodule Teiserver.Battle.BalanceLib do
   # which one will get to pick first
   @shuffle_first_pick true
 
-  @default_balance_algorithm "default"
-
   @spec defaults() :: map()
   def defaults() do
     %{
@@ -43,8 +41,7 @@ defmodule Teiserver.Battle.BalanceLib do
   end
 
   def get_default_algorithm() do
-    # For now it's a constant but this could be moved to a configurable value
-    @default_balance_algorithm
+    Config.get_site_config_cache("teiserver.Default balance algorithm")
   end
 
   @spec algorithm_modules() :: %{String.t() => module}

--- a/lib/teiserver/libs/teiserver_configs.ex
+++ b/lib/teiserver/libs/teiserver_configs.ex
@@ -328,6 +328,16 @@ defmodule Teiserver.TeiserverConfigs do
     })
 
     add_site_config_type(%{
+      key: "teiserver.Default balance algorithm",
+      section: "Lobbies",
+      type: "select",
+      default: "loser_picks",
+      permissions: ["Admin"],
+      description: "The default balance algorithm",
+      opts: [choices: ["loser_picks", "default"]]
+    })
+
+    add_site_config_type(%{
       key: "teiserver.Curse word score A",
       section: "Lobbies",
       type: "integer",

--- a/lib/teiserver/lobby/commands/explain_command.ex
+++ b/lib/teiserver/lobby/commands/explain_command.ex
@@ -8,7 +8,7 @@ defmodule Teiserver.Lobby.Commands.ExplainCommand do
   alias Teiserver.{Account, Battle, Coordinator}
   import Teiserver.Helper.NumberHelper, only: [round: 2]
 
-  @splitter "---------------------------"
+  @splitter "------------------------------------------------------"
 
   @impl true
   @spec name() :: String.t()

--- a/lib/teiserver/lobby/libs/lobby_restrictions.ex
+++ b/lib/teiserver/lobby/libs/lobby_restrictions.ex
@@ -217,9 +217,6 @@ defmodule Teiserver.Lobby.LobbyRestrictions do
           "To restrict this lobby to players who are new, use either:",
           "!maxchevlevel <chevlevel>",
           "!maxratinglevel <rating>",
-          "",
-          "To ensure new players are distributed evenly across teams:",
-          "!balancealgorithm split_noobs",
           ""
         ]
 

--- a/test/teiserver/battle/balance_lib_internal_test.exs
+++ b/test/teiserver/battle/balance_lib_internal_test.exs
@@ -101,11 +101,11 @@ defmodule Teiserver.Battle.BalanceLibInternalTest do
     is_moderator = true
     result = BalanceLib.get_allowed_algorithms(is_moderator)
 
-    assert result == ["brute_force", "force_party", "loser_picks", "split_noobs"]
+    assert result == ["brute_force", "default", "force_party", "loser_picks", "split_noobs"]
 
     is_moderator = false
     result = BalanceLib.get_allowed_algorithms(is_moderator)
-    assert result == ["loser_picks", "split_noobs"]
+    assert result == ["default", "split_noobs"]
   end
 
   defp create_test_users do

--- a/test/teiserver/lobby/commands/explain_command_test.exs
+++ b/test/teiserver/lobby/commands/explain_command_test.exs
@@ -44,9 +44,9 @@ defmodule Teiserver.Lobby.Commands.ExplainCommandTest do
       channel: "teiserver_client_messages:#{user.id}",
       event: :received_direct_message,
       message_content: [
-        "---------------------------",
+        "------------------------------------------------------",
         "No balance has been created for this room",
-        "---------------------------"
+        "------------------------------------------------------"
       ],
       sender_id: Coordinator.get_coordinator_userid()
     }


### PR DESCRIPTION
## Feature
This PR creates a new balance algo called "default" which becomes the default. It will call 

If team size != 2 then call loser_picks
Otherwise if at least one newish player call split_noobs
Otherwise call loser_picks

Finally complaints over years where people say that new players are overrated can be put to rest. I have been observing multiple noob lobby games with split_noobs and am happy with the results (other than the chev icon being wrong for an unknown reason sometimes).

In SPADS we would later need to make a change to make loser_picks not voteable, but instead make default voteable instead.

## Testing
You can go to website and pick default from the balance dropdown when inspecting a match