### PR TITLE
Replace all joinsas with joinas spec

### DIFF
--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -671,6 +671,12 @@ defmodule Teiserver.CacheUser do
         |> String.trim()
         |> String.downcase()
         |> case do
+          "!cv joinas" ->
+            "!cv joinas spec"
+
+          "!callvote joinas spec" ->
+            "!callvote joinas spec"
+
           "!joinas" ->
             "!joinas spec"
 

--- a/lib/teiserver/lobby/libs/chat_lib.ex
+++ b/lib/teiserver/lobby/libs/chat_lib.ex
@@ -21,6 +21,12 @@ defmodule Teiserver.Lobby.ChatLib do
         |> String.trim()
         |> String.downcase()
         |> case do
+          "!cv joinas" ->
+            "!cv joinas spec"
+
+          "!callvote joinas spec" ->
+            "!callvote joinas spec"
+
           "!joinas" ->
             "!joinas spec"
 


### PR DESCRIPTION
`!joinas` allows players to join as another player or spectator in an active games, unfortunately it has been used by some players to join as other players without their approval and sabotage them. There was code in place that was supposed to replace all `!joinas` commands with `!cv joinas` which would call a vote when calling the command, however this code only covered the lowercase `!joinas`, it could be bypassed by different word capitalisations (e.g `!joinAs`).
These changes fix this and furthermore replace all `!joinas` command variants with `!joinas spec`, no longer allowing joining as another player.