### PR TITLE
Memes: Late Cleanup

### DIFF
--- a/lib/teiserver/coordinator/coordinator_lib.ex
+++ b/lib/teiserver/coordinator/coordinator_lib.ex
@@ -45,7 +45,6 @@ or are following someone that voted yes are also moved to that lobby.", :everybo
       {"meme", ["meme"],
        "A predefined bunch of settings for meme games. It's all Rikerss' fault. Requires boss privileges.
 - ticks: Ticks only, don't go Cortex!
-- nodefence: No defences
 - Deathmatch:  35k metal, 1k energy, everything builds fast, runs fast and hits hard. No anti-nuke
 - rich: Infinite money
 - poor: No money generation

--- a/lib/teiserver/coordinator/coordinator_lib.ex
+++ b/lib/teiserver/coordinator/coordinator_lib.ex
@@ -46,10 +46,9 @@ or are following someone that voted yes are also moved to that lobby.", :everybo
        "A predefined bunch of settings for meme games. It's all Rikerss' fault. Requires boss privileges.
 - ticks: Ticks only, don't go Cortex!
 - nodefence: No defences
-- greenfields: No metal extractors
+- Deathmatch:  35k metal, 1k energy, everything builds fast, runs fast and hits hard. No anti-nuke
 - rich: Infinite money
 - poor: No money generation
-- hardt1: T1 but no seaplanes or hovers either
 - crazy: Random combination of several settings
 - undo: Removes all meme effects", :everybody},
       {"welcome-message", ["message"],

--- a/lib/teiserver/coordinator/rikerss_memes.ex
+++ b/lib/teiserver/coordinator/rikerss_memes.ex
@@ -4,7 +4,7 @@ defmodule Teiserver.Coordinator.RikerssMemes do
   alias Teiserver.Lobby.{ChatLib}
   alias Teiserver.Data.Types, as: T
 
-  @meme_list ~w(ticks nodefence nodefence2 greenfields poor rich hardt1 crazy undo deathmatch noscout hoversonly nofusion armonly coronly legonly armvcor)
+  @meme_list ~w(ticks nodefence poor rich crazy undo deathmatch)
 
   @crazy_multiplier_opts ~w(0.3 0.5 0.7 1 1 1 1 1 1 1 1.5 2 4)
   @crazy_multiplier_opts_middler ~w(0.5 0.7 1 1 1 1 1 1 1 1.5 2)
@@ -25,7 +25,6 @@ defmodule Teiserver.Coordinator.RikerssMemes do
 
     Battle.set_modoptions(lobby_id, %{
       "game/modoptions/map_waterislava" => "1",
-      "game/modoptions/faction_limiter" => "armada"
     })
 
     Battle.disable_units(lobby_id, labs ++ defences ++ units ++ cortex)
@@ -33,17 +32,6 @@ defmodule Teiserver.Coordinator.RikerssMemes do
     [
       "#{sender.name} has enabled the Ticks meme. In this game the only fighting unit you will be able to build will be ticks."
     ]
-  end
-
-  def handle_meme("greenfields", senderid, %{lobby_id: lobby_id} = _state) do
-    sender = Account.get_user_by_id(senderid)
-
-    Battle.disable_units(
-      lobby_id,
-      ~w(armmex armamex armmoho cormex corexp cormexp cormoho legmex legmext2 legmext15 coruwmex coruwmme armuwmex armuwmme armshockwave)
-    )
-
-    ["#{sender.name} has enabled the Greenfield meme. Metal extractors are disabled."]
   end
 
   def handle_meme("deathmatch", senderid, %{lobby_id: lobby_id} = _state) do
@@ -85,19 +73,6 @@ defmodule Teiserver.Coordinator.RikerssMemes do
     ["#{sender.name} has enabled the rich meme. Everybody has insane amounts of resources."]
   end
 
-  def handle_meme("hardt1", senderid, %{lobby_id: lobby_id} = _state) do
-    sender = Account.get_user_by_id(senderid)
-
-    armada = ~w(armfhp armhp armamsub armplat armalab armavp armaap armasy armshltx armshltxuw)
-    cortex = ~w(corfhp corhp coaramsub corplat coravp coralab coraap corgantuw corgant corasy)
-
-    Battle.disable_units(lobby_id, armada ++ cortex)
-
-    [
-      "#{sender.name} has enabled the hard T1 meme. You can only build T1 (Seaplanes and Hovers are T1.5, they are disabled)."
-    ]
-  end
-
   def handle_meme("crazy", senderid, %{lobby_id: lobby_id} = _state) do
     sender = Account.get_user_by_id(senderid)
     undo_memes(lobby_id)
@@ -110,8 +85,7 @@ defmodule Teiserver.Coordinator.RikerssMemes do
       "game/modoptions/multiplier_resourceincome" =>
         Enum.random(~w(0.1 0.25 0.5 0.75 1 1.5 2 5 10)),
       "game/modoptions/maxunits" => Enum.random(~w(100 500 1000 2000 2000 2000 2000)),
-      "game/modoptions/norushtimer" => Enum.random(~w(1 2 3 4 5 8 10 10)),
-      "game/modoptions/norush" => Enum.random(~w(0 0 0 1)),
+      "game/modoptions/norushtimer" => Enum.random(~w(0 0 0 0 0 0 0 0 0 1 2 3 4 5 8 10 10)),
       "game/modoptions/map_waterlevel" => Enum.random(~w(-200 -100 -50 0 0 0 0 50 100 200)),
       "game/modoptions/lootboxes" => Enum.random(~w(scav_only scav_only scav_only enabled)),
       "game/modoptions/lootboxes_density" => Enum.random(~w(veryrare rarer normal normal normal)),
@@ -123,13 +97,9 @@ defmodule Teiserver.Coordinator.RikerssMemes do
         Enum.random(~w(disabled disabled disabled enabled)),
       "game/modoptions/assistdronescount" => Enum.random(~w(2 4 8 10 16)),
       "game/modoptions/experimentalextraunits" => Enum.random(~w(0 0 0 1)),
-      "game/modoptions/multiplier_maxdamage" => Enum.random(@crazy_multiplier_opts),
       "game/modoptions/multiplier_turnrate" => Enum.random(@crazy_multiplier_opts),
       "game/modoptions/multiplier_builddistance" => Enum.random(@crazy_multiplier_opts_positive),
       "game/modoptions/multiplier_weaponrange" => Enum.random(@crazy_multiplier_opts),
-      "game/modoptions/multiplier_metalcost" => Enum.random(@crazy_multiplier_opts),
-      "game/modoptions/multiplier_energycost" => Enum.random(@crazy_multiplier_opts),
-      "game/modoptions/multiplier_buildtimecost" => Enum.random(@crazy_multiplier_opts),
       "game/modoptions/multiplier_weapondamage" => Enum.random(@crazy_multiplier_opts),
       "game/modoptions/multiplier_buildpower" => Enum.random(@crazy_multiplier_opts),
       "game/modoptions/multiplier_maxvelocity" => Enum.random(@crazy_multiplier_opts_middler),
@@ -185,133 +155,6 @@ defmodule Teiserver.Coordinator.RikerssMemes do
     ]
   end
 
-  def handle_meme("nodefence2", senderid, %{lobby_id: lobby_id} = _state) do
-    sender = Account.get_user_by_id(senderid)
-
-    armada_defences =
-      ~w(armllt armamb armamd armanni armbeamer armbrtha armclaw armemp armguard armhlt armjuno armmg armpb armsilo armvulc armatl armdl armfhlt armfrt armgplat armkraken armptl armtl)
-
-    armada_aa = ~w(armferret armflak armmercury armrl armfflak armfrock armcir)
-
-    cortex_defences =
-      ~w(corllt corbhmth corbuzz cordoom corexp corfmd corhllt corhlt corjuno cormaw cormexp corpun corsilo cortoast cortron corvipe coratl cordl corfdoom corfhlt corfrock corfrt corgplat corptl cortl corint)
-
-    cortex_aa = ~w(corerad corflak cormadsam corrl corscreamer corenaa)
-
-    scavt3 =
-      ~w(armannit3 cordoomt3 armbotrail armminivulc corhllllt corminibuzz corscavdrag corscavdtf corscavdtl corscavdtm)
-
-    legion_defences = ~w(legdefcarryt1 legmg legstarfall)
-
-    unit_list =
-      armada_defences ++ armada_aa ++ cortex_defences ++ cortex_aa ++ scavt3 ++ legion_defences
-
-    scav_units =
-      unit_list
-      |> Enum.map(fn unit -> "#{unit}_scav" end)
-
-    Battle.disable_units(lobby_id, unit_list ++ scav_units)
-
-    [
-      "#{sender.name} has enabled the No defense meme, No LLTs ver. In this game you will not be able to create any defences; good luck!"
-    ]
-  end
-
-  def handle_meme("noscout", senderid, %{lobby_id: lobby_id} = _state) do
-    sender = Account.get_user_by_id(senderid)
-
-    arm_scouts =
-      ~w(armflea armfav armmark armseer armpeep armawac armrad armspy armarad armeyes armfrad armason armsehak)
-
-    cor_scouts =
-      ~w(corfav corvoyr corvrad corfink corawac corrad corarad corspy coreyes corfrad corason corhunt)
-
-    Battle.disable_units(lobby_id, arm_scouts ++ cor_scouts)
-
-    [
-      "#{sender.name} has enabled the No Scouts meme. In this game you will not be able to create any scout, radar, or spy units; good luck!"
-    ]
-  end
-
-  def handle_meme("hoversonly", senderid, %{lobby_id: lobby_id} = _state) do
-    sender = Account.get_user_by_id(senderid)
-
-    new_options = %{
-      "game/modoptions/tweakdefs" =>
-        "bG9jYWwgZnVuY3Rpb24gZEMoU1QsIGNvcCkKCWNvcD1jb3Agb3Ige30KCWxvY2FsIE5UPXt9Cgljb3BbU1RdPU5UCglmb3IgaywgdiBpbiBwYWlycyhTVCkgZG8KCQlpZiB0eXBlKHYpPT0idGFibGUiIHRoZW4KCQkJaWYgTlRba109PW5pbCB0aGVuIE5UW2tdPXt9IGVuZAoJCQlOVFtrXT1jb3Bbdl0gb3IgZEModiwgY29wKQoJCWVsc2UgTlRba109diBlbmQKCWVuZAoJcmV0dXJuIE5UCmVuZApsb2NhbCB1ZCA9IFVuaXREZWZzCmZvciBjb20saW5mIGluIHBhaXJzKHthcm1jb209eyJhcm0iLCJhcm1jaCJ9LGNvcmNvbT17ImNvciIsImNvcmNoIn0sfSkgZG8KCWxvY2FsIHRlbXAgPSBkQyh1ZFtjb21dLmJ1aWxkb3B0aW9ucykKCWxvY2FsIHRlbXAyID0gZEModWRbY29tXS5jdXN0b21wYXJhbXMpCgl1ZFtjb21dPWRDKHVkW2luZlsyXV0pCgl1ZFtjb21dLmJ1aWxkb3B0aW9ucyA9IHRlbXAKCXVkW2NvbV0uY3VzdG9tcGFyYW1zID0gdGVtcDIKCXVkW2NvbV0uaWNvbnR5cGU9aW5mWzFdLi4iY29tbWFuZGVyIgoJdWRbY29tXS5zb3VuZHMudW5kZXJhdHRhY2s9Indhcm5pbmcyIgoJdWRbY29tXS5zb3VuZHMuc2VsZWN0PXtbMV09aW5mWzFdLi4iY29tc2VsIn0KCWZvciBwYXJtLCB2YWwgaW4gcGFpcnMoe3JlY2xhaW1hYmxlPWZhbHNlLHdvcmtlcnRpbWU9MzAwLG1ldGFsbWFrZT0yLG1ldGFsc3RvcmFnZT01MDAsZW5lcmd5bWFrZT0yNSxlbmVyZ3lzdG9yYWdlPTUwMCxoZWFsdGg9MzcwMCxhdXRvaGVhbD01LHNob3dwbGF5ZXJuYW1lPXRydWUsY2FubWFudWFsZmlyZT10cnVlLH0pIGRvCgkJdWRbY29tXVtwYXJtXSA9IHZhbAoJZW5kCmVuZAp1ZC5sZWdjb20gPSBkQyh1ZC5jb3Jjb20p"
-    }
-
-    cor_not_hover_fac =
-      ~w(corsy corlab corvp corap coramsub corplat coravp coralab corasy coraap corgantuw corgant)
-
-    arm_not_hover_fac =
-      ~w(armsy armlab armvp armap armamsub armplat armalab armavp armaap armasy armshltx armshltxuw)
-
-    leg_not_hover_fac = ~w(leglab legvp legap legalab legavp legaap leggant)
-    Battle.set_modoptions(lobby_id, new_options)
-    Battle.disable_units(lobby_id, cor_not_hover_fac ++ arm_not_hover_fac ++ leg_not_hover_fac)
-
-    [
-      "#{sender.name} has enabled the Hovers Only meme. In this game you will be limited to hovers only, including your commander; good luck!"
-    ]
-  end
-
-  def handle_meme("nofusion", senderid, %{lobby_id: lobby_id} = _state) do
-    sender = Account.get_user_by_id(senderid)
-    fusion_units = ~w(armfus armafus armuwfus armckfus corfus corafus coruwfus)
-    Battle.disable_units(lobby_id, fusion_units)
-
-    [
-      "#{sender.name} has enabled the No Fusion meme. In this game you will not be able to create any T2 Fusion Energy production; good luck!"
-    ]
-  end
-
-  def handle_meme("armonly", senderid, %{lobby_id: lobby_id} = _state) do
-    sender = Account.get_user_by_id(senderid)
-    new_options = %{"game/modoptions/faction_limiter" => "armada"}
-    Battle.set_modoptions(lobby_id, new_options)
-
-    [
-      "#{sender.name} has enabled the Armada Only meme. A fight of Technological Supremacy upon you; good luck!"
-    ]
-  end
-
-  def handle_meme("coronly", senderid, %{lobby_id: lobby_id} = _state) do
-    sender = Account.get_user_by_id(senderid)
-    new_options = %{"game/modoptions/faction_limiter" => "cortex"}
-    Battle.set_modoptions(lobby_id, new_options)
-
-    [
-      "#{sender.name} has enabled the Cortex Only meme. May pure Brute Strength grant you Honour in battle; good luck!"
-    ]
-  end
-
-  def handle_meme("legonly", senderid, %{lobby_id: lobby_id} = _state) do
-    sender = Account.get_user_by_id(senderid)
-
-    new_options = %{
-      "game/modoptions/faction_limiter" => "legion",
-      "game/modoptions/experimentallegionfaction" => "1"
-    }
-
-    Battle.set_modoptions(lobby_id, new_options)
-
-    [
-      "#{sender.name} has enabled the Legion Only meme. Scorched Earth be upon us all; good luck!"
-    ]
-  end
-
-  def handle_meme("armvcor", senderid, %{lobby_id: lobby_id} = _state) do
-    sender = Account.get_user_by_id(senderid)
-    new_options = %{"game/modoptions/faction_limiter" => "armada,cortex,legion"}
-
-    Battle.set_modoptions(lobby_id, new_options)
-
-    [
-      "#{sender.name} has enabled the Armada vs Cortex (+vs legion if enabled) mode. Show them which faction is clearly better!"
-    ]
-  end
-
   def handle_meme("undo", _senderid, %{lobby_id: lobby_id} = _state) do
     undo_memes(lobby_id)
 
@@ -339,8 +182,7 @@ defmodule Teiserver.Coordinator.RikerssMemes do
       "game/modoptions/startenergy" => "1000",
       "game/modoptions/multiplier_resourceincome" => "1",
       "game/modoptions/maxunits" => "2000",
-      "game/modoptions/norushtimer" => "5",
-      "game/modoptions/norush" => "0",
+      "game/modoptions/norushtimer" => "0",
       "game/modoptions/map_waterlevel" => "0",
       "game/modoptions/lootboxes" => "scav_only",
       "game/modoptions/lootboxes_density" => "normal",
@@ -350,21 +192,14 @@ defmodule Teiserver.Coordinator.RikerssMemes do
       "game/modoptions/assistdronesenabled" => "disabled",
       "game/modoptions/assistdronescount" => "10",
       "game/modoptions/experimentalextraunits" => "0",
-      "game/modoptions/multiplier_maxdamage" => "1",
       "game/modoptions/multiplier_turnrate" => "1",
       "game/modoptions/multiplier_builddistance" => "1",
       "game/modoptions/multiplier_weaponrange" => "1",
-      "game/modoptions/multiplier_metalcost" => "1",
-      "game/modoptions/multiplier_energycost" => "1",
-      "game/modoptions/multiplier_buildtimecost" => "1",
       "game/modoptions/multiplier_weapondamage" => "1",
       "game/modoptions/multiplier_buildpower" => "1",
       "game/modoptions/multiplier_maxvelocity" => "1",
       "game/modoptions/multiplier_losrange" => "1",
       "game/modoptions/multiplier_radarrange" => "1",
-      "game/modoptions/tweakdefs" => "ZG8gZW5k",
-      "game/modoptions/experimentallegionfaction" => "0",
-      "game/modoptions/faction_limiter" => "0"
     }
 
     Battle.set_modoptions(lobby_id, new_options)

--- a/lib/teiserver/coordinator/rikerss_memes.ex
+++ b/lib/teiserver/coordinator/rikerss_memes.ex
@@ -4,7 +4,7 @@ defmodule Teiserver.Coordinator.RikerssMemes do
   alias Teiserver.Lobby.{ChatLib}
   alias Teiserver.Data.Types, as: T
 
-  @meme_list ~w(ticks nodefence poor rich crazy undo deathmatch)
+  @meme_list ~w(ticks poor rich crazy undo deathmatch)
 
   @crazy_multiplier_opts ~w(0.3 0.5 0.7 1 1 1 1 1 1 1 1.5 2 4)
   @crazy_multiplier_opts_middler ~w(0.5 0.7 1 1 1 1 1 1 1 1.5 2)
@@ -24,7 +24,7 @@ defmodule Teiserver.Coordinator.RikerssMemes do
       ~w(coraap coralab corap coravp corgant corhp corlab corvp corllt corfhp corsy corjuno corhllt corhlt)
 
     Battle.set_modoptions(lobby_id, %{
-      "game/modoptions/map_waterislava" => "1",
+      "game/modoptions/map_waterislava" => "1"
     })
 
     Battle.disable_units(lobby_id, labs ++ defences ++ units ++ cortex)
@@ -123,38 +123,6 @@ defmodule Teiserver.Coordinator.RikerssMemes do
     ]
   end
 
-  def handle_meme("nodefence", senderid, %{lobby_id: lobby_id} = _state) do
-    sender = Account.get_user_by_id(senderid)
-
-    armada_defences =
-      ~w(armamb armamd armanni armbeamer armbrtha armclaw armemp armguard armhlt armjuno armmg armpb armsilo armvulc armatl armdl armfhlt armfrt armgplat armkraken armptl armtl)
-
-    armada_aa = ~w(armferret armflak armmercury armrl armfflak armfrock armcir)
-
-    cortex_defences =
-      ~w(corbhmth corbuzz cordoom corexp corfmd corhllt corhlt corjuno cormaw cormexp corpun corsilo cortoast cortron corvipe coratl cordl corfdoom corfhlt corfrock corfrt corgplat corptl cortl corint)
-
-    cortex_aa = ~w(corerad corflak cormadsam corrl corscreamer corenaa)
-
-    scavt3 =
-      ~w(armannit3 cordoomt3 armbotrail armminivulc corhllllt corminibuzz corscavdrag corscavdtf corscavdtl corscavdtm)
-
-    legion_defences = ~w(legdefcarryt1 legmg legstarfall)
-
-    unit_list =
-      armada_defences ++ armada_aa ++ cortex_defences ++ cortex_aa ++ scavt3 ++ legion_defences
-
-    scav_units =
-      unit_list
-      |> Enum.map(fn unit -> "#{unit}_scav" end)
-
-    Battle.disable_units(lobby_id, unit_list ++ scav_units)
-
-    [
-      "#{sender.name} has enabled the No defense meme. In this game you will not be able to create any defences; good luck!"
-    ]
-  end
-
   def handle_meme("undo", _senderid, %{lobby_id: lobby_id} = _state) do
     undo_memes(lobby_id)
 
@@ -199,7 +167,7 @@ defmodule Teiserver.Coordinator.RikerssMemes do
       "game/modoptions/multiplier_buildpower" => "1",
       "game/modoptions/multiplier_maxvelocity" => "1",
       "game/modoptions/multiplier_losrange" => "1",
-      "game/modoptions/multiplier_radarrange" => "1",
+      "game/modoptions/multiplier_radarrange" => "1"
     }
 
     Battle.set_modoptions(lobby_id, new_options)


### PR DESCRIPTION
A late cleanup of the rikers meme file.
The pr to move these options: https://github.com/beyond-all-reason/Beyond-All-Reason/pull/3746

Removed:
- nodefence - hardcoded list, moved to game modoption
- nodefence2 - duplciate of nodefence, but with llts disabled for past adaptabilty tournament
- greenfields - already an ingame modoption
- hardt1 - hardcoded list, swapped for a remove tech 1.5, can be recreated with disable tech1.5, tech 2 and tech 3
- noscout - hardcoded list, hard to maintain here, to be ported
- hoversonly - part of the adaptablity tournament, moved to discord other mods section
- nofusion - hardcoded list, moved to game modoption
- armonly coronly legonly armvcor - modoption required for these to be removed.