### PR TITLE
Fix timezone on report page

### DIFF
--- a/lib/teiserver_web/live/moderation/report_user/index.ex
+++ b/lib/teiserver_web/live/moderation/report_user/index.ex
@@ -177,7 +177,9 @@ defmodule TeiserverWeb.Moderation.ReportUserLive.Index do
   end
 
   defp get_user_matches(%{assigns: %{user: user}} = socket) do
-    cutoff = Timex.now() |> Timex.shift(hours: -36)
+    # For testing, change the days to a large number to see more matches
+    cutoff = Timex.now() |> Timex.shift(days: -1, hours: -12)
+    tz = socket.assigns[:tz]
 
     matches =
       Battle.list_matches(
@@ -203,7 +205,7 @@ defmodule TeiserverWeb.Moderation.ReportUserLive.Index do
 
         time_ago =
           if match.finished do
-            TimexHelper.date_to_str(match.finished, format: :hms_or_ymd, until: true)
+            TimexHelper.date_to_str(match.finished, format: :hms_or_ymd, until: true, tz: tz)
           else
             "In progress now"
           end


### PR DESCRIPTION
This PR fixes the dates on report page. To test this go to a match, then players, then report a player. Then choose ingame actions > griefing. There should be a list of matches. If there isn't a list of matches you can adjust the code to show more days. The timezone should be localised with this PR and use the user's timezone.

![Screenshot 2024-10-24 at 1 34 01 pm](https://github.com/user-attachments/assets/f4fd9903-19be-4043-b4d6-caf57853e8d7)
