### PR TITLE
Add num_matches column

### DIFF
--- a/lib/teiserver/account/schemas/rating.ex
+++ b/lib/teiserver/account/schemas/rating.ex
@@ -13,6 +13,7 @@ defmodule Teiserver.Account.Rating do
     field :leaderboard_rating, :float
 
     field :last_updated, :utc_datetime
+    field :num_matches, :integer
   end
 
   @doc false
@@ -20,8 +21,9 @@ defmodule Teiserver.Account.Rating do
     stats
     |> cast(
       attrs,
-      ~w(user_id rating_type_id rating_value skill uncertainty last_updated leaderboard_rating)a
+      ~w(user_id rating_type_id rating_value skill uncertainty last_updated leaderboard_rating num_matches)a
     )
+    # fields below are required; num_matches is not required
     |> validate_required(
       ~w(user_id rating_type_id rating_value skill uncertainty last_updated leaderboard_rating)a
     )

--- a/priv/repo/migrations/20241212224758_add_num_matches_column.exs
+++ b/priv/repo/migrations/20241212224758_add_num_matches_column.exs
@@ -1,0 +1,24 @@
+defmodule Teiserver.Repo.Migrations.AddNumMatchesColumn do
+  use Ecto.Migration
+
+  def change do
+    alter table("teiserver_account_ratings") do
+      add :num_matches, :integer
+    end
+
+    # Populate num_matches column
+    up_query = """
+    UPDATE teiserver_account_ratings  SET num_matches  = temp_table.count
+    FROM (SELECT user_id, rating_type_id , count(*) from teiserver_game_rating_logs tgrl
+    where match_id  is not null
+    group by user_id , rating_type_id  ) AS temp_table
+    WHERE teiserver_account_ratings.user_id = temp_table.user_id
+    and teiserver_account_ratings.rating_type_id  = temp_table.rating_type_id
+    """
+
+    # If we rollback we don't have to do anything
+    rollback_query = ""
+
+    execute(up_query, rollback_query)
+  end
+end

--- a/test/teiserver/game/libs/match_rating_lib_test.exs
+++ b/test/teiserver/game/libs/match_rating_lib_test.exs
@@ -1,0 +1,137 @@
+defmodule Teiserver.Game.MatchRatingLibTest do
+  @moduledoc false
+  use Teiserver.DataCase, async: true
+  alias Teiserver.Game.MatchRatingLib
+  alias Teiserver.Account.AccountTestLib
+  alias Teiserver.Battle.MatchLib
+  alias Teiserver.Account
+  alias Teiserver.Battle
+  alias Teiserver.Game
+
+  test "num_matches is updated after rating a match" do
+    # Create two user
+    user1 = AccountTestLib.user_fixture()
+    user2 = AccountTestLib.user_fixture()
+
+    match = create_fake_match(user1.id, user2.id)
+
+    # Check ratings of users before we rate the match
+    rating_type_id = Game.get_or_add_rating_type(match.game_type)
+
+    ratings =
+      Account.list_ratings(
+        search: [
+          rating_type_id: rating_type_id,
+          user_id_in: [user1.id, user2.id]
+        ]
+      )
+      |> Map.new(fn rating ->
+        {rating.user_id, rating}
+      end)
+
+    assert ratings[user1.id] == nil
+    assert ratings[user2.id] == nil
+
+    MatchRatingLib.rate_match(match.id)
+
+    # Check ratings of users after match
+    ratings = get_ratings([user1.id, user2.id], rating_type_id)
+
+    assert ratings[user1.id].skill == 27.637760127073694
+    assert ratings[user2.id].skill == 22.362239872926306
+
+    assert ratings[user1.id].num_matches == 1
+    assert ratings[user1.id].num_matches == 1
+
+    # Create another match
+    match = create_fake_match(user1.id, user2.id)
+    MatchRatingLib.rate_match(match.id)
+
+    # Check ratings of users after match
+    ratings = get_ratings([user1.id, user2.id], rating_type_id)
+
+    assert ratings[user1.id].skill == 29.662576313923775
+    assert ratings[user2.id].skill == 20.337423686076225
+
+    # Check num_matches has increased
+    assert ratings[user1.id].num_matches == 2
+    assert ratings[user1.id].num_matches == 2
+  end
+
+  defp get_ratings(userids, rating_type_id) do
+    Account.list_ratings(
+      search: [
+        rating_type_id: rating_type_id,
+        user_id_in: userids
+      ]
+    )
+    |> Map.new(fn rating ->
+      {rating.user_id, rating}
+    end)
+  end
+
+  defp create_fake_match(user1_id, user2_id) do
+    team_count = 2
+    team_size = 1
+    game_type = MatchLib.game_type(team_size, team_count)
+    server_uuid = UUID.uuid1()
+    end_time = Timex.now()
+
+    start_time = DateTime.add(end_time, 50, :minute)
+
+    # Create a match
+    {:ok, match} =
+      Battle.create_match(%{
+        server_uuid: server_uuid,
+        uuid: UUID.uuid1(),
+        map: "Koom valley",
+        data: %{},
+        tags: %{},
+        winning_team: 0,
+        team_count: team_count,
+        team_size: team_size,
+        passworded: false,
+        processed: true,
+        game_type: game_type,
+        # All rooms are hosted by the same user for now
+        founder_id: 1,
+        bots: %{},
+        queue_id: nil,
+        started: start_time,
+        finished: end_time
+      })
+
+    # Create match memberships
+    memberships1 = [
+      %{
+        team_id: 0,
+        win: match.winning_team == 0,
+        stats: %{},
+        party_id: nil,
+        user_id: user1_id,
+        match_id: match.id
+      }
+    ]
+
+    memberships2 = [
+      %{
+        team_id: 1,
+        win: match.winning_team == 1,
+        stats: %{},
+        party_id: nil,
+        user_id: user2_id,
+        match_id: match.id
+      }
+    ]
+
+    Ecto.Multi.new()
+    |> Ecto.Multi.insert_all(
+      :insert_all,
+      Battle.MatchMembership,
+      memberships1 ++ memberships2
+    )
+    |> Teiserver.Repo.transaction()
+
+    match
+  end
+end

--- a/test/teiserver/game/libs/match_rating_lib_test.exs
+++ b/test/teiserver/game/libs/match_rating_lib_test.exs
@@ -56,6 +56,13 @@ defmodule Teiserver.Game.MatchRatingLibTest do
     # Check num_matches has increased
     assert ratings[user1.id].num_matches == 2
     assert ratings[user1.id].num_matches == 2
+
+    # Rerate the same match
+    MatchRatingLib.re_rate_specific_matches([match.id])
+
+    # Check num_matches unchanged
+    assert ratings[user1.id].num_matches == 2
+    assert ratings[user1.id].num_matches == 2
   end
 
   defp get_ratings(userids, rating_type_id) do


### PR DESCRIPTION
# Feature
After running
```
mix ecto.migrate
```
This will add a new num_matches column to the database and also populate it with values. Whenever a match is rated, the num_matches numer will increase by one, with the exception that if it is a rating override, the num_matches will stay the same.

## Purpose
The num_matches column can be used in the **future** for many possible use cases:

### 1. We can change the rating to become 
```
min(1, num_matches/30) * skill
```
This idea has been approved by Marek: [Source](https://www.reddit.com/r/beyondallreason/comments/1h9fc0v/comment/m10eh2r/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button)

This means that new players start at 0 and converge towards their skill over time. We won't have tons of people stuck at 0 due to negative ratings since there's no more subtraction as with Teifion's formula of `skill-uncertainty`. Having new players start at 0 also means we can create noob lobbies that are max rating 10 instead of max 20. 

We can keep leaderboard rating the same.

### 2. The balancer can classify noobs using num_matches
Generally players prefer new players to be spread evenly across teams. The balancer does this by classifying noobs as someone who has uncertainty > 6.65 and chev level < 4. Using a num_matches to classify noobs is more intuitive and future proof.

Note these are future ideas and are not included in the PR.