### PR TITLE
Fix team size calculation for balancer server

### DIFF
--- a/lib/teiserver/game/servers/balancer_server.ex
+++ b/lib/teiserver/game/servers/balancer_server.ex
@@ -164,14 +164,7 @@ defmodule Teiserver.Game.BalancerServer do
 
   @spec do_make_balance(non_neg_integer(), [T.client()], List.t()) :: map()
   defp do_make_balance(team_count, players, opts) do
-    teams =
-      players
-      |> Enum.group_by(fn c -> c.team_number end)
-
-    team_size =
-      teams
-      |> Enum.map(fn {_, t} -> Enum.count(t) end)
-      |> Enum.max(fn -> 0 end)
+    team_size = calculate_team_size(team_count, players)
 
     # Use Large Team ratings when balancing Team FFA
     game_type =
@@ -200,6 +193,14 @@ defmodule Teiserver.Game.BalancerServer do
     else
       make_solo_balance(team_count, players, game_type, [], opts)
     end
+  end
+
+  # This calculates the team size after balancing, which is important for determining whether a game is small or large team
+  # After balancing the team size will equal the number of players divided by team count rounded up.
+  # After balancing, the team size will be as even as possible.
+  @spec calculate_team_size(non_neg_integer(), [T.client()]) :: non_neg_integer()
+  def calculate_team_size(team_count, players) do
+    (Enum.count(players) / team_count) |> ceil()
   end
 
   @spec make_grouped_balance(non_neg_integer(), [T.client()], String.t(), list()) :: map()

--- a/lib/teiserver/game/servers/balancer_server.ex
+++ b/lib/teiserver/game/servers/balancer_server.ex
@@ -195,8 +195,8 @@ defmodule Teiserver.Game.BalancerServer do
     end
   end
 
-  # This calculates the team size after balancing, which is important for determining whether a game is small or large team
-  # After balancing the team size will equal the number of players divided by team count rounded up.
+  # This function is run before balancing but calculates the expected team size after balancing, which is important for determining whether a game is small or large team.
+  # After balancing the team size will equal the number of players divided by team count rounded up. So if team 1 has 6 players and team 2 has 4 players, after balancing this will become a 5v5 not 6v4.
   # After balancing, the team size will be as even as possible.
   @spec calculate_team_size(non_neg_integer(), [T.client()]) :: non_neg_integer()
   def calculate_team_size(team_count, players) do

--- a/test/teiserver/game/balancer_server_test.exs
+++ b/test/teiserver/game/balancer_server_test.exs
@@ -15,4 +15,28 @@ defmodule Teiserver.Game.BalancerServerTest do
 
     assert result == 0
   end
+
+  test "calculate team size" do
+    team_count = 2
+    players = create_fake_players(1)
+    result = BalancerServer.calculate_team_size(team_count, players)
+    assert result == 1
+
+    players = create_fake_players(2)
+    result = BalancerServer.calculate_team_size(team_count, players)
+    assert result == 1
+
+    players = create_fake_players(6)
+    assert Enum.count(players) == 6
+    result = BalancerServer.calculate_team_size(team_count, players)
+    assert result == 3
+
+    players = create_fake_players(7)
+    result = BalancerServer.calculate_team_size(team_count, players)
+    assert result == 4
+  end
+
+  defp create_fake_players(count) do
+    1..count |> Enum.map(fn _ -> %{} end)
+  end
 end


### PR DESCRIPTION
The balancer will sometimes use large team ratings even if it is a small team game. This is a potential fix. In the old code, team size was calculated as the largest team size of all teams. So if you were in a lobby with 6 players on team 1, then 4 players on team 2, it would use large team ratings. However, this is wrong since after balancing, the teams would become 5v5 and should be small teams.

The calculation should simply divide players by team_count rounded up.