### PR TITLE
Remove deep caching hashmap in balancer server

### DIFF
--- a/lib/teiserver/game/servers/balancer_server.ex
+++ b/lib/teiserver/game/servers/balancer_server.ex
@@ -199,10 +199,9 @@ defmodule Teiserver.Game.BalancerServer do
     |> Base.encode64()
   end
 
-  # This function is public only for testing; it should not be called otherwise
-  # long term, there in interest in confirming this is a stateless pure function, which would make this easier to test
+  # long term, there in interest in confirming do_make_balance is a stateless pure function, which would make it easier to test
   @spec do_make_balance(non_neg_integer(), [T.client()], List.t()) :: map()
-  def do_make_balance(team_count, players, opts) do
+  defp do_make_balance(team_count, players, opts) do
     team_size = calculate_team_size(team_count, players)
 
     # Use Large Team ratings when balancing Team FFA

--- a/lib/teiserver/game/servers/balancer_server.ex
+++ b/lib/teiserver/game/servers/balancer_server.ex
@@ -95,7 +95,7 @@ defmodule Teiserver.Game.BalancerServer do
 
   @impl true
   def handle_cast(:reset_hashes, state) do
-    {:noreply, %{state | hashes: %{}}}
+    {:noreply, %{state | last_balance_hash: nil, last_balance_result: nil}}
   end
 
   def handle_cast({:set_algorithm, algorithm}, state) do
@@ -118,7 +118,8 @@ defmodule Teiserver.Game.BalancerServer do
         true ->
           state
           |> Map.put(key, value)
-          |> Map.put(:hashes, %{})
+          |> Map.put(:last_balance_hash, nil)
+          |> Map.put(:last_balance_result, nil)
 
         false ->
           state

--- a/lib/teiserver/game/servers/balancer_server.ex
+++ b/lib/teiserver/game/servers/balancer_server.ex
@@ -27,11 +27,7 @@ defmodule Teiserver.Game.BalancerServer do
           mean_diff_max: state.mean_diff_max,
           stddev_diff_max: state.stddev_diff_max,
           fuzz_multiplier: state.fuzz_multiplier,
-          shuffle_first_pick: state.shuffle_first_pick,
-          last_balance_hash_cache_hit: state.last_balance_hash_cache_hit,
-          last_balance_hash_cache_miss: state.last_balance_hash_cache_miss,
-          last_balance_hash: state.last_balance_hash,
-          last_balance_result: state.last_balance_result
+          shuffle_first_pick: state.shuffle_first_pick
         ]
 
     {balance, new_state} = make_balance(team_count, state, opts)
@@ -51,11 +47,7 @@ defmodule Teiserver.Game.BalancerServer do
           mean_diff_max: state.mean_diff_max,
           stddev_diff_max: state.stddev_diff_max,
           fuzz_multiplier: state.fuzz_multiplier,
-          shuffle_first_pick: state.shuffle_first_pick,
-          last_balance_hash_cache_hit: state.last_balance_hash_cache_hit,
-          last_balance_hash_cache_miss: state.last_balance_hash_cache_miss,
-          last_balance_hash: state.last_balance_hash,
-          last_balance_result: state.last_balance_result
+          shuffle_first_pick: state.shuffle_first_pick
         ]
 
     {balance, new_state} = make_balance(team_count, state, opts, players)

--- a/lib/teiserver/game/servers/balancer_server.ex
+++ b/lib/teiserver/game/servers/balancer_server.ex
@@ -9,7 +9,6 @@ defmodule Teiserver.Game.BalancerServer do
   @tick_interval 2_000
   # Balance algos that allow fuzz; randomness will be added to match rating before processing
   @algos_allowing_fuzz ~w(loser_picks force_party)
-
   @spec start_link(List.t()) :: :ignore | {:error, any} | {:ok, pid}
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts[:data], [])
@@ -28,7 +27,9 @@ defmodule Teiserver.Game.BalancerServer do
           mean_diff_max: state.mean_diff_max,
           stddev_diff_max: state.stddev_diff_max,
           fuzz_multiplier: state.fuzz_multiplier,
-          shuffle_first_pick: state.shuffle_first_pick
+          shuffle_first_pick: state.shuffle_first_pick,
+          last_balance_hash_cache_hit: state.last_balance_hash_cache_hit,
+          last_balance_hash_cache_miss: state.last_balance_hash_cache_miss
         ]
 
     {balance, new_state} = make_balance(team_count, state, opts)
@@ -48,7 +49,9 @@ defmodule Teiserver.Game.BalancerServer do
           mean_diff_max: state.mean_diff_max,
           stddev_diff_max: state.stddev_diff_max,
           fuzz_multiplier: state.fuzz_multiplier,
-          shuffle_first_pick: state.shuffle_first_pick
+          shuffle_first_pick: state.shuffle_first_pick,
+          last_balance_hash_cache_hit: state.last_balance_hash_cache_hit,
+          last_balance_hash_cache_miss: state.last_balance_hash_cache_miss
         ]
 
     {balance, new_state} = make_balance(team_count, state, opts, players)
@@ -74,7 +77,9 @@ defmodule Teiserver.Game.BalancerServer do
       mean_diff_max: state.mean_diff_max,
       fuzz_multiplier: state.fuzz_multiplier,
       stddev_diff_max: state.stddev_diff_max,
-      shuffle_first_pick: state.shuffle_first_pick
+      shuffle_first_pick: state.shuffle_first_pick,
+      last_balance_hash_cache_hit: state.last_balance_hash_cache_hit,
+      last_balance_hash_cache_miss: state.last_balance_hash_cache_miss
     }
 
     {:reply, result, state}

--- a/lib/teiserver/game/servers/balancer_server.ex
+++ b/lib/teiserver/game/servers/balancer_server.ex
@@ -19,16 +19,7 @@ defmodule Teiserver.Game.BalancerServer do
   def handle_call({:make_balance, team_count, call_opts}, _from, state) do
     opts =
       call_opts ++
-        [
-          algorithm: state.algorithm,
-          max_deviation: state.max_deviation,
-          rating_lower_boundary: state.rating_lower_boundary,
-          rating_upper_boundary: state.rating_upper_boundary,
-          mean_diff_max: state.mean_diff_max,
-          stddev_diff_max: state.stddev_diff_max,
-          fuzz_multiplier: state.fuzz_multiplier,
-          shuffle_first_pick: state.shuffle_first_pick
-        ]
+        handle_call_make_balance_additional_opts(state)
 
     {balance, new_state} = make_balance(team_count, state, opts)
     {:reply, balance, new_state}
@@ -39,19 +30,23 @@ defmodule Teiserver.Game.BalancerServer do
   def handle_call({:make_balance, team_count, call_opts, players}, _from, state) do
     opts =
       call_opts ++
-        [
-          algorithm: state.algorithm,
-          max_deviation: state.max_deviation,
-          rating_lower_boundary: state.rating_lower_boundary,
-          rating_upper_boundary: state.rating_upper_boundary,
-          mean_diff_max: state.mean_diff_max,
-          stddev_diff_max: state.stddev_diff_max,
-          fuzz_multiplier: state.fuzz_multiplier,
-          shuffle_first_pick: state.shuffle_first_pick
-        ]
+        handle_call_make_balance_additional_opts(state)
 
     {balance, new_state} = make_balance(team_count, state, opts, players)
     {:reply, balance, new_state}
+  end
+
+  defp handle_call_make_balance_additional_opts(state) do
+    [
+      algorithm: state.algorithm,
+      max_deviation: state.max_deviation,
+      rating_lower_boundary: state.rating_lower_boundary,
+      rating_upper_boundary: state.rating_upper_boundary,
+      mean_diff_max: state.mean_diff_max,
+      stddev_diff_max: state.stddev_diff_max,
+      fuzz_multiplier: state.fuzz_multiplier,
+      shuffle_first_pick: state.shuffle_first_pick
+    ]
   end
 
   def handle_call(:get_balance_mode, _from, %{last_balance_hash: hash} = state) do

--- a/test/teiserver/battle/balance_lib_internal_test.exs
+++ b/test/teiserver/battle/balance_lib_internal_test.exs
@@ -31,7 +31,7 @@ defmodule Teiserver.Battle.BalanceLibInternalTest do
            ]
   end
 
-  test "Handle groups with incomplete data in create_balance loser_pics" do
+  test "Handle groups with incomplete data in create_balance loser_picks" do
     [user1, user2, user3, user4, user5] = create_test_users()
 
     groups = [

--- a/test/teiserver/game/balancer_server_test.exs
+++ b/test/teiserver/game/balancer_server_test.exs
@@ -40,52 +40,46 @@ defmodule Teiserver.Game.BalancerServerTest do
   test "load some players in and run a balance pass or two" do
     team_count = 2
     players = create_fake_players(4)
-    _team_size = BalancerServer.calculate_team_size(team_count, players)
 
-    # spin up a lobby
-    lobby_starter_info = %{
-      "ip" => nil,
-      "port" => nil,
-      "engine_version" => nil,
-      "map_hash" => nil,
-      "map_name" => nil,
-      "game_name" => nil,
-      "hash_code" => nil,
-      "founder_id" => 4,
-      "founder_name" => "root",
-      "name" => "asdf",
-      "locked" => false,
-      "type" => "normal",
-      "nattype" => "none"
-    }
+    {:ok, start_link_results} = BalancerServer.start_link(data: %{lobby_id: 1})
 
-    {:ok, lobby} =
-      Teiserver.Lobby.create_new_lobby(lobby_starter_info)
+    starting_state = GenServer.call(start_link_results, :report_state, 5000)
+    dbg(starting_state)
 
-    # put some users in the lobby
-    users = Teiserver.Account.list_users(limit: 4)
-    _ = Enum.map(users, fn user -> Teiserver.Lobby.force_add_user_to_lobby(user.id, lobby.id) end)
-
-    # ask for the initial balance state of the lobby
-    {:ok, balance_server_init_results} = BalancerServer.init(%{lobby_id: lobby.id})
-
-    {:ok, start_link_results} = BalancerServer.start_link(data: balance_server_init_results)
-
-    assert is_pid(start_link_results)
-    state = :sys.get_state(start_link_results)
-
-    state = GenServer.call(start_link_results, :report_state)
-    dbg(state)
-    # list the players in the lobby
-    players = Teiserver.Battle.list_lobby_players(lobby.id)
     dbg(players)
-    assert Enum.any?(players)
 
-    # there should be some players in the lobby, and from there we could run a balance pass and get a hash,
-    # but we don't have any players in the lobby for some reason...
+    first_balance_pass =
+      GenServer.call(
+        start_link_results,
+        {:make_balance, team_count, [], players},
+        5000
+      )
+
+    dbg(first_balance_pass)
+
+    second_balance_pass_hash_reuse =
+      GenServer.call(
+        start_link_results,
+        {:make_balance, team_count, [], create_fake_players(4)},
+        5000
+      )
+
+    dbg(second_balance_pass_hash_reuse)
+
+    assert second_balance_pass_hash_reuse.hash == first_balance_pass.hash
+
+    third_balance_pass_with_more_players =
+      GenServer.call(
+        start_link_results,
+        {:make_balance, team_count, [], create_fake_players(160)},
+        5000
+      )
+
+    dbg(third_balance_pass_with_more_players)
+    assert second_balance_pass_hash_reuse.hash != third_balance_pass_with_more_players.hash
   end
 
   defp create_fake_players(count) do
-    1..count |> Enum.map(fn _ -> %{} end)
+    1..count |> Enum.map(fn iter -> %{userid: iter, party_id: iter} end)
   end
 end

--- a/test/teiserver/game/balancer_server_test.exs
+++ b/test/teiserver/game/balancer_server_test.exs
@@ -61,8 +61,7 @@ defmodule Teiserver.Game.BalancerServerTest do
            "Error: Lists are not of equal length. Got #{length(list_of_ranks)} and #{length(list_of_parties)}."
 
     users =
-      Enum.with_index(list_of_ranks)
-      |> Enum.map(fn {_user, _index} -> Central.Helpers.GeneralTestLib.make_user(%{}) end)
+      Enum.map(list_of_ranks, fn _ -> Central.Helpers.GeneralTestLib.make_user(%{}) end)
       |> Enum.map(fn x -> Map.put(x, :userid, x.id) end)
 
     # set the user rank

--- a/test/teiserver/game/balancer_server_test.exs
+++ b/test/teiserver/game/balancer_server_test.exs
@@ -1,54 +1,12 @@
-defmodule Teiserver.Game.BalancerServerTest do
+defmodule Teiserver.Game.BalancerServerAsyncTest do
   @moduledoc false
-  use Teiserver.DataCase, async: false
+  use ExUnit.Case, async: true
 
   @moduletag :balance_test
   alias Teiserver.Game.BalancerServer
 
-  def user_fixture(), do: make_user(%{"permissions" => []})
-
-  def make_user(params \\ %{}) do
-    requested_user = %{
-      "name" => params["name"] || "Test",
-      "email" => params["email"] || "email@email#{:rand.uniform(999_999_999_999)}",
-      "colour" => params["colour"] || "#00AA00",
-      "icon" => params["icon"] || "fa-solid fa-user",
-      "password" => params["password"] || "password",
-      "password_confirmation" => params["password"] || "password",
-      "data" => params["data"] || %{}
-    }
-
-    {:ok, u} =
-      Teiserver.Account.create_user(requested_user)
-  end
-
-  @spec make_users_with_ranks([non_neg_integer()]) ::
-          list()
-  def make_users_with_ranks(list_of_ranks_to_assign_to_users) do
-    users =
-      Enum.with_index(list_of_ranks_to_assign_to_users)
-      |> Enum.map(fn {user, index} ->
-        %{
-          "name" => "user" <> to_string(index + 1) <> "_" <> to_string(ExULID.ULID.generate()),
-          "email" => to_string(ExULID.ULID.generate()) <> "@example.com",
-          "permissions" => []
-        }
-      end)
-      |> Enum.map(fn x -> make_user(x) end)
-      # unwrap user creation response
-      |> Enum.map(fn {:ok, reply} -> reply end)
-      |> Enum.map(fn x -> Map.put(x, :userid, x.id) end)
-      # each user in their own party
-      |> Enum.map(fn x -> Map.put(x, :party_id, x.id + 1) end)
-
-    # set the user rank
-    Enum.map(Enum.with_index(users), fn {user, index} ->
-      Teiserver.Account.update_user_stat(user.id, %{
-        :rank => Enum.at(list_of_ranks_to_assign_to_users, index)
-      })
-    end)
-
-    users
+  defp create_fake_players(count) do
+    1..count |> Enum.map(fn _ -> %{} end)
   end
 
   test "get fuzz multiplier" do
@@ -81,6 +39,60 @@ defmodule Teiserver.Game.BalancerServerTest do
     players = create_fake_players(7)
     result = BalancerServer.calculate_team_size(team_count, players)
     assert result == 4
+  end
+end
+
+defmodule Teiserver.Game.BalancerServerTest do
+  @moduledoc false
+  use Teiserver.DataCase, async: false
+
+  @moduletag :balance_test
+  alias Teiserver.Game.BalancerServer
+
+  def user_fixture(), do: make_user(%{"permissions" => []})
+
+  def make_user(params \\ %{}) do
+    requested_user = %{
+      "name" => params["name"] || "Test",
+      "email" => params["email"] || "email@email#{:rand.uniform(999_999_999_999)}",
+      "colour" => params["colour"] || "#00AA00",
+      "icon" => params["icon"] || "fa-solid fa-user",
+      "password" => params["password"] || "password",
+      "password_confirmation" => params["password"] || "password",
+      "data" => params["data"] || %{}
+    }
+
+    {:ok, u} =
+      Teiserver.Account.create_user(requested_user)
+  end
+
+  @spec make_users_with_ranks([non_neg_integer()]) ::
+          list()
+  def make_users_with_ranks(list_of_ranks) do
+    users =
+      Enum.with_index(list_of_ranks)
+      |> Enum.map(fn {user, index} ->
+        %{
+          "name" => "user" <> to_string(index + 1) <> "_" <> to_string(ExULID.ULID.generate()),
+          "email" => to_string(ExULID.ULID.generate()) <> "@example.com",
+          "permissions" => []
+        }
+      end)
+      |> Enum.map(fn x -> make_user(x) end)
+      # unwrap user creation response
+      |> Enum.map(fn {:ok, reply} -> reply end)
+      |> Enum.map(fn x -> Map.put(x, :userid, x.id) end)
+      # each user in their own party
+      |> Enum.map(fn x -> Map.put(x, :party_id, x.id) end)
+
+    # set the user rank
+    for {user, rank} <- Enum.zip(users, list_of_ranks) do
+      Teiserver.Account.update_user_stat(user.id, %{
+        :rank => rank
+      })
+    end
+
+    users
   end
 
   test "load some players in and run a balance pass or two" do
@@ -177,9 +189,5 @@ defmodule Teiserver.Game.BalancerServerTest do
       GenServer.call(pid, :get_current_balance)
 
     refute get_balance_mode_returns_value == nil
-  end
-
-  defp create_fake_players(count) do
-    1..count |> Enum.map(fn _ -> %{} end)
   end
 end

--- a/test/teiserver/game/balancer_server_test.exs
+++ b/test/teiserver/game/balancer_server_test.exs
@@ -1,6 +1,8 @@
 defmodule Teiserver.Game.BalancerServerTest do
   @moduledoc false
-  use ExUnit.Case
+  use ExUnit.Case, async: true
+  use Teiserver.DataCase, async: true
+
   @moduletag :balance_test
   alias Teiserver.Game.BalancerServer
 
@@ -35,6 +37,35 @@ defmodule Teiserver.Game.BalancerServerTest do
     result = BalancerServer.calculate_team_size(team_count, players)
     assert result == 4
   end
+
+  # test "run one balance pass" do
+  #   team_count = 2
+  #   players = create_fake_players(4)
+  #   team_size = BalancerServer.calculate_team_size(team_count, players)
+
+  #   state1 = BalancerServer.init()
+  #   dbg(state1)
+  #   dbg(BalancerServer.handle_call(:report_state, nil, state1))
+
+  # end
+
+  test "report empty state" do
+    team_count = 2
+    players = create_fake_players(4)
+    team_size = BalancerServer.calculate_team_size(team_count, players)
+
+    state1 = BalancerServer.init(%{lobby_id: 1})
+    dbg(state1)
+    dbg(BalancerServer.handle_call(:report_state, nil, state1))
+  end
+
+  # defp init() do
+  #   BalancerServer.init(%{lobby_id: 1})
+  # end
+
+  # defp make_balance(team_count, state, opts) do
+  #   BalancerServer.make_balance(team_count, state, opts)
+  # end
 
   defp create_fake_players(count) do
     1..count |> Enum.map(fn _ -> %{} end)

--- a/test/teiserver/game/balancer_server_test.exs
+++ b/test/teiserver/game/balancer_server_test.exs
@@ -1,6 +1,5 @@
 defmodule Teiserver.Game.BalancerServerTest do
   @moduledoc false
-  use ExUnit.Case, async: true
   use Teiserver.DataCase, async: true
 
   @moduletag :balance_test
@@ -38,34 +37,24 @@ defmodule Teiserver.Game.BalancerServerTest do
     assert result == 4
   end
 
-  # test "run one balance pass" do
-  #   team_count = 2
-  #   players = create_fake_players(4)
-  #   team_size = BalancerServer.calculate_team_size(team_count, players)
-
-  #   state1 = BalancerServer.init()
-  #   dbg(state1)
-  #   dbg(BalancerServer.handle_call(:report_state, nil, state1))
-
-  # end
-
   test "report empty state" do
     team_count = 2
     players = create_fake_players(4)
-    team_size = BalancerServer.calculate_team_size(team_count, players)
+    _team_size = BalancerServer.calculate_team_size(team_count, players)
 
-    state1 = BalancerServer.init(%{lobby_id: 1})
-    dbg(state1)
-    dbg(BalancerServer.handle_call(:report_state, nil, state1))
+    {:ok, tharp} = BalancerServer.init(%{lobby_id: 1})
+    dbg(tharp)
+
+    {:ok, narp} = BalancerServer.start_link(data: tharp)
+    dbg(narp)
+
+    assert is_pid(narp)
+    dbg(:sys.get_state(narp))
+
+    report_state_result = GenServer.call(narp, :report_state)
+
+    dbg(report_state_result)
   end
-
-  # defp init() do
-  #   BalancerServer.init(%{lobby_id: 1})
-  # end
-
-  # defp make_balance(team_count, state, opts) do
-  #   BalancerServer.make_balance(team_count, state, opts)
-  # end
 
   defp create_fake_players(count) do
     1..count |> Enum.map(fn _ -> %{} end)

--- a/test/teiserver/game/balancer_server_test.exs
+++ b/test/teiserver/game/balancer_server_test.exs
@@ -50,31 +50,21 @@ defmodule Teiserver.Game.BalancerServerTest do
   @moduletag :balance_test
   alias Teiserver.Game.BalancerServer
 
-  @spec make_users_with_ranks_and_parties(
-          [non_neg_integer()],
-          [non_neg_integer()]
-        ) ::
+  @spec make_users_with_ranks([non_neg_integer()]) ::
           list()
 
-  def make_users_with_ranks_and_parties(list_of_ranks, list_of_parties) do
-    assert length(list_of_ranks) == length(list_of_parties),
-           "Error: Lists are not of equal length. Got #{length(list_of_ranks)} and #{length(list_of_parties)}."
-
+  def make_users_with_ranks(list_of_ranks) do
     users =
-      Enum.map(list_of_ranks, fn _ -> Central.Helpers.GeneralTestLib.make_user(%{}) end)
-      |> Enum.map(fn x -> Map.put(x, :userid, x.id) end)
+      for {rank, i} <- Enum.with_index(list_of_ranks) do
+        user = Central.Helpers.GeneralTestLib.make_user(%{})
+        user = Map.put(user, :party_id, i)
+        user = Map.put(user, :userid, user.id)
 
-    # set the user rank
-    for {user, rank} <- Enum.zip(users, list_of_ranks) do
-      Teiserver.Account.update_user_stat(user.id, %{
-        :rank => rank
-      })
-    end
+        Teiserver.Account.update_user_stat(user.id, %{
+          :rank => rank
+        })
 
-    # set the user party_id
-    users =
-      for {user, party_id} <- Enum.zip(users, list_of_parties) do
-        Map.put(user, :party_id, party_id)
+        user
       end
 
     users
@@ -84,8 +74,7 @@ defmodule Teiserver.Game.BalancerServerTest do
     team_count = 2
 
     players =
-      make_users_with_ranks_and_parties([10, 20, 30, 40, 50, 60], [1, 2, 3, 4, 5, 6])
-      |> Enum.map(fn x -> Map.put(x, :userid, x.id) end)
+      make_users_with_ranks([10, 20, 30, 40, 50, 60])
 
     {:ok, pid} = BalancerServer.start_link(data: %{lobby_id: 1})
 
@@ -125,7 +114,7 @@ defmodule Teiserver.Game.BalancerServerTest do
   test "get_current_balance returns a result" do
     team_count = 2
 
-    players = make_users_with_ranks_and_parties([10, 20, 30, 40], [1, 2, 3, 4])
+    players = make_users_with_ranks([10, 20, 30, 40])
 
     {:ok, pid} = BalancerServer.start_link(data: %{lobby_id: 1})
 
@@ -140,7 +129,7 @@ defmodule Teiserver.Game.BalancerServerTest do
   test "reset_hashes clears hash and result" do
     team_count = 2
 
-    players = make_users_with_ranks_and_parties([10, 20, 30, 40], [1, 2, 3, 4])
+    players = make_users_with_ranks([10, 20, 30, 40])
 
     {:ok, pid} = BalancerServer.start_link(data: %{lobby_id: 1})
 
@@ -164,7 +153,7 @@ defmodule Teiserver.Game.BalancerServerTest do
   test "setting the balance mode clears the hash and result" do
     team_count = 2
 
-    players = make_users_with_ranks_and_parties([10, 20, 30, 40], [1, 2, 3, 4])
+    players = make_users_with_ranks([10, 20, 30, 40])
 
     {:ok, pid} = BalancerServer.start_link(data: %{lobby_id: 1})
 

--- a/test/teiserver/game/balancer_server_test.exs
+++ b/test/teiserver/game/balancer_server_test.exs
@@ -183,7 +183,7 @@ defmodule Teiserver.Game.BalancerServerTest do
     end
   end
 
-  test "setting the balance mode resets the hash" do
+  test "setting the balance mode clears the hash and result" do
     team_count = 2
 
     players = make_users_with_ranks_and_parties([10, 20, 30, 40], [1, 2, 3, 4])

--- a/test/teiserver/game/balancer_server_test.exs
+++ b/test/teiserver/game/balancer_server_test.exs
@@ -56,9 +56,10 @@ defmodule Teiserver.Game.BalancerServerTest do
   def make_users_with_ranks(list_of_ranks) do
     users =
       for {rank, i} <- Enum.with_index(list_of_ranks) do
-        user = Central.Helpers.GeneralTestLib.make_user(%{})
-        user = Map.put(user, :party_id, i)
-        user = Map.put(user, :userid, user.id)
+        user =
+          Central.Helpers.GeneralTestLib.make_user(%{})
+          |> Map.put(:party_id, i)
+          |> then(fn user -> Map.put(user, :userid, user.id) end)
 
         Teiserver.Account.update_user_stat(user.id, %{
           :rank => rank

--- a/test/teiserver/game/balancer_server_test.exs
+++ b/test/teiserver/game/balancer_server_test.exs
@@ -66,9 +66,13 @@ defmodule Teiserver.Game.BalancerServerTest do
       Teiserver.Account.create_user(requested_user)
   end
 
-  @spec make_users_with_ranks([non_neg_integer()]) ::
+  @spec make_users_with_ranks_and_parties(
+          [non_neg_integer()],
+          [non_neg_integer()]
+        ) ::
           list()
-  def make_users_with_ranks(list_of_ranks) do
+
+  def make_users_with_ranks_and_parties(list_of_ranks, list_of_parties) do
     users =
       Enum.with_index(list_of_ranks)
       |> Enum.map(fn {user, index} ->
@@ -82,8 +86,6 @@ defmodule Teiserver.Game.BalancerServerTest do
       # unwrap user creation response
       |> Enum.map(fn {:ok, reply} -> reply end)
       |> Enum.map(fn x -> Map.put(x, :userid, x.id) end)
-      # each user in their own party
-      |> Enum.map(fn x -> Map.put(x, :party_id, x.id) end)
 
     # set the user rank
     for {user, rank} <- Enum.zip(users, list_of_ranks) do
@@ -92,6 +94,12 @@ defmodule Teiserver.Game.BalancerServerTest do
       })
     end
 
+    # set the user party_id
+    users =
+      for {user, party_id} <- Enum.zip(users, list_of_parties) do
+        Map.put(user, :party_id, party_id)
+      end
+
     users
   end
 
@@ -99,7 +107,7 @@ defmodule Teiserver.Game.BalancerServerTest do
     team_count = 2
 
     players =
-      make_users_with_ranks([10, 20, 30, 40, 50, 60])
+      make_users_with_ranks_and_parties([10, 20, 30, 40, 50, 60], [1, 2, 3, 4, 5, 6])
 
     dbg(players)
 
@@ -149,7 +157,7 @@ defmodule Teiserver.Game.BalancerServerTest do
   test "get_balance_mode works with a hash" do
     team_count = 2
 
-    players = make_users_with_ranks([10, 20, 30, 40])
+    players = make_users_with_ranks_and_parties([10, 20, 30, 40], [1, 2, 3, 4])
 
     {:ok, pid} = BalancerServer.start_link(data: %{lobby_id: 1})
 
@@ -173,7 +181,7 @@ defmodule Teiserver.Game.BalancerServerTest do
   test "get_current_balance works with a hash" do
     team_count = 2
 
-    players = make_users_with_ranks([10, 20, 30, 40])
+    players = make_users_with_ranks_and_parties([10, 20, 30, 40], [1, 2, 3, 4])
 
     {:ok, pid} = BalancerServer.start_link(data: %{lobby_id: 1})
 

--- a/test/teiserver/game/balancer_server_test.exs
+++ b/test/teiserver/game/balancer_server_test.exs
@@ -5,6 +5,25 @@ defmodule Teiserver.Game.BalancerServerTest do
   @moduletag :balance_test
   alias Teiserver.Game.BalancerServer
 
+  def user_fixture(), do: make_user(%{"permissions" => []})
+
+  def make_user(params \\ %{}) do
+    requested_user = %{
+      "name" => params["name"] || "Test",
+      "email" => params["email"] || "email@email#{:rand.uniform(999_999_999_999)}",
+      "colour" => params["colour"] || "#00AA00",
+      "icon" => params["icon"] || "fa-solid fa-user",
+      "password" => params["password"] || "password",
+      "password_confirmation" => params["password"] || "password",
+      "data" => params["data"] || %{}
+    }
+
+    dbg(requested_user)
+
+    {:ok, u} =
+      Teiserver.Account.create_user(requested_user)
+  end
+
   test "get fuzz multiplier" do
     result = BalancerServer.get_fuzz_multiplier([])
     assert result == 0
@@ -39,14 +58,39 @@ defmodule Teiserver.Game.BalancerServerTest do
 
   test "load some players in and run a balance pass or two" do
     team_count = 2
-    players = create_fake_players(4)
+
+    arbitrary_rank_for_all_test_users = 10
+
+    users =
+      create_fake_players(6)
+      # take the above sequence generator and use it to create some fake user data
+      |> Enum.map(fn x ->
+        %{
+          "name" => "user" <> to_string(x.iter) <> "_" <> to_string(ExULID.ULID.generate()),
+          "email" => to_string(ExULID.ULID.generate()) <> "@example.com",
+          "permissions" => []
+        }
+      end)
+      |> Enum.map(fn x -> make_user(x) end)
+      # unwrap user creation response
+      |> Enum.map(fn {:ok, reply} -> reply end)
+      # set the user rank
+      |> Enum.map(fn user ->
+        Teiserver.Account.update_user_stat(user.id, %{:rank => arbitrary_rank_for_all_test_users})
+      end)
+      |> Enum.map(fn {:ok, reply} -> reply end)
+      |> Enum.map(fn user -> Map.put(user, :userid, user.user_id) end)
+      # all users are in different parties
+      |> Enum.map(fn user -> Map.put(user, :party_id, user.user_id + 1) end)
+
+    dbg(users)
+    players = users
 
     {:ok, start_link_results} = BalancerServer.start_link(data: %{lobby_id: 1})
 
     starting_state = GenServer.call(start_link_results, :report_state, 5000)
-    dbg(starting_state)
 
-    dbg(players)
+    dbg(starting_state)
 
     first_balance_pass =
       GenServer.call(
@@ -60,26 +104,56 @@ defmodule Teiserver.Game.BalancerServerTest do
     second_balance_pass_hash_reuse =
       GenServer.call(
         start_link_results,
-        {:make_balance, team_count, [], create_fake_players(4)},
+        {:make_balance, team_count, [], players},
         5000
       )
-
-    dbg(second_balance_pass_hash_reuse)
 
     assert second_balance_pass_hash_reuse.hash == first_balance_pass.hash
 
-    third_balance_pass_with_more_players =
-      GenServer.call(
-        start_link_results,
-        {:make_balance, team_count, [], create_fake_players(160)},
-        5000
-      )
+    # users = [
+    #   make_user(%{
+    #     "name" => "user"+ExULID.ULID.generate(),
+    #     "email" => ExULID.ULID.generate()+"@example.com",
+    #     "permissions" => []
+    #   }),
+    #   make_user(%{
+    #     "name" => "user2",
+    #     "email" => "user2-test542684@example.com",
+    #     "permissions" => []
+    #   }),
+    #   make_user(%{
+    #     "name" => "user3",
+    #     "email" => "user3-test542684@example.com",
+    #     "permissions" => []
+    #   }),
+    #   make_user(%{
+    #     "name" => "user4",
+    #     "email" => "user4-test542684@example.com",
+    #     "permissions" => []
+    #   }),
+    #   make_user(%{
+    #     "name" => "user5",
+    #     "email" => "user5-test542684@example.com",
+    #     "permissions" => []
+    #   })
+    # ]
 
-    dbg(third_balance_pass_with_more_players)
-    assert second_balance_pass_hash_reuse.hash != third_balance_pass_with_more_players.hash
+    # dbg(users)
+
+    #### TODO
+
+    # third_balance_pass_with_more_players =
+    #   GenServer.call(
+    #     start_link_results,
+    #     {:make_balance, team_count, [], create_fake_players(160)},
+    #     5000
+    #   )
+
+    # dbg(third_balance_pass_with_more_players)
+    # assert second_balance_pass_hash_reuse.hash != third_balance_pass_with_more_players.hash
   end
 
   defp create_fake_players(count) do
-    1..count |> Enum.map(fn iter -> %{userid: iter, party_id: iter} end)
+    1..count |> Enum.map(fn iter -> %{iter: iter} end)
   end
 end


### PR DESCRIPTION
Fixes the unbounded memory consumption behavior described by #576 ; adds tests for the changed function calls.

Now BalancerServer will only retain the most recent balance result, so long as it has not been cleared by another operation like `:reset_hashes` or `:set`.

Probably needs a spin on the testing server to verify we haven't broken a function call that was depending on `handle_call(:report_state)` returning the number of hashes, but other than that I think I've written all the unit-tests for all of the parts that changed.