### PR TITLE
Increase chance worst noob paired with best captain

### DIFF
--- a/lib/teiserver/battle/balance/split_noobs.ex
+++ b/lib/teiserver/battle/balance/split_noobs.ex
@@ -260,17 +260,33 @@ defmodule Teiserver.Battle.Balance.SplitNoobs do
     end
   end
 
+  defp get_captain_rating(team) do
+    if Enum.count(team) > 0 do
+      captain =
+        Enum.max_by(team, fn x ->
+          x.rating
+        end)
+
+      captain[:rating]
+    else
+      0
+    end
+  end
+
   # Higher pick priority means that team should pick
   defp get_pick_priority(team) do
     team_rating = get_team_rating(team)
-
+    captain_rating = get_captain_rating(team)
     # Prefer smaller rating
     rating_importance = -1
     # Prefer team with less players
     size_importance = -100
+    # Prefer weaker captain
+    captain_importance = -1
 
     # Score
-    team_rating * rating_importance + length(team) * size_importance
+    team_rating * rating_importance + length(team) * size_importance +
+      captain_rating * captain_importance
   end
 
   defp get_team_rating(team) do

--- a/test/teiserver/battle/split_noobs_internal_test.exs
+++ b/test/teiserver/battle/split_noobs_internal_test.exs
@@ -560,114 +560,114 @@ defmodule Teiserver.Battle.SplitNoobsInternalTest do
              broken_party_penalty: 0,
              first_team: [
                %{
-                 id: "HungDaddy",
-                 name: "HungDaddy",
+                 id: "Dixinormus",
+                 in_party?: false,
+                 name: "Dixinormus",
                  rank: 2,
-                 rating: 2.8,
-                 uncertainty: 8,
-                 in_party?: false
+                 rating: 18.28,
+                 uncertainty: 8
                },
                %{
                  id: "fbots1998",
+                 in_party?: true,
+                 index: 1,
                  name: "fbots1998",
                  rank: 1,
                  rating: 13.98,
-                 uncertainty: 8,
-                 in_party?: true,
-                 index: 1
+                 uncertainty: 8
                },
                %{
                  id: "kyutoryu",
+                 in_party?: true,
+                 index: 2,
                  name: "kyutoryu",
                  rank: 1,
                  rating: 12.25,
-                 uncertainty: 7.1,
-                 in_party?: true,
-                 index: 2
+                 uncertainty: 7.1
                },
                %{
                  id: "[DTG]BamBin0",
+                 in_party?: false,
+                 index: 5,
                  name: "[DTG]BamBin0",
                  rank: 2,
                  rating: 20.06,
-                 uncertainty: 3,
-                 in_party?: false,
-                 index: 5
+                 uncertainty: 3
                },
                %{
                  id: "Noody",
+                 in_party?: false,
+                 index: 7,
                  name: "Noody",
                  rank: 2,
                  rating: 17.64,
-                 uncertainty: 3,
-                 in_party?: false,
-                 index: 7
+                 uncertainty: 3
                },
                %{
                  id: "MaTThiuS_82",
+                 in_party?: false,
+                 index: 9,
                  name: "MaTThiuS_82",
                  rank: 2,
                  rating: 8.26,
-                 uncertainty: 3,
-                 in_party?: false,
-                 index: 9
+                 uncertainty: 3
                }
              ],
              rating_diff_penalty: 0.4099999999999966,
              score: 0.4099999999999966,
              second_team: [
                %{
-                 id: "Dixinormus",
-                 name: "Dixinormus",
+                 id: "HungDaddy",
+                 in_party?: false,
+                 name: "HungDaddy",
                  rank: 2,
-                 rating: 18.28,
-                 uncertainty: 8,
-                 in_party?: false
+                 rating: 2.8,
+                 uncertainty: 8
                },
                %{
                  id: "jauggy",
+                 in_party?: false,
+                 index: 3,
                  name: "jauggy",
                  rank: 2,
                  rating: 20.49,
-                 uncertainty: 3,
-                 in_party?: false,
-                 index: 3
+                 uncertainty: 3
                },
                %{
                  id: "Aposis",
+                 in_party?: false,
+                 index: 4,
                  name: "Aposis",
                  rank: 2,
                  rating: 20.42,
-                 uncertainty: 3,
-                 in_party?: false,
-                 index: 4
+                 uncertainty: 3
                },
                %{
                  id: "reddragon2010",
+                 in_party?: false,
+                 index: 6,
                  name: "reddragon2010",
                  rank: 2,
                  rating: 18.4,
-                 uncertainty: 3,
-                 in_party?: false,
-                 index: 6
+                 uncertainty: 3
                },
                %{
                  id: "SLOPPYGAGGER",
+                 in_party?: false,
+                 index: 8,
                  name: "SLOPPYGAGGER",
                  rank: 2,
                  rating: 8.89,
-                 uncertainty: 3,
-                 in_party?: false,
-                 index: 8
+                 uncertainty: 3
                },
                %{
                  id: "barmalev",
+                 in_party?: false,
+                 index: 10,
                  name: "barmalev",
                  rank: 2,
                  rating: 3.58,
-                 uncertainty: 3,
-                 in_party?: false,
-                 index: 10
+                 uncertainty: 3
                }
              ]
            }
@@ -675,35 +675,6 @@ defmodule Teiserver.Battle.SplitNoobsInternalTest do
     standard_result = SplitNoobs.standardise_result(result, initial_state)
 
     assert standard_result == %{
-             team_groups: %{
-               1 => [
-                 %{count: 1, group_rating: 2.8, members: ["HungDaddy"], ratings: [2.8]},
-                 %{count: 1, group_rating: 13.98, members: ["fbots1998"], ratings: [13.98]},
-                 %{count: 1, group_rating: 12.25, members: ["kyutoryu"], ratings: [12.25]},
-                 %{count: 1, group_rating: 20.06, members: ["[DTG]BamBin0"], ratings: [20.06]},
-                 %{count: 1, group_rating: 17.64, members: ["Noody"], ratings: [17.64]},
-                 %{count: 1, group_rating: 8.26, members: ["MaTThiuS_82"], ratings: [8.26]}
-               ],
-               2 => [
-                 %{count: 1, group_rating: 18.28, members: ["Dixinormus"], ratings: [18.28]},
-                 %{count: 1, group_rating: 20.49, members: ["jauggy"], ratings: [20.49]},
-                 %{count: 1, group_rating: 20.42, members: ["Aposis"], ratings: [20.42]},
-                 %{count: 1, group_rating: 18.4, members: ["reddragon2010"], ratings: [18.4]},
-                 %{count: 1, group_rating: 8.89, members: ["SLOPPYGAGGER"], ratings: [8.89]},
-                 %{count: 1, group_rating: 3.58, members: ["barmalev"], ratings: [3.58]}
-               ]
-             },
-             team_players: %{
-               1 => ["HungDaddy", "fbots1998", "kyutoryu", "[DTG]BamBin0", "Noody", "MaTThiuS_82"],
-               2 => [
-                 "Dixinormus",
-                 "jauggy",
-                 "Aposis",
-                 "reddragon2010",
-                 "SLOPPYGAGGER",
-                 "barmalev"
-               ]
-             },
              logs: [
                "------------------------------------------------------",
                "Algorithm: split_noobs",
@@ -727,9 +698,38 @@ defmodule Teiserver.Battle.SplitNoobsInternalTest do
                "Remaining: Dixinormus, HungDaddy",
                "------------------------------------------------------",
                "Final result:",
-               "Team 1: MaTThiuS_82, Noody, [DTG]BamBin0, kyutoryu, fbots1998, HungDaddy",
-               "Team 2: barmalev, SLOPPYGAGGER, reddragon2010, Aposis, jauggy, Dixinormus"
-             ]
+               "Team 1: MaTThiuS_82, Noody, [DTG]BamBin0, kyutoryu, fbots1998, Dixinormus",
+               "Team 2: barmalev, SLOPPYGAGGER, reddragon2010, Aposis, jauggy, HungDaddy"
+             ],
+             team_groups: %{
+               1 => [
+                 %{count: 1, group_rating: 18.28, members: ["Dixinormus"], ratings: [18.28]},
+                 %{count: 1, group_rating: 13.98, members: ["fbots1998"], ratings: [13.98]},
+                 %{count: 1, group_rating: 12.25, members: ["kyutoryu"], ratings: [12.25]},
+                 %{count: 1, group_rating: 20.06, members: ["[DTG]BamBin0"], ratings: [20.06]},
+                 %{count: 1, group_rating: 17.64, members: ["Noody"], ratings: [17.64]},
+                 %{count: 1, group_rating: 8.26, members: ["MaTThiuS_82"], ratings: [8.26]}
+               ],
+               2 => [
+                 %{count: 1, group_rating: 2.8, members: ["HungDaddy"], ratings: [2.8]},
+                 %{count: 1, group_rating: 20.49, members: ["jauggy"], ratings: [20.49]},
+                 %{count: 1, group_rating: 20.42, members: ["Aposis"], ratings: [20.42]},
+                 %{count: 1, group_rating: 18.4, members: ["reddragon2010"], ratings: [18.4]},
+                 %{count: 1, group_rating: 8.89, members: ["SLOPPYGAGGER"], ratings: [8.89]},
+                 %{count: 1, group_rating: 3.58, members: ["barmalev"], ratings: [3.58]}
+               ]
+             },
+             team_players: %{
+               1 => [
+                 "Dixinormus",
+                 "fbots1998",
+                 "kyutoryu",
+                 "[DTG]BamBin0",
+                 "Noody",
+                 "MaTThiuS_82"
+               ],
+               2 => ["HungDaddy", "jauggy", "Aposis", "reddragon2010", "SLOPPYGAGGER", "barmalev"]
+             }
            }
   end
 end

--- a/test/teiserver/battle/split_noobs_test.exs
+++ b/test/teiserver/battle/split_noobs_test.exs
@@ -261,4 +261,163 @@ defmodule Teiserver.Battle.SplitNoobsTest do
              }
            }
   end
+
+  test "Very strong captain will usually have noobiest noob" do
+    # After brute force result is calculated there will be some remaining weak players to draft
+    # The team that gets pick priority will be determined by a combination of team rating and captain rating
+    # preferring lower for both
+    expanded_group = [
+      %{
+        count: 2,
+        members: ["LuBaee", "TimeContainer"],
+        ratings: [14, 21],
+        names: ["LuBaee", "TimeContainer"],
+        uncertainties: [0, 1],
+        ranks: [1, 1]
+      },
+      %{
+        count: 1,
+        members: ["colossus"],
+        ratings: [22],
+        names: ["colossus"],
+        uncertainties: [2],
+        ranks: [0]
+      },
+      %{
+        count: 1,
+        members: ["PotatoesHead"],
+        ratings: [22],
+        names: ["PotatoesHead"],
+        uncertainties: [2],
+        ranks: [0]
+      },
+      %{
+        count: 1,
+        members: ["onse"],
+        ratings: [20],
+        names: ["onse"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["976"],
+        ratings: [14],
+        names: ["976"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["HoldButyLeg"],
+        ratings: [12],
+        names: ["HoldButyLeg"],
+        uncertainties: [7.5],
+        ranks: [0]
+      },
+      %{
+        count: 1,
+        members: ["CowOfWar"],
+        ratings: [3],
+        names: ["CowOfWar"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["DUFFY"],
+        ratings: [34],
+        names: ["DUFFY"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["Orii"],
+        ratings: [23],
+        names: ["Orii"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["Theo45"],
+        ratings: [21],
+        names: ["Theo45"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["StinkBee"],
+        ratings: [15],
+        names: ["StinkBee"],
+        uncertainties: [6.7],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["Regithros"],
+        ratings: [12],
+        names: ["Regithros"],
+        uncertainties: [5],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["Darth"],
+        ratings: [11],
+        names: ["Darth"],
+        uncertainties: [5],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["Akio"],
+        ratings: [10],
+        names: ["Akio"],
+        uncertainties: [5],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["nubl"],
+        ratings: [6],
+        names: ["nubl"],
+        uncertainties: [5],
+        ranks: [2]
+      }
+    ]
+
+    result = SplitNoobs.perform(expanded_group, 2)
+
+    assert result.logs == [
+             "------------------------------------------------------",
+             "Algorithm: split_noobs",
+             "------------------------------------------------------",
+             "This algorithm will evenly distribute noobs and devalue them. Noobs are non-partied players that have either high uncertainty or 0 rating. Noobs will always be drafted last. For non-noobs, teams will prefer higher rating. For noobs, teams will prefer higher chevrons and lower uncertainty.",
+             "------------------------------------------------------",
+             "Parties: [LuBaee, TimeContainer]",
+             "Solo noobs:",
+             "StinkBee (chev: 3, σ: 6.7)",
+             "HoldButyLeg (chev: 1, σ: 7.5)",
+             "------------------------------------------------------",
+             "Perform brute force with the following players to get the best score.",
+             "Players: TimeContainer, LuBaee, DUFFY, Orii, colossus, PotatoesHead, Theo45, onse, 976, Regithros, Darth, Akio, nubl, CowOfWar",
+             "------------------------------------------------------",
+             "Brute force result:",
+             "Team rating diff penalty: 1",
+             "Broken party penalty: 0",
+             "Score: 1 (lower is better)",
+             "------------------------------------------------------",
+             "Draft remaining players (ordered from best to worst).",
+             "Remaining: StinkBee, HoldButyLeg",
+             "------------------------------------------------------",
+             "Final result:",
+             "Team 1: CowOfWar, Akio, Regithros, Orii, DUFFY, LuBaee, TimeContainer, HoldButyLeg",
+             "Team 2: nubl, Darth, 976, onse, Theo45, PotatoesHead, colossus, StinkBee"
+           ]
+
+    # Note DUFFY (Strongest captain) is on same team with noobiest noob HoldButyLeg
+  end
 end


### PR DESCRIPTION
This PR increases the probability of the best captain getting paired with the worst noob. Based on feedback here: https://discord.com/channels/549281623154229250/1275366409722925056/1281547394844065812

After we brute force 14 players, there will be two more remaining players for the teams to draft.

BEFORE
Lowest team rating gets pick priority

AFTER
Lowest (team rating + captain rating) gets pick priority
Therefore having a strong captain reduces your odds of getting pick priority and you're likely to get the worst noob i.e. the one chev. Often after brute force, the team ratings will be super close like one rating diff off.

# Testing
A test case has been added where we have strong captain (DUFFY who is 10 points higher than the next best) and his team should also have the worst player (the one chev).