### PR TITLE
Allows players to view win rate on maps

### DIFF
--- a/lib/teiserver/battle/libs/match_history_lib.ex
+++ b/lib/teiserver/battle/libs/match_history_lib.ex
@@ -7,16 +7,13 @@ defmodule Teiserver.Battle.MatchHistoryLib do
   # Includes unrated games but not bot games
   def get_win_rate_stats(user_id, match_map, match_started_date) do
     query = """
-    select tbmm.win from teiserver_game_rating_logs tgrl
-    inner join teiserver_battle_match_memberships tbmm
-    on tbmm.match_id = tgrl.match_id
-    and tgrl.user_id  = $3
-    and tgrl.user_id  = tbmm.user_id
+    select tbmm.win from  teiserver_battle_match_memberships tbmm
     inner join teiserver_battle_matches tbm
     on tbm.id  = tbmm.match_id
     and tbm.map = $1
     and tbm.bots::jsonb = '{}'::jsonb
     and tbm.started  <= $2
+    and tbmm.user_id  = $3
     order by tbm.started desc
     limit 50
     """

--- a/lib/teiserver_web/live/battles/match/show.html.heex
+++ b/lib/teiserver_web/live/battles/match/show.html.heex
@@ -106,6 +106,11 @@
         <div class="col">
           <strong>Bot count:</strong> <%= Enum.count(@match.bots) %>
         </div>
+
+        <div class="col">
+          <strong>Map win rate:</strong> <%= (@win_rate) %>
+        </div>
+
       </div>
       <hr />
 

--- a/lib/teiserver_web/live/battles/match/show.html.heex
+++ b/lib/teiserver_web/live/battles/match/show.html.heex
@@ -107,9 +107,11 @@
           <strong>Bot count:</strong> <%= Enum.count(@match.bots) %>
         </div>
 
-        <div class="col">
-          <strong>Map win rate:</strong> <%= @win_rate %>
-        </div>
+        <%= if Enum.count(@match.bots) == 0 do %>
+          <div class="col">
+            <strong>Map win rate:</strong> <%= @win_rate %>
+          </div>
+        <% end %>
       </div>
       <hr />
 

--- a/lib/teiserver_web/live/battles/match/show.html.heex
+++ b/lib/teiserver_web/live/battles/match/show.html.heex
@@ -108,9 +108,8 @@
         </div>
 
         <div class="col">
-          <strong>Map win rate:</strong> <%= (@win_rate) %>
+          <strong>Map win rate:</strong> <%= @win_rate %>
         </div>
-
       </div>
       <hr />
 

--- a/mix.exs
+++ b/mix.exs
@@ -96,7 +96,8 @@ defmodule Teiserver.MixProject do
       {:mock, "~> 0.3.0", only: :test},
 
       # Teiserver libs
-      {:openskill, git: "https://github.com/beyond-all-reason/openskill.ex.git", branch: "master"},
+      {:openskill,
+       git: "https://github.com/beyond-all-reason/openskill.ex.git", branch: "master"},
       {:cowboy, "~> 2.9"},
       {:statistics, "~> 0.6.2"},
       {:csv, "~> 2.4"},


### PR DESCRIPTION
When selecting one of your past matches you can see your win rate on that map. To get the win rate it will fetch up to 50 matches that have been played with a start date <= the match start date. So you can see how your win rate improves over time. It will include unrated matches in your winrate, but not bot matches

![Screenshot 2024-11-15 at 1 26 37 pm](https://github.com/user-attachments/assets/89a54cf8-32ac-49c5-8e77-882f45472ef4)
