### PR TITLE
Fix oauth discovery

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -102,6 +102,9 @@ if config_env() == :prod do
     issuer: Teiserver.ConfigHelpers.get_env("TEI_GUARDIAN_ISSUER", "teiserver"),
     secret_key: Teiserver.ConfigHelpers.get_env("TEI_GUARDIAN_SECRET_KEY")
 
+  config :teiserver, Teiserver.OAuth,
+    issuer: "https://#{domain_name}"
+
   if Teiserver.ConfigHelpers.get_env("TEI_ENABLE_EMAIL_INTEGRATION", true, :bool) do
     config :teiserver, Teiserver.Mailer,
       adapter: Bamboo.SMTPAdapter,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -102,8 +102,7 @@ if config_env() == :prod do
     issuer: Teiserver.ConfigHelpers.get_env("TEI_GUARDIAN_ISSUER", "teiserver"),
     secret_key: Teiserver.ConfigHelpers.get_env("TEI_GUARDIAN_SECRET_KEY")
 
-  config :teiserver, Teiserver.OAuth,
-    issuer: "https://#{domain_name}"
+  config :teiserver, Teiserver.OAuth, issuer: "https://#{domain_name}"
 
   if Teiserver.ConfigHelpers.get_env("TEI_ENABLE_EMAIL_INTEGRATION", true, :bool) do
     config :teiserver, Teiserver.Mailer,

--- a/lib/teiserver_web/views/api/o_auth/code_view.ex
+++ b/lib/teiserver_web/views/api/o_auth/code_view.ex
@@ -22,7 +22,9 @@ defmodule TeiserverWeb.OAuth.CodeView do
   end
 
   def metadata(_) do
-    base = Application.get_env(:teiserver, Teiserver.OAuth)[:issuer] || TeiserverWeb.Endpoint.static_url()
+    base =
+      Application.get_env(:teiserver, Teiserver.OAuth)[:issuer] ||
+        TeiserverWeb.Endpoint.static_url()
 
     %{
       issuer: base,

--- a/lib/teiserver_web/views/api/o_auth/code_view.ex
+++ b/lib/teiserver_web/views/api/o_auth/code_view.ex
@@ -22,7 +22,7 @@ defmodule TeiserverWeb.OAuth.CodeView do
   end
 
   def metadata(_) do
-    base = TeiserverWeb.Endpoint.static_url()
+    base = Application.get_env(:teiserver, Teiserver.OAuth)[:issuer] || TeiserverWeb.Endpoint.url()
 
     %{
       issuer: base,

--- a/lib/teiserver_web/views/api/o_auth/code_view.ex
+++ b/lib/teiserver_web/views/api/o_auth/code_view.ex
@@ -22,7 +22,7 @@ defmodule TeiserverWeb.OAuth.CodeView do
   end
 
   def metadata(_) do
-    base = Application.get_env(:teiserver, Teiserver.OAuth)[:issuer] || TeiserverWeb.Endpoint.url()
+    base = Application.get_env(:teiserver, Teiserver.OAuth)[:issuer] || TeiserverWeb.Endpoint.static_url()
 
     %{
       issuer: base,


### PR DESCRIPTION
The discovery endpoint includes port `8888` in the URLs.

https://server4.beyondallreason.info/.well-known/oauth-authorization-server

Current deployment response:
![image](https://github.com/user-attachments/assets/ad49e54f-2859-4552-93c9-08ff5947c243)

This issue was introduced by https://github.com/beyond-all-reason/teiserver/pull/523 (sorry), which fixed the urls for local development. However, the server port is `8888` internally when deployed, and the url helper methods aren't aware of the final deployed port.

This PR fixes the prod endpoint while keeping the localhost functionality.

![image](https://github.com/user-attachments/assets/911a208b-a32b-4801-ae8b-46a3e6904396)
