### PR TITLE
Add ability to view and give accolades via website

### DIFF
--- a/lib/teiserver/account/libs/accolade_lib.ex
+++ b/lib/teiserver/account/libs/accolade_lib.ex
@@ -417,4 +417,18 @@ defmodule Teiserver.Account.AccoladeLib do
     [[count]] = results.rows
     count
   end
+
+  def get_number_of_received_accolades(user_id, window_days) do
+    query = """
+    select count(*) from teiserver_account_accolades taa
+    where taa.inserted_at >= now() - interval '#{window_days} day'
+    and taa.recipient_id = $1
+    """
+
+    results =
+      Ecto.Adapters.SQL.query!(Repo, query, [user_id])
+
+    [[count]] = results.rows
+    count
+  end
 end

--- a/lib/teiserver/account/libs/accolade_lib.ex
+++ b/lib/teiserver/account/libs/accolade_lib.ex
@@ -403,4 +403,18 @@ defmodule Teiserver.Account.AccoladeLib do
         end
     end
   end
+
+  def get_number_of_gifted_accolades(user_id, window_days) do
+    query = """
+    select count(*) from teiserver_account_accolades taa
+    where taa.inserted_at >= now() - interval '#{window_days} day'
+    and taa.giver_id = $1
+    """
+
+    results =
+      Ecto.Adapters.SQL.query!(Repo, query, [user_id])
+
+    [[count]] = results.rows
+    count
+  end
 end

--- a/lib/teiserver/libs/teiserver_configs.ex
+++ b/lib/teiserver/libs/teiserver_configs.ex
@@ -76,6 +76,24 @@ defmodule Teiserver.TeiserverConfigs do
     })
 
     add_site_config_type(%{
+      key: "teiserver.Accolade gift limit",
+      section: "Accolades",
+      type: "integer",
+      permissions: ["Server"],
+      description: "The number of accolades you can gift within the allocated window.",
+      default: 10
+    })
+
+    add_site_config_type(%{
+      key: "teiserver.Accolade gift window",
+      section: "Accolades",
+      type: "integer",
+      permissions: ["Server"],
+      description: "The window in days when checking the accolade gift limit.",
+      default: 30
+    })
+
+    add_site_config_type(%{
       key: "teiserver.Require email verification",
       section: "Registrations",
       type: "boolean",

--- a/lib/teiserver_web/live/account/profile/accolades.ex
+++ b/lib/teiserver_web/live/account/profile/accolades.ex
@@ -2,6 +2,7 @@ defmodule TeiserverWeb.Account.ProfileLive.Accolades do
   @moduledoc false
   use TeiserverWeb, :live_view
   alias Teiserver.Account
+  import Central.Helpers.ComponentHelper
 
   @impl true
   def mount(%{"userid" => userid_str}, _session, socket) do
@@ -16,11 +17,25 @@ defmodule TeiserverWeb.Account.ProfileLive.Accolades do
           |> redirect(to: ~p"/")
 
         true ->
+          accolades =
+            Account.list_accolades(
+              search: [
+                filter: {"recipient", userid}
+              ],
+              preload: [
+                :giver,
+                :recipient,
+                :badge_type
+              ],
+              order_by: "Newest first"
+            )
+
           socket
           |> assign(:tab, nil)
           |> assign(:site_menu_active, "teiserver_account")
           |> assign(:view_colour, Teiserver.Account.UserLib.colours())
           |> assign(:user, user)
+          |> assign(:accolades, accolades)
           |> TeiserverWeb.Account.ProfileLive.Overview.get_relationships_and_permissions()
       end
 

--- a/lib/teiserver_web/live/account/profile/accolades.html.heex
+++ b/lib/teiserver_web/live/account/profile/accolades.html.heex
@@ -6,8 +6,40 @@
   profile_permissions={@profile_permissions}
 />
 
-<div class="row mt-2 mb-3">
-  <div class="col">
-    Stuff about how great a person they are goes here
+<%= if Enum.count(@accolades) == 0 do %>
+  You have no accolades.
+<% end %>
+<%= if Enum.count(@accolades) > 0 do %>
+  <div class="mt-2 mb-3  col-lg-6 ml-2">
+    <table class="table table-sm">
+      <thead>
+        <tr>
+          <th></th>
+
+          <th colspan="1">Accolade Type</th>
+          <th>Giver</th>
+          <th colspan="3">&nbsp;</th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= for accolade <- @accolades do %>
+          <tr>
+            <td style={"background-color: #{accolade.badge_type.colour}; color: #FFF;"} width="22">
+              <%= central_component("icon", icon: accolade.badge_type.icon) %>
+            </td>
+            <td style={"background-color: #{rgba_css accolade.badge_type.colour};"}>
+              <%= accolade.badge_type.name %>
+            </td>
+            <td><%= accolade.giver.name %></td>
+            <td><%= date_to_str(accolade.inserted_at, format: :hms_or_dmy, tz: @tz) %></td>
+            <td>
+              <a href={~p"/battle/#{accolade.match_id}/players"} class="btn btn-secondary btn-sm">
+                view match
+              </a>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
   </div>
-</div>
+<% end %>

--- a/lib/teiserver_web/live/account/profile/overview.ex
+++ b/lib/teiserver_web/live/account/profile/overview.ex
@@ -6,6 +6,7 @@ defmodule TeiserverWeb.Account.ProfileLive.Overview do
   alias Phoenix.PubSub
   alias Teiserver.Account
   alias Teiserver.Lobby
+  alias Teiserver.Account.AccoladeLib
 
   @impl true
   def mount(%{"userid" => userid_str}, _session, socket) do
@@ -34,6 +35,7 @@ defmodule TeiserverWeb.Account.ProfileLive.Overview do
           |> assign(:role_data, Account.RoleLib.role_data())
           |> assign(:client, Account.get_client_by_id(userid))
           |> get_relationships_and_permissions
+          |> check_recent_accolades
       end
 
     {:ok, socket}
@@ -357,5 +359,14 @@ defmodule TeiserverWeb.Account.ProfileLive.Overview do
     |> assign(:friendship, nil)
     |> assign(:friendship_request, nil)
     |> assign(:profile_permissions, [])
+  end
+
+  def check_recent_accolades(socket) do
+    user_id = socket.assigns.user.id
+    days = 1
+    count = AccoladeLib.get_number_of_received_accolades(user_id, days)
+    has_recent? = count > 0
+
+    socket |> assign(:has_recent_accolade?, has_recent?)
   end
 end

--- a/lib/teiserver_web/live/account/profile/overview.html.heex
+++ b/lib/teiserver_web/live/account/profile/overview.html.heex
@@ -219,6 +219,13 @@
         </div>
       <% end %>
     <% end %>
+
+    <div :if={@has_recent_accolade?} class="alert alert-success" role="alert">
+      You have received an accolade recently! &nbsp;&nbsp;
+      <a href={~p"/profile/#{@user.id}/accolades"} class="btn btn-success btn-sm float-right">
+        <i class="fa-solid fa-award"></i> &nbsp; Accolades
+      </a>
+    </div>
     <br /><br /> Once we have some privacy controls we will be adding:
     <ul>
       <li>Recent matches</li>

--- a/lib/teiserver_web/live/battles/match/give_accolade/index.ex
+++ b/lib/teiserver_web/live/battles/match/give_accolade/index.ex
@@ -1,0 +1,110 @@
+defmodule TeiserverWeb.Battle.GiveAccoladeLive.Index do
+  alias Teiserver.Account.AccoladeLib
+  use TeiserverWeb, :live_view
+  alias Teiserver.{Account}
+  alias Teiserver.Config
+  import Central.Helpers.ComponentHelper
+
+  @impl true
+  def mount(_params, _session, socket) do
+    badge_types =
+      Account.list_badge_types(order_by: "Name (A-Z)")
+
+    gift_limit = Config.get_site_config_cache("teiserver.Accolade gift limit")
+    gift_window = Config.get_site_config_cache("teiserver.Accolade gift window")
+
+    socket =
+      socket
+      |> assign(:view_colour, Teiserver.Account.UserLib.colours())
+      |> assign(:user, nil)
+      |> assign(:stage, :loading)
+      |> assign(:extra_text, "")
+      |> assign(:badge_types, badge_types)
+      |> assign(:gift_limit, gift_limit)
+      |> assign(:gift_window, gift_window)
+      |> add_breadcrumb(name: "Give Accolade", url: ~p"/")
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(%{"user_id" => user_id, "id" => match_id}, _url, socket) do
+    user = Account.get_user_by_id(user_id)
+    {match_id, _} = Integer.parse(match_id)
+
+    socket =
+      socket
+      |> assign(:id_str, user_id)
+      |> assign(:user, user)
+      |> assign(:stage, :form)
+      |> assign(:match_id, match_id)
+      |> allowed_to_use_form
+
+    {:noreply, socket}
+  end
+
+  defp allowed_to_use_form(%{assigns: %{current_user: current_user, user: target_user}} = socket) do
+    {allowed, failure_reason} =
+      cond do
+        current_user == nil ->
+          {false, "You must be logged in to give an accolade to someone"}
+
+        current_user.id == target_user.id ->
+          {false, "You cannot give accolades to yourself"}
+
+        true ->
+          {true, nil}
+      end
+
+    if allowed do
+      socket
+      |> assign_gift_history()
+    else
+      socket
+      |> assign(:failure_reason, failure_reason)
+      |> assign(:stage, :not_allowed)
+    end
+  end
+
+  defp assign_gift_history(socket) do
+    gift_window = socket.assigns.gift_window
+    user_id = socket.assigns.current_user.id
+    gift_count = AccoladeLib.get_number_of_gifted_accolades(user_id, gift_window)
+    gift_limit = socket.assigns.gift_limit
+
+    if gift_count >= gift_limit do
+      socket
+      |> assign(
+        :failure_reason,
+        "You can only gift #{gift_limit} accolades every #{gift_window} days."
+      )
+      |> assign(:stage, :not_allowed)
+    else
+      socket
+      |> assign(:gift_count, gift_count)
+    end
+  end
+
+  @impl true
+  def handle_event("give-accolade", args, socket) do
+    %{"id" => badge_id} = args
+
+    recipient_id = socket.assigns.user.id
+
+    current_user = socket.assigns.current_user
+
+    match_id = socket.assigns.match_id
+
+    Account.create_accolade(%{
+      recipient_id: recipient_id,
+      giver_id: current_user.id,
+      match_id: match_id,
+      inserted_at: Timex.now(),
+      badge_type_id: badge_id
+    })
+
+    socket = socket |> assign(:stage, :complete)
+
+    {:noreply, socket}
+  end
+end

--- a/lib/teiserver_web/live/battles/match/give_accolade/index.html.heex
+++ b/lib/teiserver_web/live/battles/match/give_accolade/index.html.heex
@@ -1,0 +1,77 @@
+<div class="row" style="padding-top: 5vh;">
+  <div class="col-sm-12 col-md-10 offset-md-1 col-lg-8 offset-lg-2 col-xl-6 offset-xl-3 col-xxl-4 offset-xxl-4">
+    <div class="card mb-3">
+      <div class="card-header">
+        <h3>
+          <img
+            src="/images/logo/logo_favicon.png"
+            height="42"
+            style="margin-right: 5px;"
+            class="d-inline align-top"
+          />
+          <span :if={@user}>
+            Give accolade to user: <%= @user.name %>
+          </span>
+        </h3>
+      </div>
+
+      <div :if={@stage == :loading} class="card-body">
+        Loading <Fontawesome.icon icon="sync" class="fa-spinner-third" />
+      </div>
+
+      <div :if={@stage == :not_allowed} class="card-body">
+        <div class="alert alert-warning">
+          <%= @failure_reason %>
+        </div>
+      </div>
+
+      <div :if={@stage == :complete} class="card-body">
+        You have succesfully gifted an accolade to <%= @user.name %>! <br /><br />
+        <a href={~p"/profile/#{@current_user.id}/accolades"} class="btn btn-sm btn-secondary">
+          <i class="fa-solid fa-award"></i> &nbsp;
+          View your accolades
+        </a>
+        <a href={~p"/profile/#{@user.id}/accolades"} class="btn btn-sm  btn-secondary">
+          <i class="fa-solid fa-award"></i> &nbsp;
+          View <%= @user.name %>'s accolades
+        </a>
+      </div>
+
+      <div :if={@stage == :form} class="card-footer">
+        You can give this player an accolade if you feel they deserve to be acknowledged for their positive behaviour in a match. You can only give <%= @gift_limit %> accolades every <%= @gift_window %> days.
+        (You have gifted <%= @gift_count %> accolades over the past <%= @gift_window %> days.)
+        <br /><br />
+
+        <table class="table table-sm">
+          <thead>
+            <tr>
+              <th colspan="1"></th>
+              <th colspan="1">Accolade Type</th>
+              <th colspan="2">&nbsp;</th>
+            </tr>
+          </thead>
+          <tbody>
+            <%= for badge_type <- @badge_types do %>
+              <tr>
+                <td style={"background-color: #{badge_type.colour}; color: #FFF;"} width="22">
+                  <%= central_component("icon", icon: badge_type.icon) %>
+                </td>
+                <td><%= badge_type.name %></td>
+
+                <td>
+                  <a
+                    phx-click="give-accolade"
+                    phx-value-id={badge_type.id}
+                    class="btn btn-secondary btn-sm"
+                  >
+                    Give
+                  </a>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/lib/teiserver_web/live/battles/match/show.html.heex
+++ b/lib/teiserver_web/live/battles/match/show.html.heex
@@ -122,17 +122,17 @@
       <table class="table table-sm">
         <thead>
           <tr>
-            <th colspan="6">&nbsp;</th>
+            <th colspan="5">&nbsp;</th>
             <th colspan="2" style="text-align: center; bbackground-color: #FEE;">Damage</th>
             <th colspan="2" style="text-align: center; bbackground-color: #EFE;">Units</th>
             <th colspan="2" style="text-align: center; bbackground-color: #EEF;">Metal</th>
             <th colspan="2" style="text-align: center; bbackground-color: #FFE;">Energy</th>
 
-            <th colspan="2">&nbsp;</th>
+            <th colspan="3">&nbsp;</th>
           </tr>
 
           <tr>
-            <th colspan="4">Name & Party</th>
+            <th colspan="3">Name & Party</th>
             <th>Team</th>
             <th>Play</th>
 
@@ -149,7 +149,7 @@
             <th>Used</th>
 
             <th colspan="1">Rating</th>
-            <th colspan="1">&nbsp;</th>
+            <th colspan="2">&nbsp;</th>
           </tr>
         </thead>
         <tbody>
@@ -167,9 +167,7 @@
                   <i class="fa-fw fa-solid fa-trophy"></i>
                 <% end %>
               </td>
-              <td style={"background-color: #{m.user.colour}; color: #FFF;"} width="22">
-                <Fontawesome.icon icon={m.user.icon} style="" />
-              </td>
+
               <td style={"background-color: #{rgba_css m.user.colour};"}>
                 <%= m.user.name %>
               </td>
@@ -224,6 +222,17 @@
                 >
                   <i class={"fa-fw #{Teiserver.Moderation.ReportLib.icon()}"}></i> &nbsp;
                   Report
+                </a>
+              </td>
+
+              <td>
+                <a
+                  :if={m.user_id != @current_user.id}
+                  href={~p"/battle/#{@match.id}/user/#{m.user_id}/give_accolade"}
+                  class="btn btn-sm btn-success"
+                >
+                  <i class="fa-solid fa-award"></i> &nbsp;
+                  Accolade
                 </a>
               </td>
             </tr>

--- a/lib/teiserver_web/router.ex
+++ b/lib/teiserver_web/router.ex
@@ -310,6 +310,7 @@ defmodule TeiserverWeb.Router do
       live "/:id/ratings", MatchLive.Show, :ratings
       live "/:id/balance", MatchLive.Show, :balance
       live "/:id/events", MatchLive.Show, :events
+      live "/:id/user/:user_id/give_accolade", GiveAccoladeLive.Index
     end
   end
 


### PR DESCRIPTION
## Feature
This allows players to gift accolades via the match page to any player. And view your own.
You can gift 10 accolades in a 30 day window. This is configurable by the admin.