### PR TITLE
Fix prematch ratings on balance tab

### DIFF
--- a/lib/teiserver_web/live/battles/match/show.html.heex
+++ b/lib/teiserver_web/live/battles/match/show.html.heex
@@ -387,12 +387,12 @@
                 <td><%= m.team_id + 1 %></td>
                 <td>
                   <%= if rating != nil do %>
-                    <%= rating.value["rating_value"] |> round(2) %>
+                    <%= (rating.value["rating_value"] - rating.value["rating_value_change"]) |> round(2) %>
                   <% end %>
                 </td>
                 <td>
                   <%= if rating != nil do %>
-                    <%= rating.value["uncertainty"] |> round(2) %>
+                    <%= (rating.value["uncertainty"] - rating.value["uncertainty_change"])|> round(2) %>
                   <% end %>
                 </td>
               </tr>

--- a/lib/teiserver_web/live/battles/match/show.html.heex
+++ b/lib/teiserver_web/live/battles/match/show.html.heex
@@ -387,12 +387,14 @@
                 <td><%= m.team_id + 1 %></td>
                 <td>
                   <%= if rating != nil do %>
-                    <%= (rating.value["rating_value"] - rating.value["rating_value_change"]) |> round(2) %>
+                    <%= (rating.value["rating_value"] - rating.value["rating_value_change"])
+                    |> round(2) %>
                   <% end %>
                 </td>
                 <td>
                   <%= if rating != nil do %>
-                    <%= (rating.value["uncertainty"] - rating.value["uncertainty_change"])|> round(2) %>
+                    <%= (rating.value["uncertainty"] - rating.value["uncertainty_change"])
+                    |> round(2) %>
                   <% end %>
                 </td>
               </tr>


### PR DESCRIPTION
The game_rating_logs table in database stores the postmatch values.
Thefore when we use the balance tab to view past match data, we need to adjust the postmatch data so that it becomes prematch data.

## Testing
Find any past match. Look at the rating of a single player in that match. This is their prematch rating. Next select the balance tab and view the logs for loser_picks balance. The rating of the player should match the prematch rating.