### PR TITLE
Fix warnings and unpinned data

### DIFF
--- a/test/teiserver_web/tachyon/user_test.exs
+++ b/test/teiserver_web/tachyon/user_test.exs
@@ -11,25 +11,27 @@ defmodule TeiserverWeb.Tachyon.UserTest do
       %{id: user_id, name: name, clan_id: clan_id} = user
       %{country: country} = Teiserver.Account.get_user_by_id(user_id)
 
+      user_id = to_string(user_id)
+
       assert %{
                "data" => %{
-                 "userId" => user_id,
-                 "username" => name,
-                 "displayName" => name,
-                 "clanId" => clan_id,
-                 "countryCode" => country
+                 "userId" => ^user_id,
+                 "username" => ^name,
+                 "displayName" => ^name,
+                 "clanId" => ^clan_id,
+                 "countryCode" => ^country
                }
              } = Tachyon.user_info!(client, user_id)
     end
 
-    test "user doesn't exist", %{user: user, client: client} do
+    test "user doesn't exist", %{client: client} do
       assert %{"status" => "failed", "reason" => "unknown_user"} =
                Tachyon.user_info!(client, "999999999")
     end
   end
 
   describe "updated" do
-    test "sent after login", %{user: user, client: client} do
+    test "sent after login", %{user: user} do
       %{client: client} = Tachyon.connect(user, swallow_first_event: false)
 
       {:ok,


### PR DESCRIPTION
Doing an assert `%{foo: x} = bar` binds `x`, but doesn't check for equality. For that, the variable needs to be pinned.