### PR TITLE
Get custom deviation result for split_noobs

### DIFF
--- a/lib/teiserver/battle/balance/split_noobs.ex
+++ b/lib/teiserver/battle/balance/split_noobs.ex
@@ -344,13 +344,35 @@ defmodule Teiserver.Battle.Balance.SplitNoobs do
           Enum.zip([members, ratings, ranks, names, uncertainties]),
         # Create result value
         do: %{
-          rating: rating,
+          rating: adjusted_rating(rating, uncertainty, rank),
           name: name,
           id: id,
           uncertainty: uncertainty,
           rank: rank,
           in_party?: count > 1
         }
+  end
+
+  # This balance algorithm will use an adjusted rating for newish players
+  # This will not be displayed in chobby ui or player list; it's only used for balance
+  # It will be used when calculating team deviation
+  defp adjusted_rating(rating, uncertainty, rank) do
+    if(is_newish_player?(rank, uncertainty)) do
+      # For newish players we assume they are the worst in the lobby e.g. 0 match rating and
+      # then they converge to their true rating over time
+      # Once their uncertainty is low enough, we fully trust their rating
+      {_skill, starting_uncertainty} = Openskill.rating()
+
+      uncertainty_cutoff = @high_uncertainty
+
+      min(
+        1,
+        (starting_uncertainty - uncertainty) /
+          (starting_uncertainty - uncertainty_cutoff)
+      ) * rating
+    else
+      rating
+    end
   end
 
   @spec get_parties([BT.expanded_group()]) :: [String.t()]

--- a/test/teiserver/battle/split_noobs_deviation_test.exs
+++ b/test/teiserver/battle/split_noobs_deviation_test.exs
@@ -1,0 +1,170 @@
+defmodule Teiserver.Battle.SplitNoobsDeviationTest do
+  @moduledoc """
+  Can run all balance tests via
+  mix test --only balance_test
+  """
+  use ExUnit.Case
+  @moduletag :balance_test
+  alias Teiserver.Battle.Balance.SplitNoobs
+  alias Teiserver.Battle.BalanceLib
+
+  test "can get reasonable deviation" do
+    # https://openskill-test.web.app/single?replay=64eceb66601a3dad2be3c0784beb2c1e
+    # This game showed a high deviation 34% in chobby
+    # https://discord.com/channels/549281623154229250/1275366409722925056/1286261827738538035
+    # However, after using adjusted ratings for newish players, this now gives a lower deviation
+    expanded_group = [
+      %{
+        count: 1,
+        members: ["Devilsreborn"],
+        ratings: [22.69],
+        names: ["Devilsreborn"],
+        uncertainties: [7.83],
+        ranks: [0]
+      },
+      %{
+        count: 1,
+        members: ["InvisibleMan"],
+        ratings: [22.22],
+        names: ["InvisibleMan"],
+        uncertainties: [8.05],
+        ranks: [0]
+      },
+      %{
+        count: 1,
+        members: ["Yotap"],
+        ratings: [17.92],
+        names: ["Yotap"],
+        uncertainties: [8.22],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["Bluto"],
+        ratings: [16.70],
+        names: ["Bluto"],
+        uncertainties: [4.43],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["dearexis"],
+        ratings: [16.67],
+        names: ["dearexis"],
+        uncertainties: [8.33],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["NoHorny"],
+        ratings: [15.64],
+        names: ["NoHorny"],
+        uncertainties: [8.22],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["[NP]sigmal"],
+        ratings: [14.52],
+        names: ["[NP]sigmal"],
+        uncertainties: [3.98],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["Aceleo"],
+        ratings: [14.50],
+        names: ["Aceleo"],
+        uncertainties: [8.16],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["masvor"],
+        ratings: [12.79],
+        names: ["Aceleo"],
+        uncertainties: [7.53],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["Tpioesmten"],
+        ratings: [8.10],
+        names: ["Tpioesmten"],
+        uncertainties: [5.15],
+        ranks: [2]
+      }
+    ]
+
+    result = SplitNoobs.perform(expanded_group, 2) |> Map.drop([:logs])
+
+    assert result == %{
+             team_groups: %{
+               1 => [
+                 %{
+                   count: 1,
+                   group_rating: 6.784534653465353,
+                   members: ["Devilsreborn"],
+                   ratings: [6.784534653465353]
+                 },
+                 %{
+                   count: 1,
+                   group_rating: 1.0529900990099004,
+                   members: ["NoHorny"],
+                   ratings: [1.0529900990099004]
+                 },
+                 %{
+                   count: 1,
+                   group_rating: 1.4930693069306968,
+                   members: ["Aceleo"],
+                   ratings: [1.4930693069306968]
+                 },
+                 %{count: 1, group_rating: 8.1, members: ["Tpioesmten"], ratings: [8.1]},
+                 %{count: 1, group_rating: 14.52, members: ["[NP]sigmal"], ratings: [14.52]}
+               ],
+               2 => [
+                 %{
+                   count: 1,
+                   group_rating: 3.7399999999999975,
+                   members: ["InvisibleMan"],
+                   ratings: [3.7399999999999975]
+                 },
+                 %{
+                   count: 1,
+                   group_rating: 0.03300990099010417,
+                   members: ["dearexis"],
+                   ratings: [0.03300990099010417]
+                 },
+                 %{
+                   count: 1,
+                   group_rating: 1.20649504950495,
+                   members: ["Yotap"],
+                   ratings: [1.20649504950495]
+                 },
+                 %{
+                   count: 1,
+                   group_rating: 6.103742574257427,
+                   members: ["masvor"],
+                   ratings: [6.103742574257427]
+                 },
+                 %{count: 1, group_rating: 16.7, members: ["Bluto"], ratings: [16.7]}
+               ]
+             },
+             team_players: %{
+               1 => ["Devilsreborn", "NoHorny", "Aceleo", "Tpioesmten", "[NP]sigmal"],
+               2 => ["InvisibleMan", "dearexis", "Yotap", "masvor", "Bluto"]
+             }
+           }
+
+    ratings =
+      result.team_groups
+      |> Map.new(fn {k, groups} ->
+        {k, BalanceLib.sum_group_rating(groups)}
+      end)
+
+    assert ratings == %{1 => 31.950594059405947, 2 => 27.78324752475248}
+
+    deviation = BalanceLib.get_deviation(ratings)
+    assert deviation == 13
+  end
+end

--- a/test/teiserver/battle/split_noobs_internal_test.exs
+++ b/test/teiserver/battle/split_noobs_internal_test.exs
@@ -6,6 +6,7 @@ defmodule Teiserver.Battle.SplitNoobsInternalTest do
   use ExUnit.Case
   @moduletag :balance_test
   alias Teiserver.Battle.Balance.SplitNoobs
+  alias Teiserver.Battle.BalanceLib
 
   test "sort noobs" do
     noobs = [
@@ -347,99 +348,99 @@ defmodule Teiserver.Battle.SplitNoobsInternalTest do
     assert players == [
              %{
                id: "kyutoryu",
+               in_party?: true,
                name: "kyutoryu",
                rank: 1,
-               rating: 12.25,
-               uncertainty: 7.1,
-               in_party?: true
+               rating: 8.975247524752481,
+               uncertainty: 7.1
              },
              %{
                id: "fbots1998",
+               in_party?: true,
                name: "fbots1998",
                rank: 1,
-               rating: 13.98,
-               uncertainty: 8,
-               in_party?: true
+               rating: 2.768316831683173,
+               uncertainty: 8
              },
              %{
                id: "Dixinormus",
+               in_party?: false,
                name: "Dixinormus",
                rank: 2,
-               rating: 18.28,
-               uncertainty: 8,
-               in_party?: false
+               rating: 3.6198019801980257,
+               uncertainty: 8
              },
              %{
                id: "HungDaddy",
+               in_party?: false,
                name: "HungDaddy",
                rank: 2,
-               rating: 2.8,
-               uncertainty: 8,
-               in_party?: false
+               rating: 0.5544554455445553,
+               uncertainty: 8
              },
              %{
                id: "SLOPPYGAGGER",
+               in_party?: false,
                name: "SLOPPYGAGGER",
                rank: 2,
                rating: 8.89,
-               uncertainty: 3,
-               in_party?: false
+               uncertainty: 3
              },
              %{
                id: "jauggy",
+               in_party?: false,
                name: "jauggy",
                rank: 2,
                rating: 20.49,
-               uncertainty: 3,
-               in_party?: false
+               uncertainty: 3
              },
              %{
                id: "reddragon2010",
+               in_party?: false,
                name: "reddragon2010",
                rank: 2,
                rating: 18.4,
-               uncertainty: 3,
-               in_party?: false
+               uncertainty: 3
              },
              %{
                id: "Aposis",
+               in_party?: false,
                name: "Aposis",
                rank: 2,
                rating: 20.42,
-               uncertainty: 3,
-               in_party?: false
+               uncertainty: 3
              },
              %{
                id: "MaTThiuS_82",
+               in_party?: false,
                name: "MaTThiuS_82",
                rank: 2,
                rating: 8.26,
-               uncertainty: 3,
-               in_party?: false
+               uncertainty: 3
              },
              %{
                id: "Noody",
+               in_party?: false,
                name: "Noody",
                rank: 2,
                rating: 17.64,
-               uncertainty: 3,
-               in_party?: false
+               uncertainty: 3
              },
              %{
                id: "[DTG]BamBin0",
+               in_party?: false,
                name: "[DTG]BamBin0",
                rank: 2,
                rating: 20.06,
-               uncertainty: 3,
-               in_party?: false
+               uncertainty: 3
              },
              %{
                id: "barmalev",
+               in_party?: false,
                name: "barmalev",
                rank: 2,
                rating: 3.58,
-               uncertainty: 3,
-               in_party?: false
+               uncertainty: 3
              }
            ]
 
@@ -451,19 +452,19 @@ defmodule Teiserver.Battle.SplitNoobsInternalTest do
     assert noobs == [
              %{
                id: "Dixinormus",
+               in_party?: false,
                name: "Dixinormus",
                rank: 2,
-               rating: 18.28,
-               uncertainty: 8,
-               in_party?: false
+               rating: 3.6198019801980257,
+               uncertainty: 8
              },
              %{
                id: "HungDaddy",
+               in_party?: false,
                name: "HungDaddy",
                rank: 2,
-               rating: 2.8,
-               uncertainty: 8,
-               in_party?: false
+               rating: 0.5544554455445553,
+               uncertainty: 8
              }
            ]
 
@@ -471,84 +472,84 @@ defmodule Teiserver.Battle.SplitNoobsInternalTest do
 
     assert experienced_players == [
              %{
-               id: "fbots1998",
-               name: "fbots1998",
-               rank: 1,
-               rating: 13.98,
-               uncertainty: 8,
-               in_party?: true
-             },
-             %{
                id: "kyutoryu",
+               in_party?: true,
                name: "kyutoryu",
                rank: 1,
-               rating: 12.25,
-               uncertainty: 7.1,
-               in_party?: true
+               rating: 8.975247524752481,
+               uncertainty: 7.1
+             },
+             %{
+               id: "fbots1998",
+               in_party?: true,
+               name: "fbots1998",
+               rank: 1,
+               rating: 2.768316831683173,
+               uncertainty: 8
              },
              %{
                id: "jauggy",
+               in_party?: false,
                name: "jauggy",
                rank: 2,
                rating: 20.49,
-               uncertainty: 3,
-               in_party?: false
+               uncertainty: 3
              },
              %{
                id: "Aposis",
+               in_party?: false,
                name: "Aposis",
                rank: 2,
                rating: 20.42,
-               uncertainty: 3,
-               in_party?: false
+               uncertainty: 3
              },
              %{
                id: "[DTG]BamBin0",
+               in_party?: false,
                name: "[DTG]BamBin0",
                rank: 2,
                rating: 20.06,
-               uncertainty: 3,
-               in_party?: false
+               uncertainty: 3
              },
              %{
                id: "reddragon2010",
+               in_party?: false,
                name: "reddragon2010",
                rank: 2,
                rating: 18.4,
-               uncertainty: 3,
-               in_party?: false
+               uncertainty: 3
              },
              %{
                id: "Noody",
+               in_party?: false,
                name: "Noody",
                rank: 2,
                rating: 17.64,
-               uncertainty: 3,
-               in_party?: false
+               uncertainty: 3
              },
              %{
                id: "SLOPPYGAGGER",
+               in_party?: false,
                name: "SLOPPYGAGGER",
                rank: 2,
                rating: 8.89,
-               uncertainty: 3,
-               in_party?: false
+               uncertainty: 3
              },
              %{
                id: "MaTThiuS_82",
+               in_party?: false,
                name: "MaTThiuS_82",
                rank: 2,
                rating: 8.26,
-               uncertainty: 3,
-               in_party?: false
+               uncertainty: 3
              },
              %{
                id: "barmalev",
+               in_party?: false,
                name: "barmalev",
                rank: 2,
                rating: 3.58,
-               uncertainty: 3,
-               in_party?: false
+               uncertainty: 3
              }
            ]
 
@@ -560,30 +561,30 @@ defmodule Teiserver.Battle.SplitNoobsInternalTest do
              broken_party_penalty: 0,
              first_team: [
                %{
-                 id: "Dixinormus",
+                 id: "HungDaddy",
                  in_party?: false,
-                 name: "Dixinormus",
+                 name: "HungDaddy",
                  rank: 2,
-                 rating: 18.28,
-                 uncertainty: 8
-               },
-               %{
-                 id: "fbots1998",
-                 in_party?: true,
-                 index: 1,
-                 name: "fbots1998",
-                 rank: 1,
-                 rating: 13.98,
+                 rating: 0.5544554455445553,
                  uncertainty: 8
                },
                %{
                  id: "kyutoryu",
                  in_party?: true,
-                 index: 2,
+                 index: 1,
                  name: "kyutoryu",
                  rank: 1,
-                 rating: 12.25,
+                 rating: 8.975247524752481,
                  uncertainty: 7.1
+               },
+               %{
+                 id: "fbots1998",
+                 in_party?: true,
+                 index: 2,
+                 name: "fbots1998",
+                 rank: 1,
+                 rating: 2.768316831683173,
+                 uncertainty: 8
                },
                %{
                  id: "[DTG]BamBin0",
@@ -595,6 +596,15 @@ defmodule Teiserver.Battle.SplitNoobsInternalTest do
                  uncertainty: 3
                },
                %{
+                 id: "reddragon2010",
+                 index: 6,
+                 name: "reddragon2010",
+                 uncertainty: 3,
+                 rating: 18.4,
+                 rank: 2,
+                 in_party?: false
+               },
+               %{
                  id: "Noody",
                  in_party?: false,
                  index: 7,
@@ -602,26 +612,17 @@ defmodule Teiserver.Battle.SplitNoobsInternalTest do
                  rank: 2,
                  rating: 17.64,
                  uncertainty: 3
-               },
-               %{
-                 id: "MaTThiuS_82",
-                 in_party?: false,
-                 index: 9,
-                 name: "MaTThiuS_82",
-                 rank: 2,
-                 rating: 8.26,
-                 uncertainty: 3
                }
              ],
-             rating_diff_penalty: 0.4099999999999966,
-             score: 0.4099999999999966,
+             rating_diff_penalty: 6.203564356435635,
+             score: 6.203564356435635,
              second_team: [
                %{
-                 id: "HungDaddy",
+                 id: "Dixinormus",
                  in_party?: false,
-                 name: "HungDaddy",
+                 name: "Dixinormus",
                  rank: 2,
-                 rating: 2.8,
+                 rating: 3.6198019801980257,
                  uncertainty: 8
                },
                %{
@@ -643,15 +644,6 @@ defmodule Teiserver.Battle.SplitNoobsInternalTest do
                  uncertainty: 3
                },
                %{
-                 id: "reddragon2010",
-                 in_party?: false,
-                 index: 6,
-                 name: "reddragon2010",
-                 rank: 2,
-                 rating: 18.4,
-                 uncertainty: 3
-               },
-               %{
                  id: "SLOPPYGAGGER",
                  in_party?: false,
                  index: 8,
@@ -659,6 +651,15 @@ defmodule Teiserver.Battle.SplitNoobsInternalTest do
                  rank: 2,
                  rating: 8.89,
                  uncertainty: 3
+               },
+               %{
+                 id: "MaTThiuS_82",
+                 index: 9,
+                 name: "MaTThiuS_82",
+                 uncertainty: 3,
+                 rating: 8.26,
+                 rank: 2,
+                 in_party?: false
                },
                %{
                  id: "barmalev",
@@ -687,48 +688,68 @@ defmodule Teiserver.Battle.SplitNoobsInternalTest do
                "HungDaddy (chev: 3, σ: 8)",
                "------------------------------------------------------",
                "Perform brute force with the following players to get the best score.",
-               "Players: fbots1998, kyutoryu, jauggy, Aposis, [DTG]BamBin0, reddragon2010, Noody, SLOPPYGAGGER, MaTThiuS_82, barmalev",
+               "Players: kyutoryu, fbots1998, jauggy, Aposis, [DTG]BamBin0, reddragon2010, Noody, SLOPPYGAGGER, MaTThiuS_82, barmalev",
                "------------------------------------------------------",
                "Brute force result:",
-               "Team rating diff penalty: 0.4",
+               "Team rating diff penalty: 6.2",
                "Broken party penalty: 0",
-               "Score: 0.4 (lower is better)",
+               "Score: 6.2 (lower is better)",
                "------------------------------------------------------",
                "Draft remaining players (ordered from best to worst).",
                "Remaining: Dixinormus, HungDaddy",
                "------------------------------------------------------",
                "Final result:",
-               "Team 1: MaTThiuS_82, Noody, [DTG]BamBin0, kyutoryu, fbots1998, Dixinormus",
-               "Team 2: barmalev, SLOPPYGAGGER, reddragon2010, Aposis, jauggy, HungDaddy"
+               "Team 1: Noody, reddragon2010, [DTG]BamBin0, fbots1998, kyutoryu, HungDaddy",
+               "Team 2: barmalev, MaTThiuS_82, SLOPPYGAGGER, Aposis, jauggy, Dixinormus"
              ],
              team_groups: %{
                1 => [
-                 %{count: 1, group_rating: 18.28, members: ["Dixinormus"], ratings: [18.28]},
-                 %{count: 1, group_rating: 13.98, members: ["fbots1998"], ratings: [13.98]},
-                 %{count: 1, group_rating: 12.25, members: ["kyutoryu"], ratings: [12.25]},
+                 %{
+                   count: 1,
+                   group_rating: 0.5544554455445553,
+                   members: ["HungDaddy"],
+                   ratings: [0.5544554455445553]
+                 },
+                 %{
+                   count: 1,
+                   group_rating: 8.975247524752481,
+                   members: ["kyutoryu"],
+                   ratings: [8.975247524752481]
+                 },
+                 %{
+                   count: 1,
+                   group_rating: 2.768316831683173,
+                   members: ["fbots1998"],
+                   ratings: [2.768316831683173]
+                 },
                  %{count: 1, group_rating: 20.06, members: ["[DTG]BamBin0"], ratings: [20.06]},
-                 %{count: 1, group_rating: 17.64, members: ["Noody"], ratings: [17.64]},
-                 %{count: 1, group_rating: 8.26, members: ["MaTThiuS_82"], ratings: [8.26]}
+                 %{count: 1, members: ["reddragon2010"], ratings: [18.4], group_rating: 18.4},
+                 %{count: 1, group_rating: 17.64, members: ["Noody"], ratings: [17.64]}
                ],
                2 => [
-                 %{count: 1, group_rating: 2.8, members: ["HungDaddy"], ratings: [2.8]},
+                 %{
+                   count: 1,
+                   group_rating: 3.6198019801980257,
+                   members: ["Dixinormus"],
+                   ratings: [3.6198019801980257]
+                 },
                  %{count: 1, group_rating: 20.49, members: ["jauggy"], ratings: [20.49]},
                  %{count: 1, group_rating: 20.42, members: ["Aposis"], ratings: [20.42]},
-                 %{count: 1, group_rating: 18.4, members: ["reddragon2010"], ratings: [18.4]},
                  %{count: 1, group_rating: 8.89, members: ["SLOPPYGAGGER"], ratings: [8.89]},
+                 %{count: 1, members: ["MaTThiuS_82"], ratings: [8.26], group_rating: 8.26},
                  %{count: 1, group_rating: 3.58, members: ["barmalev"], ratings: [3.58]}
                ]
              },
              team_players: %{
                1 => [
-                 "Dixinormus",
-                 "fbots1998",
+                 "HungDaddy",
                  "kyutoryu",
+                 "fbots1998",
                  "[DTG]BamBin0",
-                 "Noody",
-                 "MaTThiuS_82"
+                 "reddragon2010",
+                 "Noody"
                ],
-               2 => ["HungDaddy", "jauggy", "Aposis", "reddragon2010", "SLOPPYGAGGER", "barmalev"]
+               2 => ["Dixinormus", "jauggy", "Aposis", "SLOPPYGAGGER", "MaTThiuS_82", "barmalev"]
              }
            }
   end

--- a/test/teiserver/battle/split_noobs_test.exs
+++ b/test/teiserver/battle/split_noobs_test.exs
@@ -248,7 +248,12 @@ defmodule Teiserver.Battle.SplitNoobsTest do
                  %{count: 1, group_rating: 20.42, members: ["Aposis"], ratings: [20.42]}
                ],
                2 => [
-                 %{count: 1, group_rating: 12.25, members: ["kyutoryu"], ratings: [12.25]},
+                 %{
+                   count: 1,
+                   group_rating: 8.975247524752481,
+                   members: ["kyutoryu"],
+                   ratings: [8.975247524752481]
+                 },
                  %{count: 1, group_rating: 8.89, members: ["SLOPPYGAGGER"], ratings: [8.89]},
                  %{count: 1, group_rating: 18.28, members: ["Dixinormus"], ratings: [18.28]},
                  %{count: 1, group_rating: 18.4, members: ["reddragon2010"], ratings: [18.4]},

--- a/test/teiserver_web/controllers/logging/page_view_log_controller_test.exs
+++ b/test/teiserver_web/controllers/logging/page_view_log_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule TeiserverWeb.Logging.PageViewLogControllerTest do
-  use TeiserverWeb.ConnCase, async: true
+  use TeiserverWeb.ConnCase, async: false
 
   alias Teiserver.Logging
 


### PR DESCRIPTION
The deviation stat when calculating balance is displayed in chobby whenever you call !balance
If the result is very high, players can get upset. With split_noobs, we do not trust the rating (17) of new players, which can lead to high deviations. This PR aims to adjust new player's ratings in the balancer so that the deviation result is smaller.

Note that the deviation result in teiserver is already a custom deviation method that is not the same as SPADS.

Also note that teiserver adjusts people's ratings already because it applies randomness from -0.5 to 0.5. So in $explain someone could have negative rating. But in chobby nobody is displayed as negative.

split_noobs doesn't apply randomness, but does adjust ratings with this PR.

## Adjusted rating formula
```
     min(
        1,
        (starting_uncertainty - uncertainty) /
          (starting_uncertainty - uncertainty_cutoff)
      ) * rating
```
When you are at starting uncertainty, this should return 0.
When you are at the uncertainty cutoff, this should return 1 * rating.
When you are in between, it should return x*rating (where x is a number between 0 and 1)

## Testing
You can select an old match in teiserver and compare the team sums of loser_picks and split_noobs. The team sum of split_noobs will be smaller when newish players are involved since their adjusted rating ranges from 0 to their true rating.