### PR TITLE
set timezone on timezone-unaware test

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -96,7 +96,8 @@ defmodule Teiserver.MixProject do
       {:mock, "~> 0.3.0", only: :test},
 
       # Teiserver libs
-      {:openskill, git: "https://github.com/beyond-all-reason/openskill.ex.git", branch: "master"},
+      {:openskill,
+       git: "https://github.com/beyond-all-reason/openskill.ex.git", branch: "master"},
       {:cowboy, "~> 2.9"},
       {:statistics, "~> 0.6.2"},
       {:csv, "~> 2.4"},

--- a/test/teiserver/helpers/timex_helper_test.exs
+++ b/test/teiserver/helpers/timex_helper_test.exs
@@ -41,7 +41,7 @@ defmodule Teiserver.Helper.TimexHelperTest do
     end
 
     # Now test it runs with just a "now" argument
-    assert TimexHelper.date_to_str(@today) == "2013-12-04"
+    assert TimexHelper.date_to_str(@today, tz: "Europe/London") == "2013-12-04"
   end
 
   test "date_to_str until" do


### PR DESCRIPTION
This test was failing on my machine with the following (but did not fail in the GH Action build):

```
code:  assert TimexHelper.date_to_str(@today) == "2013-12-04"
     left:  "2013-12-03"
     right: "2013-12-04"
```

Some brief investigation showed that the time calculation was 6 hours prior; which lines up with my current timezone, America/Chicago, or UTC -6:00. 

```
code:  assert TimexHelper.date_to_str(@today, format: :ymd_hms) == "2013-12-04"
     left:  "2013-12-03 18:00:00"
     right: "2013-12-04"
```

Setting the timezone on the test to the same timezone specified when the initial time set up  fixed the test failure. I think it would fix the test failure for all developers west of the selected timezone of Europe/London.

(Alternative option: if there was a way to set the timezone for the container doing the testing, this would also become a host-timezone-independent test.)
