### PR TITLE
Make uncertainties viewable for tester on website lobby

### DIFF
--- a/lib/teiserver_web/live/battles/lobbies/show.html.heex
+++ b/lib/teiserver_web/live/battles/lobbies/show.html.heex
@@ -156,7 +156,7 @@ spectators =
               <th>Party</th>
 
               <th>Rating</th>
-              <%= if @moderator do %>
+              <%= if @tester_perms do %>
                 <th>Uncertainty</th>
 
                 <th>Winrate Team</th>
@@ -202,7 +202,7 @@ spectators =
                   <% end %>
 
                   <td><%= Teiserver.Helper.NumberHelper.round(rating_value, 2) %></td>
-                  <%= if @moderator do %>
+                  <%= if @tester_perms do %>
                     <td><%= Teiserver.Helper.NumberHelper.round(uncertainty, 2) %></td>
 
                     <td><%= @stats[user.id]["win_rate.team"] %></td>
@@ -249,7 +249,7 @@ spectators =
               <th>Name</th>
 
               <th>Rating</th>
-              <%= if @moderator do %>
+              <%= if @tester_perms do %>
                 <th>Uncertainty</th>
               <% end %>
 
@@ -278,7 +278,7 @@ spectators =
                   <td><%= user.name %></td>
 
                   <td><%= Teiserver.Helper.NumberHelper.round(rating_value, 2) %></td>
-                  <%= if @moderator do %>
+                  <%= if @tester_perms do %>
                     <td><%= Teiserver.Helper.NumberHelper.round(uncertainty, 2) %></td>
                   <% end %>
 


### PR DESCRIPTION
Knowing uncertainties is useful for understanding how balance is working in a lobby. For auto balance, split_noobs will be used in lobbies where there is a player with high uncertainty. Make the uncertainty column viewable to tester perm. It is currently viewable by mod perm but mods don't really need to see it. Plus mods with contributor role will also have tester perm.

![1](https://github.com/user-attachments/assets/8dbab31e-cd0d-4189-9050-2014837772a5)
