### PR TITLE
Live endpoints that require authentication are piped through the :protected pipeline

### DIFF
--- a/lib/teiserver_web/router.ex
+++ b/lib/teiserver_web/router.ex
@@ -74,7 +74,7 @@ defmodule TeiserverWeb.Router do
   end
 
   scope "/", TeiserverWeb.General do
-    pipe_through([:live_browser, :nomenu_layout])
+    pipe_through([:live_browser, :nomenu_layout, :protected])
 
     live_session :general_index,
       on_mount: [
@@ -95,6 +95,10 @@ defmodule TeiserverWeb.Router do
       live "/all", BlogLive.Index, :all
       live "/show/:post_id", BlogLive.Show, :index
     end
+  end
+
+  scope "/microblog", TeiserverWeb.Microblog do
+    pipe_through([:live_browser, :app_layout, :protected])
 
     live_session :microblog_user,
       on_mount: [
@@ -477,7 +481,7 @@ defmodule TeiserverWeb.Router do
   end
 
   scope "/moderation", TeiserverWeb.Moderation do
-    pipe_through([:browser, :app_layout])
+    pipe_through([:browser, :app_layout, :protected])
 
     live_session :overwatch,
       on_mount: [
@@ -488,6 +492,10 @@ defmodule TeiserverWeb.Router do
       live "/overwatch/target/:target_id", OverwatchLive.User, :user
       live "/overwatch/report_group/:id", OverwatchLive.ReportGroupDetail, :index
     end
+  end
+
+  scope "/moderation", TeiserverWeb.Moderation do
+    pipe_through([:browser, :app_layout])
 
     live_session :report_user,
       on_mount: [

--- a/test/teiserver_web/controllers/account/security_controller_test.exs
+++ b/test/teiserver_web/controllers/account/security_controller_test.exs
@@ -1,0 +1,16 @@
+defmodule TeiserverWeb.Account.SecurityControllerTest do
+  use TeiserverWeb.ConnCase
+
+  alias Central.Helpers.GeneralTestLib
+
+  test "redirected to edit password once logged in" do
+    {:ok, kw} = GeneralTestLib.conn_setup([], [:no_login])
+    {:ok, conn} = Keyword.fetch(kw, :conn)
+    {:ok, user} = Keyword.fetch(kw, :user)
+
+    conn = get(conn, ~p"/teiserver/account/security/edit_password")
+    assert redirected_to(conn) == ~p"/login"
+    conn = GeneralTestLib.login(conn, user.email)
+    assert redirected_to(conn) == ~p"/teiserver/account/security/edit_password"
+  end
+end

--- a/test/teiserver_web/live/account/relationship/index_live_test.exs
+++ b/test/teiserver_web/live/account/relationship/index_live_test.exs
@@ -1,27 +1,27 @@
-defmodule TeiserverWeb.Microblog.Blog.PreferenceLiveTest do
+defmodule TeiserverWeb.Account.RelationshipLive.IndexLiveTest do
   use TeiserverWeb.ConnCase, async: true
 
   alias Central.Helpers.GeneralTestLib
 
-  test "microblog preferences requires authentication" do
+  test "account relationship endpoints requires authentication" do
     {:ok, kw} =
       GeneralTestLib.conn_setup([], [:no_login])
       |> Teiserver.TeiserverTestLib.conn_setup()
 
     {:ok, conn} = Keyword.fetch(kw, :conn)
 
-    conn = get(conn, ~p"/microblog/preferences")
+    conn = get(conn, ~p"/account/relationship")
     assert redirected_to(conn) == ~p"/login"
   end
 
-  test "authenticated user can access microblog preferences" do
+  test "can access account relationship when authenticated" do
     {:ok, kw} =
       GeneralTestLib.conn_setup()
       |> Teiserver.TeiserverTestLib.conn_setup()
 
     {:ok, conn} = Keyword.fetch(kw, :conn)
 
-    conn = get(conn, ~p"/microblog/preferences")
+    conn = get(conn, ~p"/account/relationship")
     html_response(conn, 200)
   end
 end

--- a/test/teiserver_web/live/account/settings/index_live_test.exs
+++ b/test/teiserver_web/live/account/settings/index_live_test.exs
@@ -1,27 +1,27 @@
-defmodule TeiserverWeb.Microblog.Blog.PreferenceLiveTest do
+defmodule TeiserverWeb.Account.SettingsLive.IndexLiveTest do
   use TeiserverWeb.ConnCase, async: true
 
   alias Central.Helpers.GeneralTestLib
 
-  test "microblog preferences requires authentication" do
+  test "account settings endpoints requires authentication" do
     {:ok, kw} =
       GeneralTestLib.conn_setup([], [:no_login])
       |> Teiserver.TeiserverTestLib.conn_setup()
 
     {:ok, conn} = Keyword.fetch(kw, :conn)
 
-    conn = get(conn, ~p"/microblog/preferences")
+    conn = get(conn, ~p"/account/settings")
     assert redirected_to(conn) == ~p"/login"
   end
 
-  test "authenticated user can access microblog preferences" do
+  test "can access account settings when authenticated" do
     {:ok, kw} =
       GeneralTestLib.conn_setup()
       |> Teiserver.TeiserverTestLib.conn_setup()
 
     {:ok, conn} = Keyword.fetch(kw, :conn)
 
-    conn = get(conn, ~p"/microblog/preferences")
+    conn = get(conn, ~p"/account/settings")
     html_response(conn, 200)
   end
 end

--- a/test/teiserver_web/live/admin/chat/index_live_test.exs
+++ b/test/teiserver_web/live/admin/chat/index_live_test.exs
@@ -1,0 +1,26 @@
+defmodule TeiserverWeb.Admin.ChatLive.IndexLiveTest do
+  use TeiserverWeb.ConnCase, async: true
+
+  alias Central.Helpers.GeneralTestLib
+
+  test "cannot access admin chat without authenticating" do
+    {:ok, kw} = GeneralTestLib.conn_setup([], [:no_login])
+    {:ok, conn} = Keyword.fetch(kw, :conn)
+    conn = get(conn, ~p"/admin/chat")
+    assert redirected_to(conn) == ~p"/login"
+  end
+
+  test "cannot access admin chat when unauthorized" do
+    {:ok, kw} = GeneralTestLib.conn_setup()
+    {:ok, conn} = Keyword.fetch(kw, :conn)
+    conn = get(conn, ~p"/admin/chat")
+    assert redirected_to(conn) == ~p"/"
+  end
+
+  test "can access admin chat when authorized" do
+    {:ok, kw} = GeneralTestLib.conn_setup(["Reviewer"])
+    {:ok, conn} = Keyword.fetch(kw, :conn)
+    conn = get(conn, ~p"/admin/chat")
+    html_response(conn, 200)
+  end
+end

--- a/test/teiserver_web/live/battles/match/chat_live_test.exs
+++ b/test/teiserver_web/live/battles/match/chat_live_test.exs
@@ -1,0 +1,39 @@
+defmodule TeiserverWeb.Battle.MatchLive.ChatLiveTest do
+  use TeiserverWeb.ConnCase
+  import Phoenix.LiveViewTest
+
+  alias Central.Helpers.GeneralTestLib
+
+  setup do
+    {:ok, kw} = GeneralTestLib.conn_setup(["Overwatch"], [:no_login])
+
+    {:ok, user} = Keyword.fetch(kw, :user)
+
+    battle =
+      Teiserver.TeiserverTestLib.make_battle(%{
+        name: "LiveBattle",
+        founder_id: user.id,
+        founder_name: user.name
+      })
+
+    {:ok, kw ++ [battle: battle]}
+  end
+
+  test "battle chat endpoints requires authentication", %{conn: conn, battle: battle} do
+    conn = get(conn, ~p"/battle/chat/#{battle.id}")
+    assert redirected_to(conn) == ~p"/login"
+  end
+
+  test "can access battle chat when authenticated", %{conn: conn, battle: battle, user: user} do
+    conn = GeneralTestLib.login(conn, user.email)
+    conn = get(conn, ~p"/battle/chat/#{battle.id}")
+    html_response(conn, 200)
+  end
+
+  test "unauthorized user cannot access battle chat", %{conn: conn, battle: battle} do
+    user = GeneralTestLib.make_user()
+    conn = GeneralTestLib.login(conn, user.email)
+    conn = get(conn, ~p"/battle/chat/#{battle.id}")
+    assert redirected_to(conn) == ~p"/"
+  end
+end

--- a/test/teiserver_web/live/battles/match/ratings_live_test.exs
+++ b/test/teiserver_web/live/battles/match/ratings_live_test.exs
@@ -1,27 +1,27 @@
-defmodule TeiserverWeb.Microblog.Blog.PreferenceLiveTest do
+defmodule TeiserverWeb.Battle.MatchLive.RatingsLiveTest do
   use TeiserverWeb.ConnCase, async: true
 
   alias Central.Helpers.GeneralTestLib
 
-  test "microblog preferences requires authentication" do
+  test "battle ratings endpoints requires authentication" do
     {:ok, kw} =
       GeneralTestLib.conn_setup([], [:no_login])
       |> Teiserver.TeiserverTestLib.conn_setup()
 
     {:ok, conn} = Keyword.fetch(kw, :conn)
 
-    conn = get(conn, ~p"/microblog/preferences")
+    conn = get(conn, ~p"/battle/ratings")
     assert redirected_to(conn) == ~p"/login"
   end
 
-  test "authenticated user can access microblog preferences" do
+  test "can access battle ratings when authenticated" do
     {:ok, kw} =
       GeneralTestLib.conn_setup()
       |> Teiserver.TeiserverTestLib.conn_setup()
 
     {:ok, conn} = Keyword.fetch(kw, :conn)
 
-    conn = get(conn, ~p"/microblog/preferences")
+    conn = get(conn, ~p"/battle/ratings")
     html_response(conn, 200)
   end
 end

--- a/test/teiserver_web/live/communication/chat/index_live_test.exs
+++ b/test/teiserver_web/live/communication/chat/index_live_test.exs
@@ -1,0 +1,19 @@
+defmodule TeiserverWeb.Communication.ChatLive.IndexLiveTest do
+  use TeiserverWeb.ConnCase, async: true
+
+  alias Central.Helpers.GeneralTestLib
+
+  test "cannot access chat without authenticating" do
+    {:ok, kw} = GeneralTestLib.conn_setup([], [:no_login])
+    {:ok, conn} = Keyword.fetch(kw, :conn)
+    conn = get(conn, ~p"/chat")
+    assert redirected_to(conn) == ~p"/login"
+  end
+
+  test "can access chat once authenticated" do
+    {:ok, kw} = GeneralTestLib.conn_setup()
+    {:ok, conn} = Keyword.fetch(kw, :conn)
+    conn = get(conn, ~p"/chat")
+    html_response(conn, 200)
+  end
+end

--- a/test/teiserver_web/live/general/home/index_live_test.exs
+++ b/test/teiserver_web/live/general/home/index_live_test.exs
@@ -4,21 +4,21 @@ defmodule TeiserverWeb.General.Home.IndexLiveTest do
 
   import Phoenix.LiveViewTest
 
-  @moduletag :needs_attention
-
   defp auth_setup(_) do
     Central.Helpers.GeneralTestLib.conn_setup()
     |> Teiserver.TeiserverTestLib.conn_setup()
   end
 
-  describe "Anon" do
-    test "index", %{conn: conn} do
+  describe "Visit index without authentication" do
+    test "index get", %{conn: conn} do
+      conn = get(conn, ~p"/")
+      assert redirected_to(conn) == ~p"/login"
+    end
+
+    test "index live", %{conn: conn} do
       {:error, {:redirect, resp}} = live(conn, ~p"/")
 
-      assert resp == %{
-               flash: %{"error" => "You must log in to access this page."},
-               to: ~p"/login"
-             }
+      assert resp.to == ~p"/login"
     end
   end
 

--- a/test/teiserver_web/live/microblog/admin/tag_live_test.exs
+++ b/test/teiserver_web/live/microblog/admin/tag_live_test.exs
@@ -29,33 +29,26 @@ defmodule TeiserverWeb.TagLiveTest do
   describe "Anon auth test" do
     setup [:create_tag]
 
-    test "anon", %{conn: conn, tag: tag} do
+    test "unauthenticated user cannot visit", %{conn: conn, tag: tag} do
       {:error, {:redirect, resp}} = live(conn, ~p"/microblog/admin/tags")
 
-      assert resp == %{
-               flash: %{"error" => "You must log in to access this page."},
-               to: ~p"/login"
-             }
+      assert resp.to == ~p"/login"
 
       {:error, {:redirect, resp}} = live(conn, ~p"/microblog/admin/tags/#{tag}")
 
-      assert resp == %{
-               flash: %{"error" => "You must log in to access this page."},
-               to: ~p"/login"
-             }
+      assert resp.to == ~p"/login"
     end
   end
 
   describe "Basic auth test" do
     setup [:unauth_setup, :create_tag]
 
-    @tag :needs_attention
     test "basic user", %{tag: tag, conn: conn} do
       {:error, {:redirect, resp}} = live(conn, ~p"/microblog/admin/tags")
-      assert resp == %{flash: %{"info" => "Welcome back!"}, to: ~p"/microblog"}
+      assert resp.to == ~p"/"
 
       {:error, {:redirect, resp}} = live(conn, ~p"/microblog/admin/tags/#{tag}")
-      assert resp == %{flash: %{"info" => "Welcome back!"}, to: ~p"/microblog"}
+      assert resp.to == ~p"/"
     end
   end
 

--- a/test/teiserver_web/live/microblog/blog/preference_live_test.exs
+++ b/test/teiserver_web/live/microblog/blog/preference_live_test.exs
@@ -1,125 +1,27 @@
 defmodule TeiserverWeb.Microblog.Blog.PreferenceLiveTest do
-  @moduledoc false
-  use TeiserverWeb.ConnCase
+  use TeiserverWeb.ConnCase, async: true
 
-  import Phoenix.LiveViewTest
-  import Teiserver.MicroblogFixtures
   alias Central.Helpers.GeneralTestLib
-  alias Teiserver.{Microblog, TeiserverTestLib}
 
-  defp auth_setup(_) do
-    GeneralTestLib.conn_setup()
-    |> TeiserverTestLib.conn_setup()
+  test "microblog preferences requires authentication" do
+    {:ok, kw} =
+      GeneralTestLib.conn_setup([], [:no_login])
+      |> Teiserver.TeiserverTestLib.conn_setup()
+
+    {:ok, conn} = Keyword.fetch(kw, :conn)
+
+    conn = get(conn, ~p"/microblog/preferences")
+    assert redirected_to(conn) == ~p"/login"
   end
 
-  describe "Preference" do
-    setup [:auth_setup]
+  test "authenticated user can access microblog preferences" do
+    {:ok, kw} =
+      GeneralTestLib.conn_setup([], [])
+      |> Teiserver.TeiserverTestLib.conn_setup()
 
-    test "no existing user_preference", %{conn: conn, user: user} do
-      tag1 = tag_fixture(name: "tag1")
-      tag2 = tag_fixture(name: "tag2")
-      tag3 = tag_fixture(name: "tag3")
+    {:ok, conn} = Keyword.fetch(kw, :conn)
 
-      assert Microblog.get_user_preference(user.id) == nil
-
-      {:ok, index_live, _html} = live(conn, ~p"/microblog/preferences")
-      assert Microblog.get_user_preference(user.id) == nil
-
-      # We default to blocking tags
-      html = index_live |> element("#unassigned-disable-#{tag1.id}") |> render_click()
-
-      assert html =~ "disabled-reset-#{tag1.id}"
-      refute html =~ "disabled-reset-#{tag2.id}"
-      refute html =~ "disabled-reset-#{tag3.id}"
-
-      user_preference = Microblog.get_user_preference(user.id)
-      assert user_preference != nil
-      assert user_preference.tag_mode == "Block"
-      assert user_preference.enabled_tags == []
-      assert user_preference.disabled_tags == [tag1.id]
-
-      # Change mode
-      html =
-        index_live |> element("#change-tag-mode-form") |> render_change(%{"tag-mode" => "Filter"})
-
-      refute html =~ "disabled-reset-#{tag1.id}"
-      refute html =~ "disabled-reset-#{tag2.id}"
-      refute html =~ "disabled-reset-#{tag3.id}"
-
-      assert html =~ "unassigned-enable-#{tag1.id}"
-      assert html =~ "unassigned-enable-#{tag2.id}"
-      assert html =~ "unassigned-enable-#{tag3.id}"
-
-      refute html =~ "unassigned-disable-#{tag1.id}"
-      refute html =~ "unassigned-disable-#{tag2.id}"
-      refute html =~ "unassigned-disable-#{tag3.id}"
-
-      user_preference = Microblog.get_user_preference(user.id)
-      assert user_preference.tag_mode == "Filter"
-      assert user_preference.enabled_tags == []
-      assert user_preference.disabled_tags == []
-
-      # Enable two tags
-      index_live |> element("#unassigned-enable-#{tag2.id}") |> render_click()
-
-      html = index_live |> element("#unassigned-enable-#{tag1.id}") |> render_click()
-
-      refute html =~ "disabled-reset-#{tag1.id}"
-      refute html =~ "disabled-reset-#{tag2.id}"
-      refute html =~ "disabled-reset-#{tag3.id}"
-
-      refute html =~ "unassigned-enable-#{tag1.id}"
-      refute html =~ "unassigned-enable-#{tag2.id}"
-      assert html =~ "unassigned-enable-#{tag3.id}"
-
-      assert html =~ "enabled-reset-#{tag1.id}"
-      assert html =~ "enabled-reset-#{tag2.id}"
-      refute html =~ "enabled-reset-#{tag3.id}"
-
-      user_preference = Microblog.get_user_preference(user.id)
-      assert user_preference.tag_mode == "Filter"
-      assert user_preference.enabled_tags == [tag1.id, tag2.id]
-      assert user_preference.disabled_tags == []
-    end
-
-    test "with existing user_preference", %{conn: conn, user: user} do
-      tag1 = tag_fixture(name: "tag1")
-      tag2 = tag_fixture(name: "tag2")
-      tag3 = tag_fixture(name: "tag3")
-
-      Microblog.create_user_preference(%{
-        user_id: user.id,
-        tag_mode: "Filter and block",
-        enabled_tags: [tag1.id],
-        disabled_tags: [tag2.id]
-      })
-
-      {:ok, index_live, html} = live(conn, ~p"/microblog/preferences")
-
-      assert html =~ "enabled-reset-#{tag1.id}"
-      assert html =~ "disabled-reset-#{tag2.id}"
-      refute html =~ "enabled-reset-#{tag3.id}"
-      refute html =~ "disabled-reset-#{tag3.id}"
-
-      # Enable tag3
-      html = index_live |> element("#unassigned-enable-#{tag3.id}") |> render_click()
-
-      refute html =~ "unassigned-enable-#{tag1.id}"
-      refute html =~ "unassigned-enable-#{tag2.id}"
-      refute html =~ "unassigned-enable-#{tag3.id}"
-
-      refute html =~ "unassigned-disable-#{tag1.id}"
-      refute html =~ "unassigned-disable-#{tag2.id}"
-      refute html =~ "unassigned-disable-#{tag3.id}"
-
-      assert html =~ "enabled-reset-#{tag1.id}"
-      assert html =~ "disabled-reset-#{tag2.id}"
-      assert html =~ "enabled-reset-#{tag3.id}"
-
-      user_preference = Microblog.get_user_preference(user.id)
-      assert user_preference.tag_mode == "Filter and block"
-      assert user_preference.enabled_tags == [tag3.id, tag1.id]
-      assert user_preference.disabled_tags == [tag2.id]
-    end
+    conn = get(conn, ~p"/microblog/preferences")
+    html_response(conn, 200)
   end
 end

--- a/test/teiserver_web/live/microblog/blog/preference_live_test.exs
+++ b/test/teiserver_web/live/microblog/blog/preference_live_test.exs
@@ -1,7 +1,16 @@
 defmodule TeiserverWeb.Microblog.Blog.PreferenceLiveTest do
-  use TeiserverWeb.ConnCase, async: true
+  @moduledoc false
+  use TeiserverWeb.ConnCase
 
+  import Phoenix.LiveViewTest
+  import Teiserver.MicroblogFixtures
   alias Central.Helpers.GeneralTestLib
+  alias Teiserver.{Microblog, TeiserverTestLib}
+
+  defp auth_setup(_) do
+    GeneralTestLib.conn_setup()
+    |> TeiserverTestLib.conn_setup()
+  end
 
   test "microblog preferences requires authentication" do
     {:ok, kw} =
@@ -14,14 +23,114 @@ defmodule TeiserverWeb.Microblog.Blog.PreferenceLiveTest do
     assert redirected_to(conn) == ~p"/login"
   end
 
-  test "authenticated user can access microblog preferences" do
-    {:ok, kw} =
-      GeneralTestLib.conn_setup()
-      |> Teiserver.TeiserverTestLib.conn_setup()
+  describe "Preference" do
+    setup [:auth_setup]
 
-    {:ok, conn} = Keyword.fetch(kw, :conn)
+    test "no existing user_preference", %{conn: conn, user: user} do
+      tag1 = tag_fixture(name: "tag1")
+      tag2 = tag_fixture(name: "tag2")
+      tag3 = tag_fixture(name: "tag3")
 
-    conn = get(conn, ~p"/microblog/preferences")
-    html_response(conn, 200)
+      assert Microblog.get_user_preference(user.id) == nil
+
+      {:ok, index_live, _html} = live(conn, ~p"/microblog/preferences")
+      assert Microblog.get_user_preference(user.id) == nil
+
+      # We default to blocking tags
+      html = index_live |> element("#unassigned-disable-#{tag1.id}") |> render_click()
+
+      assert html =~ "disabled-reset-#{tag1.id}"
+      refute html =~ "disabled-reset-#{tag2.id}"
+      refute html =~ "disabled-reset-#{tag3.id}"
+
+      user_preference = Microblog.get_user_preference(user.id)
+      assert user_preference != nil
+      assert user_preference.tag_mode == "Block"
+      assert user_preference.enabled_tags == []
+      assert user_preference.disabled_tags == [tag1.id]
+
+      # Change mode
+      html =
+        index_live |> element("#change-tag-mode-form") |> render_change(%{"tag-mode" => "Filter"})
+
+      refute html =~ "disabled-reset-#{tag1.id}"
+      refute html =~ "disabled-reset-#{tag2.id}"
+      refute html =~ "disabled-reset-#{tag3.id}"
+
+      assert html =~ "unassigned-enable-#{tag1.id}"
+      assert html =~ "unassigned-enable-#{tag2.id}"
+      assert html =~ "unassigned-enable-#{tag3.id}"
+
+      refute html =~ "unassigned-disable-#{tag1.id}"
+      refute html =~ "unassigned-disable-#{tag2.id}"
+      refute html =~ "unassigned-disable-#{tag3.id}"
+
+      user_preference = Microblog.get_user_preference(user.id)
+      assert user_preference.tag_mode == "Filter"
+      assert user_preference.enabled_tags == []
+      assert user_preference.disabled_tags == []
+
+      # Enable two tags
+      index_live |> element("#unassigned-enable-#{tag2.id}") |> render_click()
+
+      html = index_live |> element("#unassigned-enable-#{tag1.id}") |> render_click()
+
+      refute html =~ "disabled-reset-#{tag1.id}"
+      refute html =~ "disabled-reset-#{tag2.id}"
+      refute html =~ "disabled-reset-#{tag3.id}"
+
+      refute html =~ "unassigned-enable-#{tag1.id}"
+      refute html =~ "unassigned-enable-#{tag2.id}"
+      assert html =~ "unassigned-enable-#{tag3.id}"
+
+      assert html =~ "enabled-reset-#{tag1.id}"
+      assert html =~ "enabled-reset-#{tag2.id}"
+      refute html =~ "enabled-reset-#{tag3.id}"
+
+      user_preference = Microblog.get_user_preference(user.id)
+      assert user_preference.tag_mode == "Filter"
+      assert user_preference.enabled_tags == [tag1.id, tag2.id]
+      assert user_preference.disabled_tags == []
+    end
+
+    test "with existing user_preference", %{conn: conn, user: user} do
+      tag1 = tag_fixture(name: "tag1")
+      tag2 = tag_fixture(name: "tag2")
+      tag3 = tag_fixture(name: "tag3")
+
+      Microblog.create_user_preference(%{
+        user_id: user.id,
+        tag_mode: "Filter and block",
+        enabled_tags: [tag1.id],
+        disabled_tags: [tag2.id]
+      })
+
+      {:ok, index_live, html} = live(conn, ~p"/microblog/preferences")
+
+      assert html =~ "enabled-reset-#{tag1.id}"
+      assert html =~ "disabled-reset-#{tag2.id}"
+      refute html =~ "enabled-reset-#{tag3.id}"
+      refute html =~ "disabled-reset-#{tag3.id}"
+
+      # Enable tag3
+      html = index_live |> element("#unassigned-enable-#{tag3.id}") |> render_click()
+
+      refute html =~ "unassigned-enable-#{tag1.id}"
+      refute html =~ "unassigned-enable-#{tag2.id}"
+      refute html =~ "unassigned-enable-#{tag3.id}"
+
+      refute html =~ "unassigned-disable-#{tag1.id}"
+      refute html =~ "unassigned-disable-#{tag2.id}"
+      refute html =~ "unassigned-disable-#{tag3.id}"
+
+      assert html =~ "enabled-reset-#{tag1.id}"
+      assert html =~ "disabled-reset-#{tag2.id}"
+      assert html =~ "enabled-reset-#{tag3.id}"
+
+      user_preference = Microblog.get_user_preference(user.id)
+      assert user_preference.tag_mode == "Filter and block"
+      assert user_preference.enabled_tags == [tag3.id, tag1.id]
+      assert user_preference.disabled_tags == [tag2.id]
+    end
   end
 end

--- a/test/teiserver_web/live/moderation/overwatch/index_test.exs
+++ b/test/teiserver_web/live/moderation/overwatch/index_test.exs
@@ -11,6 +11,13 @@ defmodule TeiserverWeb.Moderation.Overwatch.IndexLiveTest do
     |> TeiserverTestLib.conn_setup()
   end
 
+  test "cannot access moderation overwatch without authenticating" do
+    {:ok, kw} = GeneralTestLib.conn_setup()
+    {:ok, conn} = Keyword.fetch(kw, :conn)
+    conn = get(conn, ~p"/moderation/overwatch")
+    assert redirected_to(conn) == ~p"/"
+  end
+
   describe "Index" do
     setup [:auth_setup]
 


### PR DESCRIPTION
As detailed in https://github.com/beyond-all-reason/teiserver/issues/175#issuecomment-2385399045, live endpoints that redirect to '/login' on mount cannot set the _redirected_to cookie. Therefore, when unlogged in users try to access a live endpoint, they will be redirected to '/login', and upon logging in be redirected to '/' instead of their original destination.

This change ensures that all live endpoints use the :protected pipeline, which can redirect users back to their original destination once they completed logging in.

Added a bunch of tests to verify that the live endpoints require authentication. Added a specific test to ensure that users are redirected back to the edit password page when they complete logging in (the original reported issue in #175).

Addresses #175