### PR TITLE
Updated local_setup documentation to recommend installing libssl-dev 

### DIFF
--- a/documents/guides/local_setup.md
+++ b/documents/guides/local_setup.md
@@ -15,11 +15,11 @@ git clone git@github.com:beyond-all-reason/teiserver.git
 cd teiserver
 ```
 
-### Install build tools (gcc, g++, make)
+### Install build tools (gcc, g++, make) and cryptographic libraries
 #### Ubuntu/Debian
 ```bash
 sudo apt update
-sudo apt install build-essential
+sudo apt install build-essential libssl-dev
 ```
 
 ### Elixir setup


### PR DESCRIPTION
### Problem
When attempting to install erlang via asdf, the installation notes the following warning : 



```
*********************************************************************
**********************  APPLICATIONS DISABLED  **********************
*********************************************************************

crypto         : No usable OpenSSL found
odbc           : ODBC library - link check failed
ssh            : No usable OpenSSL found
ssl            : No usable OpenSSL found

```

When the developer then runs `mix deps.get`, they receive the following error:

  
```
** (Mix) The application "crypto" could not be found. This may happen if your Operating System broke Erlang into multiple packages and may be fixed by installing the missing "erlang-dev" and "erlang-crypto" packages
```
### Discussion
Since it seems teiserver is targeting a specific version of erlang (and I presume you do not want to install the OS default version of erlang, which is probably not the target version indicated by `.tool-versions`), we should probably attempt to figure this out by getting "a usable version of OpenSSL" 

### relevant resources found while debugging
- https://stackoverflow.com/questions/52915796/cannot-install-erlang-with-openssl-via-asdf-ubuntu-18-04-1
- https://github.com/asdf-vm/asdf-erlang/issues/82
- https://www.42.mach7x.com/2020/06/12/erlang-and-elixir-with-asdf-in-raspberry-4-with-ubuntu-20-04/
- https://elixirforum.com/t/wsl-mix-deps-get-the-application-crypto-could-not-be-found/57916/8
- https://askubuntu.com/questions/1160593/unable-to-install-rabbitmq-due-to-not-meeting-dependencies-libssl
- https://jaketrent.com/post/install-erlang-ubuntu-2204/ 

### Proposed solution
- Add `libssl-dev` to the list of recommended packages to install on Ubuntu/Debian, before installing Erlang / Elixir.
  - This appears to resolve the issue, `asdf install` and then `mix deps.get` works if I have `libssl-dev` installed.

### System information
Currently running `Linux Mint 21.3 Virginia` which is derived from `Ubuntu 22.04 Jammy Jellyfish`, if my quick checks with the aid of commands from [here](https://itsfoss.com/check-linux-mint-version/) are to be believed.



