### PR TITLE
Allow chat-restricted users to run whitelisted commands.

### DIFF
--- a/lib/teiserver/lobby.ex
+++ b/lib/teiserver/lobby.ex
@@ -795,9 +795,6 @@ defmodule Teiserver.Lobby do
       CacheUser.is_shadowbanned?(userid) ->
         false
 
-      CacheUser.is_restricted?(userid, ["All chat", "Lobby chat"]) ->
-        false
-
       lobby.founder_id == userid ->
         true
 

--- a/lib/teiserver/lobby/libs/chat_lib.ex
+++ b/lib/teiserver/lobby/libs/chat_lib.ex
@@ -302,7 +302,7 @@ defmodule Teiserver.Lobby.ChatLib do
 
   @valid_mute_chat_regex [
     ~r/^!vote( (y|yes|n|no|b|blank))?$/i,
-    ~r/^!(ev|endvote|help)$/i,
+    ~r/^!(y|n|b|ev|endvote|help)$/i,
     ~r/^!(cv |callvote )?balance$/i,
     ~r/^!(cv |callvote )?start$/i,
     ~r/^!(cv |callvote )?stop$/i,

--- a/lib/teiserver/lobby/libs/chat_lib.ex
+++ b/lib/teiserver/lobby/libs/chat_lib.ex
@@ -67,7 +67,7 @@ defmodule Teiserver.Lobby.ChatLib do
     allowed =
       cond do
         CacheUser.is_restricted?(user, ["All chat", "Lobby chat"]) ->
-          false
+          msg_allowed_when_muted?(msg)
 
         String.slice(msg, 0..0) == "!" and CacheUser.is_restricted?(user, ["Host commands"]) ->
           false
@@ -133,7 +133,7 @@ defmodule Teiserver.Lobby.ChatLib do
     allowed =
       cond do
         CacheUser.is_restricted?(user, ["All chat", "Lobby chat", "Direct chat"]) ->
-          false
+          msg_allowed_when_muted?(msg)
 
         String.starts_with?(msg, "!") and CacheUser.is_restricted?(user, ["Host commands"]) ->
           false
@@ -298,5 +298,26 @@ defmodule Teiserver.Lobby.ChatLib do
 
   defp trim_message(msg) do
     String.trim(msg)
+  end
+
+  @valid_mute_chat_regex [
+    ~r/^!vote( (y|yes|n|no|b|blank))?$/i,
+    ~r/^!(ev|endvote|help)$/i,
+		~r/^!(cv |callvote )?balance$/i,
+    ~r/^!(cv |callvote )?start$/i,
+    ~r/^!(cv |callvote )?stop$/i,
+    ~r/^!(cv |callvote )?resign$/i,
+    ~r/^!(cv |callvote )?forcestart$/i,
+  ]
+  def msg_allowed_when_muted?(msg) do
+    msg = String.replace(msg, ~r/ +/, " ") |> String.trim()
+    cond do
+      Enum.any?(@valid_mute_chat_regex, fn regex ->
+        String.match?(msg, regex)
+      end) ->
+        true
+      true ->
+        false
+    end
   end
 end

--- a/lib/teiserver/lobby/libs/chat_lib.ex
+++ b/lib/teiserver/lobby/libs/chat_lib.ex
@@ -303,19 +303,21 @@ defmodule Teiserver.Lobby.ChatLib do
   @valid_mute_chat_regex [
     ~r/^!vote( (y|yes|n|no|b|blank))?$/i,
     ~r/^!(ev|endvote|help)$/i,
-		~r/^!(cv |callvote )?balance$/i,
+    ~r/^!(cv |callvote )?balance$/i,
     ~r/^!(cv |callvote )?start$/i,
     ~r/^!(cv |callvote )?stop$/i,
     ~r/^!(cv |callvote )?resign$/i,
-    ~r/^!(cv |callvote )?forcestart$/i,
+    ~r/^!(cv |callvote )?forcestart$/i
   ]
   def msg_allowed_when_muted?(msg) do
     msg = String.replace(msg, ~r/ +/, " ") |> String.trim()
+
     cond do
       Enum.any?(@valid_mute_chat_regex, fn regex ->
         String.match?(msg, regex)
       end) ->
         true
+
       true ->
         false
     end

--- a/lib/teiserver/lobby/libs/chat_lib.ex
+++ b/lib/teiserver/lobby/libs/chat_lib.ex
@@ -312,14 +312,8 @@ defmodule Teiserver.Lobby.ChatLib do
   def msg_allowed_when_muted?(msg) do
     msg = String.replace(msg, ~r/ +/, " ") |> String.trim()
 
-    cond do
-      Enum.any?(@valid_mute_chat_regex, fn regex ->
-        String.match?(msg, regex)
-      end) ->
-        true
-
-      true ->
-        false
-    end
+    Enum.any?(@valid_mute_chat_regex, fn regex ->
+      String.match?(msg, regex)
+    end)
   end
 end


### PR DESCRIPTION
This patch allows users with an active chat restriction to use several common/necessary commands. Limitations are placed on both the commands that are allowed, as well as on the parameters (if any) allowed with each command. The following are allowed:
- `!vote`, and the various yes/no/blank parameters for it
- `!endvote` and `!ev`
- `!help`
- `!balance` (or a vote for it)
- `!start` (or a vote for it)
- `!forcestart` (or a vote for it)
- `!stop` (or a vote for it)
- `!resign` (or a vote for it)

Other commands, including commands to adjust various game settings, are still restricted. This is because most other commands would require almost-arbitrary parameters to be useful, and so they would provide an avenue to bypass a chat restriction.

A few commands were not whitelisted because they are more rarely used; such commands could be whitelisted in the future if there is a need.