### PR TITLE
Fix TeamFFA ratings and balance

### DIFF
--- a/lib/teiserver/game/servers/balancer_server.ex
+++ b/lib/teiserver/game/servers/balancer_server.ex
@@ -173,7 +173,12 @@ defmodule Teiserver.Game.BalancerServer do
       |> Enum.map(fn {_, t} -> Enum.count(t) end)
       |> Enum.max(fn -> 0 end)
 
-    game_type = MatchLib.game_type(team_size, team_count)
+    # Use Large Team ratings when balancing Team FFA
+    game_type =
+      case MatchLib.game_type(team_size, team_count) do
+        "Team FFA" -> "Large Team"
+        v -> v
+      end
 
     if opts[:allow_groups] do
       party_result = make_grouped_balance(team_count, players, game_type, opts)

--- a/lib/teiserver_web/controllers/api/spads_controller.ex
+++ b/lib/teiserver_web/controllers/api/spads_controller.ex
@@ -153,39 +153,17 @@ defmodule TeiserverWeb.API.SpadsController do
           })
 
         if balance_result do
-          # Get some counts for later
-          team_count =
-            balance_result.team_sizes
-            |> Enum.count()
-
-          team_size =
-            balance_result.team_sizes
-            |> Map.values()
-            |> Enum.max()
-
-          # Get the rating type
-          rating_type = MatchLib.game_type(team_size, team_count)
-
-          # Temporary solution until Team FFA ratings are fixed
-          rating_type =
-            case rating_type do
-              "Team FFA" -> "FFA"
-              v -> v
-            end
-
           player_result =
             balance_result.team_players
-            |> Enum.map(fn {team_id, players} ->
+            |> Enum.flat_map(fn {team_id, players} ->
               players
               |> Enum.map(fn userid ->
-                rating_value = BalanceLib.get_user_rating_value(userid, rating_type)
-                {team_id, rating_value, userid, Account.get_username_by_id(userid)}
+                {team_id, Account.get_username_by_id(userid)}
               end)
             end)
-            |> List.flatten()
             |> Enum.sort(&>=/2)
             |> Enum.with_index()
-            |> Map.new(fn {{team_id, _, _, username}, idx} ->
+            |> Map.new(fn {{team_id, username}, idx} ->
               {username,
                %{
                  "team" => team_id - 1,


### PR DESCRIPTION
Resolves #337 

`Team FFA` is now using `Large Team` ratings for balancing (matches will still rated as `Team FFA` )

Cleaned up spads_controller balance battle response, it was getting ratings which weren't even sent to or used by SPADS.