### PR TITLE
Add logs for errors inside balance result

### DIFF
--- a/lib/teiserver/battle/libs/balance_lib.ex
+++ b/lib/teiserver/battle/libs/balance_lib.ex
@@ -7,7 +7,7 @@ defmodule Teiserver.Battle.BalanceLib do
   alias Teiserver.Battle.Balance.BalanceTypes, as: BT
   alias Teiserver.Game.MatchRatingLib
   import Teiserver.Helper.NumberHelper, only: [int_parse: 1, round: 2]
-
+  require Logger
   # These are default values and can be overridden as part of the call to create_balance()
 
   # Upper boundary is how far above the group value the members can be, lower is how far below it
@@ -182,6 +182,19 @@ defmodule Teiserver.Battle.BalanceLib do
     |> calculate_balance_stats
     |> cleanup_result
     |> Map.put(:time_taken, System.system_time(:microsecond) - start_time)
+    |> validate_result(groups, team_count, opts)
+  end
+
+  def validate_result(result, groups, team_count, opts) do
+    if(Enum.empty?(result.team_sizes)) do
+      Logger.error("Invalid balance result.")
+      Logger.error(result)
+      Logger.error("groups: #{Kernel.inspect(groups)}")
+      Logger.error("team_count: #{team_count}")
+      Logger.error("opts: #{Kernel.inspect(opts)}")
+    end
+
+    result
   end
 
   @doc """

--- a/test/teiserver/battle/balance_lib_internal_test.exs
+++ b/test/teiserver/battle/balance_lib_internal_test.exs
@@ -6,6 +6,7 @@ defmodule Teiserver.Battle.BalanceLibInternalTest do
   use Teiserver.DataCase, async: true
   @moduletag :balance_test
   alias Teiserver.Battle.BalanceLib
+  require Logger
 
   test "Able to standardise groups with incomplete data" do
     [user1, user2, user3, user4, user5] = create_test_users()
@@ -113,6 +114,53 @@ defmodule Teiserver.Battle.BalanceLibInternalTest do
     is_moderator = false
     result = BalanceLib.get_allowed_algorithms(is_moderator)
     assert result == ["default", "auto", "loser_picks", "split_noobs"]
+  end
+
+  test "Validate result" do
+    balance_result = %{
+      team_groups: %{
+        1 => [
+          %{members: [4], count: 1, group_rating: 8, ratings: [8]},
+          %{members: [1], count: 1, group_rating: 5, ratings: [5]}
+        ],
+        2 => [
+          %{members: [3], count: 1, group_rating: 7, ratings: [7]},
+          %{members: [2], count: 1, group_rating: 6, ratings: [6]}
+        ]
+      },
+      team_players: %{
+        1 => [4, 1],
+        2 => [3, 2]
+      },
+      ratings: %{
+        1 => 13,
+        2 => 13
+      },
+      captains: %{
+        1 => 4,
+        2 => 3
+      },
+      team_sizes: %{},
+      deviation: 0,
+      means: %{1 => 6.5, 2 => 6.5},
+      stdevs: %{1 => 1.5, 2 => 0.5},
+      has_parties?: false
+    }
+
+    groups = [
+      %{1 => %{rating: 5}},
+      %{2 => %{rating: 6}},
+      %{3 => %{rating: 7}},
+      %{4 => %{rating: 8}}
+    ]
+
+    team_count = 2
+    opts = [algorithm: "loser_picks"]
+
+    # Add comment so that someone viewing test logs knows it's a deliberate errror
+    Logger.error("The following error is part of a test inside BalanceLibInternalTest.")
+    result = BalanceLib.validate_result(balance_result, groups, team_count, opts)
+    assert result == balance_result
   end
 
   defp create_test_users do


### PR DESCRIPTION
Add logs for: https://github.com/beyond-all-reason/teiserver/issues/430
This doesn't fix the bug. But will have more logs to look at.

Does a check to see if team_sizes is empty