### PR TITLE
Free more icons

### DIFF
--- a/lib/teiserver_web/live/admin_dashboard/index.html.heex
+++ b/lib/teiserver_web/live/admin_dashboard/index.html.heex
@@ -100,7 +100,7 @@ queue_bsname = Teiserver.Game.QueueLib.colours()
                   <%= if wait == nil do %>
                     <i class="fa-fw fa-regular fa-times text-danger"></i>
                   <% else %>
-                    <i class="fa-fw fa-regular fa-check text-success"></i>
+                    <i class="fa-fw fa-solid fa-check text-success"></i>
                   <% end %>
                 </td>
                 <td>
@@ -135,7 +135,7 @@ queue_bsname = Teiserver.Game.QueueLib.colours()
                   <%= if organiser == nil do %>
                     <i class="fa-fw fa-regular fa-times text-danger"></i>
                   <% else %>
-                    <i class="fa-fw fa-regular fa-check text-success"></i>
+                    <i class="fa-fw fa-solid fa-check text-success"></i>
                   <% end %>
                 </td>
                 <td>
@@ -167,7 +167,7 @@ queue_bsname = Teiserver.Game.QueueLib.colours()
                   <%= if server_pid == nil do %>
                     <i class="fa-fw fa-regular fa-times text-danger"></i>
                   <% else %>
-                    <i class="fa-fw fa-regular fa-check text-success"></i>
+                    <i class="fa-fw fa-solid fa-check text-success"></i>
                   <% end %>
                 </td>
               </tr>
@@ -200,21 +200,21 @@ queue_bsname = Teiserver.Game.QueueLib.colours()
               <%= if consul == nil do %>
                 <i class="fa-fw fa-regular fa-times text-danger"></i>
               <% else %>
-                <i class="fa-fw fa-regular fa-check text-success"></i>
+                <i class="fa-fw fa-solid fa-check text-success"></i>
               <% end %>
             </td>
             <td>
               <%= if balancer == nil do %>
                 <i class="fa-fw fa-regular fa-times text-danger"></i>
               <% else %>
-                <i class="fa-fw fa-regular fa-check text-success"></i>
+                <i class="fa-fw fa-solid fa-check text-success"></i>
               <% end %>
             </td>
             <td>
               <%= if throttle == nil do %>
                 <i class="fa-fw fa-regular fa-times text-danger"></i>
               <% else %>
-                <i class="fa-fw fa-regular fa-check text-success"></i>
+                <i class="fa-fw fa-solid fa-check text-success"></i>
               <% end %>
             </td>
             <td>

--- a/lib/teiserver_web/templates/admin/accolade/show.html.heex
+++ b/lib/teiserver_web/templates/admin/accolade/show.html.heex
@@ -33,7 +33,7 @@
             href={Routes.ts_admin_accolade_path(@conn, :edit, @accolade)}
             class={"btn btn-outline-#{bsname}"}
           >
-            <i class="fa-regular fa-fw fa-wrench"></i> Edit accolade
+            <i class="fa-solid fa-wrench"></i> Edit accolade
           </a>
         </div>
 

--- a/lib/teiserver_web/templates/admin/achievement/show.html.heex
+++ b/lib/teiserver_web/templates/admin/achievement/show.html.heex
@@ -33,7 +33,7 @@
             href={Routes.ts_admin_achievement_path(@conn, :edit, @achievement_type)}
             class={"btn btn-outline-#{bsname}"}
           >
-            <i class="fa-regular fa-fw fa-wrench"></i> Edit achievement type
+            <i class="fa-solid fa-wrench"></i> Edit achievement type
           </a>
         </div>
 

--- a/lib/teiserver_web/templates/admin/badge_type/show.html.heex
+++ b/lib/teiserver_web/templates/admin/badge_type/show.html.heex
@@ -33,7 +33,7 @@
             href={Routes.ts_admin_badge_type_path(@conn, :edit, @badge_type)}
             class={"btn btn-outline-#{bsname}"}
           >
-            <i class="fa-regular fa-fw fa-wrench"></i> Edit Badge type
+            <i class="fa-solid fa-wrench"></i> Edit Badge type
           </a>
         </div>
 

--- a/lib/teiserver_web/templates/admin/discord_channel/index.html.heex
+++ b/lib/teiserver_web/templates/admin/discord_channel/index.html.heex
@@ -69,7 +69,7 @@
                       href={~p"/admin/discord_channels/#{discord_channel.id}/edit"}
                       class={"btn btn-outline-#{bsname} btn-sm"}
                     >
-                      <i class="fa-fw fa-regular fa-wrench"></i> Edit
+                      <i class="fa-solid fa-wrench"></i> Edit
                     </a>
                   <% end %>
                 </td>

--- a/lib/teiserver_web/templates/admin/discord_channel/show.html.heex
+++ b/lib/teiserver_web/templates/admin/discord_channel/show.html.heex
@@ -34,7 +34,7 @@
               href={~p"/admin/discord_channels/#{@discord_channel}/edit"}
               class={"btn btn-outline-#{bsname}"}
             >
-              <i class="fa-regular fa-fw fa-wrench"></i> Edit Discord channel
+              <i class="fa-solid fa-wrench"></i> Edit Discord channel
             </a>
           <% end %>
         </div>

--- a/lib/teiserver_web/templates/admin/lobby_policy/index.html.heex
+++ b/lib/teiserver_web/templates/admin/lobby_policy/index.html.heex
@@ -66,9 +66,9 @@
 
                 <td>
                   <%= if lobby_policy.enabled do %>
-                    <i class="fa-fw fa-regular fa-check text-success"></i>
+                    <i class="fa-fw fa-solid fa-check text-success"></i>
                   <% else %>
-                    <i class="fa-fw fa-regular fa-times text-danger"></i>
+                    <i class="fa-fw fa-solid fa-times text-danger"></i>
                   <% end %>
                 </td>
 

--- a/lib/teiserver_web/templates/admin/lobby_policy/index.html.heex
+++ b/lib/teiserver_web/templates/admin/lobby_policy/index.html.heex
@@ -102,7 +102,7 @@
                       href={Routes.admin_lobby_policy_path(@conn, :edit, lobby_policy.id)}
                       class={"btn btn-outline-#{bsname} btn-sm"}
                     >
-                      <i class="fa-fw fa-regular fa-wrench"></i> Edit
+                      <i class="fa-solid fa-wrench"></i> Edit
                     </a>
                   <% end %>
                 </td>

--- a/lib/teiserver_web/templates/admin/lobby_policy/show.html.heex
+++ b/lib/teiserver_web/templates/admin/lobby_policy/show.html.heex
@@ -41,7 +41,7 @@
               href={Routes.admin_lobby_policy_path(@conn, :edit, @lobby_policy)}
               class={"btn btn-outline-#{bsname}"}
             >
-              <i class="fa-regular fa-fw fa-wrench"></i> Edit Lobby policy
+              <i class="fa-solid fa-wrench"></i> Edit Lobby policy
             </a>
           <% end %>
         </div>

--- a/lib/teiserver_web/templates/admin/text_callback/index.html.heex
+++ b/lib/teiserver_web/templates/admin/text_callback/index.html.heex
@@ -53,9 +53,9 @@
 
                 <td>
                   <%= if text_callback.enabled do %>
-                    <i class="fa-fw fa-regular fa-check text-success"></i>
+                    <i class="fa-fw fa-solid fa-check text-success"></i>
                   <% else %>
-                    <i class="fa-fw fa-regular fa-times text-danger"></i>
+                    <i class="fa-fw fa-solid fa-times text-danger"></i>
                   <% end %>
                 </td>
 

--- a/lib/teiserver_web/templates/admin/text_callback/index.html.heex
+++ b/lib/teiserver_web/templates/admin/text_callback/index.html.heex
@@ -77,7 +77,7 @@
                       href={~p"/admin/text_callbacks/#{text_callback.id}/edit"}
                       class={"btn btn-outline-#{bsname} btn-sm"}
                     >
-                      <i class="fa-fw fa-regular fa-wrench"></i> Edit
+                      <i class="fa-solid fa-wrench"></i> Edit
                     </a>
                   <% end %>
                 </td>

--- a/lib/teiserver_web/templates/admin/text_callback/show.html.heex
+++ b/lib/teiserver_web/templates/admin/text_callback/show.html.heex
@@ -34,7 +34,7 @@
               href={~p"/admin/text_callbacks/#{@text_callback}/edit"}
               class={"btn btn-outline-#{bsname}"}
             >
-              <i class="fa-regular fa-fw fa-wrench"></i> Edit Text callback
+              <i class="fa-solid fa-wrench"></i> Edit Text callback
             </a>
           <% end %>
         </div>

--- a/lib/teiserver_web/templates/admin/user/show.html.heex
+++ b/lib/teiserver_web/templates/admin/user/show.html.heex
@@ -76,7 +76,7 @@
 
           <%= if allow?(@conn, "Moderator") do %>
             <a href={~p"/teiserver/admin/user/#{@user}/edit"} class={"btn btn-outline-#{bsname}"}>
-              <i class="fa-regular fa-fw fa-wrench"></i> Edit user
+              <i class="fa-solid fa-wrench"></i> Edit user
             </a>
           <% end %>
         </div>

--- a/lib/teiserver_web/templates/game/queue/index.html.heex
+++ b/lib/teiserver_web/templates/game/queue/index.html.heex
@@ -46,9 +46,9 @@
 
                 <td>
                   <%= if queue.settings["enabled"] do %>
-                    <i class="fa-fw fa-regular fa-check text-success"></i>
+                    <i class="fa-fw fa-solid fa-check text-success"></i>
                   <% else %>
-                    <i class="fa-fw fa-regular fa-times text-danger"></i>
+                    <i class="fa-fw fa-solid fa-times text-danger"></i>
                   <% end %>
                 </td>
 

--- a/lib/teiserver_web/templates/game/queue/show.html.heex
+++ b/lib/teiserver_web/templates/game/queue/show.html.heex
@@ -33,7 +33,7 @@
             href={Routes.ts_game_queue_path(@conn, :edit, @queue)}
             class={"btn btn-outline-#{bsname}"}
           >
-            <i class="fa-regular fa-fw fa-wrench"></i> Edit queue
+            <i class="fa-solid fa-wrench"></i> Edit queue
           </a>
         </div>
 

--- a/lib/teiserver_web/templates/moderation/action/search.html.heex
+++ b/lib/teiserver_web/templates/moderation/action/search.html.heex
@@ -37,11 +37,11 @@
           selected: @params["expiry"] || "All",
           enumerable: [
             %{id: "All", icon: "fa-regular fa-th", colour: fg},
-            %{id: "Completed only", icon: "fa-regular fa-check", colour: fg},
-            %{id: "Unexpired only", icon: "fa-regular fa-play", colour: fg},
-            %{id: "Unexpired not permanent", icon: "fa-regular fa-clock", colour: fg},
-            %{id: "Permanent only", icon: "fa-regular fa-infinity", colour: fg},
-            %{id: "All active", icon: "fa-regular fa-clock", colour: fg}
+            %{id: "Completed only", icon: "fa-solid fa-check", colour: fg},
+            %{id: "Unexpired only", icon: "fa-solid fa-play", colour: fg},
+            %{id: "Unexpired not permanent", icon: "fa-solid fa-clock", colour: fg},
+            %{id: "Permanent only", icon: "fa-solid fa-infinity", colour: fg},
+            %{id: "All active", icon: "fa-solid fa-clock", colour: fg}
           ]
         }) %>
       </div>

--- a/lib/teiserver_web/templates/moderation/action/show.html.heex
+++ b/lib/teiserver_web/templates/moderation/action/show.html.heex
@@ -48,7 +48,7 @@
               href={Routes.moderation_action_path(@conn, :edit, @action)}
               class={"btn btn-outline-#{bsname}"}
             >
-              <i class="fa-regular fa-fw fa-wrench"></i> Edit action
+              <i class="fa-solid fa-wrench"></i> Edit action
             </a>
 
             <a

--- a/lib/teiserver_web/templates/moderation/ban/index.html.heex
+++ b/lib/teiserver_web/templates/moderation/ban/index.html.heex
@@ -44,7 +44,7 @@
                 <td><%= ban.source.name %></td>
                 <td>
                   <%= if ban.enabled do %>
-                    <i class="fa-fw fa-regular fa-check"></i>
+                    <i class="fa-fw fa-solid fa-check"></i>
                   <% end %>
                 </td>
 

--- a/lib/teiserver_web/templates/moderation/proposal/show.html.heex
+++ b/lib/teiserver_web/templates/moderation/proposal/show.html.heex
@@ -34,7 +34,7 @@
               href={Routes.moderation_proposal_path(@conn, :edit, @proposal)}
               class={"btn btn-outline-#{bsname}"}
             >
-              <i class="far fa-fw fa-wrench"></i> Edit proposal
+              <i class="far fa-solid fa-wrench"></i> Edit proposal
             </a>
           <% end %>
         </div>

--- a/lib/teiserver_web/templates/moderation/report/response_form.html.heex
+++ b/lib/teiserver_web/templates/moderation/report/response_form.html.heex
@@ -28,7 +28,7 @@
         name: "response[accurate]",
         id: "response_is_accurate",
         value: "true",
-        label: raw("<i class='fa-fw fa-regular fa-check'></i> Accurate report"),
+        label: raw("<i class='fa-fw fa-solid fa-check'></i> Accurate report"),
         field: :accurate,
         changeset: @response_changeset
       ) %>


### PR DESCRIPTION
Spotted a few icons using the `fa-regular` version, that is not available on the free bundle, so swapped them for `fa-solid` which is.
For example:
![2025-02-17-2276x158-scrot](https://github.com/user-attachments/assets/abd7440b-7ed6-4d9b-a4f6-cb1152eca2f3)
