### PR TITLE
User map pool, games and engines in matchmaking

### DIFF
--- a/lib/teiserver/asset.ex
+++ b/lib/teiserver/asset.ex
@@ -9,6 +9,9 @@ defmodule Teiserver.Asset do
   @spec get_map(String.t()) :: Asset.Map.t() | nil
   defdelegate get_map(spring_name), to: MapQueries
 
+  @spec get_maps_for_queue(Teiserver.Matchmaking.queue_id()) :: [Asset.Map.t()] | nil
+  defdelegate get_maps_for_queue(spring_name), to: MapQueries
+
   @spec get_all_maps() :: [Asset.Map.t()]
   defdelegate get_all_maps(), to: MapQueries
 

--- a/lib/teiserver/asset/queries/map_queries.ex
+++ b/lib/teiserver/asset/queries/map_queries.ex
@@ -8,6 +8,11 @@ defmodule Teiserver.Asset.MapQueries do
     base_query() |> where_spring_name(spring_name) |> Repo.one()
   end
 
+  @spec get_map(Teiserver.Matchmaking.queue_id()) :: [Asset.Map.t()] | nil
+  def get_maps_for_queue(queue) do
+    base_query() |> where_has_queue(queue) |> Repo.all()
+  end
+
   @spec get_all_maps() :: [Asset.Map.t()]
   def get_all_maps() do
     base_query() |> Repo.all()
@@ -26,5 +31,10 @@ defmodule Teiserver.Asset.MapQueries do
   defp where_spring_name(query, name) do
     from [map: map] in query,
       where: map.spring_name == ^name
+  end
+
+  defp where_has_queue(query, queue) do
+    from [map: map] in query,
+      where: ^queue in map.matchmaking_queues
   end
 end

--- a/lib/teiserver/matchmaking/pairing_room.ex
+++ b/lib/teiserver/matchmaking/pairing_room.ex
@@ -132,12 +132,9 @@ defmodule Teiserver.Matchmaking.PairingRoom do
       {:error, reason} ->
         QueueServer.disband_pairing(state.queue_id, self())
 
-        state.teams
-        |> List.flatten()
-        |> Enum.flat_map(& &1.player_ids)
-        |> Enum.each(fn p_id ->
+        for team <- state.teams, member <- team, p_id <- member.player_ids do
           Teiserver.Player.matchmaking_notify_lost(p_id, {:server_error, reason})
-        end)
+        end
 
         {:stop, :normal, state}
 
@@ -157,12 +154,9 @@ defmodule Teiserver.Matchmaking.PairingRoom do
           |> Map.put(:game, %{springName: game})
           |> Map.put(:map, %{springName: map})
 
-        state.teams
-        |> List.flatten()
-        |> Enum.flat_map(& &1.player_ids)
-        |> Enum.each(fn p_id ->
+        for team <- state.teams, member <- team, p_id <- member.player_ids do
           Teiserver.Player.battle_start(p_id, battle_start_data)
-        end)
+        end
 
         {:stop, :normal, state}
     end

--- a/lib/teiserver/matchmaking/queue_server.ex
+++ b/lib/teiserver/matchmaking/queue_server.ex
@@ -180,31 +180,19 @@ defmodule Teiserver.Matchmaking.QueueServer do
       :timer.send_interval(state.settings.tick_interval_ms, :tick)
     end
 
-    {:ok, state, {:continue, :init_engines}}
+    {:ok, state, {:continue, :init_engines_games_maps}}
   end
 
   @impl true
-  def handle_continue(:init_engines, state) do
-    # TODO Get engines from somewhere else
+  def handle_continue(:init_engines_games_maps, state) do
+    # TODO Get engines and games from somewhere else
     engines = state.queue.engines
-
-    {:noreply, %{state | queue: Map.put(state.queue, :engines, engines)},
-     {:continue, :init_games}}
-  end
-
-  @impl true
-  def handle_continue(:init_games, state) do
-    # TODO Get games from somewhere else
     games = state.queue.games
-
-    {:noreply, %{state | queue: Map.put(state.queue, :games, games)}, {:continue, :init_maps}}
-  end
-
-  @impl true
-  def handle_continue(:init_maps, state) do
-    # Only get maps if the map list is empty
     maps = Asset.get_maps_for_queue(state.id)
-    {:noreply, %{state | queue: Map.put(state.queue, :maps, maps)}}
+
+    queue = %{state.queue | engines: engines, games: games, maps: maps}
+
+    {:noreply, %{state | queue: queue}}
   end
 
   @impl true

--- a/lib/teiserver/matchmaking/queue_server.ex
+++ b/lib/teiserver/matchmaking/queue_server.ex
@@ -52,7 +52,10 @@ defmodule Teiserver.Matchmaking.QueueServer do
           name: String.t(),
           team_size: pos_integer(),
           team_count: pos_integer(),
-          ranked: boolean()
+          ranked: boolean(),
+          engines: [%{version: String.t()}],
+          games: [%{spring_game: String.t()}],
+          maps: [Teiserver.Asset.Map.t()]
         }
 
   @type state :: %{

--- a/lib/teiserver/matchmaking/queue_supervisor.ex
+++ b/lib/teiserver/matchmaking/queue_supervisor.ex
@@ -6,6 +6,30 @@ defmodule Teiserver.Matchmaking.QueueSupervisor do
   use Horde.DynamicSupervisor
   alias Teiserver.Matchmaking.QueueServer
 
+  @spec default_queues() :: [
+          %{
+            id: any(),
+            members: any(),
+            monitors: [],
+            pairings: [],
+            queue: %{
+              engines: any(),
+              games: any(),
+              maps: any(),
+              name: any(),
+              ranked: true,
+              team_count: any(),
+              team_size: any()
+            },
+            settings: %{
+              :max_distance => any(),
+              :pairing_timeout => any(),
+              :tick_interval_ms => any(),
+              optional(any()) => any()
+            }
+          },
+          ...
+        ]
   def default_queues() do
     [
       QueueServer.init_state(%{

--- a/lib/teiserver/matchmaking/queue_supervisor.ex
+++ b/lib/teiserver/matchmaking/queue_supervisor.ex
@@ -6,30 +6,6 @@ defmodule Teiserver.Matchmaking.QueueSupervisor do
   use Horde.DynamicSupervisor
   alias Teiserver.Matchmaking.QueueServer
 
-  @spec default_queues() :: [
-          %{
-            id: any(),
-            members: any(),
-            monitors: [],
-            pairings: [],
-            queue: %{
-              engines: any(),
-              games: any(),
-              maps: any(),
-              name: any(),
-              ranked: true,
-              team_count: any(),
-              team_size: any()
-            },
-            settings: %{
-              :max_distance => any(),
-              :pairing_timeout => any(),
-              :tick_interval_ms => any(),
-              optional(any()) => any()
-            }
-          },
-          ...
-        ]
   def default_queues() do
     [
       QueueServer.init_state(%{

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -155,12 +155,18 @@ defmodule Teiserver.Player.TachyonHandler do
     queues =
       Matchmaking.list_queues()
       |> Enum.map(fn {qid, queue} ->
+        game_names = Enum.map(queue.games, fn game -> %{springName: game.spring_game} end)
+        map_names = Enum.map(queue.maps, fn map -> %{springName: map.spring_name} end)
+
         %{
           id: qid,
           name: queue.name,
           numOfTeams: queue.team_count,
           teamSize: queue.team_size,
-          ranked: queue.ranked
+          ranked: queue.ranked,
+          engines: queue.engines,
+          games: game_names,
+          maps: map_names
         }
       end)
 
@@ -185,6 +191,15 @@ defmodule Teiserver.Player.TachyonHandler do
 
               :too_many_players ->
                 %{reason: :invalid_request, details: "too many player for a playlist"}
+
+              :missing_engines ->
+                %{reason: :internal_error, details: "missing engine list"}
+
+              :missing_games ->
+                %{reason: :internal_error, details: "missing game list"}
+
+              :missing_maps ->
+                %{reason: :internal_error, details: "missing map list"}
 
               x ->
                 %{reason: x}

--- a/priv/tachyon/schema/matchmaking/list/request.json
+++ b/priv/tachyon/schema/matchmaking/list/request.json
@@ -1,6 +1,4 @@
 {
-    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/list/request.json",
-    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MatchmakingListRequest",
     "tachyon": {
         "source": "user",

--- a/priv/tachyon/schema/matchmaking/list/response.json
+++ b/priv/tachyon/schema/matchmaking/list/response.json
@@ -1,6 +1,4 @@
 {
-    "$id": "https://schema.beyondallreason.dev/tachyon/matchmaking/list/response.json",
-    "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MatchmakingListResponse",
     "tachyon": {
         "source": "server",
@@ -29,14 +27,51 @@
                                     "name": { "type": "string" },
                                     "numOfTeams": { "type": "integer" },
                                     "teamSize": { "type": "integer" },
-                                    "ranked": { "type": "boolean" }
+                                    "ranked": { "type": "boolean" },
+                                    "engines": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "version": { "type": "string" }
+                                            },
+                                            "required": ["version"]
+                                        }
+                                    },
+                                    "games": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "springName": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": ["springName"]
+                                        }
+                                    },
+                                    "maps": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "springName": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": ["springName"]
+                                        }
+                                    }
                                 },
                                 "required": [
                                     "id",
                                     "name",
                                     "numOfTeams",
                                     "teamSize",
-                                    "ranked"
+                                    "ranked",
+                                    "engines",
+                                    "games",
+                                    "maps"
                                 ]
                             }
                         }
@@ -50,14 +85,36 @@
                                     "name": "Duel",
                                     "numOfTeams": 2,
                                     "teamSize": 1,
-                                    "ranked": true
+                                    "ranked": true,
+                                    "engines": [{ "version": "2025.01.6" }],
+                                    "games": [
+                                        {
+                                            "springName": "Beyond All Reason test-27414-a84d7e6"
+                                        }
+                                    ],
+                                    "maps": [
+                                        { "springName": "Theta Crystals 1.3" },
+                                        {
+                                            "springName": "Comet Catcher Remake 1.8"
+                                        },
+                                        { "springName": "Aurelia v4.1" }
+                                    ]
                                 },
                                 {
                                     "id": "1v1v1",
                                     "name": "3 Way FFA",
                                     "numOfTeams": 3,
                                     "teamSize": 1,
-                                    "ranked": true
+                                    "ranked": true,
+                                    "engines": [{ "version": "2025.01.6" }],
+                                    "games": [
+                                        {
+                                            "springName": "Beyond All Reason test-27414-a84d7e6"
+                                        }
+                                    ],
+                                    "maps": [
+                                        { "springName": "Ghenna Rising 4.0.1" }
+                                    ]
                                 }
                             ]
                         }

--- a/test/support/fixtures/asset.ex
+++ b/test/support/fixtures/asset.ex
@@ -1,8 +1,28 @@
 defmodule Teiserver.AssetFixtures do
+  require Logger
   alias Teiserver.Asset
   alias Teiserver.Repo
 
   def create_map(attrs) do
     %Asset.Map{} |> Asset.Map.changeset(attrs) |> Repo.insert!()
+  end
+
+  def create_or_update_map(attrs) do
+    case Asset.get_map(attrs.spring_name) do
+      nil -> create_map(attrs)
+      map -> update_map(map, attrs)
+    end
+  end
+
+  def update_map(map, attrs) do
+    Logger.warning(
+      "Map #{map.spring_name} already exists, adding matchmaking queue #{inspect(attrs.matchmaking_queues)}"
+    )
+
+    map
+    |> Asset.Map.changeset(%{
+      matchmaking_queues: map.matchmaking_queues ++ attrs.matchmaking_queues
+    })
+    |> Repo.update!()
   end
 end

--- a/test/support/fixtures/asset.ex
+++ b/test/support/fixtures/asset.ex
@@ -6,23 +6,4 @@ defmodule Teiserver.AssetFixtures do
   def create_map(attrs) do
     %Asset.Map{} |> Asset.Map.changeset(attrs) |> Repo.insert!()
   end
-
-  def create_or_update_map(attrs) do
-    case Asset.get_map(attrs.spring_name) do
-      nil -> create_map(attrs)
-      map -> update_map(map, attrs)
-    end
-  end
-
-  def update_map(map, attrs) do
-    Logger.warning(
-      "Map #{map.spring_name} already exists, adding matchmaking queue #{inspect(attrs.matchmaking_queues)}"
-    )
-
-    map
-    |> Asset.Map.changeset(%{
-      matchmaking_queues: map.matchmaking_queues ++ attrs.matchmaking_queues
-    })
-    |> Repo.update!()
-  end
 end

--- a/test/teiserver/matchmaking/queue_test.exs
+++ b/test/teiserver/matchmaking/queue_test.exs
@@ -1,5 +1,5 @@
 defmodule Teiserver.Matchmaking.QueueTest do
-  use Teiserver.DataCase, async: true
+  use Teiserver.DataCase
   alias Teiserver.Matchmaking
   alias Teiserver.Matchmaking.QueueServer
 

--- a/test/teiserver/matchmaking/queue_test.exs
+++ b/test/teiserver/matchmaking/queue_test.exs
@@ -2,13 +2,31 @@ defmodule Teiserver.Matchmaking.QueueTest do
   use Teiserver.DataCase
   alias Teiserver.Matchmaking
   alias Teiserver.Matchmaking.QueueServer
+  alias Teiserver.AssetFixtures
+
+  defp stg_attr(id),
+    do: %{
+      spring_name: "Supreme that glitters",
+      display_name: "Supreme That Glitters",
+      thumbnail_url: "https://www.beyondallreason.info/map/?!",
+      matchmaking_queues: [id]
+    }
 
   setup _context do
     user = Central.Helpers.GeneralTestLib.make_user(%{"data" => %{"roles" => ["Verified"]}})
     id = UUID.uuid4()
 
+    AssetFixtures.create_map(stg_attr(id))
+
     {:ok, pid} =
-      QueueServer.init_state(%{id: id, name: id, team_size: 1, team_count: 2})
+      QueueServer.init_state(%{
+        id: id,
+        name: id,
+        team_size: 1,
+        team_count: 2,
+        engines: ["spring", "recoil"],
+        games: ["BAR test version", "BAR release version"]
+      })
       |> QueueServer.start_link()
 
     {:ok, user: user, queue_id: id, queue_pid: pid}

--- a/test/teiserver_web/tachyon/matchmaking_test.exs
+++ b/test/teiserver_web/tachyon/matchmaking_test.exs
@@ -7,11 +7,7 @@ defmodule Teiserver.Tachyon.MatchmakingTest do
   alias Teiserver.Asset
   alias Teiserver.Matchmaking.{QueueSupervisor, QueueServer}
 
-  def altair_attr() do
-    altair_attr("8v8")
-  end
-
-  def altair_attr(id),
+  defp altair_attr(id),
     do: %{
       spring_name: "Altair Crossing Remake " <> id,
       display_name: "Altair Crossing",
@@ -19,7 +15,7 @@ defmodule Teiserver.Tachyon.MatchmakingTest do
       matchmaking_queues: [id]
     }
 
-  def rosetta_attr(id),
+  defp rosetta_attr(id),
     do: %{
       spring_name: "Rosetta " <> id,
       display_name: "Rosetta",
@@ -27,29 +23,29 @@ defmodule Teiserver.Tachyon.MatchmakingTest do
       matchmaking_queues: [id]
     }
 
-  def map_attrs(id),
+  defp map_attrs(id),
     do: [altair_attr(id), rosetta_attr(id)]
 
-  def map_names(id) do
+  defp map_names(id) do
     map_attrs(id)
     |> Enum.map(fn map -> %{"springName" => map.spring_name} end)
   end
 
-  def engine_versions(),
+  defp engine_versions(),
     do: [%{version: "105.1.1-2590-gb9462a0 bar"}, %{version: "100.2.1-2143-test bar"}]
 
-  def game_versions(),
+  defp game_versions(),
     do: [
       %{spring_game: "Beyond All Reason test-26929-d709d32"},
       %{spring_game: "BAR test version"}
     ]
 
-  def engine_names() do
+  defp engine_names() do
     engine_versions()
     |> Enum.map(fn engine -> %{"version" => engine.version} end)
   end
 
-  def game_names() do
+  defp game_names() do
     game_versions()
     |> Enum.map(fn game -> %{"springName" => game.spring_game} end)
   end
@@ -65,7 +61,7 @@ defmodule Teiserver.Tachyon.MatchmakingTest do
     setup_queue(id, team_size)
   end
 
-  def setup_queue(id, team_size) do
+  defp setup_queue(id, team_size) do
     queue_attrs(id, team_size)
     |> mk_queue()
   end

--- a/test/teiserver_web/tachyon/matchmaking_test.exs
+++ b/test/teiserver_web/tachyon/matchmaking_test.exs
@@ -13,7 +13,7 @@ defmodule Teiserver.Tachyon.MatchmakingTest do
 
   def altair_attr(id),
     do: %{
-      spring_name: "Altair Crossing Remake 1.2.3",
+      spring_name: "Altair Crossing Remake " <> id,
       display_name: "Altair Crossing",
       thumbnail_url: "https://www.beyondallreason.info/map/altair-crossing",
       matchmaking_queues: [id]
@@ -21,7 +21,7 @@ defmodule Teiserver.Tachyon.MatchmakingTest do
 
   def rosetta_attr(id),
     do: %{
-      spring_name: "Rosetta",
+      spring_name: "Rosetta " <> id,
       display_name: "Rosetta",
       thumbnail_url: "https://www.beyondallreason.info/map/rosetta",
       matchmaking_queues: [id]
@@ -72,7 +72,7 @@ defmodule Teiserver.Tachyon.MatchmakingTest do
 
   defp setup_maps(id) do
     map_attrs(id)
-    |> Enum.each(&AssetFixtures.create_or_update_map/1)
+    |> Enum.each(&AssetFixtures.create_map/1)
   end
 
   defp queue_attrs(id, team_size) do
@@ -631,7 +631,11 @@ defmodule Teiserver.Tachyon.MatchmakingTest do
                }
              } = first_message
 
-      assert spring_name in ["Altair Crossing Remake 1.2.3", "Rosetta"]
+      maps =
+        map_attrs(queue_id)
+        |> Enum.map(fn map -> map.spring_name end)
+
+      assert spring_name in maps
 
       # and then if that the rest of clients have the same map
       for client <- rest_clients do


### PR DESCRIPTION
Resolves #591 
- [x] Grabs the  relevant maps when a queue process starts
- [x] Return this list of map in the response to `matchmaking/list`
- [x] If the map list is empty, joining a queue should result in an `internal_error`
- [x] Pass the map info along to the pairing room process
- [x] When a match is confirmed, the pairing room process picks a map at random and create the start script data
Additionally added games and engines to the queue process and their selection to pairing room, passing them to start_script and showing them in `matchmaking/list`