### PR TITLE
Have auto balance choose respect_avoids when no op party

### DIFF
--- a/lib/teiserver/battle/balance/auto_balance.ex
+++ b/lib/teiserver/battle/balance/auto_balance.ex
@@ -4,6 +4,7 @@ defmodule Teiserver.Battle.Balance.AutoBalance do
   """
   alias Teiserver.Battle.Balance.SplitNoobs
   alias Teiserver.Battle.Balance.LoserPicks
+  alias Teiserver.Battle.Balance.RespectAvoids
   alias Teiserver.Battle.Balance.BalanceTypes, as: BT
   alias Teiserver.Battle.Balance.AutoBalanceTypes, as: DB
 
@@ -24,10 +25,14 @@ defmodule Teiserver.Battle.Balance.AutoBalance do
 
       true ->
         players = flatten_members(expanded_group)
-        has_noobs? = has_noobs?(players)
+        num_players = Enum.count(players)
 
         cond do
-          has_noobs? -> SplitNoobs
+          # respect_avoids keeps parties if it can find a combination where team ratings are similar. It could potentially allow op parties. If there is NOT an op party, respect_avoids is less risky and can be used.
+          # respect_avoids also treats noobs as worst in lobby.
+          num_players <= 16 && !has_op_party?(players) -> RespectAvoids
+          # split_noobs will keep parties together if it can find a combination where team rating is similar and team standard deviation is similar. It can split up op parties if it would result in team standard deviation diff that is too large.
+          has_noobs?(players) -> SplitNoobs
           get_parties_count(expanded_group) >= 1 -> SplitNoobs
           true -> LoserPicks
         end
@@ -39,19 +44,28 @@ defmodule Teiserver.Battle.Balance.AutoBalance do
   """
   @spec flatten_members([BT.expanded_group()]) :: [DB.player()]
   def flatten_members(expanded_group) do
+    players_with_party_id =
+      Enum.with_index(expanded_group, fn element, index ->
+        Map.put(element, :party_id, index)
+      end)
+
     # We only care about ranks and uncertainties for now
     # However, in the future we may use other data to decide what balance algorithm to use,
     # e.g. whether there are parties or not, whether it's a high rating lobby, etc.
     for %{
           ranks: ranks,
-          uncertainties: uncertainties
-        } <- expanded_group,
+          uncertainties: uncertainties,
+          ratings: ratings,
+          party_id: party_id
+        } <- players_with_party_id,
         # Zipping will create binary tuples from 2 lists
-        {rank, uncertainty} <-
-          Enum.zip([ranks, uncertainties]),
+        {rank, uncertainty, rating} <-
+          Enum.zip([ranks, uncertainties, ratings]),
         do: %{
           uncertainty: uncertainty,
-          rank: rank
+          rank: rank,
+          rating: rating,
+          party_id: party_id
         }
   end
 
@@ -68,5 +82,27 @@ defmodule Teiserver.Battle.Balance.AutoBalance do
     Enum.any?(players, fn x ->
       SplitNoobs.is_newish_player?(x.rank, x.uncertainty)
     end)
+  end
+
+  # If the top two players are in the same party, this will return true
+  @spec has_op_party?([DB.player()]) :: boolean()
+  def has_op_party?(players) do
+    if(Enum.count(players) >= 2) do
+      sorted_players =
+        Enum.sort_by(
+          players,
+          fn x ->
+            x.rating
+          end,
+          :desc
+        )
+
+      best_player = Enum.at(sorted_players, 0)
+      second_best_player = Enum.at(sorted_players, 1)
+
+      best_player.party_id == second_best_player.party_id
+    else
+      false
+    end
   end
 end

--- a/lib/teiserver/battle/balance/auto_balance_types.ex
+++ b/lib/teiserver/battle/balance/auto_balance_types.ex
@@ -3,6 +3,7 @@ defmodule Teiserver.Battle.Balance.AutoBalanceTypes do
 
   @type player :: %{
           rank: number(),
-          uncertainty: number()
+          uncertainty: number(),
+          rating: number()
         }
 end

--- a/test/teiserver/battle/auto_balance_internal_test.exs
+++ b/test/teiserver/battle/auto_balance_internal_test.exs
@@ -87,4 +87,128 @@ defmodule Teiserver.Battle.AutoBalanceInternalTest do
     result = AutoBalance.get_parties_count(expanded_group)
     assert result == 2
   end
+
+  test "Able to detect an op party" do
+    # The two best players are in the same party
+    expanded_group = [
+      %{
+        count: 2,
+        members: ["kyutoryu", "fbots1998"],
+        ratings: [50, 49],
+        names: ["kyutoryu", "fbots1998"],
+        uncertainties: [0, 1],
+        ranks: [1, 1]
+      },
+      %{
+        count: 2,
+        members: ["Dixinormus", "SLOPPYGAGGER"],
+        ratings: [18.28, 0],
+        names: ["Dixinormus", "SLOPPYGAGGER"],
+        uncertainties: [2, 4],
+        ranks: [0, 0]
+      },
+      %{
+        count: 1,
+        members: ["jauggy"],
+        ratings: [20.49],
+        names: ["jauggy"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["reddragon2010"],
+        ratings: [18.4],
+        names: ["reddragon2010"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["Aposis"],
+        ratings: [20.42],
+        names: ["Aposis"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["MaTThiuS_82"],
+        ratings: [8.26],
+        names: ["MaTThiuS_82"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["Noody"],
+        ratings: [17.64],
+        names: ["Noody"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["[DTG]BamBin0"],
+        ratings: [20.06],
+        names: ["[DTG]BamBin0"],
+        uncertainties: [3],
+        ranks: [2]
+      },
+      %{
+        count: 1,
+        members: ["barmalev"],
+        ratings: [3.58],
+        names: ["barmalev"],
+        uncertainties: [3],
+        ranks: [2]
+      }
+    ]
+
+    players = AutoBalance.flatten_members(expanded_group)
+    has_op_party? = AutoBalance.has_op_party?(players)
+    assert has_op_party? == true
+  end
+
+  test "Able to determine when no op party" do
+    # The two best players are in different parties
+    expanded_group = [
+      %{
+        count: 2,
+        members: ["kyutoryu", "fbots1998"],
+        ratings: [50, 49],
+        names: ["kyutoryu", "fbots1998"],
+        uncertainties: [0, 1],
+        ranks: [1, 1]
+      },
+      %{
+        count: 2,
+        members: ["Dixinormus", "SLOPPYGAGGER"],
+        ratings: [60, 0],
+        names: ["Dixinormus", "SLOPPYGAGGER"],
+        uncertainties: [2, 4],
+        ranks: [0, 0]
+      }
+    ]
+
+    players = AutoBalance.flatten_members(expanded_group)
+    has_op_party? = AutoBalance.has_op_party?(players)
+    assert has_op_party? == false
+
+    # The number of players in lobby is less than two
+    expanded_group = [
+      %{
+        count: 1,
+        members: ["MaTThiuS_82"],
+        ratings: [8.26],
+        names: ["MaTThiuS_82"],
+        uncertainties: [3],
+        ranks: [2]
+      }
+    ]
+
+    players = AutoBalance.flatten_members(expanded_group)
+    has_op_party? = AutoBalance.has_op_party?(players)
+    assert has_op_party? == false
+  end
 end


### PR DESCRIPTION
There is demand for respect_avoids to be the default algo:
https://ptb.discord.com/channels/549281623154229250/1297988341756596314

However, respect_avoids can potentially allow op parties like this:
Team 1: 0, 0, 0, 50, 50, 50
Team 2: 25, 25, 25, 25, 25, 25
Where (50,50,50) are in the same party.

This PR will make it so auto balance will pick `respect_avoids` when there are no op parties. An op party exists if the two best players in the lobby are in the same party. 

Here is an example match where there was not an op party, and if `respect_avoids` was chosen, both parties would have been kept:
https://server4.beyondallreason.info/battle/4096321/balance