### PR TITLE
Validate messages in tests

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -161,6 +161,8 @@ config :teiserver, Oban,
 
 config :teiserver, :time_zone_database, Tzdata.TimeZoneDatabase
 
+config :xema, loader: Teiserver.Tachyon.SchemaLoader
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"

--- a/lib/teiserver/autohost/tachyon_handler.ex
+++ b/lib/teiserver/autohost/tachyon_handler.ex
@@ -39,19 +39,6 @@ defmodule Teiserver.Autohost.TachyonHandler do
     {:request, "autohost/start", start_script, [cb_state: sender], state}
   end
 
-  def handle_info({:timeout, msg_id}, state) do
-    Logger.warning("Timeout detected for autohost #{state.autohost.id}, terminating")
-
-    resp =
-      Schema.event("system/disconnected", %{
-        reason: :timeout,
-        details: "timeout for message #{msg_id}"
-      })
-      |> Jason.encode!()
-
-    {:stop, :normal, 1000, [{:text, resp}], state}
-  end
-
   def handle_info(_msg, state) do
     {:ok, state}
   end

--- a/lib/teiserver/matchmaking/pairing_room.ex
+++ b/lib/teiserver/matchmaking/pairing_room.ex
@@ -86,8 +86,6 @@ defmodule Teiserver.Matchmaking.PairingRoom do
         Enum.join(initial_state.awaiting, ",")
     )
 
-    :timer.send_after(timeout, :timeout)
-
     {:ok, initial_state, {:continue, {:notify_players, timeout}}}
   end
 
@@ -98,6 +96,8 @@ defmodule Teiserver.Matchmaking.PairingRoom do
     Enum.each(state.awaiting, fn player_id ->
       Teiserver.Player.matchmaking_notify_found(player_id, state.queue_id, self(), timeout)
     end)
+
+    :timer.send_after(timeout, :timeout)
 
     {:noreply, state}
   end

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -54,14 +54,8 @@ defmodule Teiserver.Player.TachyonHandler do
       "Session for player #{state.user.id} went down because #{inspect(reason)}, terminating connection"
     )
 
-    resp =
-      Schema.event("system/disconnected", %{
-        reason: :server_error,
-        details: "session process exited with reason #{inspect(reason)}"
-      })
-      |> Jason.encode!()
-
-    {:stop, :normal, 1000, [{:text, resp}], state}
+    {:stop, :normal,
+     {1008, "Server error: session process exited with reason #{inspect(reason)}"}, state}
   end
 
   def handle_info({:matchmaking_notify_found, queue_id, timeout_ms}, state) do

--- a/lib/teiserver/tachyon/schema.ex
+++ b/lib/teiserver/tachyon/schema.ex
@@ -50,7 +50,7 @@ defmodule Teiserver.Tachyon.Schema do
   end
 
   @spec parse_message(command_id(), message_type(), term()) ::
-          :ok | :missing_schema | {:error, map()}
+          :ok | {:missing_schema, command_id(), message_type()} | {:error, map()}
   def parse_message(command_id, type, json) do
     with {:ok, schema} <- get_schema(command_id, type),
          :ok <- JsonXema.validate(schema, json) do
@@ -72,7 +72,7 @@ defmodule Teiserver.Tachyon.Schema do
            {:ok, json} <- Jason.decode(content) do
         {:ok, JsonXema.new(json)}
       else
-        {:error, :enoent} -> :missing_schema
+        {:error, :enoent} -> {:missing_schema, command_id, type}
         {:error, err} -> {:error, err}
       end
     end

--- a/lib/teiserver/tachyon/schema.ex
+++ b/lib/teiserver/tachyon/schema.ex
@@ -58,7 +58,7 @@ defmodule Teiserver.Tachyon.Schema do
     end
   end
 
-  defp get_schema(command_id, type) do
+  def parse_schema(command_id, type) do
     # improvement: cache this operation
     # basic check to avoid attack where the client could construct an
     # arbitrary path
@@ -70,11 +70,17 @@ defmodule Teiserver.Tachyon.Schema do
 
       with {:ok, content} <- File.read(path),
            {:ok, json} <- Jason.decode(content) do
-        {:ok, JsonXema.new(json)}
+        {:ok, json}
       else
         {:error, :enoent} -> {:missing_schema, command_id, type}
         {:error, err} -> {:error, err}
       end
+    end
+  end
+
+  defp get_schema(command_id, type) do
+    with {:ok, json} <- parse_schema(command_id, type) do
+      {:ok, JsonXema.new(json)}
     end
   end
 

--- a/lib/teiserver/tachyon/schema.ex
+++ b/lib/teiserver/tachyon/schema.ex
@@ -59,7 +59,6 @@ defmodule Teiserver.Tachyon.Schema do
   end
 
   def parse_schema(command_id, type) do
-    # improvement: cache this operation
     # basic check to avoid attack where the client could construct an
     # arbitrary path
     if String.contains?(command_id, ".") do
@@ -79,9 +78,11 @@ defmodule Teiserver.Tachyon.Schema do
   end
 
   defp get_schema(command_id, type) do
-    with {:ok, json} <- parse_schema(command_id, type) do
-      {:ok, JsonXema.new(json)}
-    end
+    Teiserver.cache_get_or_store(@cache_name, {command_id, type}, fn ->
+      with {:ok, json} <- parse_schema(command_id, type) do
+        {:ok, JsonXema.new(json)}
+      end
+    end)
   end
 
   @doc """

--- a/lib/teiserver/tachyon/schema_loader.ex
+++ b/lib/teiserver/tachyon/schema_loader.ex
@@ -1,0 +1,30 @@
+defmodule Teiserver.Tachyon.SchemaLoader do
+  @moduledoc """
+  Loader for json_xema: https://hexdocs.pm/json_xema/loader.html
+  to resolve the references for tachyon json schemas
+  """
+
+  @behaviour Xema.Loader
+
+  @impl Xema.Loader
+  @doc """
+  Turns a url like https://schema.beyondallreason.dev/tachyon/definitions/allyTeam.json
+  into a Xema that can be used for validation
+  """
+  def fetch(%URI{} = uri) do
+    with def_id when not is_nil(def_id) <- String.split(uri.path, "/") |> List.last(),
+         name <- Path.basename(def_id, ".json"),
+         {:ok, json} <- Teiserver.Tachyon.Schema.parse_schema("definitions", name) do
+      # For some obscure reason, if the ref has an $id, it'll mess up the way
+      # it is resolved by json_xema and basically won't work.
+      # so drop it
+      {:ok, Map.drop(json, ["$id"])}
+    else
+      {:missing_schema, _cmd_id, _type} ->
+        {:error, {:ref_not_found, uri}}
+
+      err ->
+        {:error, {:invalid_type, inspect(err)}}
+    end
+  end
+end

--- a/lib/teiserver/tachyon/transport.ex
+++ b/lib/teiserver/tachyon/transport.ex
@@ -109,7 +109,7 @@ defmodule Teiserver.Tachyon.Transport do
       :ok ->
         do_handle_command(command_id, message_type, message_id, message, state)
 
-      :missing_schema ->
+      {:missing_schema, command_id, _type} ->
         resp =
           Schema.error_response(command_id, message_id, :command_unimplemented)
           |> Jason.encode!()

--- a/lib/teiserver/tachyon/transport.ex
+++ b/lib/teiserver/tachyon/transport.ex
@@ -66,13 +66,8 @@ defmodule Teiserver.Tachyon.Transport do
   def handle_info({:timeout, message_id}, state) do
     {_, pendings} = Map.pop(state.pending_responses, message_id)
 
-    timeout =
-      Schema.event("system/disconnected", %{
-        reason: :response_timeout,
-        details: "Response to request with message id #{message_id} not received in time."
-      })
-
-    {:stop, :timeout, 1000, [{:text, Jason.encode!(timeout)}],
+    {:stop, :timeout,
+     {1008, "Response to request with message id #{message_id} not received in time."},
      %{state | pending_responses: pendings}}
   end
 
@@ -134,13 +129,8 @@ defmodule Teiserver.Tachyon.Transport do
     case Map.get(state.pending_responses, message_id) do
       # We got a response but nothing registered, which is invalid
       nil ->
-        invalid_req =
-          Schema.event("system/disconnected", %{
-            reason: :protocol_violation,
-            details: "Received response to message id #{message_id} but no request pending."
-          })
-
-        {:stop, :normal, 1000, [{:text, Jason.encode!(invalid_req)}], state}
+        {:stop, :normal,
+         {1008, "Received response to message id #{message_id} but no request pending."}, state}
 
       {tref, cb_state} ->
         :erlang.cancel_timer(tref)

--- a/priv/tachyon/schema/autohost/start/request.json
+++ b/priv/tachyon/schema/autohost/start/request.json
@@ -1,0 +1,79 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/start/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "AutohostStartRequest",
+    "tachyon": {
+        "source": "server",
+        "target": "autohost",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "autohost/start" },
+        "data": {
+            "title": "AutohostStartRequestData",
+            "type": "object",
+            "properties": {
+                "battleId": { "type": "string", "format": "uuid" },
+                "engineVersion": {
+                    "type": "string",
+                    "pattern": "^[0-9a-zA-Z .+-]+$"
+                },
+                "gameName": { "type": "string" },
+                "mapName": { "type": "string" },
+                "gameArchiveHash": {
+                    "type": "string",
+                    "pattern": "^[a-fA-F0-9]{128}$"
+                },
+                "mapArchiveHash": {
+                    "type": "string",
+                    "pattern": "^[a-fA-F0-9]{128}$"
+                },
+                "startDelay": { "type": "integer" },
+                "startPosType": {
+                    "$ref": "../../definitions/startPosType.json"
+                },
+                "allyTeams": {
+                    "type": "array",
+                    "items": { "$ref": "../../definitions/allyTeam.json" },
+                    "minItems": 1
+                },
+                "spectators": {
+                    "type": "array",
+                    "items": { "$ref": "../../definitions/player.json" }
+                },
+                "mapOptions": {
+                    "type": "object",
+                    "patternProperties": { "^(.*)$": { "type": "string" } }
+                },
+                "gameOptions": {
+                    "type": "object",
+                    "patternProperties": { "^(.*)$": { "type": "string" } }
+                },
+                "restrictions": {
+                    "description": "Mapping from unitDefId to the maximum number of units of that type that can be built.",
+                    "type": "object",
+                    "patternProperties": {
+                        "^(.*)$": { "type": "integer", "minimum": 0 }
+                    }
+                },
+                "luamsgRegexp": {
+                    "description": "When set, battle will generate updates for luamsgs matching this regexp. No updates will be generated if this is not set.",
+                    "type": "string",
+                    "format": "regex"
+                }
+            },
+            "required": [
+                "battleId",
+                "engineVersion",
+                "gameName",
+                "mapName",
+                "startPosType",
+                "allyTeams"
+            ]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/battle/start/request.json
+++ b/priv/tachyon/schema/battle/start/request.json
@@ -1,0 +1,28 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/battle/start/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "BattleStartRequest",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "battle/start" },
+        "data": {
+            "title": "BattleStartRequestData",
+            "type": "object",
+            "properties": {
+                "username": { "type": "string" },
+                "password": { "type": "string" },
+                "ip": { "type": "string" },
+                "port": { "type": "number" }
+            },
+            "required": ["username", "password", "ip", "port"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/definitions/allyTeam.json
+++ b/priv/tachyon/schema/definitions/allyTeam.json
@@ -1,0 +1,22 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/definitions/allyTeam.json",
+    "title": "AllyTeam",
+    "type": "object",
+    "properties": {
+        "teams": {
+            "type": "array",
+            "items": { "$ref": "../definitions/team.json" },
+            "minItems": 1
+        },
+        "startBox": { "$ref": "../definitions/startBox.json" },
+        "allies": {
+            "description": "0-based indexes into of the other allyteams to ally with",
+            "type": "array",
+            "items": { "type": "integer" }
+        },
+        "customProperties": {
+            "$ref": "../definitions/customStartScriptProperties.json"
+        }
+    },
+    "required": ["teams"]
+}

--- a/priv/tachyon/schema/definitions/bot.json
+++ b/priv/tachyon/schema/definitions/bot.json
@@ -1,0 +1,27 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/definitions/bot.json",
+    "title": "Bot",
+    "type": "object",
+    "properties": {
+        "hostUserId": {
+            "description": "UserId of the player hosting this AI",
+            "type": "string",
+            "format": "uuid"
+        },
+        "name": { "type": "string" },
+        "aiShortName": {
+            "description": "Short name of the AI library",
+            "type": "string"
+        },
+        "aiVersion": { "type": "string" },
+        "aiOptions": {
+            "description": "AI-specific options",
+            "type": "object",
+            "patternProperties": { "^(.*)$": { "type": "string" } }
+        },
+        "customProperties": {
+            "$ref": "../definitions/customStartScriptProperties.json"
+        }
+    },
+    "required": ["hostUserId", "aiShortName"]
+}

--- a/priv/tachyon/schema/definitions/customStartScriptProperties.json
+++ b/priv/tachyon/schema/definitions/customStartScriptProperties.json
@@ -1,0 +1,7 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/definitions/customStartScriptProperties.json",
+    "title": "CustomStartScriptProperties",
+    "description": "Additional custom properties to set in engine StartScript for this object, must not collide with existing properties",
+    "type": "object",
+    "patternProperties": { "^[a-zA-Z0-9_-]$": { "type": "string" } }
+}

--- a/priv/tachyon/schema/definitions/player.json
+++ b/priv/tachyon/schema/definitions/player.json
@@ -1,0 +1,19 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/definitions/player.json",
+    "title": "Player",
+    "type": "object",
+    "properties": {
+        "userId": { "$ref": "../definitions/userId.json" },
+        "name": {
+            "description": "Name of the player, must be unique just like userId",
+            "type": "string"
+        },
+        "password": { "type": "string" },
+        "rank": { "type": "integer" },
+        "countryCode": { "type": "string" },
+        "customProperties": {
+            "$ref": "../definitions/customStartScriptProperties.json"
+        }
+    },
+    "required": ["userId", "name", "password"]
+}

--- a/priv/tachyon/schema/definitions/startBox.json
+++ b/priv/tachyon/schema/definitions/startBox.json
@@ -1,0 +1,12 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/definitions/startBox.json",
+    "title": "StartBox",
+    "type": "object",
+    "properties": {
+        "top": { "type": "number", "minimum": 0, "maximum": 1 },
+        "bottom": { "type": "number", "minimum": 0, "maximum": 1 },
+        "left": { "type": "number", "minimum": 0, "maximum": 1 },
+        "right": { "type": "number", "minimum": 0, "maximum": 1 }
+    },
+    "required": ["top", "bottom", "left", "right"]
+}

--- a/priv/tachyon/schema/definitions/startPosType.json
+++ b/priv/tachyon/schema/definitions/startPosType.json
@@ -1,0 +1,5 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/definitions/startPosType.json",
+    "title": "StartPosType",
+    "enum": ["fixed", "random", "ingame", "beforegame"]
+}

--- a/priv/tachyon/schema/definitions/team.json
+++ b/priv/tachyon/schema/definitions/team.json
@@ -1,0 +1,38 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/definitions/team.json",
+    "title": "Team",
+    "type": "object",
+    "properties": {
+        "players": {
+            "type": "array",
+            "items": { "$ref": "../definitions/player.json" }
+        },
+        "bots": {
+            "type": "array",
+            "items": { "$ref": "../definitions/bot.json" }
+        },
+        "advantage": { "type": "number", "minimum": -1 },
+        "incomeMultiplier": { "type": "number", "minimum": 0 },
+        "faction": { "type": "string" },
+        "color": {
+            "type": "object",
+            "properties": {
+                "r": { "type": "number", "minimum": 0, "maximum": 1 },
+                "g": { "type": "number", "minimum": 0, "maximum": 1 },
+                "b": { "type": "number", "minimum": 0, "maximum": 1 }
+            },
+            "required": ["r", "g", "b"]
+        },
+        "startPos": {
+            "type": "object",
+            "properties": {
+                "x": { "type": "integer" },
+                "y": { "type": "integer" }
+            },
+            "required": ["x", "y"]
+        },
+        "customProperties": {
+            "$ref": "../definitions/customStartScriptProperties.json"
+        }
+    }
+}

--- a/priv/tachyon/schema/definitions/userId.json
+++ b/priv/tachyon/schema/definitions/userId.json
@@ -1,0 +1,6 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/definitions/userId.json",
+    "title": "UserId",
+    "type": "string",
+    "examples": ["351"]
+}

--- a/priv/tachyon/schema/matchmaking/cancel/response.json
+++ b/priv/tachyon/schema/matchmaking/cancel/response.json
@@ -1,0 +1,44 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/cancel/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "MatchmakingCancelResponse",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "MatchmakingCancelOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "matchmaking/cancel" },
+                "status": { "const": "success" }
+            },
+            "required": ["type", "messageId", "commandId", "status"]
+        },
+        {
+            "title": "MatchmakingCancelFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "matchmaking/cancel" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "not_queued",
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}

--- a/priv/tachyon/schema/matchmaking/cancelled/event.json
+++ b/priv/tachyon/schema/matchmaking/cancelled/event.json
@@ -1,0 +1,32 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/cancelled/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "MatchmakingCancelledEvent",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "event" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "matchmaking/cancelled" },
+        "data": {
+            "title": "MatchmakingCancelledEventData",
+            "type": "object",
+            "properties": {
+                "reason": {
+                    "enum": [
+                        "intentional",
+                        "server_error",
+                        "party_user_left",
+                        "ready_timeout"
+                    ]
+                }
+            },
+            "required": ["reason"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/matchmaking/foundUpdate/event.json
+++ b/priv/tachyon/schema/matchmaking/foundUpdate/event.json
@@ -1,0 +1,23 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/foundUpdate/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "MatchmakingFoundUpdateEvent",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "event" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "matchmaking/foundUpdate" },
+        "data": {
+            "title": "MatchmakingFoundUpdateEventData",
+            "type": "object",
+            "properties": { "readyCount": { "type": "integer" } },
+            "required": ["readyCount"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/matchmaking/list/response.json
+++ b/priv/tachyon/schema/matchmaking/list/response.json
@@ -1,0 +1,90 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/list/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "MatchmakingListResponse",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "MatchmakingListOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "matchmaking/list" },
+                "status": { "const": "success" },
+                "data": {
+                    "title": "MatchmakingListOkResponseData",
+                    "type": "object",
+                    "properties": {
+                        "playlists": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "id": { "type": "string" },
+                                    "name": { "type": "string" },
+                                    "numOfTeams": { "type": "integer" },
+                                    "teamSize": { "type": "integer" },
+                                    "ranked": { "type": "boolean" }
+                                },
+                                "required": [
+                                    "id",
+                                    "name",
+                                    "numOfTeams",
+                                    "teamSize",
+                                    "ranked"
+                                ]
+                            }
+                        }
+                    },
+                    "required": ["playlists"],
+                    "examples": [
+                        {
+                            "playlists": [
+                                {
+                                    "id": "1v1",
+                                    "name": "Duel",
+                                    "numOfTeams": 2,
+                                    "teamSize": 1,
+                                    "ranked": true
+                                },
+                                {
+                                    "id": "1v1v1",
+                                    "name": "3 Way FFA",
+                                    "numOfTeams": 3,
+                                    "teamSize": 1,
+                                    "ranked": true
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": ["type", "messageId", "commandId", "status", "data"]
+        },
+        {
+            "title": "MatchmakingListFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "matchmaking/list" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}

--- a/priv/tachyon/schema/matchmaking/lost/event.json
+++ b/priv/tachyon/schema/matchmaking/lost/event.json
@@ -1,0 +1,17 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/lost/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "MatchmakingLostEvent",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "event" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "matchmaking/lost" }
+    },
+    "required": ["type", "messageId", "commandId"]
+}

--- a/priv/tachyon/schema/matchmaking/queue/response.json
+++ b/priv/tachyon/schema/matchmaking/queue/response.json
@@ -1,0 +1,46 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/queue/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "MatchmakingQueueResponse",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "MatchmakingQueueOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "matchmaking/queue" },
+                "status": { "const": "success" }
+            },
+            "required": ["type", "messageId", "commandId", "status"]
+        },
+        {
+            "title": "MatchmakingQueueFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "matchmaking/queue" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "invalid_queue_specified",
+                        "already_queued",
+                        "already_inbattle",
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}

--- a/priv/tachyon/schema/matchmaking/ready/response.json
+++ b/priv/tachyon/schema/matchmaking/ready/response.json
@@ -1,0 +1,44 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/ready/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "MatchmakingReadyResponse",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "MatchmakingReadyOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "matchmaking/ready" },
+                "status": { "const": "success" }
+            },
+            "required": ["type", "messageId", "commandId", "status"]
+        },
+        {
+            "title": "MatchmakingReadyFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "matchmaking/ready" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "no_match",
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}

--- a/test/teiserver_web/tachyon/session_test.exs
+++ b/test/teiserver_web/tachyon/session_test.exs
@@ -32,7 +32,6 @@ defmodule TeiserverWeb.Tachyon.SessionTest do
     assert_receive({:DOWN, _, :process, _, _})
 
     # make sure the existing client has been disconnected
-    assert %{"commandId" => "system/disconnected"} = Tachyon.recv_message!(client)
     assert {:error, :disconnected} == WSC.recv(client)
   end
 


### PR DESCRIPTION
Ensure that the tachyon messages sent by the server conform to the json schemas.
And some light refactoring in the first 3 commits.
The schemas added here (the vast majority of the scary +617) are taken from the [tachyon repo](https://github.com/beyond-all-reason/tachyon/tree/master/schema)