### PR TITLE
Allow admin to restrict certain accolades to Ally or Enemy only

### DIFF
--- a/lib/teiserver/account/libs/accolade_lib.ex
+++ b/lib/teiserver/account/libs/accolade_lib.ex
@@ -356,6 +356,33 @@ defmodule Teiserver.Account.AccoladeLib do
     end)
   end
 
+  @spec get_viewable_accolade_types(boolean()) :: [map()]
+  def get_viewable_accolade_types(is_ally?) do
+    restriction =
+      if is_ally? do
+        "ally"
+      else
+        "enemy"
+      end
+
+    query =
+      "select id, name, icon, colour from teiserver_account_badge_types tabt
+      where (restriction in ($1) or restriction is null) and purpose = 'Accolade'
+order by name;"
+
+    results = Ecto.Adapters.SQL.query!(Repo, query, [restriction])
+
+    results.rows
+    |> Enum.map(fn [id, name, icon, colour] ->
+      %{
+        id: id,
+        name: name,
+        icon: icon,
+        colour: colour
+      }
+    end)
+  end
+
   @spec get_player_accolades(T.userid()) :: map()
   def get_player_accolades(userid) do
     Account.list_accolades(search: [recipient_id: userid, has_badge: true])

--- a/lib/teiserver/account/libs/accolade_lib.ex
+++ b/lib/teiserver/account/libs/accolade_lib.ex
@@ -356,8 +356,8 @@ defmodule Teiserver.Account.AccoladeLib do
     end)
   end
 
-  @spec get_viewable_accolade_types(boolean()) :: [map()]
-  def get_viewable_accolade_types(is_ally?) do
+  @spec get_giveable_accolade_types(boolean()) :: [map()]
+  def get_giveable_accolade_types(is_ally?) do
     restriction =
       if is_ally? do
         "Ally"

--- a/lib/teiserver/account/libs/accolade_lib.ex
+++ b/lib/teiserver/account/libs/accolade_lib.ex
@@ -360,9 +360,9 @@ defmodule Teiserver.Account.AccoladeLib do
   def get_viewable_accolade_types(is_ally?) do
     restriction =
       if is_ally? do
-        "ally"
+        "Ally"
       else
-        "enemy"
+        "Enemy"
       end
 
     query =

--- a/lib/teiserver/account/libs/badge_type_lib.ex
+++ b/lib/teiserver/account/libs/badge_type_lib.ex
@@ -28,6 +28,14 @@ defmodule Teiserver.Account.BadgeTypeLib do
       "Role"
     ]
 
+  @spec restriction_list() :: [String.t()]
+  def restriction_list(),
+    do: [
+      nil,
+      "Ally",
+      "Enemy"
+    ]
+
   @spec make_favourite(map()) :: map()
   def make_favourite(badge_type) do
     %{

--- a/lib/teiserver/account/schemas/badge_type.ex
+++ b/lib/teiserver/account/schemas/badge_type.ex
@@ -6,8 +6,8 @@ defmodule Teiserver.Account.BadgeType do
     field :icon, :string
     field :colour, :string
     field :description, :string
-
     field :purpose, :string
+    field :restriction, :string
 
     timestamps()
   end
@@ -22,7 +22,7 @@ defmodule Teiserver.Account.BadgeType do
       |> trim_strings(~w(name description)a)
 
     struct
-    |> cast(params, ~w(name icon colour purpose description)a)
+    |> cast(params, ~w(name icon colour purpose description restriction)a)
     |> validate_required(~w(name icon colour purpose)a)
   end
 

--- a/lib/teiserver_web/live/battles/match/show.ex
+++ b/lib/teiserver_web/live/battles/match/show.ex
@@ -644,6 +644,9 @@ defmodule TeiserverWeb.Battle.MatchLive.Show do
                 <% end %>
               </tbody>
             </table>
+            <a phx-click="return-to-match" class="btn btn-sm btn-secondary">
+              Cancel
+            </a>
           </div>
         </div>
       </div>

--- a/lib/teiserver_web/live/battles/match/show.ex
+++ b/lib/teiserver_web/live/battles/match/show.ex
@@ -1,6 +1,5 @@
 defmodule TeiserverWeb.Battle.MatchLive.Show do
   @moduledoc false
-  alias Teiserver.Account.Accolade
   use TeiserverWeb, :live_view
   alias Teiserver.{Account, Battle, Game, Telemetry}
   alias Teiserver.Battle.{MatchLib, BalanceLib}

--- a/lib/teiserver_web/live/battles/match/show.ex
+++ b/lib/teiserver_web/live/battles/match/show.ex
@@ -476,7 +476,7 @@ defmodule TeiserverWeb.Battle.MatchLive.Show do
     is_ally? = current_user_team_id == recipient_team_id
 
     badge_types =
-      AccoladeLib.get_viewable_accolade_types(is_ally?)
+      AccoladeLib.get_giveable_accolade_types(is_ally?)
 
     gift_limit = Config.get_site_config_cache("teiserver.Accolade gift limit")
     gift_window = Config.get_site_config_cache("teiserver.Accolade gift window")

--- a/lib/teiserver_web/live/battles/match/show.ex
+++ b/lib/teiserver_web/live/battles/match/show.ex
@@ -1,5 +1,6 @@
 defmodule TeiserverWeb.Battle.MatchLive.Show do
   @moduledoc false
+  alias Teiserver.Account.Accolade
   use TeiserverWeb, :live_view
   alias Teiserver.{Account, Battle, Game, Telemetry}
   alias Teiserver.Battle.{MatchLib, BalanceLib}
@@ -465,11 +466,18 @@ defmodule TeiserverWeb.Battle.MatchLive.Show do
 
   def handle_event(
         "give-accolade",
-        %{"recipient_id" => recipient_id, "recipient_name" => recipient_name},
+        params,
         socket
       ) do
+    recipient_id = params["recipient_id"]
+    recipient_name = params["recipient_name"]
+    current_user_team_id = params["current_user_team_id"]
+    recipient_team_id = params["recipient_team_id"]
+
+    is_ally? = current_user_team_id == recipient_team_id
+
     badge_types =
-      Account.list_accolade_types()
+      AccoladeLib.get_viewable_accolade_types(is_ally?)
 
     gift_limit = Config.get_site_config_cache("teiserver.Accolade gift limit")
     gift_window = Config.get_site_config_cache("teiserver.Accolade gift window")

--- a/lib/teiserver_web/live/battles/match/show.html.heex
+++ b/lib/teiserver_web/live/battles/match/show.html.heex
@@ -258,10 +258,11 @@
                         phx-click="give-accolade"
                         phx-value-recipient_name={m.user.name}
                         phx-value-recipient_id={m.user.id}
+                        phx-value-current_user_team_id={@current_user_team_id}
+                        phx-value-recipient_team_id={m.team_id}
                         class={[
                           "btn btn-sm btn-success",
-                          @current_user_team_id && m.team_id != @current_user_team_id &&
-                            "invisible"
+                          
                         ]}
                       >
                         <i class="fa-solid fa-award"></i>&nbsp;

--- a/lib/teiserver_web/live/battles/match/show.html.heex
+++ b/lib/teiserver_web/live/battles/match/show.html.heex
@@ -261,8 +261,7 @@
                         phx-value-current_user_team_id={@current_user_team_id}
                         phx-value-recipient_team_id={m.team_id}
                         class={[
-                          "btn btn-sm btn-success",
-                          
+                          "btn btn-sm btn-success"
                         ]}
                       >
                         <i class="fa-solid fa-award"></i>&nbsp;

--- a/lib/teiserver_web/templates/admin/badge_type/form.html.heex
+++ b/lib/teiserver_web/templates/admin/badge_type/form.html.heex
@@ -44,6 +44,11 @@
       <label class="control-label" for="badge_type_purposes">Purposes</label>
       <%= select(f, :purpose, purpose_list(), class: "form-control") %>
     </div>
+
+    <div class="form-group">
+      <label class="control-label" for="badge_type_restrictions">Restriction</label>
+      <%= select(f, :restriction, restriction_list(), class: "form-control") %>
+    </div>
   </div>
 
   <div class="row mt-4">

--- a/lib/teiserver_web/templates/admin/badge_type/index.html.heex
+++ b/lib/teiserver_web/templates/admin/badge_type/index.html.heex
@@ -32,6 +32,8 @@
             <tr>
               <th colspan="2">Name</th>
               <th>Purposes</th>
+              <th>Restriction</th>
+
               <th colspan="2">&nbsp;</th>
             </tr>
           </thead>
@@ -43,6 +45,7 @@
                 </td>
                 <td><%= badge_type.name %></td>
                 <td><%= badge_type.purpose %></td>
+                <td><%= badge_type.restriction %></td>
 
                 <td>
                   <a

--- a/lib/teiserver_web/views/admin/badge_type_view.ex
+++ b/lib/teiserver_web/views/admin/badge_type_view.ex
@@ -9,4 +9,7 @@ defmodule TeiserverWeb.Admin.BadgeTypeView do
 
   @spec purpose_list() :: [String.t()]
   defdelegate purpose_list(), to: Teiserver.Account.BadgeTypeLib
+
+  @spec restriction_list() :: [String.t()]
+  defdelegate restriction_list(), to: Teiserver.Account.BadgeTypeLib
 end

--- a/priv/repo/migrations/20250206221410_add_accolade_restriction.exs
+++ b/priv/repo/migrations/20250206221410_add_accolade_restriction.exs
@@ -1,0 +1,36 @@
+defmodule Teiserver.Repo.Migrations.AddAccoladeRestriction do
+  use Ecto.Migration
+
+  def change do
+    alter table("teiserver_account_badge_types") do
+      add :restriction, :string
+    end
+
+    # Restrict new column to certain values
+    constraint_query = """
+     ALTER TABLE teiserver_account_badge_types
+     ADD CONSTRAINT restriction_constraint check(restriction in ('ally', 'enemy') OR restriction is null);
+
+
+    """
+
+    # If we rollback remove the constraint
+    rollback_query =
+      "ALTER TABLE teiserver_account_badge_types DROP CONSTRAINT restriction_constraint;"
+
+    execute(constraint_query, rollback_query)
+
+    # Restrict new column to certain values
+    update_restrictions = """
+     UPDATE teiserver_account_badge_types
+      set restriction = 'ally'
+      where lower(name) = 'good teammate';
+    """
+
+    # If we rollback don't need to do anything extra
+    rollback_query =
+      ""
+
+    execute(update_restrictions, rollback_query)
+  end
+end

--- a/priv/repo/migrations/20250206221410_add_accolade_restriction.exs
+++ b/priv/repo/migrations/20250206221410_add_accolade_restriction.exs
@@ -9,7 +9,7 @@ defmodule Teiserver.Repo.Migrations.AddAccoladeRestriction do
     # Restrict new column to certain values
     constraint_query = """
      ALTER TABLE teiserver_account_badge_types
-     ADD CONSTRAINT restriction_constraint check(restriction in ('ally', 'enemy') OR restriction is null);
+     ADD CONSTRAINT restriction_constraint check(restriction in ('Ally', 'Enemy') OR restriction is null);
 
 
     """
@@ -20,10 +20,10 @@ defmodule Teiserver.Repo.Migrations.AddAccoladeRestriction do
 
     execute(constraint_query, rollback_query)
 
-    # Restrict new column to certain values
+    # UPDATE Good Teammate accolade to be ally only
     update_restrictions = """
      UPDATE teiserver_account_badge_types
-      set restriction = 'ally'
+      set restriction = 'Ally'
       where lower(name) = 'good teammate';
     """
 


### PR DESCRIPTION
This PR allows the admin to restrict certain accolades to ally or enemy only. By default restriction is set to null which means any.

The migration script will do the following:
1. Add a new column to teiserver_account_badge_types: restriction
2. Add a constraint such that this column can only by NULL, "Ally", or "Enemy"
3. Update the "Good Teammate" accolade so that it is restricted to Ally (if it exists already). This can still be changed by the Admin via the website.


# Testing
 Go to http://localhost:4000/teiserver/admin/badge_types
and you should see a new column called restriction. You can edit an accolade's restriction.

For example, if Good Teammate is ally only, then you cannot give this accolade in a match where you weren't the ally of the person you are gifting to.

![1](https://github.com/user-attachments/assets/64f7ecf0-ecc8-4949-9362-f3b151b93df3)

