### PR TITLE
Auto balance call split noobs when at least 3 parties

### DIFF
--- a/lib/teiserver/battle/balance/auto_balance.ex
+++ b/lib/teiserver/battle/balance/auto_balance.ex
@@ -25,11 +25,10 @@ defmodule Teiserver.Battle.Balance.AutoBalance do
       true ->
         players = flatten_members(expanded_group)
         has_noobs? = has_noobs?(players)
-        parties_count = get_parties_count(expanded_group)
 
         cond do
           has_noobs? -> SplitNoobs
-          parties_count >= 3 -> SplitNoobs
+          get_parties_count(expanded_group) >= 3 -> SplitNoobs
           true -> LoserPicks
         end
     end

--- a/lib/teiserver/battle/balance/auto_balance.ex
+++ b/lib/teiserver/battle/balance/auto_balance.ex
@@ -1,11 +1,11 @@
-defmodule Teiserver.Battle.Balance.DefaultBalance do
+defmodule Teiserver.Battle.Balance.AutoBalance do
   @moduledoc """
   This will call other balancers depending on circumstances
   """
   alias Teiserver.Battle.Balance.SplitNoobs
   alias Teiserver.Battle.Balance.LoserPicks
   alias Teiserver.Battle.Balance.BalanceTypes, as: BT
-  alias Teiserver.Battle.Balance.DefaultBalanceTypes, as: DB
+  alias Teiserver.Battle.Balance.AutoBalanceTypes, as: DB
 
   @doc """
   Main entry point used by balance_lib
@@ -25,9 +25,11 @@ defmodule Teiserver.Battle.Balance.DefaultBalance do
       true ->
         players = flatten_members(expanded_group)
         has_noobs? = has_noobs?(players)
+        parties_count = get_parties_count(expanded_group)
 
         cond do
           has_noobs? -> SplitNoobs
+          parties_count >= 3 -> SplitNoobs
           true -> LoserPicks
         end
     end
@@ -52,6 +54,14 @@ defmodule Teiserver.Battle.Balance.DefaultBalance do
           uncertainty: uncertainty,
           rank: rank
         }
+  end
+
+  @spec get_parties_count([BT.expanded_group()]) :: number()
+  def get_parties_count(expanded_group) do
+    Enum.filter(expanded_group, fn x ->
+      x[:count] >= 2
+    end)
+    |> Enum.count()
   end
 
   @spec has_noobs?([DB.player()]) :: any()

--- a/lib/teiserver/battle/balance/auto_balance_types.ex
+++ b/lib/teiserver/battle/balance/auto_balance_types.ex
@@ -1,4 +1,4 @@
-defmodule Teiserver.Battle.Balance.DefaultBalanceTypes do
+defmodule Teiserver.Battle.Balance.AutoBalanceTypes do
   @moduledoc false
 
   @type player :: %{

--- a/lib/teiserver/battle/balance/split_noobs.ex
+++ b/lib/teiserver/battle/balance/split_noobs.ex
@@ -141,7 +141,7 @@ defmodule Teiserver.Battle.Balance.SplitNoobs do
       "None"
     else
       Enum.map(parties, fn party ->
-        "[#{Enum.join(party, ", ")}]"
+        "(#{Enum.join(party, ", ")})"
       end)
       |> Enum.join(", ")
     end

--- a/lib/teiserver/battle/libs/balance_lib.ex
+++ b/lib/teiserver/battle/libs/balance_lib.ex
@@ -51,7 +51,7 @@ defmodule Teiserver.Battle.BalanceLib do
       "force_party" => Teiserver.Battle.Balance.ForceParty,
       "brute_force" => Teiserver.Battle.Balance.BruteForce,
       "split_noobs" => Teiserver.Battle.Balance.SplitNoobs,
-      "auto" => Teiserver.Battle.Balance.DefaultBalance
+      "auto" => Teiserver.Battle.Balance.AutoBalance
     }
   end
 

--- a/test/teiserver/battle/auto_balance_internal_test.exs
+++ b/test/teiserver/battle/auto_balance_internal_test.exs
@@ -1,0 +1,90 @@
+defmodule Teiserver.Battle.AutoBalanceInternalTest do
+  @moduledoc """
+  Can run all balance tests via
+  mix test --only balance_test
+  """
+  use Teiserver.DataCase, async: true
+  @moduletag :balance_test
+  alias Teiserver.Battle.Balance.AutoBalance
+  require Logger
+
+  test "Able to get parties count" do
+    expanded_group = [
+      %{
+        count: 2,
+        members: ["kyutoryu", "fbots1998"],
+        ratings: [12.25, 13.98],
+        names: ["kyutoryu", "fbots1998"],
+        uncertainties: [0, 1],
+        ranks: [1, 1]
+      },
+      %{
+        count: 2,
+        members: ["Dixinormus", "SLOPPYGAGGER"],
+        ratings: [18.28, 0],
+        names: ["Dixinormus", "SLOPPYGAGGER"],
+        uncertainties: [2, 4],
+        ranks: [0, 0]
+      },
+      %{
+        count: 1,
+        members: ["jauggy"],
+        ratings: [20.49],
+        names: ["jauggy"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["reddragon2010"],
+        ratings: [18.4],
+        names: ["reddragon2010"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["Aposis"],
+        ratings: [20.42],
+        names: ["Aposis"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["MaTThiuS_82"],
+        ratings: [8.26],
+        names: ["MaTThiuS_82"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["Noody"],
+        ratings: [17.64],
+        names: ["Noody"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["[DTG]BamBin0"],
+        ratings: [20.06],
+        names: ["[DTG]BamBin0"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["barmalev"],
+        ratings: [3.58],
+        names: ["barmalev"],
+        uncertainties: [3],
+        ranks: [2]
+      }
+    ]
+
+    result = AutoBalance.get_parties_count(expanded_group)
+    assert result == 2
+  end
+end

--- a/test/teiserver/battle/split_noobs_internal_test.exs
+++ b/test/teiserver/battle/split_noobs_internal_test.exs
@@ -682,7 +682,7 @@ defmodule Teiserver.Battle.SplitNoobsInternalTest do
                "------------------------------------------------------",
                "This algorithm will evenly distribute noobs and devalue them. Noobs are non-partied players that have either high uncertainty or 0 rating. Noobs will always be drafted last. For non-noobs, teams will prefer higher rating. For noobs, teams will prefer higher chevrons and lower uncertainty.",
                "------------------------------------------------------",
-               "Parties: [kyutoryu, fbots1998]",
+               "Parties: (kyutoryu, fbots1998)",
                "Solo noobs:",
                "Dixinormus (chev: 3, σ: 8)",
                "HungDaddy (chev: 3, σ: 8)",

--- a/test/teiserver/battle/split_noobs_test.exs
+++ b/test/teiserver/battle/split_noobs_test.exs
@@ -402,7 +402,7 @@ defmodule Teiserver.Battle.SplitNoobsTest do
              "------------------------------------------------------",
              "This algorithm will evenly distribute noobs and devalue them. Noobs are non-partied players that have either high uncertainty or 0 rating. Noobs will always be drafted last. For non-noobs, teams will prefer higher rating. For noobs, teams will prefer higher chevrons and lower uncertainty.",
              "------------------------------------------------------",
-             "Parties: [LuBaee, TimeContainer]",
+             "Parties: (LuBaee, TimeContainer)",
              "Solo noobs:",
              "StinkBee (chev: 3, σ: 6.7)",
              "HoldButyLeg (chev: 1, σ: 7.5)",

--- a/test/teiserver/protocols/spring/spring_auth_async_test.exs
+++ b/test/teiserver/protocols/spring/spring_auth_async_test.exs
@@ -1,5 +1,5 @@
 defmodule Teiserver.SpringAuthAsyncTest do
-  use Teiserver.ServerCase, async: true
+  use Teiserver.ServerCase, async: false
   alias Teiserver.Client
   alias Teiserver.Protocols.Spring
 


### PR DESCRIPTION
- Makes auto balance call split noobs when there are at least 3 parties.  
- Rename default balance to auto balance in code.

loser_picks is stricter and tends to break up parties more often than split_noobs. this was deliberate design so we don't have one stacked team versus all solos. However, preserving parties when there are at least 3 parties should be less of an issue because this means that there's a high chance both teams will have parties.



Here's examples of supporting many parties and with both teams having parties:
![image](https://github.com/user-attachments/assets/53438dab-e009-4f31-ae91-b789e55fec4d)

![image](https://github.com/user-attachments/assets/735cda6c-5f1d-427a-958e-0a72aa1290ce)


### Other minor improvements
When logging parties change grouping from [ to (. This makes it easier to read since many use clan tags that use [].
