### PR TITLE
`All lobbies` ban improvement

### DIFF
--- a/lib/teiserver/moderation/tasks/refresh_user_restrictions_task.ex
+++ b/lib/teiserver/moderation/tasks/refresh_user_restrictions_task.ex
@@ -102,8 +102,7 @@ defmodule Teiserver.Moderation.RefreshUserRestrictionsTask do
         Teiserver.Client.disconnect(client.userid, "Banned")
 
       Enum.member?(new_restrictions, "All lobbies") ->
-        Coordinator.send_to_host(client.lobby_id, "!gkick #{client.name}")
-        Teiserver.Client.disconnect(client.userid, "Removed from lobbies")
+        Coordinator.send_to_host(client.lobby_id, "!bkick #{client.name}")
 
       true ->
         pid = Coordinator.get_coordinator_pid()


### PR DESCRIPTION
`All lobbies` ban no longer disconnects moderated user's client and kicks them from their in progress game.
It still kicks from lobby and prevents joining new ones but now allows to finish current game.

Resolves #459 