### PR TITLE
testing stdev diff penalty

### DIFF
--- a/lib/teiserver/battle/balance/brute_force_avoid_types.ex
+++ b/lib/teiserver/battle/balance/brute_force_avoid_types.ex
@@ -19,6 +19,7 @@ defmodule Teiserver.Battle.Balance.BruteForceAvoidTypes do
           broken_avoid_penalty: number(),
           broken_party_penalty: number(),
           rating_diff_penalty: number(),
+          stdev_diff_penalty: number(),
           score: number(),
           first_team: [player()],
           second_team: [player()]

--- a/lib/teiserver/battle/balance/respect_avoids.ex
+++ b/lib/teiserver/battle/balance/respect_avoids.ex
@@ -297,6 +297,7 @@ defmodule Teiserver.Battle.Balance.RespectAvoids do
       "Team rating diff penalty: #{format(combo_result.rating_diff_penalty)}",
       "Broken party penalty: #{combo_result.broken_party_penalty}",
       "Broken avoid penalty: #{combo_result.broken_avoid_penalty}",
+      "Captain rating diff penalty: #{format(combo_result.captain_diff_penalty)}",
       "Score: #{format(combo_result.score)} (lower is better)",
       @splitter,
       "Draft remaining players (ordered from best to worst).",

--- a/lib/teiserver/battle/balance/respect_avoids.ex
+++ b/lib/teiserver/battle/balance/respect_avoids.ex
@@ -297,7 +297,7 @@ defmodule Teiserver.Battle.Balance.RespectAvoids do
       "Team rating diff penalty: #{format(combo_result.rating_diff_penalty)}",
       "Broken party penalty: #{combo_result.broken_party_penalty}",
       "Broken avoid penalty: #{combo_result.broken_avoid_penalty}",
-      "Captain rating diff penalty: #{format(combo_result.captain_diff_penalty)}",
+      "Stdev diff penalty: #{format(combo_result.stdev_diff_penalty)}",
       "Score: #{format(combo_result.score)} (lower is better)",
       @splitter,
       "Draft remaining players (ordered from best to worst).",

--- a/test/teiserver/battle/brute_force_avoid_internal_test.exs
+++ b/test/teiserver/battle/brute_force_avoid_internal_test.exs
@@ -1,0 +1,83 @@
+defmodule Teiserver.Battle.BruteForceAvoidInternalTest do
+  @moduledoc """
+  Can run all balance tests via
+  mix test --only balance_test
+  """
+  use ExUnit.Case
+  @moduletag :balance_test
+  alias Teiserver.Battle.Balance.BruteForceAvoid
+
+  test "can get second team" do
+    players = [
+      %{name: "kyutoryu", rating: 12.25, id: 1},
+      %{name: "fbots1998", rating: 13.98, id: 2},
+      %{name: "Dixinormus", rating: 18.28, id: 3},
+      %{name: "HungDaddy", rating: 2.8, id: 4},
+      %{name: "SLOPPYGAGGER", rating: 8.89, id: 5},
+      %{name: "jauggy", rating: 20.49, id: 6},
+      %{name: "reddragon2010", rating: 18.4, id: 7},
+      %{name: "Aposis", rating: 20.42, id: 8},
+      %{name: "MaTThiuS_82", rating: 8.26, id: 9},
+      %{name: "Noody", rating: 17.64, id: 10},
+      %{name: "[DTG]BamBin0", rating: 20.06, id: 11},
+      %{name: "barmalev", rating: 3.58, id: 12}
+    ]
+
+    first_team = [
+      %{name: "kyutoryu", rating: 12.25, id: 1},
+      %{name: "fbots1998", rating: 13.98, id: 2},
+      %{name: "Dixinormus", rating: 18.28, id: 3},
+      %{name: "HungDaddy", rating: 2.8, id: 4},
+      %{name: "SLOPPYGAGGER", rating: 8.89, id: 5},
+      %{name: "jauggy", rating: 20.49, id: 6}
+    ]
+
+    result = BruteForceAvoid.get_second_team(first_team, players)
+
+    assert result == [
+             %{id: 7, name: "reddragon2010", rating: 18.4},
+             %{id: 8, name: "Aposis", rating: 20.42},
+             %{id: 9, name: "MaTThiuS_82", rating: 8.26},
+             %{id: 10, name: "Noody", rating: 17.64},
+             %{id: 11, name: "[DTG]BamBin0", rating: 20.06},
+             %{id: 12, name: "barmalev", rating: 3.58}
+           ]
+  end
+
+  test "can get second team - side cases" do
+    players = []
+
+    first_team = []
+
+    result = BruteForceAvoid.get_second_team(first_team, players)
+
+    assert result == []
+
+    players = [%{id: 7, name: "reddragon2010", rating: 18.4}]
+
+    first_team = [%{id: 7, name: "reddragon2010", rating: 18.4}]
+
+    result = BruteForceAvoid.get_second_team(first_team, players)
+
+    assert result == []
+  end
+
+  test "can get captain rating" do
+    first_team = [
+      %{name: "kyutoryu", rating: 12.25, id: 1},
+      %{name: "fbots1998", rating: 13.98, id: 2},
+      %{name: "Dixinormus", rating: 18.28, id: 3},
+      %{name: "HungDaddy", rating: 2.8, id: 4},
+      %{name: "SLOPPYGAGGER", rating: 8.89, id: 5},
+      %{name: "jauggy", rating: 20.49, id: 6}
+    ]
+
+    result = BruteForceAvoid.get_captain_rating(first_team)
+
+    assert result == 20.49
+
+    result = BruteForceAvoid.get_captain_rating([])
+
+    assert result == 0
+  end
+end

--- a/test/teiserver/battle/respect_avoids_test.exs
+++ b/test/teiserver/battle/respect_avoids_test.exs
@@ -3,12 +3,19 @@ defmodule Teiserver.Battle.RespectAvoidsTest do
   Can run all balance tests via
   mix test --only balance_test
   """
-  use ExUnit.Case, async: false
+  use ExUnit.Case
   import Mock
 
   @moduletag :balance_test
   alias Teiserver.Battle.Balance.RespectAvoids
   alias Teiserver.Account.RelationshipLib
+  alias Teiserver.Config
+
+  setup_with_mocks([
+    {Config, [:passthrough], [get_site_config_cache: fn key -> 2 end]}
+  ]) do
+    :ok
+  end
 
   test "can process expanded_group" do
     # Setup mocks with no avoids (insteading of calling db)
@@ -123,7 +130,8 @@ defmodule Teiserver.Battle.RespectAvoidsTest do
                "Team rating diff penalty: 0.5",
                "Broken party penalty: 0",
                "Broken avoid penalty: 0",
-               "Score: 0.5 (lower is better)",
+               "Captain rating diff penalty: 0.1",
+               "Score: 0.6 (lower is better)",
                "------------------------------------------------------",
                "Draft remaining players (ordered from best to worst).",
                "Remaining: ",
@@ -259,6 +267,7 @@ defmodule Teiserver.Battle.RespectAvoidsTest do
                "Team rating diff penalty: 0.7",
                "Broken party penalty: 0",
                "Broken avoid penalty: 0",
+               "Captain rating diff penalty: 0.1",
                "Score: 0.7 (lower is better)",
                "------------------------------------------------------",
                "Draft remaining players (ordered from best to worst).",
@@ -270,6 +279,171 @@ defmodule Teiserver.Battle.RespectAvoidsTest do
              ]
 
       # Notice in result jauggy no longer on same team as reddragon2010 due to avoidance
+    end
+  end
+
+  test "gives each team the best captain" do
+    # Setup mocks with no avoids (insteading of calling db)
+    with_mock(RelationshipLib,
+      get_lobby_avoids: fn _player_ids, _limit, _player_limit, _minimum_time_hours -> [] end,
+      get_lobby_avoids: fn _player_ids, _limit, _player_limit -> [] end
+    ) do
+      expanded_group = [
+        %{
+          count: 2,
+          members: ["fraqzilla", "Spaceh"],
+          ratings: [4, 0],
+          names: ["fraqzilla", "Spaceh"],
+          uncertainties: [0, 1],
+          ranks: [1, 1]
+        },
+        %{
+          count: 1,
+          members: ["[DmE]"],
+          ratings: [34],
+          names: ["[DmE]"],
+          uncertainties: [2],
+          ranks: [0]
+        },
+        %{
+          count: 1,
+          members: ["Jeff"],
+          ratings: [31],
+          names: ["Jeff"],
+          uncertainties: [3],
+          ranks: [2]
+        },
+        %{
+          count: 1,
+          members: ["Jarial"],
+          ratings: [26],
+          names: ["Jarial"],
+          uncertainties: [0],
+          ranks: [2]
+        },
+        %{
+          count: 1,
+          members: ["Gmans"],
+          ratings: [21],
+          names: ["Gmans"],
+          uncertainties: [3],
+          ranks: [2]
+        },
+        %{
+          count: 1,
+          members: ["Threekey"],
+          ratings: [18],
+          names: ["Threekey"],
+          uncertainties: [3],
+          ranks: [2]
+        },
+        %{
+          count: 1,
+          members: ["Zippo9"],
+          ratings: [17],
+          names: ["Zippo9"],
+          uncertainties: [3],
+          ranks: [2]
+        },
+        %{
+          count: 1,
+          members: ["AcowAdonis"],
+          ratings: [25],
+          names: ["AcowAdonis"],
+          uncertainties: [3],
+          ranks: [2]
+        },
+        %{
+          count: 1,
+          members: ["AbyssWatcher"],
+          ratings: [23],
+          names: ["AbyssWatcher"],
+          uncertainties: [3],
+          ranks: [2]
+        },
+        %{
+          count: 1,
+          members: ["MeowCat"],
+          ratings: [21],
+          names: ["MeowCat"],
+          uncertainties: [3],
+          ranks: [2]
+        },
+        %{
+          count: 1,
+          members: ["mighty"],
+          ratings: [21],
+          names: ["mighty"],
+          uncertainties: [3],
+          ranks: [2]
+        },
+        %{
+          count: 1,
+          members: ["Kaa"],
+          ratings: [16],
+          names: ["Kaa"],
+          uncertainties: [3],
+          ranks: [2]
+        },
+        %{
+          count: 1,
+          members: ["Faeton"],
+          ratings: [11],
+          names: ["Faeton"],
+          uncertainties: [3],
+          ranks: [2]
+        },
+        %{
+          count: 1,
+          members: ["Saffir"],
+          ratings: [10],
+          names: ["Saffir"],
+          uncertainties: [3],
+          ranks: [2]
+        },
+        %{
+          count: 1,
+          members: ["Pantsu_Ripper"],
+          ratings: [10],
+          names: ["Pantsu_Ripper"],
+          uncertainties: [3],
+          ranks: [2]
+        }
+      ]
+
+      result = RespectAvoids.perform(expanded_group, 2)
+
+      assert result.logs == [
+               "------------------------------------------------------",
+               "Algorithm: respect_avoids",
+               "------------------------------------------------------",
+               "This algorithm will try and respect parties and avoids of players so long as it can keep team rating difference within certain bounds. Parties have higher importance than avoids.",
+               "Recent avoids will be ignored. New players will be spread evenly across teams and cannot be avoided.",
+               "------------------------------------------------------",
+               "Lobby details:",
+               "Parties: (fraqzilla, Spaceh)",
+               "Avoid min time required: 2 h",
+               "Avoids considered: 0 (Max: 6)",
+               "------------------------------------------------------",
+               "New players: None",
+               "------------------------------------------------------",
+               "Perform brute force with the following players to get the best score.",
+               "Players: fraqzilla, Spaceh, [DmE], Jeff, Jarial, AcowAdonis, AbyssWatcher, Gmans, MeowCat, mighty, Threekey, Zippo9, Kaa, Faeton",
+               "------------------------------------------------------",
+               "Brute force result:",
+               "Team rating diff penalty: 2",
+               "Broken party penalty: 0",
+               "Broken avoid penalty: 0",
+               "Captain rating diff penalty: 3",
+               "Score: 5 (lower is better)",
+               "------------------------------------------------------",
+               "Draft remaining players (ordered from best to worst).",
+               "Remaining: Saffir, Pantsu_Ripper",
+               "------------------------------------------------------",
+               "Final result:",
+               "Team 1: Gmans, AbyssWatcher, AcowAdonis, Jarial, [DmE], Spaceh, fraqzilla, Pantsu_Ripper",
+               "Team 2: Faeton, Kaa, Zippo9, Threekey, mighty, MeowCat, Jeff, Saffir"
+             ]
     end
   end
 end

--- a/test/teiserver/battle/respect_avoids_test.exs
+++ b/test/teiserver/battle/respect_avoids_test.exs
@@ -127,18 +127,18 @@ defmodule Teiserver.Battle.RespectAvoidsTest do
                "Players: Dixinormus, fbots1998, kyutoryu, HungDaddy, jauggy, Aposis, [DTG]BamBin0, reddragon2010, Noody, SLOPPYGAGGER, MaTThiuS_82, barmalev",
                "------------------------------------------------------",
                "Brute force result:",
-               "Team rating diff penalty: 0.5",
+               "Team rating diff penalty: 1.7",
                "Broken party penalty: 0",
                "Broken avoid penalty: 0",
-               "Captain rating diff penalty: 0.1",
-               "Score: 0.6 (lower is better)",
+               "Stdev diff penalty: 2.9",
+               "Score: 4.5 (lower is better)",
                "------------------------------------------------------",
                "Draft remaining players (ordered from best to worst).",
                "Remaining: ",
                "------------------------------------------------------",
                "Final result:",
-               "Team 1: barmalev, Noody, [DTG]BamBin0, Aposis, HungDaddy, Dixinormus",
-               "Team 2: MaTThiuS_82, SLOPPYGAGGER, reddragon2010, jauggy, kyutoryu, fbots1998"
+               "Team 1: Noody, reddragon2010, HungDaddy, kyutoryu, fbots1998, Dixinormus",
+               "Team 2: barmalev, MaTThiuS_82, SLOPPYGAGGER, [DTG]BamBin0, Aposis, jauggy"
              ]
     end
   end
@@ -264,18 +264,18 @@ defmodule Teiserver.Battle.RespectAvoidsTest do
                "Players: fbots1998, kyutoryu, jauggy, reddragon2010, Aposis, [DTG]BamBin0, Dixinormus, Noody, SLOPPYGAGGER, MaTThiuS_82, barmalev, HungDaddy",
                "------------------------------------------------------",
                "Brute force result:",
-               "Team rating diff penalty: 0.7",
+               "Team rating diff penalty: 1.6",
                "Broken party penalty: 0",
                "Broken avoid penalty: 0",
-               "Captain rating diff penalty: 0.1",
-               "Score: 0.7 (lower is better)",
+               "Stdev diff penalty: 2.9",
+               "Score: 4.5 (lower is better)",
                "------------------------------------------------------",
                "Draft remaining players (ordered from best to worst).",
                "Remaining: ",
                "------------------------------------------------------",
                "Final result:",
-               "Team 1: MaTThiuS_82, SLOPPYGAGGER, Aposis, reddragon2010, kyutoryu, fbots1998",
-               "Team 2: HungDaddy, barmalev, Noody, Dixinormus, [DTG]BamBin0, jauggy"
+               "Team 1: HungDaddy, Noody, Dixinormus, reddragon2010, kyutoryu, fbots1998",
+               "Team 2: barmalev, MaTThiuS_82, SLOPPYGAGGER, [DTG]BamBin0, Aposis, jauggy"
              ]
 
       # Notice in result jauggy no longer on same team as reddragon2010 due to avoidance
@@ -434,8 +434,8 @@ defmodule Teiserver.Battle.RespectAvoidsTest do
                "Team rating diff penalty: 2",
                "Broken party penalty: 0",
                "Broken avoid penalty: 0",
-               "Captain rating diff penalty: 3",
-               "Score: 5 (lower is better)",
+               "Stdev diff penalty: 11.4",
+               "Score: 13.4 (lower is better)",
                "------------------------------------------------------",
                "Draft remaining players (ordered from best to worst).",
                "Remaining: Saffir, Pantsu_Ripper",


### PR DESCRIPTION
This PR is just documentation for reference and will be deleted later.

In the image below the two best players are on the best team (Dme and Jeff)
![image](https://github.com/user-attachments/assets/8a48fc04-1218-4a39-8f9a-d6b92b530b55)

If we use st dev diff penalty with importance of 2, they get split up
```
     "Team 1: Gmans, AbyssWatcher, AcowAdonis, Jarial, [DmE], Spaceh, fraqzilla, Pantsu_Ripper",
     "Team 2: Faeton, Kaa, Zippo9, Threekey, mighty, MeowCat, Jeff, Saffir"
```

If we use st dev diff penalty with importance of 1, they stay together
```
              "Team 1: MeowCat, Gmans, AbyssWatcher, Jeff, [DmE], Spaceh, fraqzilla, Pantsu_Ripper",
              "Team 2: Faeton, Kaa, Zippo9, Threekey, mighty, AcowAdonis, Jarial, Saffir"
```

