### PR TITLE
Nicer oauth scopes UI

### DIFF
--- a/documents/guides/local_setup.md
+++ b/documents/guides/local_setup.md
@@ -134,6 +134,15 @@ mix teiserver.fakedata
 
 Will generate a large amount of fake data and setup a root account for you. The account will have full access to everything and the database will be populated with false data as if generated over a period of time to make development and testing easier.
 
+For developping tachyon, you should also run
+```bash
+mix teiserver.tachyon_setup
+```
+This setup the oauth applications required for tachyon.
+
+There is also `mix teiserver.gen_token --user CheerfulBeigeKarganeth --app generic_lobby` to generate access token valid for 24h. These help a lot when attempting to manually test the API.
+
+
 ### Resetting your user password
 When running locally it's likely you won't want to connect the server to an email account, as such password resets need to be done a little differently.
 

--- a/lib/teiserver/mix_tasks/gen_token.ex
+++ b/lib/teiserver/mix_tasks/gen_token.ex
@@ -29,7 +29,7 @@ defmodule Mix.Tasks.Teiserver.GenToken do
         exit({:shutdown, 1})
 
       user ->
-        case Teiserver.OAuth.Task.GenToken.create_token(user, parsed[:app]) do
+        case Teiserver.OAuth.Tasks.GenToken.create_token(user, parsed[:app]) do
           {:ok, token} ->
             shell.info("Generated token (id=#{token.id}) - #{token.value}")
             :ok

--- a/lib/teiserver/mix_tasks/tachyon_setup.ex
+++ b/lib/teiserver/mix_tasks/tachyon_setup.ex
@@ -1,0 +1,23 @@
+defmodule Mix.Tasks.Teiserver.TachyonSetup do
+  @usage_str "Usage: `mix teiserver.tachyon_setup`"
+
+  @moduledoc """
+  Ensure there is an OAuth app for tachyon lobby and another one to control
+  assets like maps and engines with bots.
+
+  #{@usage_str}
+  """
+
+  @shortdoc "setup oauth apps for tachyon"
+
+  use Mix.Task
+  alias Teiserver.Tachyon.Tasks.SetupApps
+
+  @impl Mix.Task
+  def run(_args) do
+    Application.ensure_all_started([:ecto, :ecto_sql, :tzdata])
+    Teiserver.Repo.start_link()
+    SetupApps.ensure_lobby_app()
+    SetupApps.ensure_asset_admin_app()
+  end
+end

--- a/lib/teiserver/o_auth/queries/application_query.ex
+++ b/lib/teiserver/o_auth/queries/application_query.ex
@@ -88,14 +88,4 @@ defmodule Teiserver.OAuth.ApplicationQueries do
     from [app: app] in query,
       where: app.uid == ^uid
   end
-
-  def join_application(query, name \\ :application) do
-    if has_named_binding?(query, :application) do
-      query
-    else
-      from token in query,
-        join: app in assoc(token, ^name),
-        as: :application
-    end
-  end
 end

--- a/lib/teiserver/o_auth/tasks/gen_token.ex
+++ b/lib/teiserver/o_auth/tasks/gen_token.ex
@@ -1,4 +1,4 @@
-defmodule Teiserver.OAuth.Task.GenToken do
+defmodule Teiserver.OAuth.Tasks.GenToken do
   @moduledoc """
   Generates a token for the given user. This is for a convenience task to ease
   the development of anything requiring OAuth tokens like tachyon protocol.

--- a/lib/teiserver/tachyon/tasks/setup_apps.ex
+++ b/lib/teiserver/tachyon/tasks/setup_apps.ex
@@ -1,0 +1,62 @@
+defmodule Teiserver.Tachyon.Tasks.SetupApps do
+  @moduledoc """
+  Ensure the database has the required OAuth applications for tachyon lobby
+  and asset managements
+  This tasks requires the root user to be setup (root@localhost)
+  """
+  require Logger
+
+  alias Teiserver.OAuth.ApplicationQueries
+
+  def ensure_lobby_app() do
+    root = find_root_user!()
+
+    ensure_app(%{
+      name: "generic tachyon lobby",
+      uid: "generic_lobby",
+      owner_id: root.id,
+      scopes: ["tachyon.lobby"],
+      description: "To support autohost and players using tachyon."
+    })
+  end
+
+  def ensure_asset_admin_app() do
+    root = find_root_user!()
+
+    ensure_app(%{
+      name: "asset admin",
+      uid: "asset_admin",
+      owner_id: root.id,
+      scopes: ["admin.map", "admin.engine"],
+      description: "To automate asset management like maps and engines."
+    })
+  end
+
+  defp ensure_app(app_attrs) do
+    case ApplicationQueries.get_application_by_uid(app_attrs.uid) do
+      %Teiserver.OAuth.Application{} = app ->
+        Logger.info("#{app_attrs.name} app already setup")
+        app
+
+      nil ->
+        res =
+          Teiserver.OAuth.create_application(app_attrs)
+
+        case res do
+          {:error, changeset} ->
+            raise "Error trying to #{app_attrs.uid}: #{changeset}"
+
+          {:ok, app} ->
+            Logger.info("New #{app_attrs.uid} OAuth app created: #{app.id}")
+            app
+        end
+    end
+  end
+
+  defp find_root_user!() do
+    case Teiserver.Account.get_user_by_email("root@localhost") do
+      nil -> raise "Cannot find root user root@localhost, set it up first"
+      root -> root
+    end
+  end
+end

--- a/lib/teiserver_web/components/core_components.ex
+++ b/lib/teiserver_web/components/core_components.ex
@@ -295,6 +295,8 @@ defmodule TeiserverWeb.CoreComponents do
   attr :prompt, :string, default: nil, doc: "the prompt for select inputs"
   attr :options, :list, doc: "the options to pass to Phoenix.HTML.Form.options_for_select/2"
   attr :multiple, :boolean, default: false, doc: "the multiple flag for select inputs"
+  attr :text, :string, doc: "regular text to follow a label"
+  attr :description, :string, doc: "optional description to display if component allows"
   attr :rest, :global, include: ~w(autocomplete cols disabled form max maxlength min minlength
                                    pattern placeholder readonly required rows size step)
   slot :inner_block
@@ -320,7 +322,7 @@ defmodule TeiserverWeb.CoreComponents do
         id={@id}
         class="form-check-input"
         type="checkbox"
-        value="true"
+        value={@value}
         checked={@checked}
       />
       <label class="form-check-label" for={@id}>

--- a/lib/teiserver_web/components/o_auth_application/application_form.ex
+++ b/lib/teiserver_web/components/o_auth_application/application_form.ex
@@ -14,13 +14,31 @@ defmodule TeiserverWeb.Components.OAuthApplicationComponent do
 
       <CC.input field={f[:name]} type="text" label="Name (user facing)" />
       <CC.input field={f[:uid]} type="text" label="client id" />
-      <CC.input
-        field={Map.update(f[:scopes], :value, "", &Enum.join(&1, ", "))}
-        type="text"
-        label="comma separated scopes"
-      />
+
+      <br />
+      <p><strong>List of scopes</strong></p>
+      <CC.error :if={@changeset.errors[:scopes]}>
+        <% {msg, _} = @changeset.errors[:scopes] %>
+        <%= msg %>
+      </CC.error>
+
+      <%= for {scope, checked, desc} <- @scopes do %>
+        <p>
+          <CC.input
+            type="checkbox"
+            value="true"
+            name={"scopes[#{scope}]"}
+            id={"application_scope_#{scope}"}
+            checked={checked}
+            label={scope}
+            description={desc}
+          />
+        </p>
+      <% end %>
+
       <p>
-        Note that changing the scopes does NOT change any existing credentials. You need to issue new ones to take the new scopes into account
+        Note that changing scopes there will <strong>NOT</strong>
+        change any authorization code, access token or client credentials
       </p>
 
       <%!-- This form is meant to be used by an admin user, so it's fine to allow supplying --%>

--- a/lib/teiserver_web/templates/admin/bot/show.html.heex
+++ b/lib/teiserver_web/templates/admin/bot/show.html.heex
@@ -25,6 +25,7 @@
         <tr>
           <th>application</th>
           <th>client id</th>
+          <th>scopes</th>
           <th>actions</th>
         </tr>
       </thead>
@@ -33,6 +34,7 @@
           <tr>
             <td><%= credential.application.name %></td>
             <td><pre> <%= credential.client_id %> </pre></td>
+            <td><%= Enum.join(credential.application.scopes, ", ") %></td>
             <td>
               <Phx.link
                 href={~p"/teiserver/admin/bot/#{@bot.id}/credential/#{credential.id}"}

--- a/lib/teiserver_web/templates/admin/o_auth_application/edit.html.heex
+++ b/lib/teiserver_web/templates/admin/o_auth_application/edit.html.heex
@@ -7,6 +7,7 @@
         <.application_form
           button_label="Update"
           changeset={@changeset}
+          scopes={@scopes}
           action={~p"/teiserver/admin/oauth_application/#{@app.id}"}
           method="PUT"
         />

--- a/lib/teiserver_web/templates/admin/o_auth_application/new.html.heex
+++ b/lib/teiserver_web/templates/admin/o_auth_application/new.html.heex
@@ -7,6 +7,7 @@
         <.application_form
           button_label="Create app"
           changeset={@changeset}
+          scopes={@scopes}
           action={~p"/teiserver/admin/oauth_application"}
         />
       </div>

--- a/test/teiserver/o_auth/gen_token_test.exs
+++ b/test/teiserver/o_auth/gen_token_test.exs
@@ -1,7 +1,7 @@
 defmodule Teiserver.OAuth.GenTokenTest do
   use Teiserver.DataCase, async: true
   alias Teiserver.OAuthFixtures
-  alias Teiserver.OAuth.Task.GenToken
+  alias Teiserver.OAuth.Tasks.GenToken
   alias Teiserver.OAuth.{Token, TokenQueries}
 
   test "no user fails" do

--- a/test/teiserver/tachyon/tasks/setup_apps_setup.exs
+++ b/test/teiserver/tachyon/tasks/setup_apps_setup.exs
@@ -1,0 +1,36 @@
+defmodule Teiserver.Tachyon.Tasks.SetupAppsTest do
+  use Teiserver.DataCase
+  alias Teiserver.OAuth.{Application, ApplicationQueries}
+  alias Teiserver.Tachyon.Tasks.SetupApps
+
+  setup _context do
+    user =
+      Central.Helpers.GeneralTestLib.make_user(%{
+        "email" => "root@localhost",
+        "data" => %{"roles" => ["Verified"]}
+      })
+
+    # because all the f*ing queries are using caches, without a way to disable that
+    on_exit(fn ->
+      Teiserver.TeiserverTestLib.clear_cache(:users_lookup_id_with_email)
+    end)
+
+    {:ok, user: user}
+  end
+
+  describe "setup tachyon apps" do
+    test "lobby app" do
+      assert ApplicationQueries.get_application_by_uid("generic_lobby") == nil
+      SetupApps.ensure_lobby_app()
+
+      assert %Application{} = ApplicationQueries.get_application_by_uid("generic_lobby")
+    end
+
+    test "asset admin app" do
+      assert ApplicationQueries.get_application_by_uid("asset_admin") == nil
+      SetupApps.ensure_asset_admin_app()
+
+      %Application{} = ApplicationQueries.get_application_by_uid("asset_admin")
+    end
+  end
+end


### PR DESCRIPTION
A few things to make our life easier around oauth apps.

* a mix task to setup the 2 required applications and the associated doc

* a better UI to manage scopes, see screenshots

![2025-02-06-1137x386-scrot](https://github.com/user-attachments/assets/053ce932-2be9-4a04-b3ae-ba10002e4749)

![2025-02-06-1894x643-scrot](https://github.com/user-attachments/assets/53198e50-40c2-4e56-bf7e-a6447694a6a5)

![2025-02-06-1909x649-scrot](https://github.com/user-attachments/assets/b02b3548-a7bd-45c9-8c72-8e279c96bafe)

![2025-02-06-1156x540-scrot](https://github.com/user-attachments/assets/6a76323d-4a9f-4564-8c24-308c11937d3c)


