### PR TITLE
Use Guardian.Plug to assert sign in status

### DIFF
--- a/test/teiserver_web/controllers/account/session_controller_test.exs
+++ b/test/teiserver_web/controllers/account/session_controller_test.exs
@@ -30,8 +30,7 @@ defmodule TeiserverWeb.Account.SessionControllerTest do
         })
 
       conn = get(conn, ~p"/one_time_login/test_code_valid_value")
-      authenticated_user = Guardian.Plug.current_resource(conn)
-      assert authenticated_user.id == user.id
+      assert Guardian.Plug.current_resource(conn).id == user.id
     end
 
     test "Valid code without IP", %{conn: conn, user: user} do
@@ -49,8 +48,7 @@ defmodule TeiserverWeb.Account.SessionControllerTest do
         })
 
       conn = get(conn, ~p"/one_time_login/test_code_valid_value")
-      authenticated_user = Guardian.Plug.current_resource(conn)
-      assert authenticated_user.id == user.id
+      assert Guardian.Plug.current_resource(conn).id == user.id
     end
 
     test "Unknown one_time_code invalid", %{conn: conn} do

--- a/test/teiserver_web/controllers/account/session_controller_test.exs
+++ b/test/teiserver_web/controllers/account/session_controller_test.exs
@@ -3,6 +3,7 @@ defmodule TeiserverWeb.Account.SessionControllerTest do
 
   alias Central.Helpers.GeneralTestLib
   alias Teiserver.Account
+  alias Teiserver.Account.Guardian
   alias Teiserver.Config
 
   describe "one time codes" do
@@ -29,12 +30,8 @@ defmodule TeiserverWeb.Account.SessionControllerTest do
         })
 
       conn = get(conn, ~p"/one_time_login/test_code_valid_value")
-      assert conn.assigns.flash["info"] =~ "Welcome back!"
-      assert redirected_to(conn) == rdr
-
-      # Profile page should be accessible.
-      conn = get(conn, rdr)
-      assert html_response(conn, 200) =~ user.name
+      authenticated_user = Guardian.Plug.current_resource(conn)
+      assert authenticated_user.id == user.id
     end
 
     test "Valid code without IP", %{conn: conn, user: user} do
@@ -52,17 +49,13 @@ defmodule TeiserverWeb.Account.SessionControllerTest do
         })
 
       conn = get(conn, ~p"/one_time_login/test_code_valid_value")
-      assert conn.assigns.flash["info"] =~ "Welcome back!"
-      assert redirected_to(conn) == rdr
-
-      conn = get(conn, rdr)
-      assert html_response(conn, 200) =~ user.name
+      authenticated_user = Guardian.Plug.current_resource(conn)
+      assert authenticated_user.id == user.id
     end
 
     test "Unknown one_time_code invalid", %{conn: conn} do
       conn = get(conn, ~p"/one_time_login/some_invalid_code")
-      assert redirected_to(conn) == ~p"/"
-      assert conn.assigns.flash["info"] != "Welcome back!"
+      assert Guardian.Plug.current_resource(conn) == nil
     end
 
     test "bad ip", %{conn: conn, user: user} do
@@ -79,8 +72,7 @@ defmodule TeiserverWeb.Account.SessionControllerTest do
         })
 
       conn = get(conn, ~p"/one_time_login/test_code_valid_value")
-      assert conn.assigns.flash["info"] != "Welcome back!"
-      assert redirected_to(conn) == ~p"/"
+      assert Guardian.Plug.current_resource(conn) == nil
     end
 
     test "expired code", %{conn: conn, user: user} do
@@ -96,8 +88,7 @@ defmodule TeiserverWeb.Account.SessionControllerTest do
         })
 
       conn = get(conn, ~p"/one_time_login/test_code_valid_value")
-      assert conn.assigns.flash["info"] != "Welcome back!"
-      assert redirected_to(conn) == ~p"/"
+      assert Guardian.Plug.current_resource(conn) == nil
     end
 
     test "disabled via site config", %{conn: conn, user: user} do
@@ -116,8 +107,7 @@ defmodule TeiserverWeb.Account.SessionControllerTest do
         })
 
       conn = get(conn, ~p"/one_time_login/test_code_valid_value")
-      assert conn.assigns.flash["info"] != "Welcome back!"
-      assert redirected_to(conn) == ~p"/"
+      assert Guardian.Plug.current_resource(conn) == nil
     end
   end
 end


### PR DESCRIPTION
We use the guardian auth framework to assert whether a user has been signed in, rather than inspecting the HTML response. This change makes tests less brittle to HTML or other view changes.