### PR TITLE
Add missing parameter for oauth discovery

### DIFF
--- a/lib/teiserver_web/views/api/o_auth/code_view.ex
+++ b/lib/teiserver_web/views/api/o_auth/code_view.ex
@@ -34,7 +34,8 @@ defmodule TeiserverWeb.OAuth.CodeView do
         "refresh_token",
         "client_credentials"
       ],
-      code_challenge_methods_supported: ["S256"]
+      code_challenge_methods_supported: ["S256"],
+      response_types_supported: ["code", "token"]
     }
   end
 end

--- a/test/teiserver_web/controllers/o_auth/code_controller_test.exs
+++ b/test/teiserver_web/controllers/o_auth/code_controller_test.exs
@@ -334,7 +334,8 @@ defmodule TeiserverWeb.OAuth.CodeControllerTest do
                  "refresh_token",
                  "client_credentials"
                ],
-               "code_challenge_methods_supported" => ["S256"]
+               "code_challenge_methods_supported" => ["S256"],
+               "response_types_supported" => ["code", "token"]
              }
     end
   end


### PR DESCRIPTION
Turn out it's mandatory