### PR TITLE
Admin Quality-of-Life feature: deduplicated the list of users when using the quicksearch

### DIFF
--- a/lib/teiserver_web/controllers/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/admin/user_controller.ex
@@ -43,7 +43,9 @@ defmodule TeiserverWeb.Admin.UserController do
         []
       end
 
-    users = (exact_match ++ users) |> Enum.uniq_by(fn user -> user.id end) |> Enum.reject(&(&1 == nil))
+    users =
+      (exact_match ++ users) |> Enum.uniq_by(fn user -> user.id end) |> Enum.reject(&(&1 == nil))
+
     user_stats = for user <- users, do: Account.get_user_stat_data(user.id)
 
     if Enum.count(users) == 1 do

--- a/lib/teiserver_web/controllers/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/admin/user_controller.ex
@@ -43,7 +43,7 @@ defmodule TeiserverWeb.Admin.UserController do
         []
       end
 
-    users = (exact_match ++ users) |> Enum.reject(&(&1 == nil))
+    users = (exact_match ++ users) |> Enum.uniq_by(fn user -> user.id end) |> Enum.reject(&(&1 == nil))
     user_stats = for user <- users, do: Account.get_user_stat_data(user.id)
 
     if Enum.count(users) == 1 do


### PR DESCRIPTION
Resolves issue #553 

### screenshots
List of users goes from 

![image](https://github.com/user-attachments/assets/f945de58-d4df-48f7-9cdc-df6574497d7f)

to 

![image](https://github.com/user-attachments/assets/8ba6031a-3520-4420-9b2d-b99b5393236d)
