### PR TITLE
More session flakes fix

### DIFF
--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -23,6 +23,7 @@ defmodule Teiserver.Support.Tachyon do
       |> OAuthFixtures.create_token()
 
     client = connect_autohost!(token, 10, 0)
+    ExUnit.Callbacks.on_exit(fn -> cleanup_connection(client, token) end)
     {:ok, autohost: autohost, autohost_client: client}
   end
 

--- a/test/teiserver_web/controllers/tachyon_controller_test.exs
+++ b/test/teiserver_web/controllers/tachyon_controller_test.exs
@@ -153,6 +153,7 @@ defmodule TeiserverWeb.TachyonControllerTest do
       ]
 
       {:ok, client} = WSC.connect(tachyon_url(), opts)
+      ExUnit.Callbacks.on_exit(fn -> Tachyon.cleanup_connection(client, token) end)
 
       conn_pid =
         Teiserver.Support.Tachyon.poll_until_some(fn ->
@@ -181,7 +182,8 @@ defmodule TeiserverWeb.TachyonControllerTest do
         ]
       ]
 
-      {:ok, _client} = WSC.connect(tachyon_url(), opts)
+      {:ok, client} = WSC.connect(tachyon_url(), opts)
+      ExUnit.Callbacks.on_exit(fn -> Tachyon.cleanup_connection(client, token) end)
 
       conn_pid =
         Tachyon.poll_until_some(fn ->


### PR DESCRIPTION
Without the second commit, the following command would fail:
`mix test --exclude needs_attention test/teiserver_web/ --seed 477485`