### PR TITLE
Autohost basics

### DIFF
--- a/lib/teiserver/autohost.ex
+++ b/lib/teiserver/autohost.ex
@@ -1,7 +1,9 @@
 defmodule Teiserver.Autohost do
-  alias Teiserver.Autohost.Autohost
+  alias Teiserver.Autohost.{Autohost, Registry}
   alias Teiserver.AutohostQueries
   alias Teiserver.Repo
+
+  @type reg_value :: Registry.reg_value()
 
   def create_autohost(attrs \\ %{}) do
     %Autohost{}
@@ -30,7 +32,7 @@ defmodule Teiserver.Autohost do
   @doc """
   Returns the pid of the autohost registered with a given id
   """
-  @spec lookup_autohost(Autohost.id()) :: pid() | nil
+  @spec lookup_autohost(Autohost.id()) :: {pid(), reg_value()} | nil
   def lookup_autohost(autohost_id) do
     Teiserver.Autohost.Registry.lookup(autohost_id)
   end

--- a/lib/teiserver/autohost/registry.ex
+++ b/lib/teiserver/autohost/registry.ex
@@ -41,6 +41,10 @@ defmodule Teiserver.Autohost.Registry do
     end
   end
 
+  def update_value(autohost_id, callback) do
+    Horde.Registry.update_value(__MODULE__, via_tuple(autohost_id), callback)
+  end
+
   def child_spec(_) do
     Supervisor.child_spec(Horde.Registry,
       id: __MODULE__,

--- a/lib/teiserver/autohost/tachyon_handler.ex
+++ b/lib/teiserver/autohost/tachyon_handler.ex
@@ -74,6 +74,17 @@ defmodule Teiserver.Autohost.TachyonHandler do
     end
   end
 
+  def handle_command("autohost/status", "event", _, msg, state) do
+    %{"data" => %{"maxBattles" => max_battles, "currentBattles" => current}} = msg
+
+    Registry.update_value(state.autohost.id, fn _ ->
+      %{id: state.autohost.id, max_battles: max_battles, current_battles: current}
+    end)
+
+    state = %{state | state: {:connected, %{max_battles: max_battles, current_battles: current}}}
+    {:ok, state}
+  end
+
   def handle_command(
         command_id,
         _message_type,

--- a/priv/tachyon/schema/autohost/status/event.json
+++ b/priv/tachyon/schema/autohost/status/event.json
@@ -1,0 +1,24 @@
+{
+    "title": "AutohostStatusEvent",
+    "tachyon": {
+        "source": "autohost",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "event" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "autohost/status" },
+        "data": {
+            "title": "AutohostStatusEventData",
+            "type": "object",
+            "properties": {
+                "maxBattles": { "type": "integer", "minimum": 0 },
+                "currentBattles": { "type": "integer", "minimum": 0 }
+            },
+            "required": ["maxBattles", "currentBattles"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -29,6 +29,21 @@ defmodule Teiserver.Support.Tachyon do
     %{client: client, token: token}
   end
 
+  @doc """
+  Connect as an autohost and ensure the first `status` event is sent
+  """
+  def connect_autohost!(token, max_battles, current) do
+    client = connect(token)
+
+    :ok =
+      send_event(client, "autohost/status", %{
+        maxBattles: max_battles,
+        currentBattles: current
+      })
+
+    client
+  end
+
   def connect_options(token) do
     [
       connection_options: [
@@ -59,6 +74,18 @@ defmodule Teiserver.Support.Tachyon do
     else
       Map.put(req, :data, data)
     end
+  end
+
+  def event(command_id, data \\ nil) do
+    request(command_id, data) |> Map.put(:type, :event)
+  end
+
+  def send_request(client, command_id, data \\ nil) do
+    WSC.send_message(client, {:text, request(command_id, data) |> Jason.encode!()})
+  end
+
+  def send_event(client, command_id, data \\ nil) do
+    WSC.send_message(client, {:text, event(command_id, data) |> Jason.encode!()})
   end
 
   # TODO tachyon_mvp: create a version of this function that also check the

--- a/test/teiserver_web/controllers/tachyon_controller_test.exs
+++ b/test/teiserver_web/controllers/tachyon_controller_test.exs
@@ -2,6 +2,7 @@ defmodule TeiserverWeb.TachyonControllerTest do
   use TeiserverWeb.ConnCase
   alias Central.Helpers.GeneralTestLib
   alias Teiserver.OAuthFixtures
+  alias Teiserver.Support.Tachyon
 
   alias WebsocketSyncClient, as: WSC
 
@@ -172,36 +173,11 @@ defmodule TeiserverWeb.TachyonControllerTest do
       {:ok, client} = WSC.connect(tachyon_url(), opts)
 
       conn_pid =
-        Teiserver.Support.Tachyon.poll_until_some(fn ->
+        Tachyon.poll_until_some(fn ->
           Teiserver.Player.lookup_connection(user.id)
         end)
 
       assert is_pid(conn_pid)
-    end
-
-    test "autohost can connect too", %{user: user} do
-      app = OAuthFixtures.app_attrs(user.id) |> OAuthFixtures.create_app()
-      autohost = Teiserver.AutohostFixtures.create_autohost("test autohost")
-
-      token =
-        OAuthFixtures.token_attrs(user.id, app)
-        |> Map.drop([:owner_id])
-        |> Map.put(:autohost_id, autohost.id)
-        |> OAuthFixtures.create_token()
-
-      opts = [
-        connection_options: [
-          extra_headers: [
-            {"authorization", "Bearer #{token.value}"},
-            {"sec-websocket-protocol", "v0.tachyon"}
-          ]
-        ]
-      ]
-
-      {:ok, client} = WSC.connect(tachyon_url(), opts)
-      {registered_pid, _} = poll(fn -> Teiserver.Autohost.lookup_autohost(autohost.id) end)
-      assert is_pid(registered_pid)
-      WSC.disconnect(client)
     end
   end
 
@@ -217,20 +193,5 @@ defmodule TeiserverWeb.TachyonControllerTest do
   defp tachyon_url() do
     conf = Application.get_env(:teiserver, TeiserverWeb.Endpoint)
     "ws://#{conf[:url][:host]}:#{conf[:http][:port]}" <> ~p"/tachyon"
-  end
-
-  defp poll(f, n \\ 10) do
-    case f.() do
-      nil ->
-        if n == 0 do
-          raise "poll timeout"
-        else
-          :timer.sleep(1)
-          poll(f, n - 1)
-        end
-
-      x ->
-        x
-    end
   end
 end

--- a/test/teiserver_web/controllers/tachyon_controller_test.exs
+++ b/test/teiserver_web/controllers/tachyon_controller_test.exs
@@ -199,7 +199,7 @@ defmodule TeiserverWeb.TachyonControllerTest do
       ]
 
       {:ok, client} = WSC.connect(tachyon_url(), opts)
-      registered_pid = poll(fn -> Teiserver.Autohost.lookup_autohost(autohost.id) end)
+      {registered_pid, _} = poll(fn -> Teiserver.Autohost.lookup_autohost(autohost.id) end)
       assert is_pid(registered_pid)
       WSC.disconnect(client)
     end

--- a/test/teiserver_web/tachyon/autohost.exs
+++ b/test/teiserver_web/tachyon/autohost.exs
@@ -1,0 +1,54 @@
+defmodule TeiserverWeb.Tachyon.Autohost do
+  use TeiserverWeb.ConnCase
+  alias Teiserver.OAuthFixtures
+  alias Teiserver.Support.Tachyon
+  alias WebsocketSyncClient, as: WSC
+
+  def create_autohost() do
+    name = for _ <- 1..20, into: "", do: <<Enum.random(?a..?z)>>
+    create_autohost(name)
+  end
+
+  def create_autohost(name), do: Teiserver.AutohostFixtures.create_autohost(name)
+
+  def setup_autohost(_context), do: {:ok, autohost: create_autohost()}
+
+  def setup_app(_context) do
+    user = Central.Helpers.GeneralTestLib.make_user(%{"data" => %{"roles" => ["Verified"]}})
+    uid = UUID.uuid4()
+
+    app =
+      OAuthFixtures.app_attrs(user.id)
+      |> Map.merge(%{name: uid, uid: uid})
+      |> OAuthFixtures.create_app()
+
+    {:ok, app: app}
+  end
+
+  def setup_token(context) do
+    creds =
+      OAuthFixtures.credential_attrs(context.autohost, context.app.id)
+      |> OAuthFixtures.create_credential()
+
+    token =
+      OAuthFixtures.token_attrs(nil, context.app)
+      |> Map.drop([:owner_id])
+      |> Map.put(:autohost_id, context.autohost.id)
+      |> OAuthFixtures.create_token()
+
+    {:ok, creds: creds, token: token}
+  end
+
+  def setup_client(context), do: {:ok, client: Tachyon.connect(context.token)}
+
+  setup [:setup_app, :setup_autohost, :setup_token]
+
+  test "must send `status` as first message", %{token: token} do
+    client = Tachyon.connect(token)
+    req = Tachyon.request("matchmaking/list") |> Jason.encode!()
+
+    assert :ok == WSC.send_message(client, {:text, req})
+    assert %{"status" => "failed", "reason" => "invalid_request"} = Tachyon.recv_message!(client)
+    assert {:error, :disconnected} = WSC.send_message(client, {:text, req})
+  end
+end


### PR DESCRIPTION
A smaller one for once. This is to handle the `autohost/status` message.
Since this is the first message that the autohost must send right after connection it should be handled before we're able to start a game.