### PR TITLE
Tachyon matchmaking: join and leave queues

### DIFF
--- a/lib/teiserver/application.ex
+++ b/lib/teiserver/application.ex
@@ -137,6 +137,7 @@ defmodule Teiserver.Application do
         # Matchmaking
         {DynamicSupervisor, strategy: :one_for_one, name: Teiserver.Game.QueueSupervisor},
         Teiserver.Data.MatchmakingCache,
+        Teiserver.Matchmaking.System,
 
         # Coordinator mode
         {DynamicSupervisor,

--- a/lib/teiserver/autohost/tachyon_handler.ex
+++ b/lib/teiserver/autohost/tachyon_handler.ex
@@ -38,6 +38,10 @@ defmodule Teiserver.Autohost.TachyonHandler do
           state()
         ) :: WebSock.handle_result()
 
+  def handle_command("system/disconnect", "request", _message_id, _message, state) do
+    {:stop, :normal, state}
+  end
+
   def handle_command(command_id, _message_type, message_id, _message, state) do
     resp =
       Schema.error_response(command_id, message_id, :command_unimplemented)

--- a/lib/teiserver/autohost/tachyon_handler.ex
+++ b/lib/teiserver/autohost/tachyon_handler.ex
@@ -40,13 +40,7 @@ defmodule Teiserver.Autohost.TachyonHandler do
 
   def handle_command(command_id, _message_type, message_id, _message, state) do
     resp =
-      %{
-        type: :response,
-        status: :failed,
-        reason: :command_unimplemented,
-        commandId: command_id,
-        messageId: message_id
-      }
+      Schema.error_response(command_id, message_id, :command_unimplemented)
       |> Jason.encode!()
 
     {:reply, :ok, {:text, resp}, state}

--- a/lib/teiserver/autohost/tachyon_handler.ex
+++ b/lib/teiserver/autohost/tachyon_handler.ex
@@ -5,7 +5,7 @@ defmodule Teiserver.Autohost.TachyonHandler do
   This is treated separately from a player connection because they fulfill
   very different roles, have very different behaviour and states.
   """
-  alias Teiserver.Tachyon.Handler
+  alias Teiserver.Tachyon.{Handler, Schema}
   alias Teiserver.Autohost.Autohost
   @behaviour Handler
 
@@ -27,5 +27,28 @@ defmodule Teiserver.Autohost.TachyonHandler do
   @impl Handler
   def handle_info(_msg, state) do
     {:ok, state}
+  end
+
+  @impl Handler
+  @spec handle_command(
+          Schema.command_id(),
+          Schema.message_type(),
+          Schema.message_id(),
+          term(),
+          state()
+        ) :: WebSock.handle_result()
+
+  def handle_command(command_id, _message_type, message_id, _message, state) do
+    resp =
+      %{
+        type: :response,
+        status: :failed,
+        reason: :command_unimplemented,
+        commandId: command_id,
+        messageId: message_id
+      }
+      |> Jason.encode!()
+
+    {:reply, :ok, {:text, resp}, state}
   end
 end

--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -1159,7 +1159,7 @@ defmodule Teiserver.CacheUser do
     update_user(%{user | restrictions: new_restrictions}, persist: true)
   end
 
-  @spec is_restricted?(T.userid() | T.user(), String.t() | [String.t()]) :: boolean()
+  @spec is_restricted?(T.userid() | T.user() | nil, String.t() | [String.t()]) :: boolean()
   def is_restricted?(nil, _), do: true
 
   def is_restricted?(userid, restriction) when is_integer(userid),

--- a/lib/teiserver/matchmaking.ex
+++ b/lib/teiserver/matchmaking.ex
@@ -6,6 +6,7 @@ defmodule Teiserver.Matchmaking do
   @type queue_id :: Matchmaking.QueueServer.id()
   @type member :: Matchmaking.QueueServer.member()
   @type join_result :: Matchmaking.QueueServer.join_result()
+  @type leave_result :: Matchmaking.QueueServer.leave_result()
 
   @spec lookup_queue(Matchmaking.QueueServer.id()) :: pid() | nil
   def lookup_queue(queue_id) do
@@ -41,5 +42,10 @@ defmodule Teiserver.Matchmaking do
 
   def join_queue(queue_id, member) do
     Matchmaking.QueueServer.join_queue(queue_id, member)
+  end
+
+  @spec leave_queue(queue_id(), T.userid()) :: leave_result()
+  def leave_queue(queue_id, user_id) do
+    Matchmaking.QueueServer.leave_queue(queue_id, user_id)
   end
 end

--- a/lib/teiserver/matchmaking.ex
+++ b/lib/teiserver/matchmaking.ex
@@ -1,5 +1,6 @@
 defmodule Teiserver.Matchmaking do
   alias Teiserver.Matchmaking
+  alias Teiserver.Data.Types, as: T
 
   @type queue :: Matchmaking.QueueServer.queue()
   @type queue_id :: Matchmaking.QueueServer.id()

--- a/lib/teiserver/matchmaking.ex
+++ b/lib/teiserver/matchmaking.ex
@@ -4,6 +4,8 @@ defmodule Teiserver.Matchmaking do
 
   @type queue :: Matchmaking.QueueServer.queue()
   @type queue_id :: Matchmaking.QueueServer.id()
+  @type member :: Matchmaking.QueueServer.member()
+  @type join_result :: Matchmaking.QueueServer.join_result()
 
   @spec lookup_queue(Matchmaking.QueueServer.id()) :: pid() | nil
   def lookup_queue(queue_id) do
@@ -16,5 +18,28 @@ defmodule Teiserver.Matchmaking do
   @spec list_queues() :: [{queue_id(), queue()}]
   def list_queues() do
     Matchmaking.QueueRegistry.list()
+  end
+
+  @doc """
+  Request the player to join the specified queue.
+  """
+  @spec join_queue(queue_id(), T.userid() | member()) :: join_result()
+  def join_queue(queue_id, member) when not is_map(member) do
+    member = %{
+      player_ids: [member],
+      # TODO tachyon_mvp: fetch ratings for the player somehow
+      rating: %{},
+      # TODO tachyon_mvp: fetch the list of player id avoided by this player
+      avoid: [],
+      joined_at: DateTime.utc_now(),
+      search_distance: 0,
+      increase_distance_after: 10
+    }
+
+    join_queue(queue_id, member)
+  end
+
+  def join_queue(queue_id, member) do
+    Matchmaking.QueueServer.join_queue(queue_id, member)
   end
 end

--- a/lib/teiserver/matchmaking.ex
+++ b/lib/teiserver/matchmaking.ex
@@ -1,0 +1,8 @@
+defmodule Teiserver.Matchmaking do
+  alias Teiserver.Matchmaking
+
+  @spec lookup_queue(Matchmaking.QueueServer.id()) :: pid() | nil
+  def lookup_queue(queue_id) do
+    Matchmaking.QueueRegistry.lookup(queue_id)
+  end
+end

--- a/lib/teiserver/matchmaking.ex
+++ b/lib/teiserver/matchmaking.ex
@@ -1,8 +1,19 @@
 defmodule Teiserver.Matchmaking do
   alias Teiserver.Matchmaking
 
+  @type queue :: Matchmaking.QueueServer.queue()
+  @type queue_id :: Matchmaking.QueueServer.id()
+
   @spec lookup_queue(Matchmaking.QueueServer.id()) :: pid() | nil
   def lookup_queue(queue_id) do
     Matchmaking.QueueRegistry.lookup(queue_id)
+  end
+
+  @doc """
+  Return the list of currently available queues
+  """
+  @spec list_queues() :: [{queue_id(), queue()}]
+  def list_queues() do
+    Matchmaking.QueueRegistry.list()
   end
 end

--- a/lib/teiserver/matchmaking/queue_registry.ex
+++ b/lib/teiserver/matchmaking/queue_registry.ex
@@ -1,0 +1,28 @@
+defmodule Teiserver.Matchmaking.QueueRegistry do
+  @moduledoc """
+  cluster wide registry of all matchmaking queues
+  """
+
+  alias Teiserver.Matchmaking.QueueServer
+
+  def start_link() do
+    Horde.Registry.start_link(keys: :unique, members: :auto, name: __MODULE__)
+  end
+
+  @spec via_tuple(QueueServer.id()) :: GenServer.name()
+  def via_tuple(queue_id) do
+    {:via, Horde.Registry, {__MODULE__, queue_id}}
+  end
+
+  def child_spec(_arg) do
+    Supervisor.child_spec(Horde.Registry, id: __MODULE__, start: {__MODULE__, :start_link, []})
+  end
+
+  @spec lookup(QueueServer.id()) :: pid() | nil
+  def lookup(queue_id) do
+    case Horde.Registry.lookup(__MODULE__, queue_id) do
+      [{pid, _}] -> pid
+      _ -> nil
+    end
+  end
+end

--- a/lib/teiserver/matchmaking/queue_registry.ex
+++ b/lib/teiserver/matchmaking/queue_registry.ex
@@ -1,6 +1,8 @@
 defmodule Teiserver.Matchmaking.QueueRegistry do
   @moduledoc """
   cluster wide registry of all matchmaking queues
+
+  The registry is also used for listing and querying running queues
   """
 
   alias Teiserver.Matchmaking.QueueServer
@@ -9,9 +11,20 @@ defmodule Teiserver.Matchmaking.QueueRegistry do
     Horde.Registry.start_link(keys: :unique, members: :auto, name: __MODULE__)
   end
 
+  @doc """
+  How to reach a given queue from its ID
+  """
   @spec via_tuple(QueueServer.id()) :: GenServer.name()
   def via_tuple(queue_id) do
     {:via, Horde.Registry, {__MODULE__, queue_id}}
+  end
+
+  @doc """
+  Used for registering a new queue with some associated data
+  """
+  @spec via_tuple(QueueServer.id(), QueueServer.queue()) :: GenServer.name()
+  def via_tuple(queue_id, queue_data) do
+    {:via, Horde.Registry, {__MODULE__, queue_id, queue_data}}
   end
 
   def child_spec(_arg) do
@@ -24,5 +37,10 @@ defmodule Teiserver.Matchmaking.QueueRegistry do
       [{pid, _}] -> pid
       _ -> nil
     end
+  end
+
+  @spec list() :: [{QueueServer.id(), QueueServer.queue()}]
+  def list() do
+    Horde.Registry.select(__MODULE__, [{{:"$1", :_, :"$2"}, [], [{{:"$1", :"$2"}}]}])
   end
 end

--- a/lib/teiserver/matchmaking/queue_server.ex
+++ b/lib/teiserver/matchmaking/queue_server.ex
@@ -45,7 +45,8 @@ defmodule Teiserver.Matchmaking.QueueServer do
   @type queue :: %{
           name: String.t(),
           team_size: pos_integer(),
-          team_count: pos_integer()
+          team_count: pos_integer(),
+          ranked: boolean()
         }
 
   @type state :: %{
@@ -80,7 +81,8 @@ defmodule Teiserver.Matchmaking.QueueServer do
       queue: %{
         name: attrs.name,
         team_size: attrs.team_size,
-        team_count: attrs.team_count
+        team_count: attrs.team_count,
+        ranked: true
       },
       settings: Map.merge(default_settings(), Map.get(attrs, :settings, %{})),
       members: Map.get(attrs, :members, [])

--- a/lib/teiserver/matchmaking/queue_server.ex
+++ b/lib/teiserver/matchmaking/queue_server.ex
@@ -1,0 +1,94 @@
+defmodule Teiserver.Matchmaking.QueueServer do
+  @moduledoc """
+  Very similar to Teiserver.Game.QueueWaitServer
+
+  This process manages a given queue and attempt to match the members to play
+  matches. Once player are matched, they are excluded from this queue and passed
+  to a QueueRoomServer
+  It also has some associated state for telemetry.
+  """
+
+  use GenServer
+
+  @typedoc """
+  member of a queue. Holds of the information required to match members together.
+  A member can be a party of players. Parties must not be broken.
+  """
+  @type member :: %{
+          player_ids: [T.userid()],
+          # maybe also add (aggregated) chevron if that's taking into account
+          # map keyed by the rating type to {skill, uncertainty}
+          # For example %{"duel" => {12, 3.2}}
+          rating: %{String.t() => {integer(), integer()}},
+          # aggregate of player to avoid for this member
+          avoid: [T.userid()],
+          joined_at: DateTime.t(),
+          search_distance: non_neg_integer(),
+          # how many ticks remaining before increasing the search distance
+          increase_distance_after: non_neg_integer()
+        }
+
+  @type id :: String.t()
+
+  @typedoc """
+  Internal settings for the queue so it's easier to control the frequency of
+  ticks and whatnot
+  """
+  @type settings :: %{
+          tick_interval_ms: pos_integer(),
+          max_distance: pos_integer()
+        }
+  @type state :: %{
+          id: id(),
+          name: String.t(),
+          team_size: pos_integer(),
+          team_count: pos_integer(),
+          settings: settings(),
+          members: [member()]
+
+          # TODO: add some bits for telemetry (see QueueWaitServer) like avg
+          # wait time and join count
+        }
+
+  @spec default_settings() :: settings()
+  def default_settings() do
+    %{tick_interval_ms: 5_000, max_distance: 15}
+  end
+
+  @doc """
+  Create a state for the GenServer, filling missing attributes with defaults
+  """
+  @spec init_state(%{
+          required(:id) => id(),
+          required(:name) => String.t(),
+          required(:team_size) => pos_integer(),
+          required(:team_count) => pos_integer(),
+          optional(:settings) => settings(),
+          optional(:members) => [member()]
+        }) :: state()
+  def init_state(attrs) do
+    %{
+      id: attrs.id,
+      name: attrs.name,
+      team_size: attrs.team_size,
+      team_count: attrs.team_count,
+      settings: Map.merge(default_settings(), Map.get(attrs, :settings, %{})),
+      members: Map.get(attrs, :members, [])
+    }
+  end
+
+  def via_tuple(queue_id) do
+    Teiserver.Matchmaking.QueueRegistry.via_tuple(queue_id)
+  end
+
+  @spec start_link(state()) :: GenServer.on_start()
+  def start_link(initial_state) do
+    GenServer.start_link(__MODULE__, initial_state, name: via_tuple(initial_state.id))
+  end
+
+  @impl true
+  def init(state) do
+    {:ok, state}
+  end
+
+end

--- a/lib/teiserver/matchmaking/queue_supervisor.ex
+++ b/lib/teiserver/matchmaking/queue_supervisor.ex
@@ -1,0 +1,39 @@
+defmodule Teiserver.Matchmaking.QueueSupervisor do
+  @moduledoc """
+  cluster wide supervisor for all matchmaking queues
+  """
+
+  use Horde.DynamicSupervisor
+  alias Teiserver.Matchmaking.QueueServer
+
+  def default_queues() do
+    [
+      QueueServer.init_state(%{
+        id: "1v1",
+        name: "Duel",
+        team_size: 1,
+        team_count: 2
+      })
+    ]
+  end
+
+  def start_queue!(state) do
+    case Horde.DynamicSupervisor.start_child(__MODULE__, {QueueServer, state}) do
+      {:error, err} -> raise "Cannot start queue: #{inspect(err)}"
+      _ -> :ok
+    end
+  end
+
+  def start_link(init_arg) do
+    {:ok, sup} = Horde.DynamicSupervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+
+    Enum.each(default_queues(), &start_queue!/1)
+
+    {:ok, sup}
+  end
+
+  @impl true
+  def init(_) do
+    Horde.DynamicSupervisor.init(strategy: :one_for_one, members: :auto)
+  end
+end

--- a/lib/teiserver/matchmaking/system.ex
+++ b/lib/teiserver/matchmaking/system.ex
@@ -1,0 +1,21 @@
+defmodule Teiserver.Matchmaking.System do
+  @moduledoc """
+  Everything required for matchmaking
+  """
+
+  use Supervisor
+
+  def start_link(init_arg) do
+    Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_) do
+    children = [
+      Teiserver.Matchmaking.QueueRegistry,
+      Teiserver.Matchmaking.QueueSupervisor
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end

--- a/lib/teiserver/player/session_registry.ex
+++ b/lib/teiserver/player/session_registry.ex
@@ -25,6 +25,10 @@ defmodule Teiserver.Player.SessionRegistry do
     end
   end
 
+  def unregister(user_id) do
+    Horde.Registry.unregister(__MODULE__, via_tuple(user_id))
+  end
+
   def child_spec(_) do
     Supervisor.child_spec(Horde.Registry,
       id: __MODULE__,

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -53,13 +53,7 @@ defmodule Teiserver.Player.TachyonHandler do
         ) :: WebSock.handle_result()
   def handle_command(command_id, _message_type, message_id, _message, state) do
     resp =
-      %{
-        type: :response,
-        status: :failed,
-        reason: :command_unimplemented,
-        commandId: command_id,
-        messageId: message_id
-      }
+      Schema.error_response(command_id, message_id, :command_unimplemented)
       |> Jason.encode!()
 
     {:reply, :ok, {:text, resp}, state}

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -43,6 +43,28 @@ defmodule Teiserver.Player.TachyonHandler do
     {:ok, state}
   end
 
+  @impl Handler
+  @spec handle_command(
+          Schema.command_id(),
+          Schema.message_type(),
+          Schema.message_id(),
+          term(),
+          state()
+        ) :: WebSock.handle_result()
+  def handle_command(command_id, _message_type, message_id, _message, state) do
+    resp =
+      %{
+        type: :response,
+        status: :failed,
+        reason: :command_unimplemented,
+        commandId: command_id,
+        messageId: message_id
+      }
+      |> Jason.encode!()
+
+    {:reply, :ok, {:text, resp}, state}
+  end
+
   # Ensure a session is started for the given user id. Register both the session
   # and the connection. If a connection already exists, terminates it and
   # replace it in the player registry.

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -53,6 +53,10 @@ defmodule Teiserver.Player.TachyonHandler do
           term(),
           state()
         ) :: WebSock.handle_result()
+  def handle_command("system/disconnect", "request", _message_id, _message, state) do
+    {:stop, :normal, state}
+  end
+
   def handle_command("matchmaking/list" = cmd_id, "request", message_id, _message, state) do
     queues =
       Matchmaking.list_queues()

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -104,6 +104,19 @@ defmodule Teiserver.Player.TachyonHandler do
     {:push, {:text, Jason.encode!(response)}, state}
   end
 
+  def handle_command("matchmaking/cancel" = cmd_id, "request", message_id, _message, state) do
+    response =
+      case Player.Session.leave_queues(state.user.id) do
+        :ok ->
+          Schema.response(cmd_id, message_id)
+
+        {:error, reason} ->
+          Schema.error_response(cmd_id, message_id, reason)
+      end
+
+    {:push, {:text, Jason.encode!(response)}, state}
+  end
+
   def handle_command(command_id, _message_type, message_id, _message, state) do
     resp =
       Schema.error_response(command_id, message_id, :command_unimplemented)

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -88,17 +88,22 @@ defmodule Teiserver.Player.TachyonHandler do
         {:error, reason} ->
           reason =
             case reason do
-              :invalid_queue -> :invalid_queue_specified
-              x -> x
+              :invalid_queue ->
+                %{reason: :invalid_queue_specified}
+
+              :too_many_players ->
+                %{reason: :invalid_request, details: "too many player for a playlist"}
+
+              x ->
+                %{reason: x}
             end
 
-          %{
+          Map.merge(reason, %{
             type: :response,
             status: :failed,
             commandId: cmd_id,
-            messageId: message_id,
-            reason: reason
-          }
+            messageId: message_id
+          })
       end
 
     {:push, {:text, Jason.encode!(response)}, state}

--- a/lib/teiserver/tachyon/handler.ex
+++ b/lib/teiserver/tachyon/handler.ex
@@ -3,6 +3,8 @@ defmodule Teiserver.Tachyon.Handler do
   Interface for connecting a tachyon client and process tachyon commands
   """
 
+  alias Teiserver.Tachyon.Schema
+
   @doc """
   Called when upgrading the http connection to websocket.
   It is given the connection object and should do whatever is required for
@@ -26,5 +28,17 @@ defmodule Teiserver.Tachyon.Handler do
   """
   @callback handle_info(term(), term()) :: WebSock.handle_result()
 
-  # TODO: add other callbacks to handle (parsed) tachyon commands
+  @doc """
+  The generic command handler. At that point, the message has already been
+  validated against the corresponding json schema
+  """
+  @callback handle_command(
+              Schema.command_id(),
+              Schema.message_type(),
+              Schema.message_id(),
+              # message
+              term(),
+              # handler's state
+              term()
+            ) :: WebSock.handle_result()
 end

--- a/lib/teiserver/tachyon/schema.ex
+++ b/lib/teiserver/tachyon/schema.ex
@@ -76,4 +76,40 @@ defmodule Teiserver.Tachyon.Schema do
       end
     end
   end
+
+  @doc """
+  helper to create a tachyon response
+  """
+  @spec response(command_id(), message_id(), term()) :: map()
+  def response(command_id, message_id, data \\ nil) do
+    resp = %{
+      type: :response,
+      status: :success,
+      commandId: command_id,
+      messageId: message_id
+    }
+
+    if is_nil(data) do
+      resp
+    else
+      Map.put(resp, :data, data)
+    end
+  end
+
+  @spec error_response(command_id(), message_id(), term(), String.t() | nil) :: map()
+  def error_response(command_id, message_id, reason, details \\ nil) do
+    resp = %{
+      type: :response,
+      status: :failed,
+      commandId: command_id,
+      messageId: message_id,
+      reason: reason
+    }
+
+    if is_nil(details) do
+      resp
+    else
+      Map.put(resp, :details, details)
+    end
+  end
 end

--- a/lib/teiserver/tachyon/transport.ex
+++ b/lib/teiserver/tachyon/transport.ex
@@ -9,13 +9,13 @@ defmodule Teiserver.Tachyon.Transport do
   require Logger
   alias Teiserver.Tachyon.Schema
 
-  @type connection_state() :: %{handler: term(), state: term()}
+  @type connection_state() :: %{handler: term(), handler_state: term()}
 
   @impl true
   def init(state) do
     # this is inside the process that maintain the connection
     schedule_ping()
-    handle_result(state.handler.init(state.state), state)
+    handle_result(state.handler.init(state.handler_state), state)
   end
 
   # dummy handle_in for now
@@ -56,7 +56,7 @@ defmodule Teiserver.Tachyon.Transport do
   end
 
   def handle_info(msg, state) do
-    handle_result(state.handler.handle_info(msg, state.state), state)
+    handle_result(state.handler.handle_info(msg, state.handler_state), state)
   end
 
   @impl true
@@ -114,19 +114,17 @@ defmodule Teiserver.Tachyon.Transport do
     {:stop, :normal, state}
   end
 
-  def do_handle_command(command_id, _message_type, message_id, _message, state) do
-    # TODO: call the handler there
-    resp =
-      %{
-        type: :response,
-        status: :failed,
-        reason: :command_unimplemented,
-        commandId: command_id,
-        messageId: message_id
-      }
-      |> Jason.encode!()
+  def do_handle_command(command_id, message_type, message_id, message, state) do
+    result =
+      state.handler.handle_command(
+        command_id,
+        message_type,
+        message_id,
+        message,
+        state.handler_state
+      )
 
-    {:reply, :ok, {:text, resp}, state}
+    handle_result(result, state)
   end
 
   # helper function to use the result from the invoked handler function
@@ -134,22 +132,22 @@ defmodule Teiserver.Tachyon.Transport do
   defp handle_result(result, conn_state) do
     case result do
       {:push, messages, state} ->
-        {:push, messages, %{conn_state | state: state}}
+        {:push, messages, %{conn_state | handler_state: state}}
 
       {:reply, term, messages, state} ->
-        {:reply, term, messages, %{conn_state | state: state}}
+        {:reply, term, messages, %{conn_state | handler_state: state}}
 
       {:ok, state} ->
-        {:ok, %{conn_state | state: state}}
+        {:ok, %{conn_state | handler_state: state}}
 
       {:stop, reason, state} ->
-        {:stop, reason, %{conn_state | state: state}}
+        {:stop, reason, %{conn_state | handler_state: state}}
 
       {:stop, reason, close_details, state} ->
-        {:stop, reason, close_details, %{conn_state | state: state}}
+        {:stop, reason, close_details, %{conn_state | handler_state: state}}
 
       {:stop, reason, close_details, messages, state} ->
-        {:stop, reason, close_details, messages, %{conn_state | state: state}}
+        {:stop, reason, close_details, messages, %{conn_state | handler_state: state}}
     end
   end
 

--- a/lib/teiserver/tachyon/transport.ex
+++ b/lib/teiserver/tachyon/transport.ex
@@ -97,10 +97,6 @@ defmodule Teiserver.Tachyon.Transport do
     end
   end
 
-  def do_handle_command("system/disconnect", "request", _message_id, _message, state) do
-    {:stop, :normal, state}
-  end
-
   def do_handle_command(command_id, message_type, message_id, message, state) do
     result =
       state.handler.handle_command(

--- a/lib/teiserver/tachyon/transport.ex
+++ b/lib/teiserver/tachyon/transport.ex
@@ -83,27 +83,14 @@ defmodule Teiserver.Tachyon.Transport do
 
       :missing_schema ->
         resp =
-          %{
-            type: :response,
-            status: :failed,
-            reason: :command_unimplemented,
-            commandId: command_id,
-            messageId: message_id
-          }
+          Schema.error_response(command_id, message_id, :command_unimplemented)
           |> Jason.encode!()
 
         {:reply, :ok, {:text, resp}, state}
 
       {:error, err} ->
         resp =
-          %{
-            type: :response,
-            status: :failed,
-            reason: :internal_error,
-            commandId: command_id,
-            messageId: message_id,
-            details: inspect(err)
-          }
+          Schema.error_response(command_id, message_id, :internal_error, inspect(err))
           |> Jason.encode!()
 
         {:reply, :ok, {:text, resp}, state}
@@ -131,15 +118,7 @@ defmodule Teiserver.Tachyon.Transport do
         str_err = inspect({e, __STACKTRACE__})
         Logger.error([inspect(message), str_err])
 
-        resp = %{
-          type: :response,
-          status: :failed,
-          messageId: message_id,
-          commandId: command_id,
-          reason: :internal_error,
-          details: str_err
-        }
-
+        resp = Schema.error_response(command_id, message_id, :internal_error, str_err)
         {:push, {:text, Jason.encode!(resp)}, state}
     end
   end

--- a/lib/teiserver/tachyon/transport.ex
+++ b/lib/teiserver/tachyon/transport.ex
@@ -124,7 +124,24 @@ defmodule Teiserver.Tachyon.Transport do
         state.handler_state
       )
 
-    handle_result(result, state)
+    try do
+      handle_result(result, state)
+    rescue
+      e ->
+        str_err = inspect({e, __STACKTRACE__})
+        Logger.error([inspect(message), str_err])
+
+        resp = %{
+          type: :response,
+          status: :failed,
+          messageId: message_id,
+          commandId: command_id,
+          reason: :internal_error,
+          details: str_err
+        }
+
+        {:push, {:text, Jason.encode!(resp)}, state}
+    end
   end
 
   # helper function to use the result from the invoked handler function

--- a/lib/teiserver_web/controllers/tachyon.ex
+++ b/lib/teiserver_web/controllers/tachyon.ex
@@ -15,7 +15,7 @@ defmodule TeiserverWeb.TachyonController do
     with {:ok, handler} <- handler_for_version(conn),
          {:ok, state} <- handler.connect(conn) do
       try do
-        conn_state = %{state: state, handler: handler}
+        conn_state = %{handler_state: state, handler: handler}
 
         conn
         |> WebSockAdapter.upgrade(Teiserver.Tachyon.Transport, conn_state, timeout: 20_000)

--- a/priv/tachyon/schema/matchmaking/cancel/request.json
+++ b/priv/tachyon/schema/matchmaking/cancel/request.json
@@ -1,0 +1,17 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/cancel/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "MatchmakingCancelRequest",
+    "tachyon": {
+        "source": "user",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "matchmaking/cancel" }
+    },
+    "required": ["type", "messageId", "commandId"]
+}

--- a/priv/tachyon/schema/matchmaking/list/request.json
+++ b/priv/tachyon/schema/matchmaking/list/request.json
@@ -1,0 +1,17 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/list/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "MatchmakingListRequest",
+    "tachyon": {
+        "source": "user",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "matchmaking/list" }
+    },
+    "required": ["type", "messageId", "commandId"]
+}

--- a/priv/tachyon/schema/matchmaking/queue/request.json
+++ b/priv/tachyon/schema/matchmaking/queue/request.json
@@ -1,0 +1,29 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/queue/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "MatchmakingQueueRequest",
+    "tachyon": {
+        "source": "user",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "matchmaking/queue" },
+        "data": {
+            "title": "MatchmakingQueueRequestData",
+            "type": "object",
+            "properties": {
+                "queues": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "minItems": 1
+                }
+            },
+            "required": ["queues"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -119,6 +119,13 @@ defmodule Teiserver.Support.Tachyon do
     resp
   end
 
+  def leave_queues!(client) do
+    req = request("matchmaking/cancel")
+    :ok = WSC.send_message(client, {:text, req |> Jason.encode!()})
+    {:ok, resp} = recv_response(client)
+    resp
+  end
+
   @doc """
   Run the given function `f` until `pred` returns true on its result.
   Waits `wait` ms between each tries. Raise an error if `pred` returns false

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -2,6 +2,7 @@ defmodule Teiserver.Support.Tachyon do
   alias WebsocketSyncClient, as: WSC
   alias Teiserver.OAuthFixtures
 
+  def setup_client(_context), do: setup_client()
   def setup_client() do
     user = Central.Helpers.GeneralTestLib.make_user(%{"data" => %{"roles" => ["Verified"]}})
     %{client: client, token: token} = connect(user)
@@ -64,6 +65,16 @@ defmodule Teiserver.Support.Tachyon do
   end
 
   @doc """
+  Cleanly disconnect a client by sending a disconnect message before closing
+  the connection.
+  """
+  def disconnect(client) do
+    req = request("system/disconnect")
+    :ok = WSC.send_message(client, {:text, req |> Jason.encode!()})
+    WSC.disconnect(client)
+  end
+
+  @doc """
   high level function to get the list of matchmaking queues
   """
   def list_queues!(client) do
@@ -84,6 +95,13 @@ defmodule Teiserver.Support.Tachyon do
       "status" => "success"
     } = resp
 
+    resp
+  end
+
+  def join_queues!(client, queue_ids) do
+    req = request("matchmaking/queue", %{queues: queue_ids})
+    :ok = WSC.send_message(client, {:text, req |> Jason.encode!()})
+    {:ok, resp} = recv_response(client)
     resp
   end
 

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -2,6 +2,14 @@ defmodule Teiserver.Support.Tachyon do
   alias WebsocketSyncClient, as: WSC
   alias Teiserver.OAuthFixtures
 
+  def setup_client() do
+    user = Central.Helpers.GeneralTestLib.make_user(%{"data" => %{"roles" => ["Verified"]}})
+    %{client: client, token: token} = connect(user)
+
+    ExUnit.Callbacks.on_exit(fn -> WSC.disconnect(client) end)
+    {:ok, user: user, client: client, token: token}
+  end
+
   @doc """
   connects the given user and returns the ws client
   """

--- a/test/teiserver/matchmaking/queue_sync_test.exs
+++ b/test/teiserver/matchmaking/queue_sync_test.exs
@@ -1,5 +1,4 @@
-defmodule Teiserver.Matchmaking.QueueTest do
-
+defmodule Teiserver.Matchmaking.QueueSyncTest do
   use Teiserver.DataCase
   alias Teiserver.Matchmaking
 
@@ -7,4 +6,7 @@ defmodule Teiserver.Matchmaking.QueueTest do
     assert is_pid(Matchmaking.lookup_queue("1v1"))
   end
 
+  test "list default queues" do
+    assert [{"1v1", _}] = Matchmaking.list_queues()
+  end
 end

--- a/test/teiserver/matchmaking/queue_test.exs
+++ b/test/teiserver/matchmaking/queue_test.exs
@@ -1,0 +1,28 @@
+defmodule Teiserver.Matchmaking.QueueSynest do
+  use Teiserver.DataCase, async: true
+  alias Teiserver.Matchmaking
+  alias Teiserver.Matchmaking.QueueServer
+
+  setup _context do
+    user = Central.Helpers.GeneralTestLib.make_user(%{"data" => %{"roles" => ["Verified"]}})
+    id = UUID.uuid4()
+
+    {:ok, pid} =
+      QueueServer.init_state(%{id: id, name: id, team_size: 1, team_count: 2})
+      |> QueueServer.start_link()
+
+    {:ok, user: user, queue_id: id, queue_pid: pid}
+  end
+
+  describe "joining" do
+    test "works", %{user: user, queue_id: queue_id} do
+      assert :ok = Matchmaking.join_queue(queue_id, user.id)
+
+      assert {:error, :already_queued} == Matchmaking.join_queue(queue_id, user.id)
+    end
+
+    test "invalid queue", %{user: user} do
+      assert {:error, :invalid_queue} == Matchmaking.join_queue("INVALID!!", user.id)
+    end
+  end
+end

--- a/test/teiserver/matchmaking/queue_test.exs
+++ b/test/teiserver/matchmaking/queue_test.exs
@@ -1,0 +1,10 @@
+defmodule Teiserver.Matchmaking.QueueTest do
+
+  use Teiserver.DataCase
+  alias Teiserver.Matchmaking
+
+  test "default queue starts" do
+    assert is_pid(Matchmaking.lookup_queue("1v1"))
+  end
+
+end

--- a/test/teiserver/matchmaking/queue_test.exs
+++ b/test/teiserver/matchmaking/queue_test.exs
@@ -25,4 +25,16 @@ defmodule Teiserver.Matchmaking.QueueSynest do
       assert {:error, :invalid_queue} == Matchmaking.join_queue("INVALID!!", user.id)
     end
   end
+
+  describe "leaving" do
+    test "works", %{user: user, queue_id: queue_id} do
+      assert {:error, :not_queued} = Matchmaking.leave_queue(queue_id, user.id)
+
+      assert {:error, :invalid_queue} =
+               Matchmaking.leave_queue("lolnope that't not a queue", user.id)
+
+      :ok = Matchmaking.join_queue(queue_id, user.id)
+      assert :ok = Matchmaking.leave_queue(queue_id, user.id)
+    end
+  end
 end

--- a/test/teiserver/matchmaking/queue_test.exs
+++ b/test/teiserver/matchmaking/queue_test.exs
@@ -24,6 +24,19 @@ defmodule Teiserver.Matchmaking.QueueSynest do
     test "invalid queue", %{user: user} do
       assert {:error, :invalid_queue} == Matchmaking.join_queue("INVALID!!", user.id)
     end
+
+    test "party too big", %{user: user, queue_id: queue_id} do
+      member = %{
+        player_ids: [user.id, user.id],
+        rating: %{},
+        avoid: [],
+        joined_at: DateTime.utc_now(),
+        search_distance: 0,
+        increase_distance_after: 10
+      }
+
+      assert {:error, :too_many_players} = Matchmaking.join_queue(queue_id, member)
+    end
   end
 
   describe "leaving" do

--- a/test/teiserver_web/controllers/logging/audit_log_controller_test.exs
+++ b/test/teiserver_web/controllers/logging/audit_log_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TeiserverWeb.Logging.AuditLogControllerTest do
-  use TeiserverWeb.ConnCase, async: true
+  use TeiserverWeb.ConnCase
 
   # alias TeiserverWeb.Logging.AuditLog
   alias Teiserver.Logging.Helpers

--- a/test/teiserver_web/controllers/logging/general_controller_test.exs
+++ b/test/teiserver_web/controllers/logging/general_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TeiserverWeb.Logging.LoggingControllerTest do
-  use TeiserverWeb.ConnCase, async: true
+  use TeiserverWeb.ConnCase
 
   alias Central.Helpers.GeneralTestLib
 

--- a/test/teiserver_web/tachyon/matchmaking_test.exs
+++ b/test/teiserver_web/tachyon/matchmaking_test.exs
@@ -1,0 +1,31 @@
+defmodule Teiserver.Matchmaking.MatchmakingTest do
+  use TeiserverWeb.ConnCase
+  alias Teiserver.Support.Tachyon
+  alias WebsocketSyncClient, as: WSC
+
+  # redefinition because ExUnit < 1.15 doesn't support passing setup
+  # definition as {Tachyon, :setup_client}
+  defp setup_client(_context), do: Tachyon.setup_client()
+
+  describe "list" do
+    setup :setup_client
+
+    test "works", %{client: client} do
+      resp = Tachyon.list_queues!(client)
+
+      # convert into a set since the order must not impact test result
+      expected_playlists =
+        MapSet.new([
+          %{
+            "id" => "1v1",
+            "name" => "Duel",
+            "numOfTeams" => 2,
+            "teamSize" => 1,
+            "ranked" => true
+          }
+        ])
+
+      assert MapSet.new(resp["data"]["playlists"]) == expected_playlists
+    end
+  end
+end

--- a/test/teiserver_web/tachyon/matchmaking_test.exs
+++ b/test/teiserver_web/tachyon/matchmaking_test.exs
@@ -73,6 +73,22 @@ defmodule Teiserver.Matchmaking.MatchmakingTest do
       %{"status" => "failed", "reason" => "already_queued"} =
         Tachyon.join_queues!(client, [queue_id])
     end
+
+    test "too many player", %{client: client} do
+      id = "emptyqueue"
+
+      {:ok, _} =
+        Teiserver.Matchmaking.QueueServer.init_state(%{
+          id: id,
+          name: id,
+          team_size: 0,
+          team_count: 2
+        })
+        |> Teiserver.Matchmaking.QueueServer.start_link()
+
+      assert %{"status" => "failed", "reason" => "invalid_request"} =
+               Tachyon.join_queues!(client, [id])
+    end
   end
 
   describe "leaving queues" do

--- a/test/teiserver_web/tachyon/matchmaking_test.exs
+++ b/test/teiserver_web/tachyon/matchmaking_test.exs
@@ -1,14 +1,9 @@
 defmodule Teiserver.Matchmaking.MatchmakingTest do
   use TeiserverWeb.ConnCase
   alias Teiserver.Support.Tachyon
-  alias WebsocketSyncClient, as: WSC
-
-  # redefinition because ExUnit < 1.15 doesn't support passing setup
-  # definition as {Tachyon, :setup_client}
-  defp setup_client(_context), do: Tachyon.setup_client()
 
   describe "list" do
-    setup :setup_client
+    setup {Tachyon, :setup_client}
 
     test "works", %{client: client} do
       resp = Tachyon.list_queues!(client)
@@ -26,6 +21,41 @@ defmodule Teiserver.Matchmaking.MatchmakingTest do
         ])
 
       assert MapSet.new(resp["data"]["playlists"]) == expected_playlists
+    end
+  end
+
+  defp setup_queue(_context) do
+    alias Teiserver.Matchmaking.QueueServer
+    id = UUID.uuid4()
+
+    {:ok, pid} =
+      QueueServer.init_state(%{id: id, name: id, team_size: 1, team_count: 2})
+      |> QueueServer.start_link()
+
+    {:ok, queue_id: id, queue_pid: pid}
+  end
+
+  describe "joining queues" do
+    setup [{Tachyon, :setup_client}, :setup_queue]
+
+    test "works", %{client: client, queue_id: queue_id} do
+      resp = Tachyon.join_queues!(client, [queue_id])
+      assert %{"status" => "success"} = resp
+      resp = Tachyon.join_queues!(client, [queue_id])
+      assert %{"status" => "failed", "reason" => "already_queued"} = resp
+    end
+
+    test "multiple", %{client: client, queue_id: queue_id} do
+      {:ok, queue_id: other_queue_id, queue_pid: _} = setup_queue(nil)
+      resp = Tachyon.join_queues!(client, [queue_id, other_queue_id])
+      assert %{"status" => "success"} = resp
+    end
+
+    test "all or nothing", %{client: client, queue_id: queue_id} do
+      resp = Tachyon.join_queues!(client, [queue_id, "lolnope that's not a queue"])
+      assert %{"status" => "failed", "reason" => "invalid_queue_specified"} = resp
+      resp = Tachyon.join_queues!(client, [queue_id])
+      assert %{"status" => "success"} = resp
     end
   end
 end

--- a/test/teiserver_web/tachyon/matchmaking_test.exs
+++ b/test/teiserver_web/tachyon/matchmaking_test.exs
@@ -74,4 +74,16 @@ defmodule Teiserver.Matchmaking.MatchmakingTest do
         Tachyon.join_queues!(client, [queue_id])
     end
   end
+
+  describe "leaving queues" do
+    setup [{Tachyon, :setup_client}, :setup_queue]
+
+    test "works", %{client: client, queue_id: queue_id} do
+      assert %{"status" => "success"} = Tachyon.join_queues!(client, [queue_id])
+      assert %{"status" => "success"} = Tachyon.leave_queues!(client)
+
+      assert %{"status" => "failed", "reason" => "not_queued"} =
+               Tachyon.leave_queues!(client)
+    end
+  end
 end

--- a/test/teiserver_web/tachyon/session_test.exs
+++ b/test/teiserver_web/tachyon/session_test.exs
@@ -6,11 +6,7 @@ defmodule TeiserverWeb.Tachyon.SessionTest do
   alias Teiserver.Player
 
   setup _context do
-    user = Central.Helpers.GeneralTestLib.make_user(%{"data" => %{"roles" => ["Verified"]}})
-    %{client: client, token: token} = Tachyon.connect(user)
-
-    on_exit(fn -> WSC.disconnect(client) end)
-    {:ok, user: user, client: client, token: token}
+    Tachyon.setup_client()
   end
 
   test "session is spawned when player connects", %{user: user} do

--- a/test/teiserver_web/tachyon/transport_test.exs
+++ b/test/teiserver_web/tachyon/transport_test.exs
@@ -4,11 +4,7 @@ defmodule TeiserverWeb.Tachyon.TransportTest do
   alias Teiserver.Support.Tachyon
 
   setup _context do
-    user = Central.Helpers.GeneralTestLib.make_user(%{"data" => %{"roles" => ["Verified"]}})
-    %{client: client, token: token} = Tachyon.connect(user)
-
-    on_exit(fn -> WSC.disconnect(client) end)
-    {:ok, user: user, client: client, token: token}
+    Tachyon.setup_client()
   end
 
   describe "general command handling" do


### PR DESCRIPTION
This is the first step to implement matchmaking, in a very mvp state.
With this, one can join and leave queues, although there is exactly one queue (1v1). There is nothing happening after this point, the actual grouping of players and messaging should be the next pull request.
Also a note, party will be supported since a queue member can be made of multiple players.


The queues are heavily inspired from the [the existing queues made by teifion](https://github.com/beyond-all-reason/teiserver/blob/e584d6bac272c5ef7bd7973b8676f499dcf9cad8/lib/teiserver/data/matchmaking.ex#L1-L35) but ultimately I chose a slightly different approach:
* existing queues have attributes that tie them to a UI like `colour` or `icon`. I think it's a distraction for the mvp and would rather focus on the core logic
* existing queues are quite tied to a db storage. I don't think they will change much so hardcoding them is a lot simpler.
* The concept of bucket is likely going away. I may end up using it after some load testing, but the recurring issue of matchmaking in games is long wait time, meaning not enough players in queue. So optimizing for large queue size seems premature
