### PR TITLE
Add more logs to explain

### DIFF
--- a/lib/teiserver/battle/balance/split_noobs.ex
+++ b/lib/teiserver/battle/balance/split_noobs.ex
@@ -97,8 +97,7 @@ defmodule Teiserver.Battle.Balance.SplitNoobs do
         length(state.noobs) > 0 ->
           noobs_string =
             Enum.map(state.noobs, fn x ->
-              chev = Map.get(x, :rank, 0) + 1
-              "#{x.name} (chev: #{chev}, σ: #{format(x.uncertainty)})"
+              log_noob(x)
             end)
 
           [
@@ -241,7 +240,7 @@ defmodule Teiserver.Battle.Balance.SplitNoobs do
 
     logs = [
       "Perform brute force with the following players to get the best score.",
-      "Players: #{Enum.join(Enum.map(state.top_experienced, fn x -> x.name end), ", ")}",
+      "Players: #{Enum.join(Enum.map(state.top_experienced, fn x -> log_player(x) end), ", ")}",
       @splitter,
       "Brute force result:",
       "Team rating diff penalty: #{format(combo_result.rating_diff_penalty)}",
@@ -250,7 +249,7 @@ defmodule Teiserver.Battle.Balance.SplitNoobs do
       "Score: #{format(combo_result.score)} (lower is better)",
       @splitter,
       "Draft remaining players (ordered from best to worst).",
-      "Remaining: #{Enum.join(Enum.map(remaining, fn x -> x.name end), ", ")}"
+      "Remaining: #{Enum.join(Enum.map(remaining, fn x -> log_player(x) end), ", ")}"
     ]
 
     default_acc = combo_result
@@ -262,6 +261,16 @@ defmodule Teiserver.Battle.Balance.SplitNoobs do
       Map.put(acc, picking_team, [noob | acc[picking_team]])
     end)
     |> Map.put(:logs, logs)
+  end
+
+  def log_player(%{name: name, rating: rating}) do
+    "#{name} (#{format(rating)})"
+  end
+
+  def log_noob(%{name: name, rating: rating, uncertainty: uncertainty, rank: rank}) do
+    chev = rank || 0 + 1
+
+    "#{name} (#{format(rating)}, chev: #{chev}, σ: #{format(uncertainty)})"
   end
 
   def get_picking_team(first_team, second_team) do

--- a/test/teiserver/battle/split_noobs_internal_test.exs
+++ b/test/teiserver/battle/split_noobs_internal_test.exs
@@ -684,11 +684,11 @@ defmodule Teiserver.Battle.SplitNoobsInternalTest do
                "------------------------------------------------------",
                "Parties: (kyutoryu, fbots1998)",
                "Solo noobs:",
-               "Dixinormus (chev: 3, σ: 8)",
-               "HungDaddy (chev: 3, σ: 8)",
+               "Dixinormus (3.6, chev: 2, σ: 8)",
+               "HungDaddy (0.6, chev: 2, σ: 8)",
                "------------------------------------------------------",
                "Perform brute force with the following players to get the best score.",
-               "Players: kyutoryu, fbots1998, jauggy, Aposis, [DTG]BamBin0, reddragon2010, Noody, SLOPPYGAGGER, MaTThiuS_82, barmalev",
+               "Players: kyutoryu (9.0), fbots1998 (2.8), jauggy (20.5), Aposis (20.4), [DTG]BamBin0 (20.1), reddragon2010 (18.4), Noody (17.6), SLOPPYGAGGER (8.9), MaTThiuS_82 (8.3), barmalev (3.6)",
                "------------------------------------------------------",
                "Brute force result:",
                "Team rating diff penalty: 6.2",
@@ -697,7 +697,7 @@ defmodule Teiserver.Battle.SplitNoobsInternalTest do
                "Score: 7.2 (lower is better)",
                "------------------------------------------------------",
                "Draft remaining players (ordered from best to worst).",
-               "Remaining: Dixinormus, HungDaddy",
+               "Remaining: Dixinormus (3.6), HungDaddy (0.6)",
                "------------------------------------------------------",
                "Final result:",
                "Team 1: Noody, reddragon2010, [DTG]BamBin0, fbots1998, kyutoryu, HungDaddy",
@@ -723,9 +723,24 @@ defmodule Teiserver.Battle.SplitNoobsInternalTest do
                    members: ["fbots1998"],
                    ratings: [2.768316831683173]
                  },
-                 %{count: 1, group_rating: 20.06, members: ["[DTG]BamBin0"], ratings: [20.06]},
-                 %{count: 1, group_rating: 18.4, members: ["reddragon2010"], ratings: [18.4]},
-                 %{count: 1, group_rating: 17.64, members: ["Noody"], ratings: [17.64]}
+                 %{
+                   count: 1,
+                   group_rating: 20.06,
+                   members: ["[DTG]BamBin0"],
+                   ratings: [20.06]
+                 },
+                 %{
+                   count: 1,
+                   group_rating: 18.4,
+                   members: ["reddragon2010"],
+                   ratings: [18.4]
+                 },
+                 %{
+                   count: 1,
+                   group_rating: 17.64,
+                   members: ["Noody"],
+                   ratings: [17.64]
+                 }
                ],
                2 => [
                  %{
@@ -734,11 +749,36 @@ defmodule Teiserver.Battle.SplitNoobsInternalTest do
                    members: ["Dixinormus"],
                    ratings: [3.6198019801980257]
                  },
-                 %{count: 1, group_rating: 20.49, members: ["jauggy"], ratings: [20.49]},
-                 %{count: 1, group_rating: 20.42, members: ["Aposis"], ratings: [20.42]},
-                 %{count: 1, group_rating: 8.89, members: ["SLOPPYGAGGER"], ratings: [8.89]},
-                 %{count: 1, group_rating: 8.26, members: ["MaTThiuS_82"], ratings: [8.26]},
-                 %{count: 1, group_rating: 3.58, members: ["barmalev"], ratings: [3.58]}
+                 %{
+                   count: 1,
+                   group_rating: 20.49,
+                   members: ["jauggy"],
+                   ratings: [20.49]
+                 },
+                 %{
+                   count: 1,
+                   group_rating: 20.42,
+                   members: ["Aposis"],
+                   ratings: [20.42]
+                 },
+                 %{
+                   count: 1,
+                   group_rating: 8.89,
+                   members: ["SLOPPYGAGGER"],
+                   ratings: [8.89]
+                 },
+                 %{
+                   count: 1,
+                   group_rating: 8.26,
+                   members: ["MaTThiuS_82"],
+                   ratings: [8.26]
+                 },
+                 %{
+                   count: 1,
+                   group_rating: 3.58,
+                   members: ["barmalev"],
+                   ratings: [3.58]
+                 }
                ]
              },
              team_players: %{
@@ -750,7 +790,14 @@ defmodule Teiserver.Battle.SplitNoobsInternalTest do
                  "reddragon2010",
                  "Noody"
                ],
-               2 => ["Dixinormus", "jauggy", "Aposis", "SLOPPYGAGGER", "MaTThiuS_82", "barmalev"]
+               2 => [
+                 "Dixinormus",
+                 "jauggy",
+                 "Aposis",
+                 "SLOPPYGAGGER",
+                 "MaTThiuS_82",
+                 "barmalev"
+               ]
              }
            }
   end

--- a/test/teiserver/battle/split_noobs_test.exs
+++ b/test/teiserver/battle/split_noobs_test.exs
@@ -231,8 +231,8 @@ defmodule Teiserver.Battle.SplitNoobsTest do
                "------------------------------------------------------",
                "Parties: None",
                "Solo noobs:",
-               "kyutoryu (chev: 2, σ: 7.1)",
-               "HungDaddy (chev: 1, σ: 2)",
+               "kyutoryu (9.0, chev: 1, σ: 7.1)",
+               "HungDaddy (0, chev: 0, σ: 2)",
                "------------------------------------------------------",
                "Teams constructed by simple draft",
                "------------------------------------------------------",
@@ -242,11 +242,36 @@ defmodule Teiserver.Battle.SplitNoobsTest do
              ],
              team_groups: %{
                1 => [
-                 %{count: 1, group_rating: 0, members: ["HungDaddy"], ratings: [0]},
-                 %{count: 1, group_rating: 8.26, members: ["MaTThiuS_82"], ratings: [8.26]},
-                 %{count: 1, group_rating: 17.64, members: ["Noody"], ratings: [17.64]},
-                 %{count: 1, group_rating: 20.06, members: ["[DTG]BamBin0"], ratings: [20.06]},
-                 %{count: 1, group_rating: 20.42, members: ["Aposis"], ratings: [20.42]}
+                 %{
+                   count: 1,
+                   group_rating: 0,
+                   members: ["HungDaddy"],
+                   ratings: [0]
+                 },
+                 %{
+                   count: 1,
+                   group_rating: 8.26,
+                   members: ["MaTThiuS_82"],
+                   ratings: [8.26]
+                 },
+                 %{
+                   count: 1,
+                   group_rating: 17.64,
+                   members: ["Noody"],
+                   ratings: [17.64]
+                 },
+                 %{
+                   count: 1,
+                   group_rating: 20.06,
+                   members: ["[DTG]BamBin0"],
+                   ratings: [20.06]
+                 },
+                 %{
+                   count: 1,
+                   group_rating: 20.42,
+                   members: ["Aposis"],
+                   ratings: [20.42]
+                 }
                ],
                2 => [
                  %{
@@ -255,15 +280,47 @@ defmodule Teiserver.Battle.SplitNoobsTest do
                    members: ["kyutoryu"],
                    ratings: [8.975247524752481]
                  },
-                 %{count: 1, group_rating: 8.89, members: ["SLOPPYGAGGER"], ratings: [8.89]},
-                 %{count: 1, group_rating: 18.28, members: ["Dixinormus"], ratings: [18.28]},
-                 %{count: 1, group_rating: 18.4, members: ["reddragon2010"], ratings: [18.4]},
-                 %{count: 1, group_rating: 20.49, members: ["jauggy"], ratings: [20.49]}
+                 %{
+                   count: 1,
+                   group_rating: 8.89,
+                   members: ["SLOPPYGAGGER"],
+                   ratings: [8.89]
+                 },
+                 %{
+                   count: 1,
+                   group_rating: 18.28,
+                   members: ["Dixinormus"],
+                   ratings: [18.28]
+                 },
+                 %{
+                   count: 1,
+                   group_rating: 18.4,
+                   members: ["reddragon2010"],
+                   ratings: [18.4]
+                 },
+                 %{
+                   count: 1,
+                   group_rating: 20.49,
+                   members: ["jauggy"],
+                   ratings: [20.49]
+                 }
                ]
              },
              team_players: %{
-               1 => ["HungDaddy", "MaTThiuS_82", "Noody", "[DTG]BamBin0", "Aposis"],
-               2 => ["kyutoryu", "SLOPPYGAGGER", "Dixinormus", "reddragon2010", "jauggy"]
+               1 => [
+                 "HungDaddy",
+                 "MaTThiuS_82",
+                 "Noody",
+                 "[DTG]BamBin0",
+                 "Aposis"
+               ],
+               2 => [
+                 "kyutoryu",
+                 "SLOPPYGAGGER",
+                 "Dixinormus",
+                 "reddragon2010",
+                 "jauggy"
+               ]
              }
            }
   end
@@ -405,11 +462,11 @@ defmodule Teiserver.Battle.SplitNoobsTest do
              "------------------------------------------------------",
              "Parties: (LuBaee, TimeContainer)",
              "Solo noobs:",
-             "StinkBee (chev: 3, σ: 6.7)",
-             "HoldButyLeg (chev: 1, σ: 7.5)",
+             "StinkBee (14.6, chev: 2, σ: 6.7)",
+             "HoldButyLeg (5.9, chev: 0, σ: 7.5)",
              "------------------------------------------------------",
              "Perform brute force with the following players to get the best score.",
-             "Players: TimeContainer, LuBaee, DUFFY, Orii, colossus, PotatoesHead, Theo45, onse, 976, Regithros, Darth, Akio, nubl, CowOfWar",
+             "Players: TimeContainer (21), LuBaee (14), DUFFY (34), Orii (23), colossus (22), PotatoesHead (22), Theo45 (21), onse (20), 976 (14), Regithros (12), Darth (11), Akio (10), nubl (6), CowOfWar (3)",
              "------------------------------------------------------",
              "Brute force result:",
              "Team rating diff penalty: 1",
@@ -418,7 +475,7 @@ defmodule Teiserver.Battle.SplitNoobsTest do
              "Score: 1.2 (lower is better)",
              "------------------------------------------------------",
              "Draft remaining players (ordered from best to worst).",
-             "Remaining: StinkBee, HoldButyLeg",
+             "Remaining: StinkBee (14.6), HoldButyLeg (5.9)",
              "------------------------------------------------------",
              "Final result:",
              "Team 1: Akio, Darth, Regithros, 976, DUFFY, LuBaee, TimeContainer, HoldButyLeg",
@@ -572,10 +629,10 @@ defmodule Teiserver.Battle.SplitNoobsTest do
              "------------------------------------------------------",
              "Parties: None",
              "Solo noobs:",
-             "BIL (chev: 1, σ: 8.3)",
+             "BIL (0.3, chev: 0, σ: 8.3)",
              "------------------------------------------------------",
              "Perform brute force with the following players to get the best score.",
-             "Players: Raigeki, Engolianth, Demodred, FRODODOR, shoeofobama, Larch, Artifical_Banana, Cobaltstore, quest, SHAAARKBATE, illusiveman2024, UnreasonableIkko, ColorlesScum, Renkei",
+             "Players: Raigeki (59.9), Engolianth (27.0), Demodred (26.0), FRODODOR (25.7), shoeofobama (23.9), Larch (22.0), Artifical_Banana (20.1), Cobaltstore (13.6), quest (13.1), SHAAARKBATE (9.9), illusiveman2024 (7.0), UnreasonableIkko (6.0), ColorlesScum (2.3), Renkei (1.2)",
              "------------------------------------------------------",
              "Brute force result:",
              "Team rating diff penalty: 1.5",
@@ -584,7 +641,7 @@ defmodule Teiserver.Battle.SplitNoobsTest do
              "Score: 28.9 (lower is better)",
              "------------------------------------------------------",
              "Draft remaining players (ordered from best to worst).",
-             "Remaining: MrKicks, BIL",
+             "Remaining: MrKicks (0.9), BIL (0.3)",
              "------------------------------------------------------",
              "Final result:",
              "Team 1: UnreasonableIkko, illusiveman2024, SHAAARKBATE, quest, Cobaltstore, Artifical_Banana, Raigeki, BIL",


### PR DESCRIPTION
This will simply add ratings to $explain for split_noobs. 
```
               "Perform brute force with the following players to get the best score.",
               "Players: kyutoryu (9.0), fbots1998 (2.8), jauggy (20.5), Aposis (20.4), [DTG]BamBin0 (20.1), reddragon2010 (18.4), Noody (17.6), SLOPPYGAGGER (8.9), MaTThiuS_82 (8.3), barmalev (3.6)"
```
The numbers in brackets are their ratings. 

I'm trying to understand why the ratings don't add up to team rating in this bug:
https://discord.com/channels/549281623154229250/1332129520538615818