### PR TITLE
Avoided users are no longer considered ignored

### DIFF
--- a/lib/teiserver/account/libs/relationship_lib.ex
+++ b/lib/teiserver/account/libs/relationship_lib.ex
@@ -263,8 +263,7 @@ defmodule Teiserver.Account.RelationshipLib do
 
   @spec does_a_ignore_b?(T.userid(), T.userid()) :: boolean
   def does_a_ignore_b?(u1, u2) do
-    Enum.member?(list_userids_ignored_by_userid(u1), u2) or
-      does_a_avoid_b?(u1, u2)
+    Enum.member?(list_userids_ignored_by_userid(u1), u2)
   end
 
   @spec does_a_avoid_b?(T.userid(), T.userid()) :: boolean

--- a/lib/teiserver_web/live/account/relationship/index.html.heex
+++ b/lib/teiserver_web/live/account/relationship/index.html.heex
@@ -196,7 +196,7 @@
       <Fontawesome.icon icon={Teiserver.Account.RelationshipLib.icon_avoid()} style="regular" />
     </h4>
     <div :if={@show_help} class="help-box">
-      In addition to the effects of ignoring; if you avoid someone, there's less chance the balance algorithm will place you on the same team. However, avoids will be broken if the algorithm cannot balance teams fairly. This feature is still under development.
+      If you avoid someone, there's less chance the balance algorithm will place you on the same team. However, avoids will be broken if the algorithm cannot balance teams fairly. This feature is still under development.
     </div>
     <.table id="avoids-table" table_class="table-sm" rows={@avoids}>
       <:col :let={avoid} label="Name"><%= avoid.to_user.name %></:col>


### PR DESCRIPTION
Current relationships:
- Ignore - you can't see messages from ignored users
- Avoid - if enough people avoid someone, they can't play in that lobby
- Block - if enough people block someone, they can't join that lobby
All avoided users are currently also considered ignored and all blocked users are also considered avoided.

This PR is a simple change allowing users to Avoid or Block someone without Ignoring them