### PR TITLE
lengthen tachyon test client timeout 

### DIFF
--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -125,7 +125,7 @@ defmodule Teiserver.Support.Tachyon do
   # TODO tachyon_mvp: create a version of this function that also check the
   # the response against the expected json schema
   def recv_message(client, opts \\ []) do
-    opts = Keyword.put_new(opts, :timeout, 40)
+    opts = Keyword.put_new(opts, :timeout, 300)
 
     case WSC.recv(client, opts) do
       {:ok, {:text, resp}} ->


### PR DESCRIPTION
to accommodate slower processors or variable compute availability. 

Per conversation with BlackMelon and jauggy on Discord.

This also addresses some timeout errors I was seeing on my (slow) machine when running `mix test test/teiserver_web/tachyon/matchmaking_test.exs`