### PR TITLE
Ignore avoids/blocks once player

### DIFF
--- a/lib/teiserver/account/libs/relationship_lib.ex
+++ b/lib/teiserver/account/libs/relationship_lib.ex
@@ -175,7 +175,7 @@ defmodule Teiserver.Account.RelationshipLib do
       Account.list_relationships(
         where: [
           to_user_id: userid,
-          state: "avoid"
+          state_in: ["avoid", "block"]
         ],
         select: [:from_user_id]
       )
@@ -207,7 +207,7 @@ defmodule Teiserver.Account.RelationshipLib do
       Account.list_relationships(
         where: [
           from_user_id: userid,
-          state_in: ["avoid", "block"]
+          state_in: ["block"]
         ],
         select: [:to_user_id]
       )
@@ -223,7 +223,7 @@ defmodule Teiserver.Account.RelationshipLib do
       Account.list_relationships(
         where: [
           to_user_id: userid,
-          state_in: ["avoid", "block"]
+          state_in: ["block"]
         ],
         select: [:from_user_id]
       )

--- a/lib/teiserver/account/libs/relationship_lib.ex
+++ b/lib/teiserver/account/libs/relationship_lib.ex
@@ -169,6 +169,7 @@ defmodule Teiserver.Account.RelationshipLib do
     end)
   end
 
+  # Blocks will also count as avoids (but not the other way round)
   @spec list_userids_avoiding_this_userid(T.userid()) :: [T.userid()]
   def list_userids_avoiding_this_userid(userid) do
     Teiserver.cache_get_or_store(:account_avoiding_this_cache, userid, fn ->
@@ -185,13 +186,14 @@ defmodule Teiserver.Account.RelationshipLib do
     end)
   end
 
+  # Blocks will also count as avoids (but not the other way round)
   @spec list_userids_avoided_by_userid(T.userid()) :: [T.userid()]
   def list_userids_avoided_by_userid(userid) do
     Teiserver.cache_get_or_store(:account_avoid_cache, userid, fn ->
       Account.list_relationships(
         where: [
           from_user_id: userid,
-          state: "avoid"
+          state_in: ["avoid", "block"]
         ],
         select: [:to_user_id]
       )


### PR DESCRIPTION
## Current implementation
Avoids are checked:
1. When going from spec to player
2. When pressing the ready button
3. After a match ends

Blocks are checked
1. When joining a lobby
2. After a match ends

## New implementation
This PR removes the avoid/block checks when the person is already a player.

Avoids are checked:
1. When going from spec to player

Blocks are checked
1. When joining a lobby

## Other fixes
Avoids now no longer count as blocks
Blocks count as avoids. 
They seem to have been inverted

## Testing
Testing this PR is very difficult but I did manage to test locally using two players.