### PR TITLE
Display "Smurf Link" as a restriction on user overview page.

### DIFF
--- a/lib/teiserver_web/templates/admin/user/tab_overview.html.heex
+++ b/lib/teiserver_web/templates/admin/user/tab_overview.html.heex
@@ -25,10 +25,13 @@
   <div class="col-md-12 col-lg-4">
     <h4>Restrictions</h4>
     <div class="row">
-      <%= if Enum.empty?(@user.data["restrictions"] || []) do %>
+      <%= if Enum.empty?(@user.data["restrictions"] || []) && !@user.smurf_of_id do %>
         No restrictions
       <% else %>
-        <div class="col-lg-3 col-xl-2 col-xxl-2">
+        <div class="col">
+          <%= if @user.smurf_of_id do %>
+            Smurf Link<br />
+          <% end %>
           <%= for r <- @user.data["restrictions"] do %>
             <%= r %><br />
           <% end %>


### PR DESCRIPTION
Currently, When viewing the single-user overview page ("/teiserver/admin/user/$id"), it is not immediately obvious whether or not the user has been flagged as a Smurf.

This is because, when no actions are active, the "Restrictions" section contains a single "No restrictions" entry. However, while a Smurf Link is *technically* not a restriction, it does prevent the user from logging in.

This patch updates the user overview page's "Restrictions" section as follows:
- "No restrictions" is only listed if there are no active actions AND no Smurf Link for the user.
- When the user has a Smurf Link, it is displayed in the same way as any other active actions.