### PR TITLE
Allow Moderation Reviewers to access the global chat search tool.

### DIFF
--- a/lib/teiserver_web/live/admin/chat/index.ex
+++ b/lib/teiserver_web/live/admin/chat/index.ex
@@ -4,7 +4,7 @@ defmodule TeiserverWeb.Admin.ChatLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
-    case allow?(socket.assigns[:current_user], "Moderator") do
+    case allow?(socket.assigns[:current_user], "Reviewer") do
       true ->
         socket =
           socket

--- a/lib/teiserver_web/router.ex
+++ b/lib/teiserver_web/router.ex
@@ -615,7 +615,7 @@ defmodule TeiserverWeb.Router do
     live_session :admin_chat_liveview,
       on_mount: [
         {Teiserver.Account.AuthPlug, :ensure_authenticated},
-        {Teiserver.Account.AuthPlug, {:authorise, "Moderator"}}
+        {Teiserver.Account.AuthPlug, {:authorise, "Reviewer"}}
       ] do
       live "/chat", ChatLive.Index, :index
     end


### PR DESCRIPTION
### Please deploy to the Integration server, to allow for some final testing

Currently, users with the "Reviewer" role are only able to view chat logs for individual/reported matches.

This change allows those users to also use the global chat search tool (`<...>/admin/chat`), so that they can search a player's chat history for patterns of behavior.

This change was approved in principle by @PtaQQ (but, he did not review the code itself).