### PR TITLE
Update auto_balance to use split_noobs when at least 2 parties

### DIFF
--- a/lib/teiserver/battle/balance/auto_balance.ex
+++ b/lib/teiserver/battle/balance/auto_balance.ex
@@ -28,7 +28,7 @@ defmodule Teiserver.Battle.Balance.AutoBalance do
 
         cond do
           has_noobs? -> SplitNoobs
-          get_parties_count(expanded_group) >= 2 -> SplitNoobs
+          get_parties_count(expanded_group) >= 1 -> SplitNoobs
           true -> LoserPicks
         end
     end

--- a/lib/teiserver/battle/balance/auto_balance.ex
+++ b/lib/teiserver/battle/balance/auto_balance.ex
@@ -28,7 +28,7 @@ defmodule Teiserver.Battle.Balance.AutoBalance do
 
         cond do
           has_noobs? -> SplitNoobs
-          get_parties_count(expanded_group) >= 3 -> SplitNoobs
+          get_parties_count(expanded_group) >= 2 -> SplitNoobs
           true -> LoserPicks
         end
     end


### PR DESCRIPTION
In the past I suggested using split_noobs when at least three parties. I think now that we have added standard deviation importance to split_noobs it's less risky to use it for more circumstances. This PR makes it so that if there are at least two parties, split_noobs will be used (must be two teams).

This is a sample match where split_noobs didn't keep both parties because it was trying to keep standard deviation diff close: 
https://server4.beyondallreason.info/battle/4096321/balance

respect_avoids did keep both parties together, but the standard deviation diff was probably too large for split_noobs to like.

## Should we use split_noobs for only one party?
I think it's ok and shouldn't be that risky. But maybe we see first how this goes.