### PR TITLE
Fix logs for loser picks

### DIFF
--- a/lib/teiserver/battle/libs/balance_lib.ex
+++ b/lib/teiserver/battle/libs/balance_lib.ex
@@ -375,8 +375,8 @@ defmodule Teiserver.Battle.BalanceLib do
           end)
 
         names =
-          group.members
-          |> Enum.map_join(", ", fn userid -> Account.get_username_by_id(userid) || userid end)
+          group.names
+          |> Enum.join(", ")
 
         pairing_logs = [
           "Unable to find a combination match for group of #{names} (stats: #{Enum.sum(group.ratings) |> round(2)}, #{group_mean |> round(2)}, #{group_stddev |> round(2)}), treating them as solo players"
@@ -403,8 +403,8 @@ defmodule Teiserver.Battle.BalanceLib do
           end)
 
         names =
-          group.members
-          |> Enum.map_join(", ", fn userid -> Account.get_username_by_id(userid) || userid end)
+          group.names
+          |> Enum.join(", ")
 
         pairing_logs = [
           "Unable to find a player match for group of #{names} (stats: #{Enum.sum(group.ratings) |> round(2)}, #{group_mean |> round(2)}, #{group_stddev |> round(2)}), treating them as solo players"
@@ -437,8 +437,8 @@ defmodule Teiserver.Battle.BalanceLib do
           [group | found_groups]
           |> Enum.map(fn fgroup ->
             fgroup_name =
-              fgroup.members
-              |> Enum.map_join(", ", fn userid -> Account.get_username_by_id(userid) || userid end)
+              fgroup.names
+              |> Enum.join(", ")
 
             fgroup_mean = Enum.sum(fgroup.ratings) / Enum.count(fgroup.ratings)
             fgroup_stddev = Statistics.stdev(fgroup.ratings)
@@ -868,12 +868,14 @@ defmodule Teiserver.Battle.BalanceLib do
 
         # Now turn a list of groups into one group
         selected_group
-        |> Enum.reduce(%{members: [], ratings: [], count: 0, group_rating: 0}, fn solo, acc ->
+        |> Enum.reduce(%{members: [], ratings: [], count: 0, group_rating: 0, names: []}, fn solo,
+                                                                                             acc ->
           %{
             members: acc.members ++ solo.members,
             ratings: acc.ratings ++ solo.ratings,
             count: acc.count + solo.count,
-            group_rating: acc.group_rating + solo.group_rating
+            group_rating: acc.group_rating + solo.group_rating,
+            names: acc.names ++ solo.names
           }
         end)
     end


### PR DESCRIPTION
Currently logs for loser_picks show user ids when there are parties
![1](https://github.com/user-attachments/assets/b4956b28-cdb6-4ce2-a26d-d86f9ffc4528)

This PR shows names of players instead of user ids for logs
![2](https://github.com/user-attachments/assets/f06782b2-6015-4ed4-ac61-48f34db53a1a)

## Testing
Simply go to a match on website and look at loser_picks balance logs
