### PR TITLE
Add rating seasons

### DIFF
--- a/lib/teiserver/account.ex
+++ b/lib/teiserver/account.ex
@@ -929,16 +929,7 @@ defmodule Teiserver.Account do
 
   def get_rating(user_id, rating_type_id)
       when is_integer(user_id) and is_integer(rating_type_id) do
-    Teiserver.cache_get_or_store(:teiserver_user_ratings, {user_id, rating_type_id}, fn ->
-      rating_query(
-        search: [
-          user_id: user_id,
-          rating_type_id: rating_type_id
-        ],
-        limit: 1
-      )
-      |> Repo.one()
-    end)
+    get_rating(user_id, rating_type_id, Config.get_site_config_cache("rating.Season"))
   end
 
   def get_rating(user_id, rating_type_id, season)

--- a/lib/teiserver/account/reports/leaderboard_report.ex
+++ b/lib/teiserver/account/reports/leaderboard_report.ex
@@ -39,7 +39,8 @@ defmodule Teiserver.Account.LeaderboardReport do
       Account.list_ratings(
         search: [
           rating_type_id: type_id,
-          updated_after: activity_time
+          updated_after: activity_time,
+          season: MatchRatingLib.active_season()
         ],
         order_by: "Leaderboard rating high to low",
         preload: [:user],

--- a/lib/teiserver/account/reports/tournament_report.ex
+++ b/lib/teiserver/account/reports/tournament_report.ex
@@ -105,7 +105,8 @@ defmodule Teiserver.Account.TournamentReport do
       Account.list_ratings(
         search: [
           rating_type_id: type_id,
-          user_id_in: Map.values(name_to_id_map)
+          user_id_in: Map.values(name_to_id_map),
+          season: MatchRatingLib.active_season()
         ],
         order_by: order_by,
         preload: [:user],

--- a/lib/teiserver/coordinator/coordinator_commands.ex
+++ b/lib/teiserver/coordinator/coordinator_commands.ex
@@ -188,7 +188,8 @@ defmodule Teiserver.Coordinator.CoordinatorCommands do
     ratings =
       Account.list_ratings(
         search: [
-          user_id: sender.id
+          user_id: sender.id,
+          season: Teiserver.Game.MatchRatingLib.active_season()
         ],
         preload: [:rating_type]
       )
@@ -273,7 +274,8 @@ defmodule Teiserver.Coordinator.CoordinatorCommands do
         ratings =
           Account.list_ratings(
             search: [
-              user_id: user.id
+              user_id: user.id,
+              season: Teiserver.Game.MatchRatingLib.active_season()
             ],
             preload: [:rating_type]
           )

--- a/lib/teiserver/game/exports/player_ratings_export.ex
+++ b/lib/teiserver/game/exports/player_ratings_export.ex
@@ -36,11 +36,13 @@ defmodule Teiserver.Game.PlayerRatingsExport do
     start_time = System.system_time(:second)
 
     rating_type_id = MatchRatingLib.rating_type_name_lookup()[params["rating_type"]]
+    season = MatchRatingLib.active_season()
 
     ratings =
       Account.list_ratings(
         search: [
-          rating_type_id: rating_type_id
+          rating_type_id: rating_type_id,
+          season: season
         ],
         select:
           ~w(user_id rating_type_id rating_value skill uncertainty leaderboard_rating last_updated)a,

--- a/lib/teiserver/game/libs/match_rating_lib.ex
+++ b/lib/teiserver/game/libs/match_rating_lib.ex
@@ -146,7 +146,8 @@ defmodule Teiserver.Game.MatchRatingLib do
       Account.list_ratings(
         search: [
           rating_type_id: rating_type_id,
-          user_id_in: solo_user_ids
+          user_id_in: solo_user_ids,
+          season: active_season()
         ]
       )
       |> Map.new(fn rating ->
@@ -164,7 +165,8 @@ defmodule Teiserver.Game.MatchRatingLib do
       Account.list_ratings(
         search: [
           rating_type_id: partied_rating_type_id,
-          user_id_in: partied_user_ids
+          user_id_in: partied_user_ids,
+          season: active_season()
         ]
       )
       |> Map.new(fn rating ->
@@ -284,7 +286,8 @@ defmodule Teiserver.Game.MatchRatingLib do
       Account.list_ratings(
         search: [
           rating_type_id: rating_type_id,
-          user_id_in: solo_user_ids
+          user_id_in: solo_user_ids,
+          season: active_season()
         ]
       )
       |> Map.new(fn rating ->
@@ -302,7 +305,8 @@ defmodule Teiserver.Game.MatchRatingLib do
       Account.list_ratings(
         search: [
           rating_type_id: partied_rating_type_id,
-          user_id_in: partied_user_ids
+          user_id_in: partied_user_ids,
+          season: active_season()
         ]
       )
       |> Map.new(fn rating ->
@@ -773,7 +777,7 @@ defmodule Teiserver.Game.MatchRatingLib do
     Config.get_site_config_cache("rating.Tau")
   end
 
-  defp active_season() do
+  def active_season() do
     Config.get_site_config_cache("rating.Season")
   end
 end

--- a/lib/teiserver/game/libs/rating_log_lib.ex
+++ b/lib/teiserver/game/libs/rating_log_lib.ex
@@ -93,6 +93,11 @@ defmodule Teiserver.Game.RatingLogLib do
       where: rating_logs.inserted_at < ^datetime
   end
 
+  def _search(query, :season, season) do
+    from rating_logs in query,
+      where: rating_logs.season == ^season
+  end
+
   def _search(query, :basic_search, ref) do
     ref_like = "%" <> String.replace(ref, "*", "%") <> "%"
 

--- a/lib/teiserver_web/controllers/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/admin/user_controller.ex
@@ -408,12 +408,14 @@ defmodule TeiserverWeb.Admin.UserController do
       {true, _} ->
         filter = params["filter"]
         filter_type_id = MatchRatingLib.rating_type_name_lookup()[filter]
+        season = MatchRatingLib.active_season()
         limit = (params["limit"] || "50") |> int_parse
 
         ratings =
           Account.list_ratings(
             search: [
-              user_id: user.id
+              user_id: user.id,
+              season: season
             ],
             preload: [:rating_type]
           )
@@ -425,7 +427,8 @@ defmodule TeiserverWeb.Admin.UserController do
           Game.list_rating_logs(
             search: [
               user_id: user.id,
-              rating_type_id: filter_type_id
+              rating_type_id: filter_type_id,
+              season: season
             ],
             order_by: "Newest first",
             limit: limit,
@@ -473,7 +476,8 @@ defmodule TeiserverWeb.Admin.UserController do
         ratings =
           Account.list_ratings(
             search: [
-              user_id: user.id
+              user_id: user.id,
+              season: MatchRatingLib.active_season()
             ],
             preload: [:rating_type]
           )

--- a/lib/teiserver_web/controllers/battle/match_controller.ex
+++ b/lib/teiserver_web/controllers/battle/match_controller.ex
@@ -90,11 +90,13 @@ defmodule TeiserverWeb.Battle.MatchController do
 
     filter = params["filter"] || "Large Team"
     filter_type_id = MatchRatingLib.rating_type_name_lookup()[filter] || 1
+    season = MatchRatingLib.active_season()
 
     ratings =
       Account.list_ratings(
         search: [
-          user_id: user.id
+          user_id: user.id,
+          season: season
         ],
         preload: [:rating_type]
       )
@@ -106,7 +108,8 @@ defmodule TeiserverWeb.Battle.MatchController do
       Game.list_rating_logs(
         search: [
           user_id: user.id,
-          rating_type_id: filter_type_id
+          rating_type_id: filter_type_id,
+          season: season
         ],
         order_by: "Newest first",
         limit: 50,
@@ -146,11 +149,13 @@ defmodule TeiserverWeb.Battle.MatchController do
 
     filter = params["filter"] || "Large Team"
     filter_type_id = MatchRatingLib.rating_type_name_lookup()[filter] || 1
+    season = MatchRatingLib.active_season()
 
     ratings =
       Account.list_ratings(
         search: [
-          user_id: user.id
+          user_id: user.id,
+          season: season
         ],
         preload: [:rating_type]
       )
@@ -162,7 +167,8 @@ defmodule TeiserverWeb.Battle.MatchController do
       Game.list_rating_logs(
         search: [
           user_id: user.id,
-          rating_type_id: filter_type_id
+          rating_type_id: filter_type_id,
+          season: season
         ],
         order_by: "Newest first",
         limit: 50,

--- a/lib/teiserver_web/controllers/battle/ratings_controller.ex
+++ b/lib/teiserver_web/controllers/battle/ratings_controller.ex
@@ -41,7 +41,8 @@ defmodule TeiserverWeb.Battle.RatingsController do
       Account.list_ratings(
         search: [
           rating_type_id: type_id,
-          updated_after: activity_time
+          updated_after: activity_time,
+          season: MatchRatingLib.active_season()
         ],
         order_by: "Leaderboard rating high to low",
         preload: [:user],

--- a/lib/teiserver_web/live/battles/match/ratings.ex
+++ b/lib/teiserver_web/live/battles/match/ratings.ex
@@ -10,7 +10,8 @@ defmodule TeiserverWeb.Battle.MatchLive.Ratings do
     user_ratings =
       Account.list_ratings(
         search: [
-          user_id: socket.assigns.current_user.id
+          user_id: socket.assigns.current_user.id,
+          season: MatchRatingLib.active_season()
         ],
         preload: [:rating_type]
       )
@@ -92,7 +93,8 @@ defmodule TeiserverWeb.Battle.MatchLive.Ratings do
       Game.list_rating_logs(
         search: [
           user_id: user.id,
-          rating_type_id: filter_type_id
+          rating_type_id: filter_type_id,
+          season: MatchRatingLib.active_season()
         ],
         order_by: "Newest first",
         limit: 50,

--- a/test/teiserver/game/libs/match_rating_lib_test.exs
+++ b/test/teiserver/game/libs/match_rating_lib_test.exs
@@ -18,12 +18,14 @@ defmodule Teiserver.Game.MatchRatingLibTest do
 
     # Check ratings of users before we rate the match
     rating_type_id = Game.get_or_add_rating_type(match.game_type)
+    season = MatchRatingLib.active_season()
 
     ratings =
       Account.list_ratings(
         search: [
           rating_type_id: rating_type_id,
-          user_id_in: [user1.id, user2.id]
+          user_id_in: [user1.id, user2.id],
+          season: season
         ]
       )
       |> Map.new(fn rating ->
@@ -51,7 +53,8 @@ defmodule Teiserver.Game.MatchRatingLibTest do
     rating_logs =
       Game.list_rating_logs(
         search: [
-          match_id: match.id
+          match_id: match.id,
+          season: season
         ],
         limit: :infinity
       )
@@ -135,7 +138,8 @@ defmodule Teiserver.Game.MatchRatingLibTest do
     Account.list_ratings(
       search: [
         rating_type_id: rating_type_id,
-        user_id_in: userids
+        user_id_in: userids,
+        season: MatchRatingLib.active_season()
       ]
     )
     |> Map.new(fn rating ->


### PR DESCRIPTION
Continuation to https://github.com/beyond-all-reason/teiserver/pull/617.
Adding season filter to all `list_ratings` because `teiserver_account_ratings` used to hold only one rating per player.