### PR TITLE
Make OAuth discovery work locally

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -183,5 +183,3 @@ if config_env() == :prod do
       bot_name: Teiserver.ConfigHelpers.get_env("TEI_DISCORD_BOT_NAME")
   end
 end
-
-config :teiserver, Teiserver.OAuth, issuer: "https://#{domain_name}"

--- a/lib/teiserver_web/views/api/o_auth/code_view.ex
+++ b/lib/teiserver_web/views/api/o_auth/code_view.ex
@@ -22,7 +22,7 @@ defmodule TeiserverWeb.OAuth.CodeView do
   end
 
   def metadata(_) do
-    base = Application.fetch_env!(:teiserver, Teiserver.OAuth)[:issuer]
+    base = TeiserverWeb.Endpoint.static_url()
 
     %{
       issuer: base,


### PR DESCRIPTION
Resolves #499 

### Problems

1. If the environment variable `TEI_DOMAIN_NAME` isn't set in local dev, then the `domain_name` local in runtime.exs used the default of `"beyondallreason.info"`.
2. Even if `TEI_DOMAIN_NAME` was set, the manual string interpolation `"https://#{domain_name}"` didn't give the correct urls if TLS/SSL wasn't enabled.
3. This causes the http://localhost:4000/.well-known/oauth-authorization-server url to return incorrect endpoints.

### Solution

* Use `TeiserverWeb.Endpoint.static_url()` [static_url/0 docs](https://hexdocs.pm/phoenix/Phoenix.Endpoint.html#c:static_url/0) to get the base url.
* Since the `domain_name` is set on the endpoint module with `url: [host: domain_name]`, the domain should work the exact same as before in test/prod.
* The uri scheme should also pull in correctly based on the `http:` vs `https:` config used.
  * If just `http:` is used for local dev:
    * http://localhost:4000/.well-known/oauth-authorization-server --> `{ issuer: "http://localhost:4000/" ...`
  * If `http:` and `https:` are used, the https url will take precedence.
    * https://localhost:4040/.well-known/oauth-authorization-server --> `{ issuer: "https://localhost:4040/" ...`
    * http://localhost:4000/.well-known/oauth-authorization-server --> `{ issuer: "https://localhost:4040/" ...`