### PR TITLE
Naming improvements for balance algos

### DIFF
--- a/lib/teiserver/battle/libs/balance_lib.ex
+++ b/lib/teiserver/battle/libs/balance_lib.ex
@@ -51,7 +51,7 @@ defmodule Teiserver.Battle.BalanceLib do
       "force_party" => Teiserver.Battle.Balance.ForceParty,
       "brute_force" => Teiserver.Battle.Balance.BruteForce,
       "split_noobs" => Teiserver.Battle.Balance.SplitNoobs,
-      "default" => Teiserver.Battle.Balance.DefaultBalance
+      "auto" => Teiserver.Battle.Balance.DefaultBalance
     }
   end
 
@@ -60,12 +60,15 @@ defmodule Teiserver.Battle.BalanceLib do
   """
   @spec get_allowed_algorithms(boolean()) :: [String.t()]
   def get_allowed_algorithms(is_moderator) do
-    if(is_moderator) do
-      Teiserver.Battle.BalanceLib.algorithm_modules() |> Map.keys()
-    else
-      mod_only = ["force_party", "brute_force", "loser_picks"]
-      Teiserver.Battle.BalanceLib.algorithm_modules() |> Map.drop(mod_only) |> Map.keys()
-    end
+    result =
+      if(is_moderator) do
+        Teiserver.Battle.BalanceLib.algorithm_modules() |> Map.keys()
+      else
+        mod_only = ["force_party", "brute_force"]
+        Teiserver.Battle.BalanceLib.algorithm_modules() |> Map.drop(mod_only) |> Map.keys()
+      end
+
+    ["default" | result]
   end
 
   @doc """

--- a/lib/teiserver/coordinator/consul_commands.ex
+++ b/lib/teiserver/coordinator/consul_commands.ex
@@ -6,6 +6,7 @@ defmodule Teiserver.Coordinator.ConsulCommands do
   alias Teiserver.{Account, Battle, Lobby, Coordinator, CacheUser, Client, Telemetry}
   alias Teiserver.Lobby.{ChatLib, LobbyLib, LobbyRestrictions}
   alias Teiserver.Chat.WordLib
+  alias Teiserver.Battle.BalanceLib
   alias Teiserver.Data.Types, as: T
   import Teiserver.Helper.NumberHelper, only: [int_parse: 1, round: 2]
 
@@ -633,6 +634,18 @@ defmodule Teiserver.Coordinator.ConsulCommands do
   def handle_command(%{command: "balancemode", remaining: remaining, senderid: senderid}, state) do
     handle_command(
       %{command: "balancealgorithm", remaining: remaining, senderid: senderid},
+      state
+    )
+  end
+
+  def handle_command(
+        %{command: "balancealgorithm", remaining: "default", senderid: senderid},
+        state
+      ) do
+    default_algo = BalanceLib.get_default_algorithm()
+
+    handle_command(
+      %{command: "balancealgorithm", remaining: default_algo, senderid: senderid},
       state
     )
   end

--- a/lib/teiserver/libs/teiserver_configs.ex
+++ b/lib/teiserver/libs/teiserver_configs.ex
@@ -334,7 +334,7 @@ defmodule Teiserver.TeiserverConfigs do
       default: "loser_picks",
       permissions: ["Admin"],
       description: "The default balance algorithm",
-      opts: [choices: ["loser_picks", "default"]]
+      opts: [choices: ["loser_picks", "auto"]]
     })
 
     add_site_config_type(%{

--- a/test/teiserver/battle/balance_lib_internal_test.exs
+++ b/test/teiserver/battle/balance_lib_internal_test.exs
@@ -101,11 +101,18 @@ defmodule Teiserver.Battle.BalanceLibInternalTest do
     is_moderator = true
     result = BalanceLib.get_allowed_algorithms(is_moderator)
 
-    assert result == ["brute_force", "default", "force_party", "loser_picks", "split_noobs"]
+    assert result == [
+             "default",
+             "auto",
+             "brute_force",
+             "force_party",
+             "loser_picks",
+             "split_noobs"
+           ]
 
     is_moderator = false
     result = BalanceLib.get_allowed_algorithms(is_moderator)
-    assert result == ["default", "split_noobs"]
+    assert result == ["default", "auto", "loser_picks", "split_noobs"]
   end
 
   defp create_test_users do


### PR DESCRIPTION
The following algos are now callable via boss
```
$balancealgorithm default
$balancealgorithm auto
$balancealgorithm split_noobs
```

default will check the config for what it should pick (loser_picks probably). 

In the future maybe could rename DefaultBalance to be AutoBalance but I wanted to keep this PR short.

For SPADS I need to adjust so that auto is an option.

auto will pick between split_noobs or loser_picks depending on circumstances

## Testing
You can simply call the algos listed above.
![Screenshot 2024-09-06 224747](https://github.com/user-attachments/assets/f002d5a5-53a6-4ad1-829d-5447bb745ad5)

When you call "default" the text output will say loser_picks