### PR TITLE
Fix num matches not appearing

### DIFF
--- a/lib/teiserver/game/libs/match_rating_lib.ex
+++ b/lib/teiserver/game/libs/match_rating_lib.ex
@@ -490,7 +490,8 @@ defmodule Teiserver.Game.MatchRatingLib do
         uncertainty: new_uncertainty,
         rating_value_change: new_rating_value - user_rating.rating_value,
         skill_change: new_skill - user_rating.skill,
-        uncertainty_change: new_uncertainty - user_rating.uncertainty
+        uncertainty_change: new_uncertainty - user_rating.uncertainty,
+        num_matches: new_num_matches
       }
     }
   end

--- a/test/teiserver/game/libs/match_rating_lib_test.exs
+++ b/test/teiserver/game/libs/match_rating_lib_test.exs
@@ -40,8 +40,21 @@ defmodule Teiserver.Game.MatchRatingLibTest do
     assert ratings[user1.id].skill == 27.637760127073694
     assert ratings[user2.id].skill == 22.362239872926306
 
+    # Check num_matches in teiserver_account_ratings table
     assert ratings[user1.id].num_matches == 1
     assert ratings[user1.id].num_matches == 1
+
+    # Check num_matches in teiserver_game_rating_logs table
+    rating_logs =
+      Game.list_rating_logs(
+        search: [
+          match_id: match.id
+        ],
+        limit: :infinity
+      )
+
+    assert Enum.at(rating_logs, 0).value["num_matches"] == 1
+    assert Enum.at(rating_logs, 1).value["num_matches"] == 1
 
     # Create another match
     match = create_fake_match(user1.id, user2.id)


### PR DESCRIPTION
When rating a match, num_matches is updated in two tables:
1. teiserver_account_ratings
2. teiserver_game_rating_logs

The update to the second table was missing and is now fixed