### PR TITLE
Fix error when viewing profile when not logged in

### DIFF
--- a/lib/teiserver_web/live/account/profile/accolades.ex
+++ b/lib/teiserver_web/live/account/profile/accolades.ex
@@ -58,7 +58,7 @@ defmodule TeiserverWeb.Account.ProfileLive.Accolades do
   end
 
   defp assign_summary(socket) do
-    current_user_id = socket.assigns.current_user.id
+    current_user_id = socket.assigns.current_user && socket.assigns.current_user.id
     viewed_user_id = socket.assigns.user.id
     viewed_user_name = socket.assigns.user.name
 
@@ -81,6 +81,7 @@ defmodule TeiserverWeb.Account.ProfileLive.Accolades do
 
   defp fix_pronouns(message, current_user_id, viewed_user_id, viewed_user_name) do
     if(current_user_id != viewed_user_id) do
+      # When viewing someone else's accolades, replace "you" with person's name
       String.replace(message, "You have", "#{viewed_user_name} has")
     else
       message

--- a/lib/teiserver_web/live/account/profile/overview.ex
+++ b/lib/teiserver_web/live/account/profile/overview.ex
@@ -362,18 +362,24 @@ defmodule TeiserverWeb.Account.ProfileLive.Overview do
   end
 
   def assign_accolade_notification(socket) do
-    user_id = socket.assigns.user.id
-    current_user_id = socket.assigns.current_user.id
-    days = 1
-
-    message =
-      with true <- user_id == current_user_id,
-           %{map: map, giver_name: giver_name} <- AccoladeLib.recent_accolade(user_id, days) do
-        "You have recently received an accolade from #{giver_name} for your match in #{map}!"
-      else
-        _ -> nil
-      end
+    message = get_accolade_notification_message(socket.assigns.user, socket.assigns.current_user)
 
     socket |> assign(:accolade_notification, message)
+  end
+
+  def get_accolade_notification_message(viewed_user, current_user) do
+    days = 1
+
+    with true <- viewed_user != nil,
+         true <- current_user != nil,
+         true <- viewed_user.id == current_user.id && current_user.id != nil,
+         %{map: map, giver_name: giver_name} <-
+           AccoladeLib.recent_accolade(current_user.id, days) do
+      "You have recently received an accolade from #{giver_name} for your match in #{map}!"
+    else
+      # Goes here if the viewed user is not the same as the logged in user
+      # Or if there are no recent accolades
+      _ -> nil
+    end
   end
 end

--- a/lib/teiserver_web/live/account/profile/overview.ex
+++ b/lib/teiserver_web/live/account/profile/overview.ex
@@ -370,11 +370,11 @@ defmodule TeiserverWeb.Account.ProfileLive.Overview do
   def get_accolade_notification_message(viewed_user, current_user) do
     days = 1
 
-    with true <- viewed_user != nil,
-         true <- current_user != nil,
-         true <- viewed_user.id == current_user.id && current_user.id != nil,
+    with %{id: viewed_user_id} <- viewed_user,
+         %{id: current_user_id} <- current_user,
+         true <- viewed_user_id == current_user_id,
          %{map: map, giver_name: giver_name} <-
-           AccoladeLib.recent_accolade(current_user.id, days) do
+           AccoladeLib.recent_accolade(current_user_id, days) do
       "You have recently received an accolade from #{giver_name} for your match in #{map}!"
     else
       # Goes here if the viewed user is not the same as the logged in user

--- a/test/teiserver_web/live/account/profile/overview_test.exs
+++ b/test/teiserver_web/live/account/profile/overview_test.exs
@@ -5,6 +5,7 @@ defmodule TeiserverWeb.Live.Account.Profile.OverviewTest do
   alias Central.Helpers.GeneralTestLib
   alias Teiserver.{Battle, TeiserverTestLib, Client}
   alias Teiserver.Lobby
+  alias TeiserverWeb.Account.ProfileLive.Overview
 
   setup do
     {:ok, data} =
@@ -89,6 +90,11 @@ defmodule TeiserverWeb.Live.Account.Profile.OverviewTest do
       Lobby.close_lobby(lobby_id)
       assert Lobby.get_lobby(lobby_id) == nil
     end
+  end
+
+  test "get_accolade_notification_message should be able to handle when user not logged in" do
+    result = Overview.get_accolade_notification_message(nil, nil)
+    assert result == nil
   end
 
   defp login_user(user) do


### PR DESCRIPTION
There is an error that occurs:
```
** (exit) an exception was raised:
    ** (KeyError) key :id not found in: nil

If you are using the dot syntax, such as map.field, make sure the left-hand side of the dot is a map
        (teiserver 0.1.0) lib/teiserver_web/live/account/profile/overview.ex:366: TeiserverWeb.Account.ProfileLive.Overview.assign_accolade_notification/1
        (teiserver 0.1.0) lib/teiserver_web/live/account/profile/overview.ex:38: TeiserverWeb.Account.ProfileLive.Overview.mount/3
        (phoenix_live_view 0.19.3) lib/phoenix_live_view/utils.ex:394: anonymous fn/6 in Phoenix.LiveView.Utils.maybe_call_live_view_mount!/5
        (telemetry 1.3.0) /build/deps/telemetry/src/telemetry.erl:324: :telemetry.span/3
        (phoenix_live_view 0.19.3) lib/phoenix_live_view/static.ex:278: Phoenix.LiveView.Static.call_mount_and_handle_params!/5
        (phoenix_live_view 0.19.3) lib/phoenix_live_view/static.ex:119: Phoenix.LiveView.Static.render/3
        (phoenix_live_view 0.19.3) lib/phoenix_live_view/controller.ex:39: Phoenix.LiveView.Controller.live_render/3
        (phoenix 1.7.14) lib/phoenix/router.ex:484: Phoenix.Router.__call__/5
2025-02-02 11:47:44.261 [error] request_id=SpringTcpServer#311895  311895 LuaRules upload_infolog - contents contain invalid characters
^C
```

This points to this line  (teiserver 0.1.0) lib/teiserver_web/live/account/profile/overview.ex:366
```
current_user_id = socket.assigns.current_user.id
```

Which can be blank if you are viewing someone's profile and not logged in. 

This PR fixes by checking for nil.

## Testing
In local development you can just login as a user and find a past match and gift an accolade to someone. Then login as that other user. Their email is listed in http://localhost:4000/teiserver/admin/user
and the password is`password`

The recipient of the accolade will see this on login:

![Screenshot 2025-02-03 000048](https://github.com/user-attachments/assets/17b9868e-a37b-4a13-88f1-6d88dc8971f3)

If you logout and try to access the same page you will see

![Screenshot 2025-02-03 000112](https://github.com/user-attachments/assets/52946d3b-334d-4c33-968b-60e837ecbd66)
