### PR TITLE
Battle processes

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -96,7 +96,7 @@ config :teiserver, Teiserver,
 
 config :logger, :default_handler, false
 
-metadata = [:request_id, :user_id, :queue_id]
+metadata = [:request_id, :user_id, :queue_id, :pid]
 
 config :logger, LoggerBackends.Console,
   format: "$date $time [$level] $metadata $message\n",

--- a/lib/teiserver/application.ex
+++ b/lib/teiserver/application.ex
@@ -142,7 +142,6 @@ defmodule Teiserver.Application do
         # Matchmaking
         {DynamicSupervisor, strategy: :one_for_one, name: Teiserver.Game.QueueSupervisor},
         Teiserver.Data.MatchmakingCache,
-        Teiserver.Matchmaking.System,
 
         # Coordinator mode
         {DynamicSupervisor,

--- a/lib/teiserver/autohost.ex
+++ b/lib/teiserver/autohost.ex
@@ -68,8 +68,8 @@ defmodule Teiserver.Autohost do
     if autohost_val == nil, do: nil, else: autohost_val[:id]
   end
 
-  @spec start_matchmaking(Bot.id(), start_script()) ::
+  @spec start_battle(Bot.id(), start_script()) ::
           {:ok, start_response()} | {:error, term()}
-  defdelegate start_matchmaking(bot_id, start_script),
+  defdelegate start_battle(bot_id, start_script),
     to: Teiserver.Autohost.TachyonHandler
 end

--- a/lib/teiserver/autohost.ex
+++ b/lib/teiserver/autohost.ex
@@ -7,7 +7,7 @@ defmodule Teiserver.Autohost do
   @type reg_value :: Registry.reg_value()
 
   @type start_script :: %{
-          battleId: String.t(),
+          battleId: Teiserver.TachyonBattle.id(),
           engineVersion: String.t(),
           gameName: String.t(),
           mapName: String.t(),

--- a/lib/teiserver/autohost.ex
+++ b/lib/teiserver/autohost.ex
@@ -55,6 +55,19 @@ defmodule Teiserver.Autohost do
   @spec list() :: [reg_value()]
   defdelegate list(), to: Registry
 
+  @doc """
+  Given some search params (none for now), find a autohost that is connected,
+  has capacity, and matches the search params.
+  """
+  @spec find_autohost(term()) :: id() | nil
+  def find_autohost(_params \\ %{}) do
+    autohost_val =
+      Registry.list()
+      |> Enum.find(fn %{max_battles: m, current_battles: c} -> m > c end)
+
+    if autohost_val == nil, do: nil, else: autohost_val[:id]
+  end
+
   @spec start_matchmaking(Bot.id(), start_script()) ::
           {:ok, start_response()} | {:error, term()}
   defdelegate start_matchmaking(bot_id, start_script),

--- a/lib/teiserver/autohost/registry.ex
+++ b/lib/teiserver/autohost/registry.ex
@@ -33,6 +33,11 @@ defmodule Teiserver.Autohost.Registry do
     Horde.Registry.register(__MODULE__, via_tuple(autohost_id), val)
   end
 
+  @spec unregister(Bot.id()) :: :ok
+  def unregister(autohost_id) do
+    Horde.Registry.unregister(__MODULE__, via_tuple(autohost_id))
+  end
+
   @spec lookup(Bot.id()) :: {pid(), reg_value()} | nil
   def lookup(autohost_id) do
     case Horde.Registry.lookup(__MODULE__, via_tuple(autohost_id)) do

--- a/lib/teiserver/matchmaking/pairing_room.ex
+++ b/lib/teiserver/matchmaking/pairing_room.ex
@@ -62,6 +62,8 @@ defmodule Teiserver.Matchmaking.PairingRoom do
 
   @impl true
   def init({queue_id, queue, teams, timeout}) do
+    Logger.metadata(queue_id: queue_id)
+
     initial_state =
       %{
         queue_id: queue_id,
@@ -81,10 +83,7 @@ defmodule Teiserver.Matchmaking.PairingRoom do
           end
       }
 
-    Logger.debug(
-      "Pairing room for queue #{initial_state.queue_id} starting for players " <>
-        Enum.join(initial_state.awaiting, ",")
-    )
+    Logger.debug("Pairing room for players " <> Enum.join(initial_state.awaiting, ","))
 
     {:ok, initial_state, {:continue, {:notify_players, timeout}}}
   end
@@ -107,9 +106,7 @@ defmodule Teiserver.Matchmaking.PairingRoom do
   def handle_continue(:start_match, state) do
     case Teiserver.Autohost.find_autohost() do
       nil ->
-        Logger.warning(
-          "No autohost available to start a paired matchmaking for queue #{inspect(state.queue)}"
-        )
+        Logger.warning("No autohost available to start a paired matchmaking")
 
         QueueServer.disband_pairing(state.queue_id, self())
 
@@ -140,10 +137,7 @@ defmodule Teiserver.Matchmaking.PairingRoom do
                 p_id
               end
 
-            Logger.debug(
-              "Pairing completed for queue #{state.queue_id} is starting for players " <>
-                Enum.join(ids, ",")
-            )
+            Logger.debug("Pairing completed for players " <> Enum.join(ids, ","))
 
             for team <- state.teams, member <- team, p_id <- member.player_ids do
               Teiserver.Player.battle_start(p_id, battle_start_data)

--- a/lib/teiserver/matchmaking/pairing_room.ex
+++ b/lib/teiserver/matchmaking/pairing_room.ex
@@ -119,7 +119,7 @@ defmodule Teiserver.Matchmaking.PairingRoom do
       id ->
         start_script = hardcoded_start_script(state)
 
-        case Teiserver.Autohost.start_matchmaking(id, start_script) do
+        case Teiserver.TachyonBattle.start_battle(id, start_script) do
           {:error, reason} ->
             QueueServer.disband_pairing(state.queue_id, self())
 
@@ -211,10 +211,9 @@ defmodule Teiserver.Matchmaking.PairingRoom do
     {:stop, :normal, state}
   end
 
-  @spec hardcoded_start_script(state()) :: Teiserver.Autohost.start_script()
+  @spec hardcoded_start_script(state()) :: Teiserver.TachyonBattle.start_script()
   defp hardcoded_start_script(state) do
     %{
-      battleId: UUID.uuid4(),
       engineVersion: "105.1.1-2590-gb9462a0 bar",
       gameName: "Beyond All Reason test-26929-d709d32",
       mapName: "Red Comet Remake 1.8",

--- a/lib/teiserver/matchmaking/pairing_room.ex
+++ b/lib/teiserver/matchmaking/pairing_room.ex
@@ -105,8 +105,8 @@ defmodule Teiserver.Matchmaking.PairingRoom do
   # It's go time! Find an autohost, send it the start script and let all the players
   # know about the autohost waiting for them.
   def handle_continue(:start_match, state) do
-    case Teiserver.Autohost.list() do
-      [] ->
+    case Teiserver.Autohost.find_autohost() do
+      nil ->
         Logger.warning(
           "No autohost available to start a paired matchmaking for queue #{inspect(state.queue)}"
         )
@@ -119,7 +119,7 @@ defmodule Teiserver.Matchmaking.PairingRoom do
 
         {:stop, :normal, state}
 
-      [%{id: id} | _] ->
+      id ->
         start_script = hardcoded_start_script(state)
 
         case Teiserver.Autohost.start_matchmaking(id, start_script) do

--- a/lib/teiserver/tachyon/system.ex
+++ b/lib/teiserver/tachyon/system.ex
@@ -11,6 +11,7 @@ defmodule Teiserver.Tachyon.System do
   def init(_) do
     children = [
       Teiserver.Tachyon.Schema.cache_spec(),
+      Teiserver.TachyonBattle.System,
       Teiserver.Autohost.System,
       Teiserver.Player.System
     ]

--- a/lib/teiserver/tachyon/system.ex
+++ b/lib/teiserver/tachyon/system.ex
@@ -13,6 +13,7 @@ defmodule Teiserver.Tachyon.System do
       Teiserver.Tachyon.Schema.cache_spec(),
       Teiserver.TachyonBattle.System,
       Teiserver.Autohost.System,
+      Teiserver.Matchmaking.System,
       Teiserver.Player.System
     ]
 

--- a/lib/teiserver/tachyon_battle.ex
+++ b/lib/teiserver/tachyon_battle.ex
@@ -1,0 +1,35 @@
+defmodule Teiserver.TachyonBattle do
+  @moduledoc """
+  To track ongoing battle. A battle should be linked with a running instance
+  of the engine on an autohost.
+
+  Ideally this should only be called Battle, but this clashes with the existing
+  battle system tied to spring protocol and spads. This version, as the name
+  suggest, is meant to be used with tachyon and autohosts.
+  """
+
+  alias Teiserver.TachyonBattle.Types, as: T
+  alias Teiserver.TachyonBattle
+
+  @type id :: T.id()
+
+  @spec start_battle(Teiserver.Autohost.id()) :: {:ok, T.id()} | {:error, term()}
+  def start_battle(autohost_id) do
+    battle_id = gen_id()
+    # TODO: handle potential errors, like "already registered"
+    case TachyonBattle.Supervisor.start_battle(battle_id, autohost_id) do
+      {:ok, _pid} -> {:ok, battle_id}
+      {:ok, _pid, _info} -> {:ok, battle_id}
+      _ -> {:error, "cannot start battle"}
+    end
+  end
+
+  @spec lookup(T.id()) :: pid() | nil
+  defdelegate lookup(battle_id), to: Teiserver.TachyonBattle.Registry
+
+  @doc """
+  Generate a battle id
+  """
+  @spec gen_id() :: T.id()
+  def gen_id(), do: UUID.uuid4()
+end

--- a/lib/teiserver/tachyon_battle.ex
+++ b/lib/teiserver/tachyon_battle.ex
@@ -8,28 +8,50 @@ defmodule Teiserver.TachyonBattle do
   suggest, is meant to be used with tachyon and autohosts.
   """
 
+  require Logger
+  alias Teiserver.Bot
   alias Teiserver.TachyonBattle.Types, as: T
-  alias Teiserver.TachyonBattle
+  alias Teiserver.{TachyonBattle, Autohost}
 
   @type id :: T.id()
+  @type start_script :: T.start_script()
 
   @spec start_battle(Teiserver.Autohost.id()) :: {:ok, T.id()} | {:error, term()}
   def start_battle(autohost_id) do
     battle_id = gen_id()
     # TODO: handle potential errors, like "already registered"
     case TachyonBattle.Supervisor.start_battle(battle_id, autohost_id) do
-      {:ok, _pid} -> {:ok, battle_id}
-      {:ok, _pid, _info} -> {:ok, battle_id}
-      _ -> {:error, "cannot start battle"}
+      {:ok, _pid} ->
+        {:ok, battle_id}
+
+      {:ok, _pid, _info} ->
+        {:ok, battle_id}
+
+      err ->
+        Logger.warning("Cannot start battle: #{inspect(err)}")
+        {:error, "cannot start battle: #{inspect(err)}"}
     end
   end
 
   @spec lookup(T.id()) :: pid() | nil
-  defdelegate lookup(battle_id), to: Teiserver.TachyonBattle.Registry
+  defdelegate lookup(battle_id), to: TachyonBattle.Registry
 
   @doc """
-  Generate a battle id
+  Start a battle process and connects it to the given autohost
   """
+  @spec start_battle(Bot.id(), T.start_script()) ::
+          {:ok, Autohost.start_response()} | {:error, term()}
+  def start_battle(autohost_id, start_script) do
+    with {:ok, battle_id} <- start_battle(autohost_id) do
+      start_script = Map.put(start_script, :battleId, battle_id)
+      Logger.info("Starting battle with id #{battle_id} on autohost #{autohost_id}")
+      Teiserver.Autohost.start_battle(autohost_id, start_script)
+    end
+  end
+
+  # keep this function private to dissuade caller to misuse the API.
+  # Generating a battle id is meaningless unless the corresponding
+  # Battle genserver is also started and connected to an autohost
   @spec gen_id() :: T.id()
-  def gen_id(), do: UUID.uuid4()
+  defp gen_id(), do: UUID.uuid4()
 end

--- a/lib/teiserver/tachyon_battle/battle.ex
+++ b/lib/teiserver/tachyon_battle/battle.ex
@@ -1,0 +1,38 @@
+defmodule Teiserver.TachyonBattle.Battle do
+  require Logger
+
+  alias Teiserver.TachyonBattle.Types, as: T
+  alias Teiserver.TachyonBattle.Registry
+
+  # For now, don't do any restart. The genserver is only used to hold some
+  # transient state. Later, we can attempt to reconstruct some state after
+  # a restart based on the message we get.
+  use GenServer, restart: :temporary
+
+  @type state :: %{
+          id: T.id(),
+          autohost_id: Teiserver.Autohost.id()
+        }
+
+  def start_link({battle_id, _autohost_id} = arg) do
+    GenServer.start_link(__MODULE__, arg, name: via_tuple(battle_id))
+  end
+
+  @impl true
+  def init({battle_id, autohost_id}) do
+    Logger.metadata(battle_id: battle_id)
+
+    state = %{
+      id: battle_id,
+      autohost_id: autohost_id
+    }
+
+    Logger.info("init battle for autohost #{autohost_id}")
+
+    {:ok, state}
+  end
+
+  defp via_tuple(battle_id) do
+    Registry.via_tuple(battle_id)
+  end
+end

--- a/lib/teiserver/tachyon_battle/battle.ex
+++ b/lib/teiserver/tachyon_battle/battle.ex
@@ -14,12 +14,12 @@ defmodule Teiserver.TachyonBattle.Battle do
           autohost_id: Teiserver.Autohost.id()
         }
 
-  def start_link({battle_id, _autohost_id} = arg) do
+  def start_link(%{battle_id: battle_id} = arg) do
     GenServer.start_link(__MODULE__, arg, name: via_tuple(battle_id))
   end
 
   @impl true
-  def init({battle_id, autohost_id}) do
+  def init(%{battle_id: battle_id, autohost_id: autohost_id}) do
     Logger.metadata(battle_id: battle_id)
 
     state = %{

--- a/lib/teiserver/tachyon_battle/battle.ex
+++ b/lib/teiserver/tachyon_battle/battle.ex
@@ -36,6 +36,10 @@ defmodule Teiserver.TachyonBattle.Battle do
       autohost_timeout: Map.get(args, :autohost_timeout, 100)
     }
 
+    # we need an overall timeout to avoid any potential zombie process
+    # 8h is more than enough time for any online game
+    :timer.send_after(8 * 60 * 60_000, :battle_timeout)
+
     case Teiserver.Autohost.lookup_autohost(autohost_id) do
       {pid, _} ->
         Logger.info("init battle for autohost #{autohost_id}")
@@ -59,6 +63,9 @@ defmodule Teiserver.TachyonBattle.Battle do
     {:stop, :normal, state}
   end
 
+  def handle_info(:battle_timeout, state) do
+    Logger.info("Battle shutting down to save resources")
+    {:stop, :normal, state}
   end
 
   defp via_tuple(battle_id) do

--- a/lib/teiserver/tachyon_battle/battle.ex
+++ b/lib/teiserver/tachyon_battle/battle.ex
@@ -11,25 +11,54 @@ defmodule Teiserver.TachyonBattle.Battle do
 
   @type state :: %{
           id: T.id(),
-          autohost_id: Teiserver.Autohost.id()
+          autohost_id: Teiserver.Autohost.id(),
+          autohost_timeout: timeout()
         }
+
+  def start(%{battle_id: battle_id} = arg) do
+    GenServer.start(__MODULE__, arg, name: via_tuple(battle_id))
+  end
 
   def start_link(%{battle_id: battle_id} = arg) do
     GenServer.start_link(__MODULE__, arg, name: via_tuple(battle_id))
   end
 
   @impl true
-  def init(%{battle_id: battle_id, autohost_id: autohost_id}) do
+  def init(%{battle_id: battle_id, autohost_id: autohost_id} = args) do
     Logger.metadata(battle_id: battle_id)
 
     state = %{
       id: battle_id,
-      autohost_id: autohost_id
+      autohost_id: autohost_id,
+      # the timeout is absurdly short because there is no real recovery if the
+      # autohost goes away. When we implement state recovery this timeout
+      # should be increased to a more reasonable value (1 min?)
+      autohost_timeout: Map.get(args, :autohost_timeout, 100)
     }
 
-    Logger.info("init battle for autohost #{autohost_id}")
+    case Teiserver.Autohost.lookup_autohost(autohost_id) do
+      {pid, _} ->
+        Logger.info("init battle for autohost #{autohost_id}")
+        Process.monitor(pid)
+        {:ok, state}
 
-    {:ok, state}
+      nil ->
+        {:stop, :no_autohost}
+    end
+  end
+
+  @impl true
+  def handle_info({:DOWN, _ref, :process, _pid, _reason}, state) do
+    timeout = state.autohost_timeout
+    if timeout != :infinity, do: :timer.send_after(timeout, :autohost_timeout)
+    {:noreply, state}
+  end
+
+  def handle_info(:autohost_timeout, state) do
+    Logger.info("Autohost #{state.autohost_id} disconnected for too long, shutting down battle")
+    {:stop, :normal, state}
+  end
+
   end
 
   defp via_tuple(battle_id) do

--- a/lib/teiserver/tachyon_battle/registry.ex
+++ b/lib/teiserver/tachyon_battle/registry.ex
@@ -1,0 +1,22 @@
+defmodule Teiserver.TachyonBattle.Registry do
+  @moduledoc """
+  Registry to track ongoing battles, linked with a autohost
+  """
+  alias Teiserver.TachyonBattle.Types, as: T
+
+  def child_spec(_) do
+    Supervisor.child_spec(Horde.Registry,
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, []}
+    )
+  end
+
+  def start_link() do
+    Horde.Registry.start_link(keys: :unique, name: __MODULE__)
+  end
+
+  @spec via_tuple(T.id()) :: GenServer.name()
+  def via_tuple(battle_id) do
+    {:via, Horde.Registry, {__MODULE__, battle_id}}
+  end
+end

--- a/lib/teiserver/tachyon_battle/registry.ex
+++ b/lib/teiserver/tachyon_battle/registry.ex
@@ -19,4 +19,12 @@ defmodule Teiserver.TachyonBattle.Registry do
   def via_tuple(battle_id) do
     {:via, Horde.Registry, {__MODULE__, battle_id}}
   end
+
+  @spec lookup(T.id()) :: pid() | nil
+  def lookup(battle_id) do
+    case Horde.Registry.lookup(__MODULE__, battle_id) do
+      [{pid, _}] -> pid
+      _ -> nil
+    end
+  end
 end

--- a/lib/teiserver/tachyon_battle/supervisor.ex
+++ b/lib/teiserver/tachyon_battle/supervisor.ex
@@ -16,6 +16,9 @@ defmodule Teiserver.TachyonBattle.Supervisor do
 
   @spec start_battle(T.id(), Teiserver.Autohost.id()) :: DynamicSupervisor.on_start_child()
   def start_battle(battle_id, autohost_id) do
-    DynamicSupervisor.start_child(__MODULE__, {Battle, {battle_id, autohost_id}})
+    DynamicSupervisor.start_child(
+      __MODULE__,
+      {Battle, %{battle_id: battle_id, autohost_id: autohost_id}}
+    )
   end
 end

--- a/lib/teiserver/tachyon_battle/supervisor.ex
+++ b/lib/teiserver/tachyon_battle/supervisor.ex
@@ -1,0 +1,21 @@
+defmodule Teiserver.TachyonBattle.Supervisor do
+  @moduledoc false
+
+  use DynamicSupervisor
+  alias Teiserver.TachyonBattle.Types, as: T
+  alias Teiserver.TachyonBattle.Battle
+
+  def start_link(init_arg) do
+    DynamicSupervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+
+  @spec start_battle(T.id(), Teiserver.Autohost.id()) :: DynamicSupervisor.on_start_child()
+  def start_battle(battle_id, autohost_id) do
+    DynamicSupervisor.start_child(__MODULE__, {Battle, {battle_id, autohost_id}})
+  end
+end

--- a/lib/teiserver/tachyon_battle/system.ex
+++ b/lib/teiserver/tachyon_battle/system.ex
@@ -1,0 +1,13 @@
+defmodule Teiserver.TachyonBattle.System do
+  use Supervisor
+
+  def start_link(init_arg) do
+    Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_) do
+    children = []
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end

--- a/lib/teiserver/tachyon_battle/system.ex
+++ b/lib/teiserver/tachyon_battle/system.ex
@@ -7,7 +7,7 @@ defmodule Teiserver.TachyonBattle.System do
 
   @impl true
   def init(_) do
-    children = []
+    children = [Teiserver.TachyonBattle.Registry]
     Supervisor.init(children, strategy: :one_for_one)
   end
 end

--- a/lib/teiserver/tachyon_battle/system.ex
+++ b/lib/teiserver/tachyon_battle/system.ex
@@ -1,5 +1,6 @@
 defmodule Teiserver.TachyonBattle.System do
   use Supervisor
+  alias Teiserver.TachyonBattle
 
   def start_link(init_arg) do
     Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
@@ -7,7 +8,7 @@ defmodule Teiserver.TachyonBattle.System do
 
   @impl true
   def init(_) do
-    children = [Teiserver.TachyonBattle.Registry]
+    children = [TachyonBattle.Supervisor, TachyonBattle.Registry]
     Supervisor.init(children, strategy: :one_for_one)
   end
 end

--- a/lib/teiserver/tachyon_battle/types.ex
+++ b/lib/teiserver/tachyon_battle/types.ex
@@ -5,4 +5,29 @@ defmodule Teiserver.TachyonBattle.Types do
   """
 
   @type id :: String.t()
+
+  # unfortunately typespecs don't support merging maps, so this is a
+  # redeclaration of Autohost.start_script(), but without the battle id
+  # https://elixirforum.com/t/typespec-combining-maps/31416
+  @type start_script :: %{
+          engineVersion: String.t(),
+          gameName: String.t(),
+          mapName: String.t(),
+          startPosType: :fixed | :random | :ingame | :beforegame,
+          allyTeams: [ally_team(), ...]
+        }
+
+  @type ally_team :: %{
+          teams: [team(), ...]
+        }
+
+  @type team :: %{
+          players: [player()]
+        }
+
+  @type player :: %{
+          userId: String.t(),
+          name: String.t(),
+          password: String.t()
+        }
 end

--- a/lib/teiserver/tachyon_battle/types.ex
+++ b/lib/teiserver/tachyon_battle/types.ex
@@ -1,0 +1,8 @@
+defmodule Teiserver.TachyonBattle.Types do
+  @moduledoc """
+  for shared types across the tachyon battle modules when there is no clear
+  module that should own them
+  """
+
+  @type id :: String.t()
+end

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -273,4 +273,11 @@ defmodule Teiserver.Support.Tachyon do
   def poll_until_some(f, opts \\ []) do
     poll_until(f, fn x -> not is_nil(x) end, opts)
   end
+
+  @doc """
+  the dual of poll_until_some
+  """
+  def poll_until_nil(f, opts \\ []) do
+    poll_until(f, &is_nil/1, opts)
+  end
 end

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -255,7 +255,7 @@ defmodule Teiserver.Support.Tachyon do
     if pred.(res) do
       res
     else
-      limit = Keyword.get(opts, :limit, 10)
+      limit = Keyword.get(opts, :limit, 50)
 
       if limit <= 0 do
         raise "poll timeout"

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -12,6 +12,19 @@ defmodule Teiserver.Support.Tachyon do
     {:ok, user: user, client: client, token: token}
   end
 
+  def setup_autohost(context) do
+    autohost = Teiserver.BotFixtures.create_bot()
+
+    token =
+      OAuthFixtures.token_attrs(nil, context.app)
+      |> Map.drop([:owner_id])
+      |> Map.put(:bot_id, autohost.id)
+      |> OAuthFixtures.create_token()
+
+    client = connect_autohost!(token, 10, 0)
+    {:ok, autohost: autohost, autohost_client: client}
+  end
+
   @doc """
   connects the given user and returns the ws client
   """

--- a/test/teiserver/autohost/autohost_test.exs
+++ b/test/teiserver/autohost/autohost_test.exs
@@ -1,0 +1,43 @@
+defmodule Teiserver.Autohost.AutohostTest do
+  use ExUnit.Case, async: false
+
+  alias Teiserver.Autohost
+
+  describe "find autohost" do
+    test "no autohost available" do
+      assert nil == Autohost.find_autohost()
+    end
+
+    test "one available autohost" do
+      register_autohost(123, 10, 1)
+      assert 123 == Autohost.find_autohost()
+    end
+
+    test "no capacity" do
+      register_autohost(123, 0, 2)
+      assert nil == Autohost.find_autohost()
+    end
+
+    test "look at all autohosts" do
+      register_autohost(123, 0, 10)
+      register_autohost(456, 10, 2)
+      assert 456 == Autohost.find_autohost()
+    end
+  end
+
+  defp register_autohost(id, max, current) do
+    Autohost.Registry.register(%{id: id, max_battles: max, current_battles: current})
+
+    # Teiserver.Support.Tachyon.poll_until_some(fn ->
+    #   Autohost.Registry.lookup(id)
+    # end)
+
+    on_exit(fn ->
+      Autohost.Registry.unregister(id)
+
+      Teiserver.Support.Tachyon.poll_until_nil(fn ->
+        Autohost.Registry.lookup(id)
+      end)
+    end)
+  end
+end

--- a/test/teiserver/tachyon_battle/battle_test.exs
+++ b/test/teiserver/tachyon_battle/battle_test.exs
@@ -1,0 +1,12 @@
+defmodule Teiserver.TachyonBattle.BattleTest do
+  use Teiserver.DataCase, async: true
+  import Teiserver.Support.Tachyon, only: [poll_until_some: 1]
+  alias Teiserver.TachyonBattle, as: Battle
+
+  describe "start battle" do
+    test "happy path" do
+      {:ok, battle_id} = Battle.start_battle("irrelevant_autohost_id")
+      poll_until_some(fn -> Battle.lookup(battle_id) end)
+    end
+  end
+end

--- a/test/teiserver/tachyon_battle/battle_test.exs
+++ b/test/teiserver/tachyon_battle/battle_test.exs
@@ -5,7 +5,10 @@ defmodule Teiserver.TachyonBattle.BattleTest do
 
   describe "start battle" do
     test "happy path" do
-      {:ok, battle_id} = Battle.start_battle("irrelevant_autohost_id")
+      autohost_id = 123
+      Teiserver.Autohost.Registry.register(%{id: autohost_id})
+      on_exit(fn -> Teiserver.Autohost.Registry.unregister(autohost_id) end)
+      {:ok, battle_id} = Battle.start_battle(autohost_id)
       poll_until_some(fn -> Battle.lookup(battle_id) end)
     end
   end

--- a/test/teiserver_web/tachyon/battle_test.exs
+++ b/test/teiserver_web/tachyon/battle_test.exs
@@ -1,0 +1,37 @@
+defmodule TeiserverWeb.Tachyon.BattleTest do
+  use TeiserverWeb.ConnCase
+  alias Teiserver.Support.Tachyon
+  alias Teiserver.OAuthFixtures
+  alias Teiserver.TachyonBattle
+
+  defp setup_app(_context) do
+    owner = Central.Helpers.GeneralTestLib.make_user(%{"data" => %{"roles" => ["Verified"]}})
+
+    app =
+      OAuthFixtures.app_attrs(owner.id)
+      |> Map.put(:uid, UUID.uuid4())
+      |> OAuthFixtures.create_app()
+
+    {:ok, app: app}
+  end
+
+  setup [:setup_app, {Tachyon, :setup_autohost}]
+
+  # this test is a bit meh because it uses a fairly high level API (the tachyon ws protocol)
+  # but tests some internals of the Battle process
+  # Not sure about a better way though
+  test "battle timeout", %{autohost: autohost, autohost_client: autohost_client} do
+    Tachyon.poll_until_some(&Teiserver.Autohost.find_autohost/0)
+
+    assert {:ok, pid} =
+             TachyonBattle.Battle.start(%{
+               battle_id: "whatever",
+               autohost_id: autohost.id,
+               autohost_timeout: 1
+             })
+
+    Tachyon.disconnect!(autohost_client)
+    Tachyon.poll_until(&Teiserver.Autohost.find_autohost/0, &is_nil/1)
+    Tachyon.poll_until(fn -> Process.alive?(pid) end, &(&1 == false))
+  end
+end

--- a/test/teiserver_web/tachyon/matchmaking_test.exs
+++ b/test/teiserver_web/tachyon/matchmaking_test.exs
@@ -409,21 +409,8 @@ defmodule Teiserver.Tachyon.MatchmakingTest do
     end
   end
 
-  def setup_autohost(context) do
-    autohost = Teiserver.BotFixtures.create_bot()
-
-    token =
-      OAuthFixtures.token_attrs(nil, context.app)
-      |> Map.drop([:owner_id])
-      |> Map.put(:bot_id, autohost.id)
-      |> OAuthFixtures.create_token()
-
-    client = Tachyon.connect_autohost!(token, 10, 0)
-    {:ok, autohost: autohost, autohost_client: client}
-  end
-
   describe "join with autohost" do
-    setup [{Tachyon, :setup_client}, :setup_app, :setup_queue, :setup_autohost]
+    setup [{Tachyon, :setup_client}, :setup_app, :setup_queue, {Tachyon, :setup_autohost}]
 
     test "happy full path", %{
       app: app,


### PR DESCRIPTION
Add a system similar to the existing battles. A tree of dynamic processes that are tied to an ongoing battle with an autohost.
The goal is for these process to handle messages from autohost, right now they do nothing.