### PR TITLE
Asymmetric avoid checks

### DIFF
--- a/lib/teiserver/account/libs/relationship_lib.ex
+++ b/lib/teiserver/account/libs/relationship_lib.ex
@@ -345,7 +345,7 @@ defmodule Teiserver.Account.RelationshipLib do
     user = Account.get_user_by_id(userid)
     userid_count = Enum.count(userid_list) |> max(1)
 
-    {avoid_count_needed, avoid_percentage_needed} =
+    {avoiding_you_count_needed, avoiding_others_count_needed, avoid_percentage_needed} =
       cond do
         user.behaviour_score <= 5000 ->
           {2, 20}
@@ -355,7 +355,8 @@ defmodule Teiserver.Account.RelationshipLib do
 
         true ->
           {
-            Config.get_site_config_cache("lobby.Avoid count to prevent playing"),
+            Config.get_site_config_cache("lobby.Avoid you count to prevent playing"),
+            Config.get_site_config_cache("lobby.Avoid others count to prevent playing"),
             Config.get_site_config_cache("lobby.Avoid percentage to prevent playing")
           }
       end
@@ -376,10 +377,10 @@ defmodule Teiserver.Account.RelationshipLib do
     cond do
       # You are being avoided
       being_avoided_percentage >= avoid_percentage_needed -> :avoided
-      being_avoided_count >= avoid_count_needed -> :avoided
+      being_avoided_count >= avoiding_you_count_needed -> :avoided
       # You are avoiding
       avoiding_percentage >= avoid_percentage_needed -> :avoiding
-      avoiding_count >= avoid_count_needed -> :avoiding
+      avoiding_count >= avoiding_others_count_needed -> :avoiding
       true -> :ok
     end
   end

--- a/lib/teiserver/libs/teiserver_configs.ex
+++ b/lib/teiserver/libs/teiserver_configs.ex
@@ -385,7 +385,7 @@ defmodule Teiserver.TeiserverConfigs do
     })
 
     add_site_config_type(%{
-      key: "lobby.Avoiding you count to prevent playing",
+      key: "lobby.Avoid you count to prevent playing",
       section: "Lobbies",
       type: "integer",
       permissions: ["Admin"],
@@ -394,7 +394,7 @@ defmodule Teiserver.TeiserverConfigs do
     })
 
     add_site_config_type(%{
-      key: "lobby.Avoiding others count to prevent playing",
+      key: "lobby.Avoid others count to prevent playing",
       section: "Lobbies",
       type: "integer",
       permissions: ["Admin"],

--- a/lib/teiserver/libs/teiserver_configs.ex
+++ b/lib/teiserver/libs/teiserver_configs.ex
@@ -385,13 +385,21 @@ defmodule Teiserver.TeiserverConfigs do
     })
 
     add_site_config_type(%{
-      key: "lobby.Avoid count to prevent playing",
+      key: "lobby.Avoiding you count to prevent playing",
       section: "Lobbies",
       type: "integer",
       permissions: ["Admin"],
-      description:
-        "The raw number of players who would need to avoid someone to prevent them becoming a player",
+      description: "If there are this many players avoiding you, you cannot play.",
       default: 6
+    })
+
+    add_site_config_type(%{
+      key: "lobby.Avoiding others count to prevent playing",
+      section: "Lobbies",
+      type: "integer",
+      permissions: ["Admin"],
+      description: "If you are avoiding this number of players, you cannot play",
+      default: 3
     })
 
     add_site_config_type(%{
@@ -399,8 +407,7 @@ defmodule Teiserver.TeiserverConfigs do
       section: "Lobbies",
       type: "integer",
       permissions: ["Admin"],
-      description:
-        "The percentage of players who would need to avoid someone to prevent them becoming a player",
+      description: "The percentage of players avoiding or avoided to prevent someone playing",
       default: 50
     })
 


### PR DESCRIPTION
This PR makes avoids non-symmetrical. The idea is that if you are avoiding/blocking 3 players in a lobby you cannot play. However, the number of players to avoid/block you to prevent you playing is unchanged (6 or 50%). This should motivate you to cull your avoid list if it's too many.

## Before
**Avoids**
If you are avoiding/blocking 6 players or 50%, you cannot play
If 6 players or 50% are avoiding/blocking you, you cannot play

**Blocks**
If you are blocking 8 players or 50%, you cannot join the lobby
If 8 players or 50% are blocking you, you cannot join the lobby

## After
Avoids are no longer symmetrical

**Avoids**
If you are avoiding/blocking **3** players or 50%, you cannot play
If 6 players or 50% are avoiding/blocking you, you cannot play

**Blocks**
No change