### PR TITLE
Reveal balance algorithm to regular users on website

### DIFF
--- a/lib/teiserver_web/live/battles/lobbies/show.html.heex
+++ b/lib/teiserver_web/live/battles/lobbies/show.html.heex
@@ -108,8 +108,8 @@ spectators =
               <li>
                 Queue size: <%= Enum.count(@consul.join_queue ++ @consul.low_priority_join_queue) %>
               </li>
+              <li>Balance algorithm: <%= @consul.balance_algorithm %></li>
               <%= if @tester_perms do %>
-                <li>Balance algorithm: <%= @consul.balance_algorithm %></li>
                 <li>Match ID: <%= Map.get(@modoptions, "game/server_match_id") %></li>
               <% end %>
 


### PR DESCRIPTION
Currently if we go here: https://server4.beyondallreason.info/battle/lobbies/show/9517
only testers can see the balance algorithm

However, it is useful for normal users to know such as if they want to play in party certain algos are better for them. It is not very intrusive as most people won't even use the website for joining games so it would only be used by advanced users.

An example is MVPete https://ptb.discord.com/channels/549281623154229250/1284942772482347159/1285110298306674729
who dodged games to get parties to work. It might be more convenient to use the website to find games where the balance algo is favourable to parties.