### PR TITLE
Add num_wins column to ratings table

### DIFF
--- a/lib/teiserver/account/schemas/rating.ex
+++ b/lib/teiserver/account/schemas/rating.ex
@@ -14,6 +14,7 @@ defmodule Teiserver.Account.Rating do
 
     field :last_updated, :utc_datetime
     field :num_matches, :integer
+    field :num_wins, :integer
   end
 
   @doc false
@@ -21,7 +22,7 @@ defmodule Teiserver.Account.Rating do
     stats
     |> cast(
       attrs,
-      ~w(user_id rating_type_id rating_value skill uncertainty last_updated leaderboard_rating num_matches)a
+      ~w(user_id rating_type_id rating_value skill uncertainty last_updated leaderboard_rating num_matches num_wins)a
     )
     # fields below are required; num_matches is not required
     |> validate_required(

--- a/priv/repo/migrations/20250220221332_add_num_wins.exs
+++ b/priv/repo/migrations/20250220221332_add_num_wins.exs
@@ -1,0 +1,28 @@
+defmodule Teiserver.Repo.Migrations.AddNumWins do
+  use Ecto.Migration
+
+  def change do
+    alter table("teiserver_account_ratings") do
+      add :num_wins, :integer, default: 0
+    end
+
+    # Populate num_wins column
+    up_query = """
+    UPDATE teiserver_account_ratings  SET num_wins  = temp_table.num_wins
+    FROM (SELECT tgrl.user_id, rating_type_id, count(*) as num_wins   from teiserver_game_rating_logs tgrl
+    inner join teiserver_battle_match_memberships tbmm
+    on tbmm.match_id = tgrl.match_id
+    and tbmm.user_id  = tgrl.user_id
+    and tbmm.match_id  is not null
+    and win = true
+    group by tgrl.user_id, rating_type_id) AS temp_table
+    WHERE teiserver_account_ratings.user_id = temp_table.user_id
+    and teiserver_account_ratings.rating_type_id  = temp_table.rating_type_id
+    """
+
+    # If we rollback we don't have to do anything
+    rollback_query = ""
+
+    execute(up_query, rollback_query)
+  end
+end

--- a/test/teiserver/game/libs/match_rating_lib_test.exs
+++ b/test/teiserver/game/libs/match_rating_lib_test.exs
@@ -8,7 +8,7 @@ defmodule Teiserver.Game.MatchRatingLibTest do
   alias Teiserver.Battle
   alias Teiserver.Game
 
-  test "num_matches is updated after rating a match" do
+  test "num_matches and num_wins is updated after rating a match" do
     # Create two user
     user1 = AccountTestLib.user_fixture()
     user2 = AccountTestLib.user_fixture()
@@ -40,11 +40,13 @@ defmodule Teiserver.Game.MatchRatingLibTest do
     assert ratings[user1.id].skill == 27.637760127073694
     assert ratings[user2.id].skill == 22.362239872926306
 
-    # Check num_matches in teiserver_account_ratings table
+    # Check num_matches and num_wins in teiserver_account_ratings table
     assert ratings[user1.id].num_matches == 1
-    assert ratings[user1.id].num_matches == 1
+    assert ratings[user2.id].num_matches == 1
+    assert ratings[user1.id].num_wins == 1
+    assert ratings[user2.id].num_wins == 0
 
-    # Check num_matches in teiserver_game_rating_logs table
+    # Check num_matches and num_wins in teiserver_game_rating_logs table
     rating_logs =
       Game.list_rating_logs(
         search: [
@@ -54,7 +56,9 @@ defmodule Teiserver.Game.MatchRatingLibTest do
       )
 
     assert Enum.at(rating_logs, 0).value["num_matches"] == 1
+    assert Enum.at(rating_logs, 0).value["num_wins"] == 1
     assert Enum.at(rating_logs, 1).value["num_matches"] == 1
+    assert Enum.at(rating_logs, 1).value["num_wins"] == 0
 
     # Create another match
     match = create_fake_match(user1.id, user2.id)
@@ -66,16 +70,20 @@ defmodule Teiserver.Game.MatchRatingLibTest do
     assert ratings[user1.id].skill == 29.662576313923775
     assert ratings[user2.id].skill == 20.337423686076225
 
-    # Check num_matches has increased
+    # Check num_matches and num_wins has increased
     assert ratings[user1.id].num_matches == 2
-    assert ratings[user1.id].num_matches == 2
+    assert ratings[user2.id].num_matches == 2
+    assert ratings[user1.id].num_wins == 2
+    assert ratings[user2.id].num_wins == 0
 
     # Rerate the same match
     MatchRatingLib.re_rate_specific_matches([match.id])
 
-    # Check num_matches unchanged
+    # Check num_matches and num_wins unchanged
     assert ratings[user1.id].num_matches == 2
-    assert ratings[user1.id].num_matches == 2
+    assert ratings[user2.id].num_matches == 2
+    assert ratings[user1.id].num_wins == 2
+    assert ratings[user2.id].num_wins == 0
   end
 
   defp get_ratings(userids, rating_type_id) do


### PR DESCRIPTION
## Purpose of num_wins column in ratings table
One of the feedback from Borg King about using a provisional rating was this:

> I like the simplicity of this idea but I suspect there are side effects of it, as you are applying a linear filter to a player's skill, even if they are actually quite good. Happy to explore this in more detail by looking at some examples in the ratings data

https://ptb.discord.com/channels/549281623154229250/643197947441315840/1335225491191369851

If someone is a smurf and actually good, we could make them lose their provisional rating faster by basing the provisional rating on num_wins rather than num_matches (or do a combination of both). In Counterstrike for example, you get your true rating after winning 10 matches. So a smurf with a 100% win rate gets to unlock their rating faster than a bad player. In order for us to adopt a similar system we need to do some analysis but this requires us to have a num_wins column in the database.