### PR TITLE
Ensure test cleanup sessions

### DIFF
--- a/lib/teiserver/player/session.ex
+++ b/lib/teiserver/player/session.ex
@@ -376,7 +376,7 @@ defmodule Teiserver.Player.Session do
         {:stop, :normal, state}
 
       st ->
-        if reason != :normal do
+        if reason not in [:normal, :test_cleanup] do
           Logger.warning(
             "unhandled DOWN: #{inspect(ref)} went down because #{reason}. state: #{inspect(st)}"
           )

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -9,7 +9,7 @@ defmodule Teiserver.Support.Tachyon do
     user = Central.Helpers.GeneralTestLib.make_user(%{"data" => %{"roles" => ["Verified"]}})
     %{client: client, token: token} = connect(user)
 
-    ExUnit.Callbacks.on_exit(fn -> WSC.disconnect(client) end)
+    ExUnit.Callbacks.on_exit(fn -> cleanup_connection(client, token) end)
     {:ok, user: user, client: client, token: token}
   end
 
@@ -43,20 +43,7 @@ defmodule Teiserver.Support.Tachyon do
       {:ok, _user_updated} = recv_message(client)
     end
 
-    ExUnit.Callbacks.on_exit(fn ->
-      WSC.disconnect(client)
-
-      case Player.lookup_session(token.owner_id) do
-        nil -> :ok
-        pid -> Process.exit(pid, :test_cleanup)
-      end
-
-      poll_until(
-        fn -> Player.lookup_session(token.owner_id) end,
-        fn x -> is_nil(x) end
-      )
-    end)
-
+    ExUnit.Callbacks.on_exit(fn -> cleanup_connection(client, token) end)
     client
   end
 
@@ -65,6 +52,22 @@ defmodule Teiserver.Support.Tachyon do
 
     client = connect(token, opts)
     %{client: client, token: token}
+  end
+
+  # used for on_exit callback and make sure nothing is lingering after the test
+  def cleanup_connection(client, token) do
+    WSC.disconnect(client)
+
+    if not is_nil(token.owner_id) do
+      poll_until_nil(fn -> Player.lookup_connection(token.owner_id) end)
+
+      case Player.lookup_session(token.owner_id) do
+        nil -> :ok
+        pid -> Process.exit(pid, :test_cleanup)
+      end
+
+      poll_until_nil(fn -> Player.lookup_session(token.owner_id) end)
+    end
   end
 
   @doc """

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -68,6 +68,10 @@ defmodule Teiserver.Support.Tachyon do
 
       poll_until_nil(fn -> Player.lookup_session(token.owner_id) end)
     end
+
+    if not is_nil(token.bot_id) do
+      poll_until_nil(fn -> Teiserver.Autohost.Registry.lookup(token.bot_id) end)
+    end
   end
 
   @doc """

--- a/test/teiserver_web/tachyon/session_test.exs
+++ b/test/teiserver_web/tachyon/session_test.exs
@@ -41,6 +41,7 @@ defmodule TeiserverWeb.Tachyon.SessionTest do
   } do
     opts = Tachyon.connect_options(token)
     {:ok, client2} = WSC.connect(Tachyon.tachyon_url(), opts)
+    on_exit(fn -> Tachyon.cleanup_connection(client2, token) end)
     ensure_connected(client2)
     WSC.send_message(client, {:text, "test_ping"})
     assert {:error, :disconnected} == WSC.recv(client)


### PR DESCRIPTION
Make real sure the connection and the sessions are both gone after tests.
And it turn out that some tests were not using `Tachyon.connect`, so fixed these as well.