### PR TITLE
Fix incorrect timezone on match list page

### DIFF
--- a/lib/teiserver_web/live/battles/match/index.html.heex
+++ b/lib/teiserver_web/live/battles/match/index.html.heex
@@ -77,7 +77,7 @@
             <%= if match.finished, do: duration_to_str_short(match.game_duration) %>
           </:col>
           <:col :let={match} label="Ended">
-            <%= date_to_str(match.finished, format: :hms_or_ymd) %>
+            <%= date_to_str(match.finished, format: :hms_or_ymd, tz: @tz) %>
           </:col>
 
           <:action :let={match}>

--- a/lib/teiserver_web/live/battles/match/ratings.html.heex
+++ b/lib/teiserver_web/live/battles/match/ratings.html.heex
@@ -123,7 +123,7 @@
               <%= round(log.value["skill_change"] - 3 * log.value["uncertainty_change"], 2) %>
             </td>
 
-            <td><%= date_to_str(log.inserted_at, format: :hms_or_dmy) %></td>
+            <td><%= date_to_str(log.inserted_at, format: :hms_or_dmy, tz: @tz) %></td>
 
             <%= if log.match do %>
               <td>


### PR DESCRIPTION
The timezone is incorrect on the list page
https://discord.com/channels/549281623154229250/1297333683619106938

This PR fixes it by applying code change that is similar on other pages which is working correctly.

The correct code has a tz parameter e.g. on `/lib/teiserver_web/live/battles/match/show.html.heex` we have:
```
       <div class="col">
          <strong>Started:</strong> <%= date_to_str(@match.started, format: :ymd_hms, tz: @tz) %>
        </div>

        <div class="col">
          <strong>Finished:</strong> <%= date_to_str(@match.finished, format: :ymd_hms, tz: @tz) %>
        </div>
```