### PR TITLE
Add pattern detection for SPADS `!unboss` command output.

### DIFF
--- a/lib/teiserver/coordinator/spads_parser.ex
+++ b/lib/teiserver/coordinator/spads_parser.ex
@@ -43,6 +43,13 @@ defmodule Teiserver.Coordinator.SpadsParser do
       _match = Regex.run(~r/Boss mode disabled by \S+/, msg) ->
         {:host_update, %{host_bosses: []}}
 
+      # Remove an individual boss
+      match = Regex.run(~r/Boss mode disabled for (\S+) \(by \S+\)/, msg) ->
+        [_, player_name] = match
+        player_id = CacheUser.get_userid(player_name)
+
+        {:host_update, %{host_bosses: List.delete(state.host_bosses, player_id)}}
+
       # Not handling it, return nil
       true ->
         nil


### PR DESCRIPTION
Teiserver currently tracks who is the boss of a lobby by looking for known outputs from the `!boss` SPADS command.

However, an `!unboss` command was recently added to SPADS, and Teiserver currently does not recognize the output of that command. As a result, whenever the `!unboss` command is used, Teiserver's list of bosses becomes out of sync with SPADS's list.

This patch adds an additional pattern so that the output of `!unboss` is recognized and parsed.