### PR TITLE
Add task to calculate balance stats

### DIFF
--- a/lib/teiserver/mix_tasks/balance_stats.ex
+++ b/lib/teiserver/mix_tasks/balance_stats.ex
@@ -1,0 +1,306 @@
+defmodule Mix.Tasks.Teiserver.BalanceStats do
+  @moduledoc """
+  Get stats on different balance algorithms
+  mix teiserver.balance_stats
+  On integration server it is recommended you output to a specific path as follows:
+  mix teiserver.balance_stats /var/log/teiserver/results.txt
+  """
+
+  use Mix.Task
+  require Logger
+  alias Teiserver.Repo
+  alias Teiserver.{Battle, Game}
+  alias Teiserver.Battle.{BalanceLib}
+  alias Teiserver.Config
+
+  def run(args) do
+    Logger.info("Args: #{args}")
+    write_log_filepath = Enum.at(args, 0, nil)
+
+    Application.ensure_all_started(:teiserver)
+    game_types = ["Large Team", "Small Team"]
+    opts = []
+
+    result =
+      Enum.map(game_types, fn game_type ->
+        get_balance_test_results(game_type, opts)
+      end)
+
+    # For each match id
+
+    json_result = Jason.encode(result)
+
+    case json_result do
+      {:ok, json_string} -> write_to_file(json_string, write_log_filepath)
+    end
+
+    Logger.info("Finished processing matches")
+  end
+
+  defp get_balance_test_results(game_type, opts) do
+    match_ids = get_match_ids(game_type)
+    max_deviation = Config.get_site_config_cache("teiserver.Max deviation")
+    balance_algos = ["loser_picks", "auto"]
+
+    balance_result =
+      Enum.map(balance_algos, fn algo ->
+        test_balancer(algo, match_ids, max_deviation, opts)
+      end)
+
+    %{
+      game_type: game_type,
+      balance_result: balance_result,
+      config_max_deviation: max_deviation
+    }
+  end
+
+  defp test_balancer(algo, match_ids, max_deviation, opts) do
+    start_time = System.system_time(:microsecond)
+    # For each match id
+    result =
+      Enum.map(match_ids, fn match_id ->
+        process_match(match_id, algo, max_deviation, opts)
+      end)
+
+    num_matches = length(match_ids)
+    time_taken = System.system_time(:microsecond) - start_time
+
+    avg_time_taken =
+      case num_matches do
+        0 -> 0
+        _ -> time_taken / num_matches / 1000
+      end
+
+    avg_team_rating_diff =
+      (Enum.map(result, fn x -> x.team_rating_diff end) |> Enum.sum()) / num_matches
+
+    avg_adjusted_team_rating_diff =
+      (Enum.map(result, fn x -> x.adjusted_team_rating_diff end) |> Enum.sum()) / num_matches
+
+    %{
+      algo: algo,
+      matches_processed: num_matches,
+      avg_time_taken: avg_time_taken,
+      avg_team_rating_diff: avg_team_rating_diff,
+      avg_adjusted_team_rating_diff: avg_adjusted_team_rating_diff
+    }
+  end
+
+  defp process_match(id, algorithm, max_deviation, _opts) do
+    match =
+      Battle.get_match!(id,
+        preload: [:members_and_users]
+      )
+
+    members = match.members
+
+    rating_logs =
+      Game.list_rating_logs(
+        search: [
+          match_id: match.id
+        ]
+      )
+      |> Map.new(fn log -> {log.user_id, log} end)
+
+    past_balance =
+      make_balance(2, members, rating_logs,
+        algorithm: algorithm,
+        max_deviation: max_deviation
+      )
+
+    rating_diff = calculate_rating_diff(past_balance[:team_players], rating_logs)
+
+    Map.merge(
+      rating_diff,
+      %{
+        match_id: id,
+        team_players: past_balance[:team_players]
+      }
+    )
+  end
+
+  def calculate_rating_diff(team_players, rating_logs) do
+    team1 = team_players[1]
+    team2 = team_players[2]
+
+    team1_adjusted_rating = calculate_adjusted_team_rating(team1, rating_logs)
+    team2_adjusted_rating = calculate_adjusted_team_rating(team2, rating_logs)
+
+    team1_rating = calculate_team_rating(team1, rating_logs)
+    team2_rating = calculate_team_rating(team2, rating_logs)
+
+    %{
+      team_rating_diff: abs(team1_rating - team2_rating),
+      adjusted_team_rating_diff: abs(team1_adjusted_rating - team2_adjusted_rating)
+    }
+  end
+
+  defp calculate_adjusted_team_rating(player_ids, rating_logs) do
+    adjusted_ratings = Enum.map(player_ids, fn x -> adjusted_rating(x, rating_logs) end)
+    Enum.sum(adjusted_ratings)
+  end
+
+  defp calculate_team_rating(player_ids, rating_logs) do
+    ratings = Enum.map(player_ids, fn x -> raw_rating(x, rating_logs) end)
+    Enum.sum(ratings)
+  end
+
+  defp raw_rating(user_id, rating_logs) do
+    rating_logs[user_id].value["rating_value"]
+  end
+
+  # split_noobs assumes new players are the worst in game
+  # So their adjusted rating starts at 0
+  # We trust their rating when their uncertainty reaches 6.65
+  # This functions returns a value between 0 and their rating depending on their uncertainty
+  def adjusted_rating(user_id, rating_logs) do
+    rating = rating_logs[user_id].value["rating_value"]
+    uncertainty = rating_logs[user_id].value["uncertainty"]
+
+    starting_uncertainty = 25 / 3
+    uncertainty_cutoff = 6.65
+
+    # When uncertainty is less than 6.65 this will return just rating
+    # When uncertainty is default this will return 0
+    min(
+      1,
+      (starting_uncertainty - uncertainty) /
+        (starting_uncertainty -
+           uncertainty_cutoff)
+    ) * rating
+  end
+
+  @spec make_balance(non_neg_integer(), [any()], any(), list()) :: map()
+  defp make_balance(team_count, players, rating_logs, opts) do
+    party_result = make_grouped_balance(team_count, players, rating_logs, opts)
+    has_parties? = Map.get(party_result, :has_parties?, true)
+
+    if has_parties? && party_result.deviation > opts[:max_deviation] do
+      solo_result =
+        make_solo_balance(
+          team_count,
+          players,
+          rating_logs,
+          opts
+        )
+
+      Map.put(solo_result, :parties, party_result.parties)
+    else
+      party_result
+    end
+  end
+
+  @spec make_grouped_balance(non_neg_integer(), [any()], any(), list()) :: map()
+  defp make_grouped_balance(team_count, players, rating_logs, opts) do
+    # Group players into parties
+    partied_players =
+      players
+      |> Enum.group_by(fn p -> p.party_id end, fn p -> p.user_id end)
+
+    groups =
+      partied_players
+      |> Enum.map(fn
+        # The nil group is players without a party, they need to
+        # be broken out of the party
+        {nil, player_id_list} ->
+          player_id_list
+          |> Enum.map(fn userid ->
+            %{userid => rating_logs[userid].value}
+          end)
+
+        {_party_id, player_id_list} ->
+          player_id_list
+          |> Map.new(fn userid ->
+            {userid, rating_logs[userid].value}
+          end)
+      end)
+      |> List.flatten()
+
+    BalanceLib.create_balance(groups, team_count, opts)
+    |> Map.put(:balance_mode, :grouped)
+    |> Map.put(:parties, get_parties(partied_players))
+  end
+
+  @spec make_solo_balance(non_neg_integer(), [any()], any(), list()) ::
+          map()
+  defp make_solo_balance(team_count, players, rating_logs, opts) do
+    groups =
+      players
+      |> Enum.map(fn %{user_id: userid} ->
+        %{userid => rating_logs[userid].value}
+      end)
+
+    result = BalanceLib.create_balance(groups, team_count, opts)
+
+    Map.merge(result, %{
+      balance_mode: :solo
+    })
+  end
+
+  defp get_match_ids("Large Team") do
+    get_match_ids(8, 2)
+  end
+
+  defp get_match_ids("Small Team") do
+    get_match_ids(5, 2)
+  end
+
+  defp get_match_ids(team_size, team_count) do
+    query = """
+    select distinct  tbm.id, tbm.inserted_at  from teiserver_battle_match_memberships tbmm
+    inner join teiserver_battle_matches tbm
+    on tbm.id = tbmm.match_id
+    and tbm.team_size = $1
+    and tbm.team_count = $2
+    inner join teiserver_game_rating_logs tgrl
+    on tgrl.match_id = tbm.id
+    and tgrl.value is not null
+     order by tbm.inserted_at DESC
+    limit 500;
+    """
+
+    results = Ecto.Adapters.SQL.query!(Repo, query, [team_size, team_count])
+
+    results.rows
+    |> Enum.map(fn [id, _insert_date] ->
+      id
+    end)
+  end
+
+  defp get_parties(partied_players) do
+    partied_players
+    |> Enum.map(fn
+      # The nil group is players without a party, they need to
+      # be broken out of the party
+      {nil, _player_id_list} ->
+        nil
+
+      {_party_id, player_id_list} ->
+        player_id_list
+    end)
+    |> Enum.filter(fn x ->
+      x != nil
+    end)
+  end
+
+  defp write_to_file(contents, nil) do
+    app_dir = File.cwd!()
+    new_file_path = Path.join([app_dir, "results.txt"])
+
+    write_to_file(contents, new_file_path)
+  end
+
+  defp write_to_file(contents, filepath) do
+    result =
+      File.write(
+        filepath,
+        contents,
+        [:write]
+      )
+
+    case result do
+      {:error, message} -> Logger.error("Cannot write to #{filepath} #{message}")
+      _ -> Logger.info("Successfully output logs to #{filepath}")
+    end
+  end
+end

--- a/test/teiserver/mix_tasks/balance_stats_test.ex
+++ b/test/teiserver/mix_tasks/balance_stats_test.ex
@@ -1,0 +1,285 @@
+defmodule Mix.Tasks.Teiserver.BalanceStatsTests do
+  @moduledoc """
+  Can run all balance tests via
+  mix test --only balance_test
+  """
+  use ExUnit.Case
+  @moduletag :balance_test
+  alias Mix.Tasks.Teiserver.BalanceStats
+
+  test "Adjusted rating calculation" do
+    team_players = %{1 => [31, 15, 40, 1, 39, 12, 28, 3], 2 => [17, 10, 33, 19, 23, 35, 36, 18]}
+    rating_logs = get_large_team_rating_logs()
+    rating = BalanceStats.adjusted_rating(31, rating_logs)
+    assert rating == 0.7676847201440002
+
+    # Calculate team adjusted rating
+    rating = BalanceStats.calculate_rating_diff(team_players, rating_logs)
+
+    assert rating == %{
+             adjusted_team_rating_diff: 2.047099982927838,
+             team_rating_diff: 3.1937394354587525
+           }
+  end
+
+  defp get_large_team_rating_logs() do
+    %{
+      1 => %Teiserver.Game.RatingLog{
+        id: 317,
+        user_id: 1,
+        rating_type_id: 4,
+        match_id: 38,
+        party_id: nil,
+        value: %{
+          "rating_value" => 21.990324316979112,
+          "rating_value_change" => 0.8536998038911463,
+          "skill" => 30.02382729538406,
+          "skill_change" => 0.820207243963992,
+          "uncertainty" => 8.033502978404949,
+          "uncertainty_change" => -0.03349255992715072
+        },
+        inserted_at: ~U[2024-09-03 00:50:00Z]
+      },
+      3 => %Teiserver.Game.RatingLog{
+        id: 325,
+        user_id: 3,
+        rating_type_id: 4,
+        match_id: 38,
+        party_id: nil,
+        value: %{
+          "rating_value" => 12.945810679569687,
+          "rating_value_change" => -0.7955581015208075,
+          "skill" => 21.02629801073986,
+          "skill_change" => -0.8299582827594669,
+          "uncertainty" => 8.080487331170174,
+          "uncertainty_change" => -0.0344001812386594
+        },
+        inserted_at: ~U[2024-09-03 00:50:00Z]
+      },
+      10 => %Teiserver.Game.RatingLog{
+        id: 312,
+        user_id: 10,
+        rating_type_id: 4,
+        match_id: 38,
+        party_id: nil,
+        value: %{
+          "rating_value" => 17.050760205536292,
+          "rating_value_change" => 0.8489687243580626,
+          "skill" => 25.062959178945828,
+          "skill_change" => 0.8158188187110724,
+          "uncertainty" => 8.012198973409534,
+          "uncertainty_change" => -0.03314990564699194
+        },
+        inserted_at: ~U[2024-09-03 00:50:00Z]
+      },
+      12 => %Teiserver.Game.RatingLog{
+        id: 323,
+        user_id: 12,
+        rating_type_id: 4,
+        match_id: 38,
+        party_id: nil,
+        value: %{
+          "rating_value" => 16.900594909902587,
+          "rating_value_change" => -0.7805077795744424,
+          "skill" => 24.90198790222699,
+          "skill_change" => -0.8136261620124223,
+          "uncertainty" => 8.001392992324403,
+          "uncertainty_change" => -0.033118382437978156
+        },
+        inserted_at: ~U[2024-09-03 00:50:00Z]
+      },
+      15 => %Teiserver.Game.RatingLog{
+        id: 316,
+        user_id: 15,
+        rating_type_id: 4,
+        match_id: 38,
+        party_id: nil,
+        value: %{
+          "rating_value" => 20.7465750071461,
+          "rating_value_change" => 0.846617497382887,
+          "skill" => 28.748163241128765,
+          "skill_change" => 0.8136376310906428,
+          "uncertainty" => 8.001588233982666,
+          "uncertainty_change" => -0.03297986629224248
+        },
+        inserted_at: ~U[2024-09-03 00:50:00Z]
+      },
+      17 => %Teiserver.Game.RatingLog{
+        id: 320,
+        user_id: 17,
+        rating_type_id: 4,
+        match_id: 38,
+        party_id: nil,
+        value: %{
+          "rating_value" => 13.681950729816448,
+          "rating_value_change" => -0.8026254930596437,
+          "skill" => 21.799320756738933,
+          "skill_change" => -0.8376313757099076,
+          "uncertainty" => 8.117370026922485,
+          "uncertainty_change" => -0.03500588265026394
+        },
+        inserted_at: ~U[2024-09-03 00:50:00Z]
+      },
+      18 => %Teiserver.Game.RatingLog{
+        id: 321,
+        user_id: 18,
+        rating_type_id: 4,
+        match_id: 38,
+        party_id: nil,
+        value: %{
+          "rating_value" => 16.254407653196623,
+          "rating_value_change" => -0.8040877490904776,
+          "skill" => 24.379388443189605,
+          "skill_change" => -0.8392192548275048,
+          "uncertainty" => 8.124980789992984,
+          "uncertainty_change" => -0.03513150573702717
+        },
+        inserted_at: ~U[2024-09-03 00:50:00Z]
+      },
+      19 => %Teiserver.Game.RatingLog{
+        id: 311,
+        user_id: 19,
+        rating_type_id: 4,
+        match_id: 38,
+        party_id: nil,
+        value: %{
+          "rating_value" => 19.911872074252834,
+          "rating_value_change" => 0.8548696146779271,
+          "skill" => 27.950633132007184,
+          "skill_change" => 0.82129222569462,
+          "uncertainty" => 8.038761057754348,
+          "uncertainty_change" => -0.033577388983308865
+        },
+        inserted_at: ~U[2024-09-03 00:50:00Z]
+      },
+      23 => %Teiserver.Game.RatingLog{
+        id: 318,
+        user_id: 23,
+        rating_type_id: 4,
+        match_id: 38,
+        party_id: nil,
+        value: %{
+          "rating_value" => 18.914815307810343,
+          "rating_value_change" => 0.8802705944743963,
+          "skill" => 27.066829793305708,
+          "skill_change" => 0.8448410940152868,
+          "uncertainty" => 8.152014485495366,
+          "uncertainty_change" => -0.03542950045910764
+        },
+        inserted_at: ~U[2024-09-03 00:50:00Z]
+      },
+      28 => %Teiserver.Game.RatingLog{
+        id: 314,
+        user_id: 28,
+        rating_type_id: 4,
+        match_id: 38,
+        party_id: nil,
+        value: %{
+          "rating_value" => 16.55046981481037,
+          "rating_value_change" => 0.8834210584337523,
+          "skill" => 24.716410534718168,
+          "skill_change" => 0.8477604913614805,
+          "uncertainty" => 8.1659407199078,
+          "uncertainty_change" => -0.035660567072270055
+        },
+        inserted_at: ~U[2024-09-03 00:50:00Z]
+      },
+      31 => %Teiserver.Game.RatingLog{
+        id: 324,
+        user_id: 31,
+        rating_type_id: 4,
+        match_id: 38,
+        party_id: nil,
+        value: %{
+          "rating_value" => 16.920187736488288,
+          "rating_value_change" => -0.8296565654251218,
+          "skill" => 25.17714666434607,
+          "skill_change" => -0.8670014554023133,
+          "uncertainty" => 8.256958927857779,
+          "uncertainty_change" => -0.03734488997719332
+        },
+        inserted_at: ~U[2024-09-03 00:50:00Z]
+      },
+      33 => %Teiserver.Game.RatingLog{
+        id: 326,
+        user_id: 33,
+        rating_type_id: 4,
+        match_id: 38,
+        party_id: nil,
+        value: %{
+          "rating_value" => 15.996383809875415,
+          "rating_value_change" => -0.8188213615518407,
+          "skill" => 24.197666944229535,
+          "skill_change" => -0.8552244238000739,
+          "uncertainty" => 8.20128313435412,
+          "uncertainty_change" => -0.0364030622482332
+        },
+        inserted_at: ~U[2024-09-03 00:50:00Z]
+      },
+      35 => %Teiserver.Game.RatingLog{
+        id: 319,
+        user_id: 35,
+        rating_type_id: 4,
+        match_id: 38,
+        party_id: nil,
+        value: %{
+          "rating_value" => 18.078967552248244,
+          "rating_value_change" => -0.8172880435191772,
+          "skill" => 26.272342158954853,
+          "skill_change" => -0.8535582849747918,
+          "uncertainty" => 8.193374606706609,
+          "uncertainty_change" => -0.036270241455616414
+        },
+        inserted_at: ~U[2024-09-03 00:50:00Z]
+      },
+      36 => %Teiserver.Game.RatingLog{
+        id: 315,
+        user_id: 36,
+        rating_type_id: 4,
+        match_id: 38,
+        party_id: nil,
+        value: %{
+          "rating_value" => 17.57967901065515,
+          "rating_value_change" => 0.9130123439884841,
+          "skill" => 25.875166955461587,
+          "skill_change" => 0.8751669554615873,
+          "uncertainty" => 8.295487944806439,
+          "uncertainty_change" => -0.03784538852689501
+        },
+        inserted_at: ~U[2024-09-03 00:50:00Z]
+      },
+      39 => %Teiserver.Game.RatingLog{
+        id: 313,
+        user_id: 39,
+        rating_type_id: 4,
+        match_id: 38,
+        party_id: nil,
+        value: %{
+          "rating_value" => 18.65403724626335,
+          "rating_value_change" => 0.9041929443499406,
+          "skill" => 26.911149575150695,
+          "skill_change" => 0.8670014554023133,
+          "uncertainty" => 8.257112328887345,
+          "uncertainty_change" => -0.03719148894762725
+        },
+        inserted_at: ~U[2024-09-03 00:50:00Z]
+      },
+      40 => %Teiserver.Game.RatingLog{
+        id: 322,
+        user_id: 40,
+        rating_type_id: 4,
+        match_id: 38,
+        party_id: nil,
+        value: %{
+          "rating_value" => 15.954576067690587,
+          "rating_value_change" => -0.8198493989404927,
+          "skill" => 24.161157450788576,
+          "skill_change" => -0.8563415768276279,
+          "uncertainty" => 8.206581383097989,
+          "uncertainty_change" => -0.03649217788713521
+        },
+        inserted_at: ~U[2024-09-03 00:50:00Z]
+      }
+    }
+  end
+end


### PR DESCRIPTION
Goes through 500 games of 8v8 and 500 games 5v5 to calculate some stats using loser_picks and auto balance

It will return team rating diff and also the adjusted rating team diff. Adjusted team rating diff is where was adjust the rating of newish players. split_noobs assumes new players are the worst in game (i.e. 0 rating) and we trust their rating once they hit 6.65 uncertainty. We can use a formula to interpolate their adjusted rating:

```
    starting_uncertainty = 25 / 3
    uncertainty_cutoff = 6.65

    # When uncertainty is less than 6.65 this will return just rating
    # When uncertainty is default this will return 0
    min(
      1,   (starting_uncertainty - uncertainty) /   (starting_uncertainty -    uncertainty_cutoff)
      ) * rating
```

## Testing
  On integration server it is recommended you output to a specific path as follows:
```
  mix teiserver.balance_stats /var/log/teiserver/results.txt
```