### PR TITLE
Add season to ratings

### DIFF
--- a/lib/teiserver/account/libs/rating_lib.ex
+++ b/lib/teiserver/account/libs/rating_lib.ex
@@ -60,6 +60,11 @@ defmodule Teiserver.Account.RatingLib do
       where: ratings.last_updated > ^datetime
   end
 
+  def _search(query, :season, season) do
+    from ratings in query,
+      where: ratings.season == ^season
+  end
+
   @spec order_by(Ecto.Query.t(), String.t() | nil) :: Ecto.Query.t()
   def order_by(query, nil), do: query
 

--- a/lib/teiserver/account/schemas/rating.ex
+++ b/lib/teiserver/account/schemas/rating.ex
@@ -15,6 +15,8 @@ defmodule Teiserver.Account.Rating do
     field :last_updated, :utc_datetime
     field :num_matches, :integer
     field :num_wins, :integer
+
+    field :season, :integer
   end
 
   @doc false
@@ -22,11 +24,11 @@ defmodule Teiserver.Account.Rating do
     stats
     |> cast(
       attrs,
-      ~w(user_id rating_type_id rating_value skill uncertainty last_updated leaderboard_rating num_matches num_wins)a
+      ~w(user_id rating_type_id rating_value skill uncertainty last_updated leaderboard_rating num_matches num_wins season)a
     )
     # fields below are required; num_matches is not required
     |> validate_required(
-      ~w(user_id rating_type_id rating_value skill uncertainty last_updated leaderboard_rating)a
+      ~w(user_id rating_type_id rating_value skill uncertainty last_updated leaderboard_rating season)a
     )
   end
 end

--- a/lib/teiserver/account/tasks/smurf_merge_task.ex
+++ b/lib/teiserver/account/tasks/smurf_merge_task.ex
@@ -56,6 +56,8 @@ defmodule Teiserver.Account.SmurfMergeTask do
       from_value = BalanceLib.convert_rating(from_rating)
       to_value = BalanceLib.convert_rating(to_rating)
 
+      season = Teiserver.Config.get_site_config_cache("rating.Season")
+
       if from_value > to_value do
         {:ok, _rating} =
           Account.create_or_update_rating(%{
@@ -74,6 +76,7 @@ defmodule Teiserver.Account.SmurfMergeTask do
             rating_type_id: rating_type_id,
             match_id: nil,
             inserted_at: Timex.now(),
+            season: season,
             value: %{
               reason: "Smurf adjustment",
               rating_value: from_rating.rating_value,

--- a/lib/teiserver/game/libs/match_rating_lib.ex
+++ b/lib/teiserver/game/libs/match_rating_lib.ex
@@ -449,7 +449,8 @@ defmodule Teiserver.Game.MatchRatingLib do
             Map.merge(user_rating, %{
               user_id: user_id,
               last_updated: match.finished,
-              num_matches: 0
+              num_matches: 0,
+              season: active_season()
             })
           )
 
@@ -482,7 +483,8 @@ defmodule Teiserver.Game.MatchRatingLib do
       leaderboard_rating: new_leaderboard_rating,
       last_updated: match.finished,
       num_matches: new_num_matches,
-      num_wins: new_num_wins
+      num_wins: new_num_wins,
+      season: active_season()
     })
 
     %{
@@ -490,6 +492,7 @@ defmodule Teiserver.Game.MatchRatingLib do
       rating_type_id: rating_type_id,
       match_id: match.id,
       inserted_at: match.finished,
+      season: active_season(),
       value: %{
         rating_value: new_rating_value,
         skill: new_skill,
@@ -768,5 +771,9 @@ defmodule Teiserver.Game.MatchRatingLib do
 
   defp get_tau() do
     Config.get_site_config_cache("rating.Tau")
+  end
+
+  defp active_season() do
+    Config.get_site_config_cache("rating.Season")
   end
 end

--- a/lib/teiserver/game/schemas/rating_log.ex
+++ b/lib/teiserver/game/schemas/rating_log.ex
@@ -13,6 +13,8 @@ defmodule Teiserver.Game.RatingLog do
 
     has_one :match_membership,
       through: [:match, :members]
+
+    field :season, :integer
   end
 
   @doc """
@@ -21,8 +23,8 @@ defmodule Teiserver.Game.RatingLog do
   @spec changeset(map(), map()) :: Ecto.Changeset.t()
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, ~w(user_id rating_type_id match_id value inserted_at party_id)a)
-    |> validate_required(~w(user_id rating_type_id value inserted_at)a)
+    |> cast(params, ~w(user_id rating_type_id match_id value inserted_at party_id season)a)
+    |> validate_required(~w(user_id rating_type_id value inserted_at season)a)
   end
 
   @spec authorize(Atom.t(), Plug.Conn.t(), map()) :: Boolean.t()

--- a/lib/teiserver/libs/teiserver_configs.ex
+++ b/lib/teiserver/libs/teiserver_configs.ex
@@ -662,5 +662,14 @@ defmodule Teiserver.TeiserverConfigs do
       description: "Tau used by openskill lib",
       default: 1 / 3
     })
+
+    add_site_config_type(%{
+      key: "rating.Season",
+      section: "Rating",
+      type: "integer",
+      permissions: ["Admin"],
+      description: "Active season",
+      default: 1
+    })
   end
 end

--- a/lib/teiserver_web/controllers/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/admin/user_controller.ex
@@ -531,7 +531,8 @@ defmodule TeiserverWeb.Admin.UserController do
                     skill: new_skill,
                     uncertainty: new_uncertainty,
                     leaderboard_rating: new_leaderboard_rating,
-                    last_updated: Timex.now()
+                    last_updated: Timex.now(),
+                    season: active_season()
                   })
 
                 existing ->
@@ -540,7 +541,8 @@ defmodule TeiserverWeb.Admin.UserController do
                     skill: new_skill,
                     uncertainty: new_uncertainty,
                     leaderboard_rating: new_leaderboard_rating,
-                    last_updated: Timex.now()
+                    last_updated: Timex.now(),
+                    season: active_season()
                   })
               end
 
@@ -549,6 +551,7 @@ defmodule TeiserverWeb.Admin.UserController do
               rating_type_id: rating_type_id,
               match_id: nil,
               inserted_at: Timex.now(),
+              season: active_season(),
               value: %{
                 reason: "Manual adjustment",
                 rating_value: new_rating_value,
@@ -1121,5 +1124,9 @@ defmodule TeiserverWeb.Admin.UserController do
         |> put_flash(:danger, "Unable to access this user")
         |> redirect(to: ~p"/teiserver/admin/user")
     end
+  end
+
+  defp active_season() do
+    Teiserver.Config.get_site_config_cache("rating.Season")
   end
 end

--- a/priv/repo/migrations/20250311104815_add_seasons.exs
+++ b/priv/repo/migrations/20250311104815_add_seasons.exs
@@ -1,0 +1,13 @@
+defmodule Teiserver.Repo.Migrations.AddSeasons do
+  use Ecto.Migration
+
+  def change do
+    alter table(:teiserver_game_rating_logs) do
+      add :season, :integer, default: 1
+    end
+
+    alter table(:teiserver_account_ratings) do
+      add :season, :integer, default: 1
+    end
+  end
+end

--- a/test/teiserver_web/controllers/api/spads_controller_test.exs
+++ b/test/teiserver_web/controllers/api/spads_controller_test.exs
@@ -24,7 +24,8 @@ defmodule TeiserverWeb.API.SpadsControllerTest do
         skill: rating_value,
         uncertainty: 0,
         leaderboard_rating: rating_value,
-        last_updated: Timex.now()
+        last_updated: Timex.now(),
+        season: 1
       })
   end
 
@@ -50,7 +51,8 @@ defmodule TeiserverWeb.API.SpadsControllerTest do
           skill: 25,
           uncertainty: 5,
           leaderboard_rating: 5,
-          last_updated: Timex.now()
+          last_updated: Timex.now(),
+          season: 1
         })
 
       Client.login(user, :spring, "127.0.0.1")


### PR DESCRIPTION
Adds a new column `season` to account ratings and rating logs tables. Keeping it an integer for simplicity (new season table with additional season data can be added in the future if necessary).

## Future plans/ideas:
I was planning to add a season selector to the leaderboard page, but ran into some issues so decided to keep it as simple as possible for now, additional features can be added later.
Another idea is to also have a new season management page through which new seasons could be added and activated while old ones could show all kinds of seasonal statistics (e.g. number of matches and players, rating distributions)