### PR TITLE
Make tau configurable by admin

### DIFF
--- a/lib/teiserver/config.ex
+++ b/lib/teiserver/config.ex
@@ -458,6 +458,7 @@ defmodule Teiserver.Config do
 
     case type.type do
       "integer" -> Teiserver.Helper.NumberHelper.int_parse(value)
+      "float" -> Teiserver.Helper.NumberHelper.float_parse(value)
       "boolean" -> if value == "true" or value == true, do: true, else: false
       "select" -> value
       "string" -> value

--- a/lib/teiserver/game/libs/match_rating_lib.ex
+++ b/lib/teiserver/game/libs/match_rating_lib.ex
@@ -719,6 +719,9 @@ defmodule Teiserver.Game.MatchRatingLib do
         end)
       end)
 
+    default_opts = [tau: get_tau()]
+    options = Keyword.merge(default_opts, options)
+
     result =
       Openskill.rate(rating_groups_without_ids, options)
       |> Enum.zip(rating_groups)
@@ -761,5 +764,9 @@ defmodule Teiserver.Game.MatchRatingLib do
       |> Ecto.Multi.insert_all(:insert_all, Teiserver.Game.RatingLog, win_ratings ++ loss_ratings)
       |> Teiserver.Repo.transaction()
     end
+  end
+
+  defp get_tau() do
+    Config.get_site_config_cache("lobby.Tau")
   end
 end

--- a/lib/teiserver/game/libs/match_rating_lib.ex
+++ b/lib/teiserver/game/libs/match_rating_lib.ex
@@ -719,7 +719,7 @@ defmodule Teiserver.Game.MatchRatingLib do
         end)
       end)
 
-    default_opts = [tau: get_tau()]
+    default_opts = [tau: get_tau(), prevent_sigma_increase: true]
     options = Keyword.merge(default_opts, options)
 
     result =
@@ -767,6 +767,6 @@ defmodule Teiserver.Game.MatchRatingLib do
   end
 
   defp get_tau() do
-    Config.get_site_config_cache("lobby.Tau")
+    Config.get_site_config_cache("rating.Tau")
   end
 end

--- a/lib/teiserver/libs/teiserver_configs.ex
+++ b/lib/teiserver/libs/teiserver_configs.ex
@@ -419,6 +419,15 @@ defmodule Teiserver.TeiserverConfigs do
       description: "Maximum team size to be considered as a small team game",
       default: 5
     })
+
+    add_site_config_type(%{
+      key: "lobby.Tau",
+      section: "Lobbies",
+      type: "float",
+      permissions: ["Admin"],
+      description: "Tau used by openskill lib",
+      default: 1 / 3
+    })
   end
 
   defp discord_configs() do

--- a/lib/teiserver/libs/teiserver_configs.ex
+++ b/lib/teiserver/libs/teiserver_configs.ex
@@ -13,6 +13,7 @@ defmodule Teiserver.TeiserverConfigs do
     lobby_configs()
     debugging_configs()
     profile_configs()
+    rating_configs()
   end
 
   @spec site_configs :: any
@@ -419,15 +420,6 @@ defmodule Teiserver.TeiserverConfigs do
       description: "Maximum team size to be considered as a small team game",
       default: 5
     })
-
-    add_site_config_type(%{
-      key: "lobby.Tau",
-      section: "Lobbies",
-      type: "float",
-      permissions: ["Admin"],
-      description: "Tau used by openskill lib",
-      default: 1 / 3
-    })
   end
 
   defp discord_configs() do
@@ -658,6 +650,17 @@ defmodule Teiserver.TeiserverConfigs do
       opts: [],
       default: false,
       value_label: "Light mode as default"
+    })
+  end
+
+  defp rating_configs do
+    add_site_config_type(%{
+      key: "rating.Tau",
+      section: "Rating",
+      type: "float",
+      permissions: ["Admin"],
+      description: "Tau used by openskill lib",
+      default: 1 / 3
     })
   end
 end

--- a/test/teiserver/game/libs/match_rating_lib_test.exs
+++ b/test/teiserver/game/libs/match_rating_lib_test.exs
@@ -106,7 +106,7 @@ defmodule Teiserver.Game.MatchRatingLibTest do
     assert ratings[user1.id].uncertainty == ratings[user2.id].uncertainty
 
     # Change tau in config to a lower number
-    Config.update_site_config("lobby.Tau", 0)
+    Config.update_site_config("rating.Tau", 0)
 
     # Create two user
     user1 = AccountTestLib.user_fixture()
@@ -128,7 +128,7 @@ defmodule Teiserver.Game.MatchRatingLibTest do
   end
 
   defp reset_to_default_tau() do
-    Config.delete_site_config("lobby.Tau")
+    Config.delete_site_config("rating.Tau")
   end
 
   defp get_ratings(userids, rating_type_id) do

--- a/test/teiserver/game/libs/match_rating_lib_test.exs
+++ b/test/teiserver/game/libs/match_rating_lib_test.exs
@@ -7,6 +7,7 @@ defmodule Teiserver.Game.MatchRatingLibTest do
   alias Teiserver.Account
   alias Teiserver.Battle
   alias Teiserver.Game
+  alias Teiserver.Config
 
   test "num_matches and num_wins is updated after rating a match" do
     # Create two user
@@ -84,6 +85,50 @@ defmodule Teiserver.Game.MatchRatingLibTest do
     assert ratings[user2.id].num_matches == 2
     assert ratings[user1.id].num_wins == 2
     assert ratings[user2.id].num_wins == 0
+  end
+
+  test "tau in config is used when rating matches" do
+    # Create two user
+    user1 = AccountTestLib.user_fixture()
+    user2 = AccountTestLib.user_fixture()
+
+    match = create_fake_match(user1.id, user2.id)
+    rating_type_id = Game.get_or_add_rating_type(match.game_type)
+
+    MatchRatingLib.rate_match(match.id)
+
+    # Check ratings of users after match
+    ratings = get_ratings([user1.id, user2.id], rating_type_id)
+
+    # Remember the new uncertainty after 1 match when using default tau
+    expected_uncertainty_default_tau = ratings[user1.id].uncertainty
+    # Both users will have same uncertainty
+    assert ratings[user1.id].uncertainty == ratings[user2.id].uncertainty
+
+    # Change tau in config to a lower number
+    Config.update_site_config("lobby.Tau", 0)
+
+    # Create two user
+    user1 = AccountTestLib.user_fixture()
+    user2 = AccountTestLib.user_fixture()
+
+    match = create_fake_match(user1.id, user2.id)
+    rating_type_id = Game.get_or_add_rating_type(match.game_type)
+
+    MatchRatingLib.rate_match(match.id)
+
+    # Check ratings of users after match
+    ratings = get_ratings([user1.id, user2.id], rating_type_id)
+
+    # Lower value of tau means that uncertainty drops MORE
+    assert ratings[user1.id].uncertainty < expected_uncertainty_default_tau
+    assert ratings[user1.id].uncertainty == ratings[user2.id].uncertainty
+
+    reset_to_default_tau()
+  end
+
+  defp reset_to_default_tau() do
+    Config.delete_site_config("lobby.Tau")
   end
 
   defp get_ratings(userids, rating_type_id) do


### PR DESCRIPTION
Tau is configurable by admin in Site Config -> Lobby section

The default value of tau is unchanged (which is 1/3)

Also adding in prevent_sigma_increase to true