### PR TITLE
Add contributor alias to blost post

### DIFF
--- a/lib/teiserver/microblog/schemas/post.ex
+++ b/lib/teiserver/microblog/schemas/post.ex
@@ -9,6 +9,7 @@ defmodule Teiserver.Microblog.Post do
     field :summary, :string
     field :contents, :string
     field :view_count, :integer, default: 0
+    field :poster_alias, :string
 
     belongs_to :discord_channel, Teiserver.Communication.DiscordChannel
     field :discord_post_id, :integer
@@ -39,7 +40,7 @@ defmodule Teiserver.Microblog.Post do
     struct
     |> cast(
       params,
-      ~w(poster_id title summary contents view_count discord_channel_id discord_post_id)a
+      ~w(poster_id title summary contents view_count discord_channel_id discord_post_id poster_alias)a
     )
     |> cast_assoc(:post_tags, tag_ids)
     |> validate_required(~w(poster_id title contents)a)

--- a/lib/teiserver_web/live/microblog/admin/post/post_form_component.ex
+++ b/lib/teiserver_web/live/microblog/admin/post/post_form_component.ex
@@ -30,6 +30,23 @@ defmodule TeiserverWeb.Microblog.PostFormComponent do
             <label for="post_title" class="control-label">Title:</label>
             <.input field={@form[:title]} type="text" autofocus="autofocus" phx-debounce="100" />
             <br />
+            <label for="poster_alias" class="control-label">Contributor Alias:</label>
+            <span class="font-italic">
+              <small>
+                <small>
+                  Edit this if your contributor name is different from your in-game name. Your user id will still be linked to this blog post in the database.
+                </small>
+              </small>
+            </span>
+            <.input
+              id="poster_alias"
+              field={@form[:poster_alias]}
+              type="text"
+              phx-debounce="100"
+              placeholder={@current_user.name}
+            />
+
+            <br />
 
             <label for="post_contents" class="control-label">Summary:</label>
             <em class="float-end">Plain text, 1-3 lines</em>
@@ -99,7 +116,7 @@ defmodule TeiserverWeb.Microblog.PostFormComponent do
                 <span class="monospace">$discord</span>
                 in a public room and the server will send you a one time code to send the bridge.
 
-                You can still post microblog messages to discord but it will not include your name/profile in them.
+                You can still post microblog messages to discord but it will not include your name/profile in them. It will use your contributor alias if provided.
               </div>
             <% end %>
           </div>
@@ -330,14 +347,19 @@ defmodule TeiserverWeb.Microblog.PostFormComponent do
   defp create_discord_text(post) do
     user = Account.get_user_by_id(post.poster_id)
 
+    host = Application.get_env(:teiserver, TeiserverWeb.Endpoint)[:url][:host]
+    create_discord_text(user, post, host)
+  end
+
+  def create_discord_text(user, post, host) do
     discord_tag =
       if user.discord_id do
         " - Posted by <@#{user.discord_id}>"
       else
-        " - Posted by #{user.name}"
+        username = post.poster_alias || user.name
+        " - Posted by #{username}"
       end
 
-    host = Application.get_env(:teiserver, TeiserverWeb.Endpoint)[:url][:host]
     url = "https://#{host}/microblog/show/#{post.id}"
 
     [

--- a/lib/teiserver_web/live/microblog/blog/index.html.heex
+++ b/lib/teiserver_web/live/microblog/blog/index.html.heex
@@ -54,7 +54,7 @@
               <%= post.title %> &nbsp;&nbsp;&nbsp;&nbsp;
               <span style={"color: #{post.poster.colour};"}>
                 <Fontawesome.icon icon={post.poster.icon} style="solid" />
-                <%= post.poster.name %>
+                <%= post.poster_alias || post.poster.name %>
               </span>
             </h5>
             Posted at <%= date_to_str(post.inserted_at, format: :ymd_hms) %>

--- a/priv/repo/migrations/20241229013049_add_microblog_poster_alias.exs
+++ b/priv/repo/migrations/20241229013049_add_microblog_poster_alias.exs
@@ -1,0 +1,9 @@
+defmodule Teiserver.Repo.Migrations.AddMicroblogPosterAlias do
+  use Ecto.Migration
+
+  def change do
+    alter table("microblog_posts") do
+      add :poster_alias, :string
+    end
+  end
+end

--- a/test/teiserver_web/live/microblog/post_form_component_test.exs
+++ b/test/teiserver_web/live/microblog/post_form_component_test.exs
@@ -1,0 +1,105 @@
+defmodule TeiserverWeb.Microblog.PostFormComponentTest do
+  @moduledoc false
+  use TeiserverWeb.ConnCase
+
+  alias TeiserverWeb.Microblog.PostFormComponent
+  alias Teiserver.Microblog
+
+  test "create_post works with or without poster_alias" do
+    post_params = %{
+      "contents" => "test",
+      "discord_channel_id" => "",
+      "poster_alias" => "",
+      "poster_id" => 4,
+      "summary" => "test",
+      "title" => "test"
+    }
+
+    {:ok, result} = Microblog.create_post(post_params)
+    assert result.poster_alias == nil
+
+    post_params = %{
+      "contents" => "test",
+      "discord_channel_id" => "",
+      "poster_alias" => "Jenny",
+      "poster_id" => 4,
+      "summary" => "test",
+      "title" => "test"
+    }
+
+    {:ok, result} = Microblog.create_post(post_params)
+    assert result.poster_alias == "Jenny"
+  end
+
+  test "Get discord text when discord id present" do
+    post_params = %{
+      "contents" => "test",
+      "discord_channel_id" => "",
+      "poster_alias" => "contributor alias",
+      "poster_id" => 4,
+      "summary" => "test",
+      "title" => "test"
+    }
+
+    {:ok, post} = Microblog.create_post(post_params)
+
+    user = %{
+      discord_id: "mydiscordname",
+      name: "ign"
+    }
+
+    host = "localhost"
+
+    result = PostFormComponent.create_discord_text(user, post, host)
+
+    assert String.contains?(result, "Posted by <@mydiscordname>")
+  end
+
+  test "Get discord text when discord id not present and alias is present" do
+    post_params = %{
+      "contents" => "test",
+      "discord_channel_id" => "",
+      "poster_alias" => "contributoralias",
+      "poster_id" => 4,
+      "summary" => "test",
+      "title" => "test"
+    }
+
+    {:ok, post} = Microblog.create_post(post_params)
+
+    user = %{
+      discord_id: nil,
+      name: "ign"
+    }
+
+    host = "localhost"
+
+    result = PostFormComponent.create_discord_text(user, post, host)
+
+    assert String.contains?(result, "Posted by contributoralias")
+  end
+
+  test "Get discord text when discord id not present and alias not present" do
+    post_params = %{
+      "contents" => "test",
+      "discord_channel_id" => "",
+      "poster_alias" => "",
+      "poster_id" => 4,
+      "summary" => "test",
+      "title" => "test"
+    }
+
+    {:ok, post} = Microblog.create_post(post_params)
+
+    user = %{
+      discord_id: nil,
+      name: "ingame_name"
+    }
+
+    host = "localhost"
+
+    result = PostFormComponent.create_discord_text(user, post, host)
+
+    assert String.contains?(result, "Posted by ingame_name")
+  end
+end


### PR DESCRIPTION
This feature is useful for people who have a contributor name that is different from their in-game name. Currently when you make a blogpost, it uses your ingame name. This feature allows you to set a contributor alias (display name) to show for your blog post. The userid is still saved in the database so if there is any abuse (like impersonation), an admin would know.

![Screenshot 2024-12-29 132602](https://github.com/user-attachments/assets/18a090f5-8278-49f9-9833-d83eb0959834)
![Screenshot 2024-12-29 174315](https://github.com/user-attachments/assets/be05c4fa-feec-4329-93cf-f0fc9a397791)


# Testing
Local testing
```
mix ecto.migrate
```
This will create a new column in the database.

Login to website and go to Blog > Blog Admin

Fill in the form. You will notice the Post button is disabled. That's because you must attach a tag. If there are no tags, go to the Tags tab and create one. Then you can press post.

Check the post appears. 

You can retest using a different author alias or even a blank contributor alias (will use your in-game name).

# Testing discord integration
Currently blog posts have a post in discord too. I don't know how to test this manually. However, I've added some unit tests.
