### PR TITLE
Correctly verify one_time_code IP address; log expired code access

### DIFF
--- a/lib/teiserver_web/controllers/account/session_controller.ex
+++ b/lib/teiserver_web/controllers/account/session_controller.ex
@@ -59,6 +59,25 @@ defmodule TeiserverWeb.Account.SessionController do
       code == nil ->
         Logger.debug("SessionController.one_time_login No code matching #{value}")
 
+        if expired_code =
+             Account.get_code(nil,
+               search: [
+                 value: value,
+                 purpose: "one_time_login",
+                 expired: true
+               ]
+             ) do
+          diff =
+            Timex.format_duration(
+              Timex.diff(expired_code.expires, Timex.now(), :duration),
+              :humanized
+            )
+
+          Logger.debug(
+            "SessionController.one_time_login User tried to use expired code (expired for #{diff})"
+          )
+        end
+
         conn
         |> redirect(to: "/")
 

--- a/lib/teiserver_web/controllers/account/session_controller.ex
+++ b/lib/teiserver_web/controllers/account/session_controller.ex
@@ -57,13 +57,13 @@ defmodule TeiserverWeb.Account.SessionController do
 
     cond do
       code == nil ->
-        Logger.debug("SessionController.one_time_login No code")
+        Logger.debug("SessionController.one_time_login No code matching #{value}")
 
         conn
         |> redirect(to: "/")
 
-      code.metadata["ip"] != ip ->
-        Logger.debug("SessionController.one_time_login Bad IP")
+      code.metadata["ip"] != nil && code.metadata["ip"] != ip ->
+        Logger.debug("SessionController.one_time_login Bad IP. Got #{ip}; want #{code.metadata["ip"]}")
 
         conn
         |> redirect(to: "/")

--- a/lib/teiserver_web/controllers/account/session_controller.ex
+++ b/lib/teiserver_web/controllers/account/session_controller.ex
@@ -63,7 +63,9 @@ defmodule TeiserverWeb.Account.SessionController do
         |> redirect(to: "/")
 
       code.metadata["ip"] != nil && code.metadata["ip"] != ip ->
-        Logger.debug("SessionController.one_time_login Bad IP. Got #{ip}; want #{code.metadata["ip"]}")
+        Logger.debug(
+          "SessionController.one_time_login Bad IP. Got #{ip}; want #{code.metadata["ip"]}"
+        )
 
         conn
         |> redirect(to: "/")

--- a/test/teiserver_web/controllers/account/session_controller_test.exs
+++ b/test/teiserver_web/controllers/account/session_controller_test.exs
@@ -83,6 +83,23 @@ defmodule TeiserverWeb.Account.SessionControllerTest do
       assert redirected_to(conn) == ~p"/"
     end
 
+    test "expired code", %{conn: conn, user: user} do
+      {:ok, _} =
+        Account.create_code(%{
+          value: "test_code_valid_value",
+          purpose: "one_time_login",
+          expires: Timex.now() |> Timex.shift(days: -5_000),
+          user_id: user.id,
+          metadata: %{
+            redirect: ~p"/profile/" <> Integer.to_string(user.id)
+          }
+        })
+
+      conn = get(conn, ~p"/one_time_login/test_code_valid_value")
+      assert conn.assigns.flash["info"] != "Welcome back!"
+      assert redirected_to(conn) == ~p"/"
+    end
+
     test "disabled via site config", %{conn: conn, user: user} do
       Config.update_site_config("user.Enable one time links", false)
 

--- a/test/teiserver_web/controllers/account/session_controller_test.exs
+++ b/test/teiserver_web/controllers/account/session_controller_test.exs
@@ -31,6 +31,10 @@ defmodule TeiserverWeb.Account.SessionControllerTest do
       conn = get(conn, ~p"/one_time_login/test_code_valid_value")
       assert conn.assigns.flash["info"] =~ "Welcome back!"
       assert redirected_to(conn) == rdr
+
+      # Profile page should be accessible.
+      conn = get(conn, rdr)
+      assert html_response(conn, 200) =~ user.name
     end
 
     test "Unknown one_time_code invalid", %{conn: conn} do

--- a/test/teiserver_web/controllers/account/session_controller_test.exs
+++ b/test/teiserver_web/controllers/account/session_controller_test.exs
@@ -1,0 +1,80 @@
+defmodule TeiserverWeb.Account.SessionControllerTest do
+  use TeiserverWeb.ConnCase
+
+  alias Central.Helpers.GeneralTestLib
+  alias Teiserver.Account
+  alias Teiserver.Config
+
+  describe "one time codes" do
+    setup do
+      Config.update_site_config("user.Enable one time links", true)
+
+      GeneralTestLib.conn_setup(Teiserver.TeiserverTestLib.player_permissions(), [:no_login])
+      |> Teiserver.TeiserverTestLib.conn_setup()
+    end
+
+    test "Valid code", %{conn: conn, user: user} do
+      rdr = ~p"/profile/" <> Integer.to_string(user.id)
+
+      {:ok, _} =
+        Account.create_code(%{
+          value: "test_code_valid_value",
+          purpose: "one_time_login",
+          expires: Timex.now() |> Timex.shift(days: 5_000),
+          user_id: user.id,
+          metadata: %{
+            ip: "127.0.0.1",
+            redirect: rdr
+          }
+        })
+
+      conn = get(conn, ~p"/one_time_login/test_code_valid_value")
+      assert conn.assigns.flash["info"] =~ "Welcome back!"
+      assert redirected_to(conn) == rdr
+    end
+
+    test "Unknown one_time_code invalid", %{conn: conn} do
+      conn = get(conn, ~p"/one_time_login/some_invalid_code")
+      assert redirected_to(conn) == ~p"/"
+      assert conn.assigns.flash["info"] != "Welcome back!"
+    end
+
+    test "bad ip", %{conn: conn, user: user} do
+      {:ok, _} =
+        Account.create_code(%{
+          value: "test_code_valid_value",
+          purpose: "one_time_login",
+          expires: Timex.now() |> Timex.shift(days: 5_000),
+          user_id: user.id,
+          metadata: %{
+            ip: "1.1.1.1",
+            redirect: ~p"/profile/" <> Integer.to_string(user.id)
+          }
+        })
+
+      conn = get(conn, ~p"/one_time_login/test_code_valid_value")
+      assert conn.assigns.flash["info"] != "Welcome back!"
+      assert redirected_to(conn) == ~p"/"
+    end
+
+    test "disabled via site config", %{conn: conn, user: user} do
+      Config.update_site_config("user.Enable one time links", false)
+
+      {:ok, _} =
+        Account.create_code(%{
+          value: "test_code_valid_value",
+          purpose: "one_time_login",
+          expires: Timex.now() |> Timex.shift(days: 5_000),
+          user_id: user.id,
+          metadata: %{
+            ip: "127.0.0.1",
+            redirect: ~p"/profile/" <> Integer.to_string(user.id)
+          }
+        })
+
+      conn = get(conn, ~p"/one_time_login/test_code_valid_value")
+      assert conn.assigns.flash["info"] != "Welcome back!"
+      assert redirected_to(conn) == ~p"/"
+    end
+  end
+end

--- a/test/teiserver_web/controllers/account/session_controller_test.exs
+++ b/test/teiserver_web/controllers/account/session_controller_test.exs
@@ -37,6 +37,28 @@ defmodule TeiserverWeb.Account.SessionControllerTest do
       assert html_response(conn, 200) =~ user.name
     end
 
+    test "Valid code without IP", %{conn: conn, user: user} do
+      rdr = ~p"/profile/" <> Integer.to_string(user.id)
+
+      {:ok, _} =
+        Account.create_code(%{
+          value: "test_code_valid_value",
+          purpose: "one_time_login",
+          expires: Timex.now() |> Timex.shift(days: 5_000),
+          user_id: user.id,
+          metadata: %{
+            redirect: rdr
+          }
+        })
+
+      conn = get(conn, ~p"/one_time_login/test_code_valid_value")
+      assert conn.assigns.flash["info"] =~ "Welcome back!"
+      assert redirected_to(conn) == rdr
+
+      conn = get(conn, rdr)
+      assert html_response(conn, 200) =~ user.name
+    end
+
     test "Unknown one_time_code invalid", %{conn: conn} do
       conn = get(conn, ~p"/one_time_login/some_invalid_code")
       assert redirected_to(conn) == ~p"/"


### PR DESCRIPTION
Addresses #133 

Note that tests do not verify the added log lines when an expired code is accessed (although the code path is exercised).