### PR TITLE
Add captain diff penalty to respect avoids

### DIFF
--- a/lib/teiserver/battle/balance/brute_force_avoid.ex
+++ b/lib/teiserver/battle/balance/brute_force_avoid.ex
@@ -22,6 +22,7 @@ defmodule Teiserver.Battle.Balance.BruteForceAvoid do
   @max_team_diff_importance 10000
   @party_importance 1000
   @avoid_importance 10
+  @captain_diff_importance 1
 
   def get_best_combo(players, avoids, parties) do
     potential_teams = potential_teams(length(players))
@@ -34,27 +35,13 @@ defmodule Teiserver.Battle.Balance.BruteForceAvoid do
     players_with_index = Enum.with_index(players)
 
     # Go through every possibility and get the combination with the lowest score
-    result =
-      Enum.map(combos, fn x ->
-        team = get_players_from_indexes(x, players_with_index)
-        result = score_combo(team, players, avoids, parties)
-        Map.put(result, :first_team, team)
-      end)
-      |> Enum.min_by(fn z ->
-        z.score
-      end)
-
-    first_team = result.first_team
-
-    second_team =
-      players
-      |> Enum.filter(fn x ->
-        !Enum.any?(first_team, fn y ->
-          y.id == x.id
-        end)
-      end)
-
-    Map.put(result, :second_team, second_team)
+    Enum.map(combos, fn x ->
+      team = get_players_from_indexes(x, players_with_index)
+      score_combo(team, players, avoids, parties)
+    end)
+    |> Enum.min_by(fn z ->
+      z.score
+    end)
   end
 
   @spec potential_teams(integer()) :: any()
@@ -71,11 +58,34 @@ defmodule Teiserver.Battle.Balance.BruteForceAvoid do
     max(total_lobby_rating / num_teams * percentage_of_team, @max_team_diff_abs)
   end
 
-  @spec score_combo([BF.player()], [BF.player()], [[number()]], [[number()]]) :: any()
+  @spec get_second_team([BF.player()], [BF.player()]) :: [BF.player()]
+  def get_second_team(first_team, all_players) do
+    all_players
+    |> Enum.filter(fn player -> !Enum.any?(first_team, fn x -> x.id == player.id end) end)
+  end
+
+  @spec get_captain_rating([BF.player()]) :: any()
+  def get_captain_rating(team) do
+    if(length(team) > 0) do
+      captain = Enum.max_by(team, fn player -> player.rating end, &>=/2)
+      captain.rating
+    else
+      0
+    end
+  end
+
+  @spec score_combo([BF.player()], [BF.player()], [[number()]], [[number()]]) :: BF.combo_result()
   def score_combo(first_team, all_players, avoids, parties) do
+    second_team = get_second_team(first_team, all_players)
     first_team_rating = get_team_rating(first_team)
+
     both_team_rating = get_team_rating(all_players)
     rating_diff_penalty = abs(both_team_rating - first_team_rating * 2)
+
+    captain_diff_penalty =
+      abs(get_captain_rating(first_team) - get_captain_rating(second_team)) *
+        @captain_diff_importance
+
     num_teams = 2
 
     max_team_diff_penalty =
@@ -100,13 +110,17 @@ defmodule Teiserver.Battle.Balance.BruteForceAvoid do
       end
 
     score =
-      rating_diff_penalty + broken_avoid_penalty + broken_party_penalty + max_team_diff_penalty
+      rating_diff_penalty + broken_avoid_penalty + broken_party_penalty + max_team_diff_penalty +
+        captain_diff_penalty
 
     %{
       score: score,
       rating_diff_penalty: rating_diff_penalty,
       broken_avoid_penalty: broken_avoid_penalty,
-      broken_party_penalty: broken_party_penalty
+      broken_party_penalty: broken_party_penalty,
+      captain_diff_penalty: captain_diff_penalty,
+      second_team: second_team,
+      first_team: first_team
     }
   end
 

--- a/lib/teiserver/battle/balance/brute_force_avoid_types.ex
+++ b/lib/teiserver/battle/balance/brute_force_avoid_types.ex
@@ -19,6 +19,7 @@ defmodule Teiserver.Battle.Balance.BruteForceAvoidTypes do
           broken_avoid_penalty: number(),
           broken_party_penalty: number(),
           rating_diff_penalty: number(),
+          captain_diff_penalty: number(),
           score: number(),
           first_team: [player()],
           second_team: [player()]

--- a/lib/teiserver/battle/balance/brute_force_types.ex
+++ b/lib/teiserver/battle/balance/brute_force_types.ex
@@ -18,6 +18,7 @@ defmodule Teiserver.Battle.Balance.BruteForceTypes do
   @type combo_result :: %{
           broken_party_penalty: number(),
           rating_diff_penalty: number(),
+          stdev_diff_penalty: number(),
           score: number(),
           first_team: [player()],
           second_team: [player()]

--- a/lib/teiserver/battle/balance/respect_avoids.ex
+++ b/lib/teiserver/battle/balance/respect_avoids.ex
@@ -297,6 +297,7 @@ defmodule Teiserver.Battle.Balance.RespectAvoids do
       "Team rating diff penalty: #{format(combo_result.rating_diff_penalty)}",
       "Broken party penalty: #{combo_result.broken_party_penalty}",
       "Broken avoid penalty: #{combo_result.broken_avoid_penalty}",
+      "Captain rating diff penalty: #{format(combo_result.captain_diff_penalty)}",
       "Score: #{format(combo_result.score)} (lower is better)",
       @splitter,
       "Draft remaining players (ordered from best to worst).",

--- a/lib/teiserver/battle/balance/split_noobs.ex
+++ b/lib/teiserver/battle/balance/split_noobs.ex
@@ -246,6 +246,7 @@ defmodule Teiserver.Battle.Balance.SplitNoobs do
       "Brute force result:",
       "Team rating diff penalty: #{format(combo_result.rating_diff_penalty)}",
       "Broken party penalty: #{combo_result.broken_party_penalty}",
+      "Stdev diff penalty: #{format(combo_result.stdev_diff_penalty)}",
       "Score: #{format(combo_result.score)} (lower is better)",
       @splitter,
       "Draft remaining players (ordered from best to worst).",

--- a/test/teiserver/battle/brute_force_avoid_internal_test.exs
+++ b/test/teiserver/battle/brute_force_avoid_internal_test.exs
@@ -1,0 +1,83 @@
+defmodule Teiserver.Battle.BruteForceAvoidInternalTest do
+  @moduledoc """
+  Can run all balance tests via
+  mix test --only balance_test
+  """
+  use ExUnit.Case
+  @moduletag :balance_test
+  alias Teiserver.Battle.Balance.BruteForceAvoid
+
+  test "can get second team" do
+    players = [
+      %{name: "kyutoryu", rating: 12.25, id: 1},
+      %{name: "fbots1998", rating: 13.98, id: 2},
+      %{name: "Dixinormus", rating: 18.28, id: 3},
+      %{name: "HungDaddy", rating: 2.8, id: 4},
+      %{name: "SLOPPYGAGGER", rating: 8.89, id: 5},
+      %{name: "jauggy", rating: 20.49, id: 6},
+      %{name: "reddragon2010", rating: 18.4, id: 7},
+      %{name: "Aposis", rating: 20.42, id: 8},
+      %{name: "MaTThiuS_82", rating: 8.26, id: 9},
+      %{name: "Noody", rating: 17.64, id: 10},
+      %{name: "[DTG]BamBin0", rating: 20.06, id: 11},
+      %{name: "barmalev", rating: 3.58, id: 12}
+    ]
+
+    first_team = [
+      %{name: "kyutoryu", rating: 12.25, id: 1},
+      %{name: "fbots1998", rating: 13.98, id: 2},
+      %{name: "Dixinormus", rating: 18.28, id: 3},
+      %{name: "HungDaddy", rating: 2.8, id: 4},
+      %{name: "SLOPPYGAGGER", rating: 8.89, id: 5},
+      %{name: "jauggy", rating: 20.49, id: 6}
+    ]
+
+    result = BruteForceAvoid.get_second_team(first_team, players)
+
+    assert result == [
+             %{id: 7, name: "reddragon2010", rating: 18.4},
+             %{id: 8, name: "Aposis", rating: 20.42},
+             %{id: 9, name: "MaTThiuS_82", rating: 8.26},
+             %{id: 10, name: "Noody", rating: 17.64},
+             %{id: 11, name: "[DTG]BamBin0", rating: 20.06},
+             %{id: 12, name: "barmalev", rating: 3.58}
+           ]
+  end
+
+  test "can get second team - side cases" do
+    players = []
+
+    first_team = []
+
+    result = BruteForceAvoid.get_second_team(first_team, players)
+
+    assert result == []
+
+    players = [%{id: 7, name: "reddragon2010", rating: 18.4}]
+
+    first_team = [%{id: 7, name: "reddragon2010", rating: 18.4}]
+
+    result = BruteForceAvoid.get_second_team(first_team, players)
+
+    assert result == []
+  end
+
+  test "can get captain rating" do
+    first_team = [
+      %{name: "kyutoryu", rating: 12.25, id: 1},
+      %{name: "fbots1998", rating: 13.98, id: 2},
+      %{name: "Dixinormus", rating: 18.28, id: 3},
+      %{name: "HungDaddy", rating: 2.8, id: 4},
+      %{name: "SLOPPYGAGGER", rating: 8.89, id: 5},
+      %{name: "jauggy", rating: 20.49, id: 6}
+    ]
+
+    result = BruteForceAvoid.get_captain_rating(first_team)
+
+    assert result == 20.49
+
+    result = BruteForceAvoid.get_captain_rating([])
+
+    assert result == 0
+  end
+end

--- a/test/teiserver/battle/brute_force_internal_test.exs
+++ b/test/teiserver/battle/brute_force_internal_test.exs
@@ -118,32 +118,50 @@ defmodule Teiserver.Battle.BruteForceInternalTest do
 
     assert result == %{
              broken_party_penalty: 0,
+             first_team: [
+               %{id: 1, name: "kyutoryu", rating: 12.25},
+               %{id: 2, name: "fbots1998", rating: 13.98},
+               %{id: 3, name: "Dixinormus", rating: 18.28},
+               %{id: 4, name: "HungDaddy", rating: 2.8},
+               %{id: 5, name: "SLOPPYGAGGER", rating: 8.89},
+               %{id: 6, name: "jauggy", rating: 20.49}
+             ],
              rating_diff_penalty: 11.670000000000044,
-             score: 11.670000000000044
+             score: 13.987048974705417,
+             second_team: [
+               %{id: 7, name: "reddragon2010", rating: 18.4},
+               %{id: 8, name: "Aposis", rating: 20.42},
+               %{id: 9, name: "MaTThiuS_82", rating: 8.26},
+               %{id: 10, name: "Noody", rating: 17.64},
+               %{id: 11, name: "[DTG]BamBin0", rating: 20.06},
+               %{id: 12, name: "barmalev", rating: 3.58}
+             ],
+             stdev_diff_penalty: 2.317048974705372
            }
 
     best_combo = BruteForce.get_best_combo(combos, input.players, input.parties)
 
     assert best_combo == %{
              broken_party_penalty: 0,
-             rating_diff_penalty: 0.5100000000000477,
-             score: 0.5100000000000477,
              first_team: [
                %{id: 1, name: "kyutoryu", rating: 12.25},
                %{id: 2, name: "fbots1998", rating: 13.98},
                %{id: 5, name: "SLOPPYGAGGER", rating: 8.89},
                %{id: 6, name: "jauggy", rating: 20.49},
-               %{id: 7, name: "reddragon2010", rating: 18.4},
-               %{id: 9, name: "MaTThiuS_82", rating: 8.26}
+               %{id: 8, name: "Aposis", rating: 20.42},
+               %{id: 12, name: "barmalev", rating: 3.58}
              ],
+             rating_diff_penalty: 5.830000000000041,
+             score: 7.322550984245979,
              second_team: [
                %{id: 3, name: "Dixinormus", rating: 18.28},
                %{id: 4, name: "HungDaddy", rating: 2.8},
-               %{id: 8, name: "Aposis", rating: 20.42},
+               %{id: 7, name: "reddragon2010", rating: 18.4},
+               %{id: 9, name: "MaTThiuS_82", rating: 8.26},
                %{id: 10, name: "Noody", rating: 17.64},
-               %{id: 11, name: "[DTG]BamBin0", rating: 20.06},
-               %{id: 12, name: "barmalev", rating: 3.58}
-             ]
+               %{id: 11, name: "[DTG]BamBin0", rating: 20.06}
+             ],
+             stdev_diff_penalty: 1.4925509842459377
            }
 
     result = BruteForce.standardise_result(best_combo, input.parties) |> Map.drop([:logs])
@@ -155,19 +173,19 @@ defmodule Teiserver.Battle.BruteForceInternalTest do
                  %{count: 1, group_rating: 13.98, members: [2], ratings: [13.98]},
                  %{count: 1, group_rating: 8.89, members: [5], ratings: [8.89]},
                  %{count: 1, group_rating: 20.49, members: [6], ratings: [20.49]},
-                 %{count: 1, group_rating: 18.4, members: [7], ratings: [18.4]},
-                 %{count: 1, group_rating: 8.26, members: [9], ratings: [8.26]}
+                 %{count: 1, group_rating: 20.42, members: ~c"\b", ratings: [20.42]},
+                 %{count: 1, group_rating: 3.58, members: ~c"\f", ratings: [3.58]}
                ],
                2 => [
                  %{count: 1, group_rating: 18.28, members: [3], ratings: [18.28]},
                  %{count: 1, group_rating: 2.8, members: [4], ratings: [2.8]},
-                 %{count: 1, group_rating: 20.42, members: [8], ratings: [20.42]},
-                 %{count: 1, group_rating: 17.64, members: [10], ratings: [17.64]},
-                 %{count: 1, group_rating: 20.06, members: [11], ratings: [20.06]},
-                 %{count: 1, group_rating: 3.58, members: [12], ratings: [3.58]}
+                 %{count: 1, group_rating: 18.4, members: ~c"\a", ratings: [18.4]},
+                 %{count: 1, group_rating: 8.26, members: ~c"\t", ratings: [8.26]},
+                 %{count: 1, members: ~c"\n", ratings: [17.64], group_rating: 17.64},
+                 %{count: 1, group_rating: 20.06, members: ~c"\v", ratings: [20.06]}
                ]
              },
-             team_players: %{1 => [1, 2, 5, 6, 7, 9], 2 => [3, 4, 8, 10, 11, 12]}
+             team_players: %{1 => [1, 2, 5, 6, 8, 12], 2 => [3, 4, 7, 9, 10, 11]}
            }
   end
 

--- a/test/teiserver/battle/brute_force_test.exs
+++ b/test/teiserver/battle/brute_force_test.exs
@@ -102,6 +102,7 @@ defmodule Teiserver.Battle.BruteForceTest do
 
     result = BruteForce.perform(expanded_group, 2) |> Map.drop([:logs])
 
+    # If we us a stdev penalty of less than 4, then all the 20+ players end up on the same team
     assert result == %{
              team_groups: %{
                1 => [
@@ -109,28 +110,28 @@ defmodule Teiserver.Battle.BruteForceTest do
                  %{count: 1, group_rating: 13.98, members: ["fbots1998"], ratings: [13.98]},
                  %{count: 1, group_rating: 8.89, members: ["SLOPPYGAGGER"], ratings: [8.89]},
                  %{count: 1, group_rating: 20.49, members: ["jauggy"], ratings: [20.49]},
-                 %{count: 1, group_rating: 18.4, members: ["reddragon2010"], ratings: [18.4]},
-                 %{count: 1, group_rating: 8.26, members: ["MaTThiuS_82"], ratings: [8.26]}
+                 %{count: 1, group_rating: 20.42, members: ["Aposis"], ratings: [20.42]},
+                 %{count: 1, group_rating: 3.58, members: ["barmalev"], ratings: [3.58]}
                ],
                2 => [
                  %{count: 1, group_rating: 18.28, members: ["Dixinormus"], ratings: [18.28]},
                  %{count: 1, group_rating: 2.8, members: ["HungDaddy"], ratings: [2.8]},
-                 %{count: 1, group_rating: 20.42, members: ["Aposis"], ratings: [20.42]},
-                 %{count: 1, group_rating: 17.64, members: ["Noody"], ratings: [17.64]},
-                 %{count: 1, group_rating: 20.06, members: ["[DTG]BamBin0"], ratings: [20.06]},
-                 %{count: 1, group_rating: 3.58, members: ["barmalev"], ratings: [3.58]}
+                 %{count: 1, group_rating: 18.4, members: ["reddragon2010"], ratings: [18.4]},
+                 %{count: 1, group_rating: 8.26, members: ["MaTThiuS_82"], ratings: [8.26]},
+                 %{count: 1, members: ["Noody"], ratings: [17.64], group_rating: 17.64},
+                 %{count: 1, group_rating: 20.06, members: ["[DTG]BamBin0"], ratings: [20.06]}
                ]
              },
              team_players: %{
-               1 => [
-                 "kyutoryu",
-                 "fbots1998",
-                 "SLOPPYGAGGER",
-                 "jauggy",
+               1 => ["kyutoryu", "fbots1998", "SLOPPYGAGGER", "jauggy", "Aposis", "barmalev"],
+               2 => [
+                 "Dixinormus",
+                 "HungDaddy",
                  "reddragon2010",
-                 "MaTThiuS_82"
-               ],
-               2 => ["Dixinormus", "HungDaddy", "Aposis", "Noody", "[DTG]BamBin0", "barmalev"]
+                 "MaTThiuS_82",
+                 "Noody",
+                 "[DTG]BamBin0"
+               ]
              }
            }
   end

--- a/test/teiserver/battle/respect_avoids_test.exs
+++ b/test/teiserver/battle/respect_avoids_test.exs
@@ -12,7 +12,8 @@ defmodule Teiserver.Battle.RespectAvoidsTest do
   alias Teiserver.Config
 
   setup_with_mocks([
-    {Config, [:passthrough], [get_site_config_cache: fn key -> 2 end]}
+    # Set avoid min hours to 2
+    {Config, [:passthrough], [get_site_config_cache: fn _key -> 2 end]}
   ]) do
     :ok
   end

--- a/test/teiserver/battle/respect_avoids_test.exs
+++ b/test/teiserver/battle/respect_avoids_test.exs
@@ -425,7 +425,7 @@ defmodule Teiserver.Battle.RespectAvoidsTest do
                "Avoid min time required: 2 h",
                "Avoids considered: 0 (Max: 6)",
                "------------------------------------------------------",
-               "New players: None",
+               "Solo new players: None",
                "------------------------------------------------------",
                "Perform brute force with the following players to get the best score.",
                "Players: fraqzilla, Spaceh, [DmE], Jeff, Jarial, AcowAdonis, AbyssWatcher, Gmans, MeowCat, mighty, Threekey, Zippo9, Kaa, Faeton",

--- a/test/teiserver/battle/respect_avoids_test.exs
+++ b/test/teiserver/battle/respect_avoids_test.exs
@@ -3,12 +3,19 @@ defmodule Teiserver.Battle.RespectAvoidsTest do
   Can run all balance tests via
   mix test --only balance_test
   """
-  use ExUnit.Case, async: false
+  use ExUnit.Case
   import Mock
 
   @moduletag :balance_test
   alias Teiserver.Battle.Balance.RespectAvoids
   alias Teiserver.Account.RelationshipLib
+  alias Teiserver.Config
+
+  setup_with_mocks([
+    {Config, [:passthrough], [get_site_config_cache: fn key -> 2 end]}
+  ]) do
+    :ok
+  end
 
   test "can process expanded_group" do
     # Setup mocks with no avoids (insteading of calling db)
@@ -123,7 +130,8 @@ defmodule Teiserver.Battle.RespectAvoidsTest do
                "Team rating diff penalty: 0.5",
                "Broken party penalty: 0",
                "Broken avoid penalty: 0",
-               "Score: 0.5 (lower is better)",
+               "Captain rating diff penalty: 0.1",
+               "Score: 0.6 (lower is better)",
                "------------------------------------------------------",
                "Draft remaining players (ordered from best to worst).",
                "Remaining: ",
@@ -259,6 +267,7 @@ defmodule Teiserver.Battle.RespectAvoidsTest do
                "Team rating diff penalty: 0.7",
                "Broken party penalty: 0",
                "Broken avoid penalty: 0",
+               "Captain rating diff penalty: 0.1",
                "Score: 0.7 (lower is better)",
                "------------------------------------------------------",
                "Draft remaining players (ordered from best to worst).",
@@ -270,6 +279,171 @@ defmodule Teiserver.Battle.RespectAvoidsTest do
              ]
 
       # Notice in result jauggy no longer on same team as reddragon2010 due to avoidance
+    end
+  end
+
+  test "gives each team the best captain" do
+    # Setup mocks with no avoids (insteading of calling db)
+    with_mock(RelationshipLib,
+      get_lobby_avoids: fn _player_ids, _limit, _player_limit, _minimum_time_hours -> [] end,
+      get_lobby_avoids: fn _player_ids, _limit, _player_limit -> [] end
+    ) do
+      expanded_group = [
+        %{
+          count: 2,
+          members: ["fraqzilla", "Spaceh"],
+          ratings: [4, 0],
+          names: ["fraqzilla", "Spaceh"],
+          uncertainties: [0, 1],
+          ranks: [1, 1]
+        },
+        %{
+          count: 1,
+          members: ["[DmE]"],
+          ratings: [34],
+          names: ["[DmE]"],
+          uncertainties: [2],
+          ranks: [0]
+        },
+        %{
+          count: 1,
+          members: ["Jeff"],
+          ratings: [31],
+          names: ["Jeff"],
+          uncertainties: [3],
+          ranks: [2]
+        },
+        %{
+          count: 1,
+          members: ["Jarial"],
+          ratings: [26],
+          names: ["Jarial"],
+          uncertainties: [0],
+          ranks: [2]
+        },
+        %{
+          count: 1,
+          members: ["Gmans"],
+          ratings: [21],
+          names: ["Gmans"],
+          uncertainties: [3],
+          ranks: [2]
+        },
+        %{
+          count: 1,
+          members: ["Threekey"],
+          ratings: [18],
+          names: ["Threekey"],
+          uncertainties: [3],
+          ranks: [2]
+        },
+        %{
+          count: 1,
+          members: ["Zippo9"],
+          ratings: [17],
+          names: ["Zippo9"],
+          uncertainties: [3],
+          ranks: [2]
+        },
+        %{
+          count: 1,
+          members: ["AcowAdonis"],
+          ratings: [25],
+          names: ["AcowAdonis"],
+          uncertainties: [3],
+          ranks: [2]
+        },
+        %{
+          count: 1,
+          members: ["AbyssWatcher"],
+          ratings: [23],
+          names: ["AbyssWatcher"],
+          uncertainties: [3],
+          ranks: [2]
+        },
+        %{
+          count: 1,
+          members: ["MeowCat"],
+          ratings: [21],
+          names: ["MeowCat"],
+          uncertainties: [3],
+          ranks: [2]
+        },
+        %{
+          count: 1,
+          members: ["mighty"],
+          ratings: [21],
+          names: ["mighty"],
+          uncertainties: [3],
+          ranks: [2]
+        },
+        %{
+          count: 1,
+          members: ["Kaa"],
+          ratings: [16],
+          names: ["Kaa"],
+          uncertainties: [3],
+          ranks: [2]
+        },
+        %{
+          count: 1,
+          members: ["Faeton"],
+          ratings: [11],
+          names: ["Faeton"],
+          uncertainties: [3],
+          ranks: [2]
+        },
+        %{
+          count: 1,
+          members: ["Saffir"],
+          ratings: [10],
+          names: ["Saffir"],
+          uncertainties: [3],
+          ranks: [2]
+        },
+        %{
+          count: 1,
+          members: ["Pantsu_Ripper"],
+          ratings: [10],
+          names: ["Pantsu_Ripper"],
+          uncertainties: [3],
+          ranks: [2]
+        }
+      ]
+
+      result = RespectAvoids.perform(expanded_group, 2)
+
+      assert result.logs == [
+               "------------------------------------------------------",
+               "Algorithm: respect_avoids",
+               "------------------------------------------------------",
+               "This algorithm will try and respect parties and avoids of players so long as it can keep team rating difference within certain bounds. Parties have higher importance than avoids.",
+               "Recent avoids will be ignored. New players will be spread evenly across teams and cannot be avoided.",
+               "------------------------------------------------------",
+               "Lobby details:",
+               "Parties: (fraqzilla, Spaceh)",
+               "Avoid min time required: 2 h",
+               "Avoids considered: 0 (Max: 6)",
+               "------------------------------------------------------",
+               "New players: None",
+               "------------------------------------------------------",
+               "Perform brute force with the following players to get the best score.",
+               "Players: fraqzilla, Spaceh, [DmE], Jeff, Jarial, AcowAdonis, AbyssWatcher, Gmans, MeowCat, mighty, Threekey, Zippo9, Kaa, Faeton",
+               "------------------------------------------------------",
+               "Brute force result:",
+               "Team rating diff penalty: 2",
+               "Broken party penalty: 0",
+               "Broken avoid penalty: 0",
+               "Captain rating diff penalty: 3",
+               "Score: 5 (lower is better)",
+               "------------------------------------------------------",
+               "Draft remaining players (ordered from best to worst).",
+               "Remaining: Saffir, Pantsu_Ripper",
+               "------------------------------------------------------",
+               "Final result:",
+               "Team 1: Gmans, AbyssWatcher, AcowAdonis, Jarial, [DmE], Spaceh, fraqzilla, Pantsu_Ripper",
+               "Team 2: Faeton, Kaa, Zippo9, Threekey, mighty, MeowCat, Jeff, Saffir"
+             ]
     end
   end
 end

--- a/test/teiserver/battle/split_noobs_internal_test.exs
+++ b/test/teiserver/battle/split_noobs_internal_test.exs
@@ -596,12 +596,12 @@ defmodule Teiserver.Battle.SplitNoobsInternalTest do
                },
                %{
                  id: "reddragon2010",
+                 in_party?: false,
                  index: 6,
                  name: "reddragon2010",
-                 uncertainty: 3,
-                 rating: 18.4,
                  rank: 2,
-                 in_party?: false
+                 rating: 18.4,
+                 uncertainty: 3
                },
                %{
                  id: "Noody",
@@ -614,7 +614,7 @@ defmodule Teiserver.Battle.SplitNoobsInternalTest do
                }
              ],
              rating_diff_penalty: 6.203564356435635,
-             score: 6.203564356435635,
+             score: 7.221262567387239,
              second_team: [
                %{
                  id: "Dixinormus",
@@ -653,12 +653,12 @@ defmodule Teiserver.Battle.SplitNoobsInternalTest do
                },
                %{
                  id: "MaTThiuS_82",
+                 in_party?: false,
                  index: 9,
                  name: "MaTThiuS_82",
-                 uncertainty: 3,
-                 rating: 8.26,
                  rank: 2,
-                 in_party?: false
+                 rating: 8.26,
+                 uncertainty: 3
                },
                %{
                  id: "barmalev",
@@ -669,7 +669,8 @@ defmodule Teiserver.Battle.SplitNoobsInternalTest do
                  rating: 3.58,
                  uncertainty: 3
                }
-             ]
+             ],
+             stdev_diff_penalty: 1.017698210951604
            }
 
     standard_result = SplitNoobs.standardise_result(result, initial_state)
@@ -692,7 +693,8 @@ defmodule Teiserver.Battle.SplitNoobsInternalTest do
                "Brute force result:",
                "Team rating diff penalty: 6.2",
                "Broken party penalty: 0",
-               "Score: 6.2 (lower is better)",
+               "Stdev diff penalty: 1.0",
+               "Score: 7.2 (lower is better)",
                "------------------------------------------------------",
                "Draft remaining players (ordered from best to worst).",
                "Remaining: Dixinormus, HungDaddy",
@@ -722,7 +724,7 @@ defmodule Teiserver.Battle.SplitNoobsInternalTest do
                    ratings: [2.768316831683173]
                  },
                  %{count: 1, group_rating: 20.06, members: ["[DTG]BamBin0"], ratings: [20.06]},
-                 %{count: 1, members: ["reddragon2010"], ratings: [18.4], group_rating: 18.4},
+                 %{count: 1, group_rating: 18.4, members: ["reddragon2010"], ratings: [18.4]},
                  %{count: 1, group_rating: 17.64, members: ["Noody"], ratings: [17.64]}
                ],
                2 => [
@@ -735,7 +737,7 @@ defmodule Teiserver.Battle.SplitNoobsInternalTest do
                  %{count: 1, group_rating: 20.49, members: ["jauggy"], ratings: [20.49]},
                  %{count: 1, group_rating: 20.42, members: ["Aposis"], ratings: [20.42]},
                  %{count: 1, group_rating: 8.89, members: ["SLOPPYGAGGER"], ratings: [8.89]},
-                 %{count: 1, members: ["MaTThiuS_82"], ratings: [8.26], group_rating: 8.26},
+                 %{count: 1, group_rating: 8.26, members: ["MaTThiuS_82"], ratings: [8.26]},
                  %{count: 1, group_rating: 3.58, members: ["barmalev"], ratings: [3.58]}
                ]
              },

--- a/test/teiserver/battle/split_noobs_test.exs
+++ b/test/teiserver/battle/split_noobs_test.exs
@@ -102,35 +102,36 @@ defmodule Teiserver.Battle.SplitNoobsTest do
 
     result = SplitNoobs.perform(expanded_group, 2) |> Map.drop([:logs])
 
+    # If we use stdev importance less than 4, all 20+ players end up on same team
     assert result == %{
              team_groups: %{
                1 => [
                  %{count: 1, group_rating: 13.98, members: ["fbots1998"], ratings: [13.98]},
                  %{count: 1, group_rating: 12.25, members: ["kyutoryu"], ratings: [12.25]},
                  %{count: 1, group_rating: 20.49, members: ["jauggy"], ratings: [20.49]},
-                 %{count: 1, group_rating: 18.4, members: ["reddragon2010"], ratings: [18.4]},
+                 %{count: 1, group_rating: 20.42, members: ["Aposis"], ratings: [20.42]},
                  %{count: 1, group_rating: 8.89, members: ["SLOPPYGAGGER"], ratings: [8.89]},
-                 %{count: 1, group_rating: 8.26, members: ["MaTThiuS_82"], ratings: [8.26]}
+                 %{count: 1, group_rating: 3.58, members: ["barmalev"], ratings: [3.58]}
                ],
                2 => [
-                 %{count: 1, group_rating: 20.42, members: ["Aposis"], ratings: [20.42]},
                  %{count: 1, group_rating: 20.06, members: ["[DTG]BamBin0"], ratings: [20.06]},
-                 %{count: 1, group_rating: 18.28, members: ["Dixinormus"], ratings: [18.28]},
-                 %{count: 1, group_rating: 17.64, members: ["Noody"], ratings: [17.64]},
-                 %{count: 1, group_rating: 3.58, members: ["barmalev"], ratings: [3.58]},
+                 %{count: 1, group_rating: 18.4, members: ["reddragon2010"], ratings: [18.4]},
+                 %{count: 1, members: ["Dixinormus"], ratings: [18.28], group_rating: 18.28},
+                 %{count: 1, members: ["Noody"], ratings: [17.64], group_rating: 17.64},
+                 %{count: 1, group_rating: 8.26, members: ["MaTThiuS_82"], ratings: [8.26]},
                  %{count: 1, group_rating: 2.8, members: ["HungDaddy"], ratings: [2.8]}
                ]
              },
              team_players: %{
-               1 => [
-                 "fbots1998",
-                 "kyutoryu",
-                 "jauggy",
+               1 => ["fbots1998", "kyutoryu", "jauggy", "Aposis", "SLOPPYGAGGER", "barmalev"],
+               2 => [
+                 "[DTG]BamBin0",
                  "reddragon2010",
-                 "SLOPPYGAGGER",
-                 "MaTThiuS_82"
-               ],
-               2 => ["Aposis", "[DTG]BamBin0", "Dixinormus", "Noody", "barmalev", "HungDaddy"]
+                 "Dixinormus",
+                 "Noody",
+                 "MaTThiuS_82",
+                 "HungDaddy"
+               ]
              }
            }
   end
@@ -413,14 +414,15 @@ defmodule Teiserver.Battle.SplitNoobsTest do
              "Brute force result:",
              "Team rating diff penalty: 1",
              "Broken party penalty: 0",
-             "Score: 1 (lower is better)",
+             "Stdev diff penalty: 0.2",
+             "Score: 1.2 (lower is better)",
              "------------------------------------------------------",
              "Draft remaining players (ordered from best to worst).",
              "Remaining: StinkBee, HoldButyLeg",
              "------------------------------------------------------",
              "Final result:",
-             "Team 1: CowOfWar, Akio, Regithros, Orii, DUFFY, LuBaee, TimeContainer, HoldButyLeg",
-             "Team 2: nubl, Darth, 976, onse, Theo45, PotatoesHead, colossus, StinkBee"
+             "Team 1: Akio, Darth, Regithros, 976, DUFFY, LuBaee, TimeContainer, HoldButyLeg",
+             "Team 2: CowOfWar, nubl, onse, Theo45, PotatoesHead, colossus, Orii, StinkBee"
            ]
 
     # Note DUFFY (Strongest captain) is on same team with noobiest noob HoldButyLeg
@@ -576,16 +578,17 @@ defmodule Teiserver.Battle.SplitNoobsTest do
              "Players: Raigeki, Engolianth, Demodred, FRODODOR, shoeofobama, Larch, Artifical_Banana, Cobaltstore, quest, SHAAARKBATE, illusiveman2024, UnreasonableIkko, ColorlesScum, Renkei",
              "------------------------------------------------------",
              "Brute force result:",
-             "Team rating diff penalty: 0.0",
+             "Team rating diff penalty: 1.5",
              "Broken party penalty: 0",
-             "Score: 0.0 (lower is better)",
+             "Stdev diff penalty: 27.4",
+             "Score: 28.9 (lower is better)",
              "------------------------------------------------------",
              "Draft remaining players (ordered from best to worst).",
              "Remaining: MrKicks, BIL",
              "------------------------------------------------------",
              "Final result:",
-             "Team 1: Renkei, ColorlesScum, UnreasonableIkko, SHAAARKBATE, shoeofobama, FRODODOR, Raigeki, BIL",
-             "Team 2: illusiveman2024, quest, Cobaltstore, Artifical_Banana, Larch, Demodred, Engolianth, MrKicks"
+             "Team 1: UnreasonableIkko, illusiveman2024, SHAAARKBATE, quest, Cobaltstore, Artifical_Banana, Raigeki, BIL",
+             "Team 2: Renkei, ColorlesScum, Larch, shoeofobama, FRODODOR, Demodred, Engolianth, MrKicks"
            ]
   end
 end


### PR DESCRIPTION
In the image below the two best players DmE and Jeff are on the same team. If we add a captain rating diff penalty then they will be split
![image](https://github.com/user-attachments/assets/ca08f296-b0da-4d14-a35a-e1ccca5cc5b6)

Here is the new result:
```
               "Team 1: Gmans, AbyssWatcher, AcowAdonis, Jarial, [DmE], Spaceh, fraqzilla, Pantsu_Ripper",
               "Team 2: Faeton, Kaa, Zippo9, Threekey, mighty, MeowCat, Jeff, Saffir"
```

Note that this is the exact same result if we use a stdev penalty with importance of 2:
```
     "Team 1: Gmans, AbyssWatcher, AcowAdonis, Jarial, [DmE], Spaceh, fraqzilla, Pantsu_Ripper",
     "Team 2: Faeton, Kaa, Zippo9, Threekey, mighty, MeowCat, Jeff, Saffir"
```
See this PR for using stdev diff penalty instead:
https://github.com/beyond-all-reason/teiserver/pull/508

We can still use stdev penalty in brute_force.ex (called by split_noobs) if we want.

## More details
The score will have a new component captain diff penalty which is simply the rating difference between both teams' captains. If both captains have similar rating, this score will be lower which is preferred.

## Fix for new players in parties
In addition, while doing this PR I noticed a bug in respect_avoids
Normally newish players are not part of the brute force since we want to draft and spread them evenly across teams after the brute force. However, if a newish player is in a party, we do want them to be part of the brute force calculation to try and get them together with their party. 