### PR TITLE
Tachyon friends

### DIFF
--- a/lib/teiserver/account.ex
+++ b/lib/teiserver/account.ex
@@ -1607,6 +1607,17 @@ defmodule Teiserver.Account do
   end
 
   @doc """
+  Returns the list of friends for the given user
+  """
+  @spec list_friends_for_user(map() | T.userid()) :: [map()]
+  def list_friends_for_user(%{id: id}), do: list_friends_for_user(id)
+
+  def list_friends_for_user(user_id) do
+    FriendQueries.query_friends(where: [either_user_is: user_id])
+    |> Repo.all()
+  end
+
+  @doc """
   Gets a single friend.
 
   Raises `Ecto.NoResultsError` if the Friend does not exist.
@@ -1952,6 +1963,9 @@ defmodule Teiserver.Account do
 
   @spec list_outgoing_friend_requests_of_userid(T.userid()) :: [T.userid()]
   defdelegate list_outgoing_friend_requests_of_userid(userid), to: FriendRequestLib
+
+  @spec list_requests_for_user(T.userid()) :: {outgoing :: [map()], incoming :: [map()]}
+  defdelegate list_requests_for_user(userid), to: FriendRequestLib
 
   @spec list_incoming_friend_requests_of_userid(T.userid()) :: [T.userid()]
   defdelegate list_incoming_friend_requests_of_userid(userid), to: FriendRequestLib

--- a/lib/teiserver/account/queries/friend_request_queries.ex
+++ b/lib/teiserver/account/queries/friend_request_queries.ex
@@ -53,6 +53,11 @@ defmodule Teiserver.Account.FriendRequestQueries do
           (friend_requests.from_user_id == ^u2 and friend_requests.to_user_id == ^u1)
   end
 
+  defp _where(query, :to_or_from_is, id) do
+    from friend_requests in query,
+      where: friend_requests.from_user_id == ^id or friend_requests.to_user_id == ^id
+  end
+
   @spec do_order_by(Ecto.Query.t(), list | nil) :: Ecto.Query.t()
   defp do_order_by(query, nil), do: query
 

--- a/lib/teiserver/player/session.ex
+++ b/lib/teiserver/player/session.ex
@@ -172,6 +172,16 @@ defmodule Teiserver.Player.Session do
     GenServer.cast(via_tuple(user_id), {:messaging, {:dm, message}})
   end
 
+  @doc """
+  notify the connected player that they received a new friend request.
+  If the player isn't connected it's a no-op. They'll get the friend request
+  as part of the friend/list response next time they connect.
+  """
+  @spec friend_request_received(target_id :: T.userid(), originator_id :: T.userid()) :: :ok
+  def friend_request_received(target_id, originator_id) do
+    GenServer.cast(via_tuple(target_id), {:friend, {:request_received, originator_id}})
+  end
+
   def start_link({_conn_pid, user} = arg) do
     GenServer.start_link(__MODULE__, arg, name: via_tuple(user.id))
   end
@@ -454,6 +464,11 @@ defmodule Teiserver.Player.Session do
       _ ->
         {:noreply, state}
     end
+  end
+
+  def handle_cast({:friend, {:request_received, from_id}}, state) do
+    state = send_to_player({:friend, {:request_received, from_id}}, state)
+    {:noreply, state}
   end
 
   @impl true

--- a/lib/teiserver/player/session.ex
+++ b/lib/teiserver/player/session.ex
@@ -182,6 +182,15 @@ defmodule Teiserver.Player.Session do
     GenServer.cast(via_tuple(target_id), {:friend, {:request_received, originator_id}})
   end
 
+  @doc """
+  notify the connected player that a pending friend request has been cancelled
+  If the player isn't connected it's a no-op.
+  """
+  @spec friend_request_cancelled(target_id :: T.userid(), originator_id :: T.userid()) :: :ok
+  def friend_request_cancelled(target_id, originator_id) do
+    GenServer.cast(via_tuple(target_id), {:friend, {:request_cancelled, originator_id}})
+  end
+
   def start_link({_conn_pid, user} = arg) do
     GenServer.start_link(__MODULE__, arg, name: via_tuple(user.id))
   end
@@ -466,8 +475,9 @@ defmodule Teiserver.Player.Session do
     end
   end
 
-  def handle_cast({:friend, {:request_received, from_id}}, state) do
-    state = send_to_player({:friend, {:request_received, from_id}}, state)
+  def handle_cast({:friend, {event, from_id}}, state)
+      when event in [:request_received, :request_cancelled] do
+    state = send_to_player({:friend, {event, from_id}}, state)
     {:noreply, state}
   end
 

--- a/lib/teiserver/player/session.ex
+++ b/lib/teiserver/player/session.ex
@@ -191,6 +191,15 @@ defmodule Teiserver.Player.Session do
     GenServer.cast(via_tuple(target_id), {:friend, {:request_cancelled, originator_id}})
   end
 
+  @doc """
+  notify the connected originator player that their friend request
+  has been accepted by the target.
+  """
+  @spec friend_request_accepted(originator_id :: T.userid(), target_id :: T.userid()) :: :ok
+  def friend_request_accepted(originator_id, target_id) do
+    GenServer.cast(via_tuple(originator_id), {:friend, {:request_accepted, target_id}})
+  end
+
   def start_link({_conn_pid, user} = arg) do
     GenServer.start_link(__MODULE__, arg, name: via_tuple(user.id))
   end
@@ -476,7 +485,7 @@ defmodule Teiserver.Player.Session do
   end
 
   def handle_cast({:friend, {event, from_id}}, state)
-      when event in [:request_received, :request_cancelled] do
+      when event in [:request_received, :request_cancelled, :request_accepted] do
     state = send_to_player({:friend, {event, from_id}}, state)
     {:noreply, state}
   end

--- a/lib/teiserver/player/session.ex
+++ b/lib/teiserver/player/session.ex
@@ -209,6 +209,15 @@ defmodule Teiserver.Player.Session do
     GenServer.cast(via_tuple(originator_id), {:friend, {:request_rejected, target_id}})
   end
 
+  @doc """
+  notify the connected player that they have been removed from a friendlist
+  by the given user
+  """
+  @spec friend_request_rejected(user_id :: T.userid(), from_id :: T.userid()) :: :ok
+  def friend_removed(user_id, from_id) do
+    GenServer.cast(via_tuple(user_id), {:friend, {:removed, from_id}})
+  end
+
   def start_link({_conn_pid, user} = arg) do
     GenServer.start_link(__MODULE__, arg, name: via_tuple(user.id))
   end
@@ -494,7 +503,13 @@ defmodule Teiserver.Player.Session do
   end
 
   def handle_cast({:friend, {event, from_id}}, state)
-      when event in [:request_received, :request_cancelled, :request_accepted, :request_rejected] do
+      when event in [
+             :request_received,
+             :request_cancelled,
+             :request_accepted,
+             :request_rejected,
+             :removed
+           ] do
     state = send_to_player({:friend, {event, from_id}}, state)
     {:noreply, state}
   end

--- a/lib/teiserver/player/session.ex
+++ b/lib/teiserver/player/session.ex
@@ -200,6 +200,15 @@ defmodule Teiserver.Player.Session do
     GenServer.cast(via_tuple(originator_id), {:friend, {:request_accepted, target_id}})
   end
 
+  @doc """
+  notify the connected originator player that their friend request
+  has been rejected by the target.
+  """
+  @spec friend_request_rejected(originator_id :: T.userid(), target_id :: T.userid()) :: :ok
+  def friend_request_rejected(originator_id, target_id) do
+    GenServer.cast(via_tuple(originator_id), {:friend, {:request_rejected, target_id}})
+  end
+
   def start_link({_conn_pid, user} = arg) do
     GenServer.start_link(__MODULE__, arg, name: via_tuple(user.id))
   end
@@ -485,7 +494,7 @@ defmodule Teiserver.Player.Session do
   end
 
   def handle_cast({:friend, {event, from_id}}, state)
-      when event in [:request_received, :request_cancelled, :request_accepted] do
+      when event in [:request_received, :request_cancelled, :request_accepted, :request_rejected] do
     state = send_to_player({:friend, {event, from_id}}, state)
     {:noreply, state}
   end

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -400,6 +400,36 @@ defmodule Teiserver.Player.TachyonHandler do
     end
   end
 
+  def handle_command("friend/rejectRequest" = cmd_id, "request", message_id, msg, state) do
+    with {:ok, originator_id} <- parse_user_id(msg["data"]["from"]),
+         :ok <- Account.decline_friend_request(originator_id, state.user.id) do
+      {:response, cmd_id, nil, state}
+    else
+      {:error, :invalid_id} ->
+        resp =
+          Schema.error_response(cmd_id, message_id, :invalid_user)
+          |> Jason.encode!()
+
+        {:reply, :ok, {:text, resp}, state}
+
+      {:error, "no request"} ->
+        resp =
+          Schema.error_response(cmd_id, message_id, :no_pending_request)
+          |> Jason.encode!()
+
+        {:reply, :ok, {:text, resp}, state}
+
+      err ->
+        Logger.error("Unhandled error in rejectRequest: #{inspect(err)}")
+
+        resp =
+          Schema.error_response(cmd_id, message_id, :internal_error, inspect(err))
+          |> Jason.encode!()
+
+        {:reply, :ok, {:text, resp}, state}
+    end
+  end
+
   def handle_command("friend/cancelRequest" = cmd_id, "request", message_id, msg, state) do
     with {:ok, target_id} <- parse_user_id(msg["data"]["to"]),
          :ok <- Account.rescind_friend_request(state.user.id, target_id) do

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -132,6 +132,10 @@ defmodule Teiserver.Player.TachyonHandler do
     {:event, "friend/requestAccepted", %{from: to_string(from_id)}, state}
   end
 
+  def handle_info({:friend, {:request_rejected, from_id}}, state) do
+    {:event, "friend/requestRejected", %{from: to_string(from_id)}, state}
+  end
+
   def handle_info({:timeout, message_id}, state)
       when is_map_key(state.pending_responses, message_id) do
     Logger.debug("User did not reply in time to request with id #{message_id}")
@@ -403,6 +407,7 @@ defmodule Teiserver.Player.TachyonHandler do
   def handle_command("friend/rejectRequest" = cmd_id, "request", message_id, msg, state) do
     with {:ok, originator_id} <- parse_user_id(msg["data"]["from"]),
          :ok <- Account.decline_friend_request(originator_id, state.user.id) do
+      Player.Session.friend_request_rejected(originator_id, state.user.id)
       {:response, cmd_id, nil, state}
     else
       {:error, :invalid_id} ->

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -128,6 +128,10 @@ defmodule Teiserver.Player.TachyonHandler do
     {:event, "friend/requestCancelled", %{from: to_string(from_id)}, state}
   end
 
+  def handle_info({:friend, {:request_accepted, from_id}}, state) do
+    {:event, "friend/requestAccepted", %{from: to_string(from_id)}, state}
+  end
+
   def handle_info({:timeout, message_id}, state)
       when is_map_key(state.pending_responses, message_id) do
     Logger.debug("User did not reply in time to request with id #{message_id}")
@@ -377,6 +381,7 @@ defmodule Teiserver.Player.TachyonHandler do
   def handle_command("friend/acceptRequest" = cmd_id, "request", message_id, msg, state) do
     with {:ok, originator_id} <- parse_user_id(msg["data"]["from"]),
          :ok <- Account.accept_friend_request(originator_id, state.user.id) do
+      Player.Session.friend_request_accepted(originator_id, state.user.id)
       {:response, cmd_id, nil, state}
     else
       {:error, :invalid_id} ->

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -136,6 +136,10 @@ defmodule Teiserver.Player.TachyonHandler do
     {:event, "friend/requestRejected", %{from: to_string(from_id)}, state}
   end
 
+  def handle_info({:friend, {:removed, from_id}}, state) do
+    {:event, "friend/removed", %{from: to_string(from_id)}, state}
+  end
+
   def handle_info({:timeout, message_id}, state)
       when is_map_key(state.pending_responses, message_id) do
     Logger.debug("User did not reply in time to request with id #{message_id}")
@@ -457,6 +461,7 @@ defmodule Teiserver.Player.TachyonHandler do
     with {:ok, target_id} <- parse_user_id(msg["data"]["userId"]),
          %Account.Friend{} = friend <- Account.get_friend(state.user.id, target_id),
          {:ok, _changeset} <- Account.delete_friend(friend) do
+      Player.Session.friend_removed(target_id, state.user.id)
       {:response, cmd_id, nil, state}
     else
       nil ->

--- a/priv/tachyon/schema/friend/acceptRequest/request.json
+++ b/priv/tachyon/schema/friend/acceptRequest/request.json
@@ -1,0 +1,25 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/acceptRequest/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "FriendAcceptRequestRequest",
+    "tachyon": {
+        "source": "user",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "friend/acceptRequest" },
+        "data": {
+            "title": "FriendAcceptRequestRequestData",
+            "type": "object",
+            "properties": {
+                "from": { "$ref": "../../definitions/userId.json" }
+            },
+            "required": ["from"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/friend/acceptRequest/response.json
+++ b/priv/tachyon/schema/friend/acceptRequest/response.json
@@ -1,0 +1,45 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/acceptRequest/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "FriendAcceptRequestResponse",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "FriendAcceptRequestOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "friend/acceptRequest" },
+                "status": { "const": "success" }
+            },
+            "required": ["type", "messageId", "commandId", "status"]
+        },
+        {
+            "title": "FriendAcceptRequestFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "friend/acceptRequest" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "invalid_user",
+                        "no_pending_request",
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}

--- a/priv/tachyon/schema/friend/cancelRequest/request.json
+++ b/priv/tachyon/schema/friend/cancelRequest/request.json
@@ -1,0 +1,23 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/cancelRequest/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "FriendCancelRequestRequest",
+    "tachyon": {
+        "source": "user",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "friend/cancelRequest" },
+        "data": {
+            "title": "FriendCancelRequestRequestData",
+            "type": "object",
+            "properties": { "to": { "$ref": "../../definitions/userId.json" } },
+            "required": ["to"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/friend/cancelRequest/response.json
+++ b/priv/tachyon/schema/friend/cancelRequest/response.json
@@ -1,0 +1,44 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/cancelRequest/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "FriendCancelRequestResponse",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "FriendCancelRequestOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "friend/cancelRequest" },
+                "status": { "const": "success" }
+            },
+            "required": ["type", "messageId", "commandId", "status"]
+        },
+        {
+            "title": "FriendCancelRequestFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "friend/cancelRequest" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "invalid_user",
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}

--- a/priv/tachyon/schema/friend/list/request.json
+++ b/priv/tachyon/schema/friend/list/request.json
@@ -1,0 +1,17 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/list/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "FriendListRequest",
+    "tachyon": {
+        "source": "user",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "friend/list" }
+    },
+    "required": ["type", "messageId", "commandId"]
+}

--- a/priv/tachyon/schema/friend/list/response.json
+++ b/priv/tachyon/schema/friend/list/response.json
@@ -1,0 +1,99 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/list/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "FriendListResponse",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "FriendListOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "friend/list" },
+                "status": { "const": "success" },
+                "data": {
+                    "title": "FriendListOkResponseData",
+                    "type": "object",
+                    "properties": {
+                        "friends": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "userId": {
+                                        "$ref": "../../definitions/userId.json"
+                                    },
+                                    "addedAt": {
+                                        "$ref": "../../definitions/unixTime.json"
+                                    }
+                                },
+                                "required": ["userId", "addedAt"]
+                            }
+                        },
+                        "outgoingPendingRequests": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "to": {
+                                        "$ref": "../../definitions/userId.json"
+                                    },
+                                    "sentAt": {
+                                        "$ref": "../../definitions/unixTime.json"
+                                    }
+                                },
+                                "required": ["to", "sentAt"]
+                            }
+                        },
+                        "incomingPendingRequests": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "from": {
+                                        "$ref": "../../definitions/userId.json"
+                                    },
+                                    "sentAt": {
+                                        "$ref": "../../definitions/unixTime.json"
+                                    }
+                                },
+                                "required": ["from", "sentAt"]
+                            }
+                        }
+                    },
+                    "required": [
+                        "friends",
+                        "outgoingPendingRequests",
+                        "incomingPendingRequests"
+                    ]
+                }
+            },
+            "required": ["type", "messageId", "commandId", "status", "data"]
+        },
+        {
+            "title": "FriendListFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "friend/list" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}

--- a/priv/tachyon/schema/friend/rejectRequest/request.json
+++ b/priv/tachyon/schema/friend/rejectRequest/request.json
@@ -1,0 +1,25 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/rejectRequest/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "FriendRejectRequestRequest",
+    "tachyon": {
+        "source": "user",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "friend/rejectRequest" },
+        "data": {
+            "title": "FriendRejectRequestRequestData",
+            "type": "object",
+            "properties": {
+                "from": { "$ref": "../../definitions/userId.json" }
+            },
+            "required": ["from"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/friend/rejectRequest/response.json
+++ b/priv/tachyon/schema/friend/rejectRequest/response.json
@@ -1,0 +1,45 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/rejectRequest/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "FriendRejectRequestResponse",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "FriendRejectRequestOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "friend/rejectRequest" },
+                "status": { "const": "success" }
+            },
+            "required": ["type", "messageId", "commandId", "status"]
+        },
+        {
+            "title": "FriendRejectRequestFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "friend/rejectRequest" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "invalid_user",
+                        "no_pending_request",
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}

--- a/priv/tachyon/schema/friend/remove/request.json
+++ b/priv/tachyon/schema/friend/remove/request.json
@@ -1,0 +1,25 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/remove/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "FriendRemoveRequest",
+    "tachyon": {
+        "source": "user",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "friend/remove" },
+        "data": {
+            "title": "FriendRemoveRequestData",
+            "type": "object",
+            "properties": {
+                "userId": { "$ref": "../../definitions/userId.json" }
+            },
+            "required": ["userId"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/friend/remove/response.json
+++ b/priv/tachyon/schema/friend/remove/response.json
@@ -1,0 +1,45 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/remove/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "FriendRemoveResponse",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "FriendRemoveOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "friend/remove" },
+                "status": { "const": "success" }
+            },
+            "required": ["type", "messageId", "commandId", "status"]
+        },
+        {
+            "title": "FriendRemoveFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "friend/remove" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "invalid_user",
+                        "not_in_friendlist",
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}

--- a/priv/tachyon/schema/friend/removed/event.json
+++ b/priv/tachyon/schema/friend/removed/event.json
@@ -1,0 +1,25 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/removed/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "FriendRemovedEvent",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "event" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "friend/removed" },
+        "data": {
+            "title": "FriendRemovedEventData",
+            "type": "object",
+            "properties": {
+                "from": { "$ref": "../../definitions/userId.json" }
+            },
+            "required": ["from"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/friend/requestAccepted/event.json
+++ b/priv/tachyon/schema/friend/requestAccepted/event.json
@@ -1,0 +1,25 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/requestAccepted/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "FriendRequestAcceptedEvent",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "event" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "friend/requestAccepted" },
+        "data": {
+            "title": "FriendRequestAcceptedEventData",
+            "type": "object",
+            "properties": {
+                "from": { "$ref": "../../definitions/userId.json" }
+            },
+            "required": ["from"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/friend/requestCancelled/event.json
+++ b/priv/tachyon/schema/friend/requestCancelled/event.json
@@ -1,0 +1,25 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/requestCancelled/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "FriendRequestCancelledEvent",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "event" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "friend/requestCancelled" },
+        "data": {
+            "title": "FriendRequestCancelledEventData",
+            "type": "object",
+            "properties": {
+                "from": { "$ref": "../../definitions/userId.json" }
+            },
+            "required": ["from"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/friend/requestReceived/event.json
+++ b/priv/tachyon/schema/friend/requestReceived/event.json
@@ -1,0 +1,25 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/requestReceived/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "FriendRequestReceivedEvent",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "event" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "friend/requestReceived" },
+        "data": {
+            "title": "FriendRequestReceivedEventData",
+            "type": "object",
+            "properties": {
+                "from": { "$ref": "../../definitions/userId.json" }
+            },
+            "required": ["from"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/friend/requestRejected/event.json
+++ b/priv/tachyon/schema/friend/requestRejected/event.json
@@ -1,0 +1,25 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/requestRejected/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "FriendRequestRejectedEvent",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "event" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "friend/requestRejected" },
+        "data": {
+            "title": "FriendRequestRejectedEventData",
+            "type": "object",
+            "properties": {
+                "from": { "$ref": "../../definitions/userId.json" }
+            },
+            "required": ["from"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/friend/sendRequest/request.json
+++ b/priv/tachyon/schema/friend/sendRequest/request.json
@@ -1,0 +1,23 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/sendRequest/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "FriendSendRequestRequest",
+    "tachyon": {
+        "source": "user",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "friend/sendRequest" },
+        "data": {
+            "title": "FriendSendRequestRequestData",
+            "type": "object",
+            "properties": { "to": { "$ref": "../../definitions/userId.json" } },
+            "required": ["to"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/friend/sendRequest/response.json
+++ b/priv/tachyon/schema/friend/sendRequest/response.json
@@ -1,0 +1,47 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/friend/sendRequest/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "FriendSendRequestResponse",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "FriendSendRequestOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "friend/sendRequest" },
+                "status": { "const": "success" }
+            },
+            "required": ["type", "messageId", "commandId", "status"]
+        },
+        {
+            "title": "FriendSendRequestFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "friend/sendRequest" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "invalid_user",
+                        "already_in_friendlist",
+                        "outgoing_capacity_reached",
+                        "incoming_capacity_reached",
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}

--- a/test/support/fixtures/account/account_fixtures.ex
+++ b/test/support/fixtures/account/account_fixtures.ex
@@ -31,4 +31,15 @@ defmodule Teiserver.AccountFixtures do
 
     tag
   end
+
+  @doc """
+  Make the two given users friends
+  """
+  def create_friend(%{id: id1}, user2), do: create_friend(id1, user2)
+  def create_friend(user1, %{id: id}), do: create_friend(user1, id)
+
+  def create_friend(user_id1, user_id2) do
+    {:ok, friend} = Account.create_friend(user_id1, user_id2)
+    friend
+  end
 end

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -325,4 +325,9 @@ defmodule Teiserver.Support.Tachyon do
     :ok = send_request(client, "friend/cancelRequest", %{to: to_string(user_id)})
     recv_message!(client)
   end
+
+  def remove_friend!(client, friend_id) do
+    :ok = send_request(client, "friend/remove", %{userId: to_string(friend_id)})
+    recv_message!(client)
+  end
 end

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -5,10 +5,14 @@ defmodule Teiserver.Support.Tachyon do
 
   alias Teiserver.Support.Polling
 
+  def create_user() do
+    Central.Helpers.GeneralTestLib.make_user(%{"data" => %{"roles" => ["Verified"]}})
+  end
+
   def setup_client(_context), do: setup_client()
 
   def setup_client() do
-    user = Central.Helpers.GeneralTestLib.make_user(%{"data" => %{"roles" => ["Verified"]}})
+    user = create_user()
     %{client: client, token: token} = connect(user)
 
     ExUnit.Callbacks.on_exit(fn -> cleanup_connection(client, token) end)
@@ -295,5 +299,10 @@ defmodule Teiserver.Support.Tachyon do
     :ok = send_request(client, "user/info", %{userId: to_string(user_id)})
     {:ok, resp} = recv_message(client)
     resp
+  end
+
+  def friend_list!(client) do
+    :ok = send_request(client, "friend/list")
+    recv_message!(client)
   end
 end

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -311,6 +311,11 @@ defmodule Teiserver.Support.Tachyon do
     recv_message!(client)
   end
 
+  def accept_friend_request!(client, from_id) do
+    :ok = send_request(client, "friend/acceptRequest", %{from: to_string(from_id)})
+    recv_message!(client)
+  end
+
   def cancel_friend_request!(client, user_id) do
     :ok = send_request(client, "friend/cancelRequest", %{to: to_string(user_id)})
     recv_message!(client)

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -316,6 +316,11 @@ defmodule Teiserver.Support.Tachyon do
     recv_message!(client)
   end
 
+  def reject_friend_request!(client, from_id) do
+    :ok = send_request(client, "friend/rejectRequest", %{from: to_string(from_id)})
+    recv_message!(client)
+  end
+
   def cancel_friend_request!(client, user_id) do
     :ok = send_request(client, "friend/cancelRequest", %{to: to_string(user_id)})
     recv_message!(client)

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -305,4 +305,14 @@ defmodule Teiserver.Support.Tachyon do
     :ok = send_request(client, "friend/list")
     recv_message!(client)
   end
+
+  def send_friend_request!(client, user_id) do
+    :ok = send_request(client, "friend/sendRequest", %{to: to_string(user_id)})
+    recv_message!(client)
+  end
+
+  def cancel_friend_request!(client, user_id) do
+    :ok = send_request(client, "friend/cancelRequest", %{to: to_string(user_id)})
+    recv_message!(client)
+  end
 end

--- a/test/teiserver/account/friend_request_lib_test.exs
+++ b/test/teiserver/account/friend_request_lib_test.exs
@@ -1,0 +1,28 @@
+defmodule Teiserver.Account.FriendRequestLibTest do
+  use Teiserver.DataCase, async: true
+  alias Teiserver.Account.AccountTestLib
+  alias Teiserver.Account.{FriendRequest, FriendRequestLib}
+
+  defp friend_request_fixture(%{id: id}, to), do: friend_request_fixture(id, to)
+  defp friend_request_fixture(from, %{id: id}), do: friend_request_fixture(from, id)
+
+  defp friend_request_fixture(from, to) do
+    %FriendRequest{}
+    |> FriendRequest.changeset(%{from_user_id: from, to_user_id: to})
+    |> Teiserver.Repo.insert!()
+  end
+
+  test "list requests" do
+    user1 = AccountTestLib.user_fixture()
+    user2 = AccountTestLib.user_fixture()
+    user3 = AccountTestLib.user_fixture()
+    friend_request_fixture(user1, user2)
+    friend_request_fixture(user3, user1)
+
+    assert {[outgoing], [incoming]} = FriendRequestLib.list_requests_for_user(user1.id)
+    assert outgoing.from_user_id == user1.id
+    assert outgoing.to_user_id == user2.id
+    assert incoming.from_user_id == user3.id
+    assert incoming.to_user_id == user1.id
+  end
+end

--- a/test/teiserver_web/tachyon/friend_test.exs
+++ b/test/teiserver_web/tachyon/friend_test.exs
@@ -96,6 +96,10 @@ defmodule TeiserverWeb.Tachyon.FriendTest do
                Tachyon.accept_friend_request!(ctx[:client2], ctx[:user].id)
 
       assert %Account.Friend{} = Account.get_friend(ctx[:user].id, ctx[:user2].id)
+      expected = %{"from" => to_string(ctx[:user2].id)}
+
+      assert %{"commandId" => "friend/requestAccepted", "data" => ^expected} =
+               Tachyon.recv_message!(ctx[:client])
     end
 
     test "cancel for invalid user", ctx do

--- a/test/teiserver_web/tachyon/friend_test.exs
+++ b/test/teiserver_web/tachyon/friend_test.exs
@@ -138,6 +138,11 @@ defmodule TeiserverWeb.Tachyon.FriendTest do
 
       assert nil == Account.get_friend(ctx[:user].id, ctx[:user2].id)
       assert nil == Account.get_friend_request(ctx[:user].id, ctx[:user2].id)
+
+      expected = %{"from" => to_string(ctx[:user2].id)}
+
+      assert %{"commandId" => "friend/requestRejected", "data" => ^expected} =
+               Tachyon.recv_message!(ctx[:client])
     end
   end
 end

--- a/test/teiserver_web/tachyon/friend_test.exs
+++ b/test/teiserver_web/tachyon/friend_test.exs
@@ -1,0 +1,44 @@
+defmodule TeiserverWeb.Tachyon.FriendTest do
+  use TeiserverWeb.ConnCase
+  alias Teiserver.Support.Tachyon
+  alias Teiserver.Account
+
+  describe "friends" do
+    setup [{Tachyon, :setup_client}]
+
+    test "list", ctx1 do
+      {:ok, ctx2} = Tachyon.setup_client()
+      {:ok, ctx3} = Tachyon.setup_client()
+      {:ok, ctx4} = Tachyon.setup_client()
+      {:ok, _} = Account.create_friend(ctx1[:user].id, ctx2[:user].id)
+      # outgoing
+      {:ok, _} = Account.create_friend_request(ctx1[:user].id, ctx3[:user].id)
+      # incoming
+      {:ok, _} = Account.create_friend_request(ctx4[:user].id, ctx1[:user].id)
+
+      # should not be included
+      {:ok, _} = Account.create_friend(ctx3[:user].id, ctx4[:user].id)
+
+      assert %{"status" => "success", "data" => data} = Tachyon.friend_list!(ctx1[:client])
+
+      user1_id = to_string(ctx1[:user].id)
+      user2_id = to_string(ctx2[:user].id)
+      user3_id = to_string(ctx3[:user].id)
+      user4_id = to_string(ctx4[:user].id)
+
+      assert %{
+               "friends" => [%{"userId" => ^user2_id}],
+               "outgoingPendingRequests" => [%{"to" => ^user3_id}],
+               "incomingPendingRequests" => [%{"from" => ^user4_id}]
+             } = data
+
+      assert %{"status" => "success", "data" => data} = Tachyon.friend_list!(ctx2[:client])
+
+      assert %{
+               "friends" => [%{"userId" => ^user1_id}],
+               "outgoingPendingRequests" => [],
+               "incomingPendingRequests" => []
+             } = data
+    end
+  end
+end

--- a/test/teiserver_web/tachyon/friend_test.exs
+++ b/test/teiserver_web/tachyon/friend_test.exs
@@ -79,6 +79,25 @@ defmodule TeiserverWeb.Tachyon.FriendTest do
                Tachyon.recv_message!(ctx[:client2])
     end
 
+    test "accept from invalid user", ctx do
+      assert %{"status" => "failed", "reason" => "invalid_user"} =
+               Tachyon.accept_friend_request!(ctx[:client], "wtfid")
+    end
+
+    test "accept non existant request", ctx do
+      assert %{"status" => "failed", "reason" => "no_pending_request"} =
+               Tachyon.accept_friend_request!(ctx[:client], ctx[:user2].id)
+    end
+
+    test "can accept friend request", ctx do
+      {:ok, _} = Account.create_friend_request(ctx[:user].id, ctx[:user2].id)
+
+      assert %{"status" => "success"} =
+               Tachyon.accept_friend_request!(ctx[:client2], ctx[:user].id)
+
+      assert %Account.Friend{} = Account.get_friend(ctx[:user].id, ctx[:user2].id)
+    end
+
     test "cancel for invalid user", ctx do
       assert %{"status" => "failed", "reason" => "invalid_user"} =
                Tachyon.cancel_friend_request!(ctx[:client], "invalid-id")

--- a/test/teiserver_web/tachyon/friend_test.exs
+++ b/test/teiserver_web/tachyon/friend_test.exs
@@ -72,6 +72,11 @@ defmodule TeiserverWeb.Tachyon.FriendTest do
 
       assert %Account.FriendRequest{from_user_id: ^user_id} =
                Account.get_friend_request(user_id, ctx[:user2].id)
+
+      expected = %{"from" => to_string(ctx[:user].id)}
+
+      assert %{"commandId" => "friend/requestReceived", "data" => ^expected} =
+               Tachyon.recv_message!(ctx[:client2])
     end
   end
 end

--- a/test/teiserver_web/tachyon/friend_test.exs
+++ b/test/teiserver_web/tachyon/friend_test.exs
@@ -177,6 +177,10 @@ defmodule TeiserverWeb.Tachyon.FriendTest do
     test "can remove friend", ctx do
       assert %{"status" => "success"} = Tachyon.remove_friend!(ctx[:client], ctx[:user2].id)
       assert nil == Account.get_friend(ctx[:user].id, ctx[:user2].id)
+      expected = %{"from" => to_string(ctx[:user].id)}
+
+      assert %{"commandId" => "friend/removed", "data" => ^expected} =
+               Tachyon.recv_message!(ctx[:client2])
     end
   end
 end

--- a/test/teiserver_web/tachyon/friend_test.exs
+++ b/test/teiserver_web/tachyon/friend_test.exs
@@ -124,5 +124,20 @@ defmodule TeiserverWeb.Tachyon.FriendTest do
       assert %{"commandId" => "friend/requestCancelled", "data" => ^expected} =
                Tachyon.recv_message!(ctx[:client2])
     end
+
+    test "can't reject non existant request", ctx do
+      assert %{"status" => "failed", "reason" => "no_pending_request"} =
+               Tachyon.reject_friend_request!(ctx[:client2], ctx[:user].id)
+    end
+
+    test "reject request", ctx do
+      {:ok, _} = Account.create_friend_request(ctx[:user].id, ctx[:user2].id)
+
+      assert %{"status" => "success"} =
+               Tachyon.reject_friend_request!(ctx[:client2], ctx[:user].id)
+
+      assert nil == Account.get_friend(ctx[:user].id, ctx[:user2].id)
+      assert nil == Account.get_friend_request(ctx[:user].id, ctx[:user2].id)
+    end
   end
 end

--- a/test/teiserver_web/tachyon/friend_test.exs
+++ b/test/teiserver_web/tachyon/friend_test.exs
@@ -78,5 +78,28 @@ defmodule TeiserverWeb.Tachyon.FriendTest do
       assert %{"commandId" => "friend/requestReceived", "data" => ^expected} =
                Tachyon.recv_message!(ctx[:client2])
     end
+
+    test "cancel for invalid user", ctx do
+      assert %{"status" => "failed", "reason" => "invalid_user"} =
+               Tachyon.cancel_friend_request!(ctx[:client], "invalid-id")
+    end
+
+    test "cancel non existant request", ctx do
+      # it's a no-op
+      assert %{"status" => "success"} =
+               Tachyon.cancel_friend_request!(ctx[:client], ctx[:user2].id)
+    end
+
+    test "can cancel request", ctx do
+      {:ok, _} = Account.create_friend_request(ctx[:user].id, ctx[:user2].id)
+
+      assert %{"status" => "success"} =
+               Tachyon.cancel_friend_request!(ctx[:client], ctx[:user2].id)
+
+      expected = %{"from" => to_string(ctx[:user].id)}
+
+      assert %{"commandId" => "friend/requestCancelled", "data" => ^expected} =
+               Tachyon.recv_message!(ctx[:client2])
+    end
   end
 end


### PR DESCRIPTION
This should cover the messages to [handle friends](https://github.com/beyond-all-reason/teiserver/issues/619).

I noticed it's getting a bit verbose sending error responses, I'll refactor that and put it as part of the [handler](https://github.com/beyond-all-reason/teiserver/blob/master/lib/teiserver/tachyon/handler.ex) behaviour, but that can be done in another PR.