### PR TITLE
default generated fake_data users to be verified

### DIFF
--- a/lib/teiserver/mix_tasks/fake_data.ex
+++ b/lib/teiserver/mix_tasks/fake_data.ex
@@ -108,7 +108,8 @@ defmodule Mix.Tasks.Teiserver.Fakedata do
             data: %{
               lobby_client: "FakeData",
               bot: false,
-              password_hash: root_user.data.password_hash
+              password_hash: root_user.data.password_hash,
+              roles: ["Verified"]
             },
             inserted_at: Timex.shift(Timex.now(), days: -day, minutes: -minutes) |> time_convert,
             updated_at: Timex.shift(Timex.now(), days: -day, minutes: -minutes) |> time_convert


### PR DESCRIPTION
I believe this will resolve https://github.com/beyond-all-reason/teiserver/issues/500

Not quite sure how to verify this automatically, as I don't see any unit tests for fake data, but here are some manual tests:
- Running `mix test --exclude needs_attention` only returns 2 errors locally (same as master branch)
- Searching the `account_users` table shows what I expected in the data column:
   
![image](https://github.com/user-attachments/assets/35fdb40e-364c-42a2-92e5-3297a4bc0704)

- Running a Verified Report shows only 3 unverified out of 37... I think that's the expected outcome. (EDIT: nevermind, looks like that was looking at the roles column.)

![image](https://github.com/user-attachments/assets/f92f4232-3cac-4f57-b47d-39f69712db7d)

- Clicking into an arbitrary user shows their data section has a "roles" key with a list, that includes "Verified"
![image](https://github.com/user-attachments/assets/b302f7a3-88da-40e6-9bb4-4383714a91a2)
