### PR TITLE
Fix invite broadcast

### DIFF
--- a/lib/teiserver/account/servers/party_server.ex
+++ b/lib/teiserver/account/servers/party_server.ex
@@ -54,7 +54,8 @@ defmodule Teiserver.Account.PartyServer do
               channel: "teiserver_party:#{party.id}",
               event: :updated_values,
               party_id: party.id,
-              new_values: %{pending_invites: new_invites}
+              new_values: %{pending_invites: new_invites},
+              operation: {:invite_created, userid}
             }
           )
 

--- a/lib/teiserver/account/servers/party_server.ex
+++ b/lib/teiserver/account/servers/party_server.ex
@@ -91,7 +91,7 @@ defmodule Teiserver.Account.PartyServer do
               event: :updated_values,
               party_id: party.id,
               new_values: %{pending_invites: new_invites},
-              operation: {:invite_cancelled, userid}
+              operation: {:invite_cancelled, [userid]}
             }
           )
 
@@ -123,7 +123,20 @@ defmodule Teiserver.Account.PartyServer do
               channel: "teiserver_party:#{party.id}",
               event: :closed,
               party_id: party.id,
-              reason: "No members"
+              reason: "No members",
+              last_member: userid
+            }
+          )
+
+          PubSub.broadcast(
+            Teiserver.PubSub,
+            "teiserver_party:#{party.id}",
+            %{
+              channel: "teiserver_party:#{party.id}",
+              event: :updated_values,
+              party_id: party.id,
+              new_values: %{pending_invites: []},
+              operation: {:invite_cancelled, party.pending_invites}
             }
           )
 

--- a/lib/teiserver/account/servers/party_server.ex
+++ b/lib/teiserver/account/servers/party_server.ex
@@ -66,7 +66,8 @@ defmodule Teiserver.Account.PartyServer do
               channel: "teiserver_client_messages:#{userid}",
               event: :party_invite,
               party_id: party.id,
-              members: party.members
+              members: party.members,
+              pending_invites: party.pending_invites
             }
           )
 

--- a/lib/teiserver/protocols/spring/spring_party_in.ex
+++ b/lib/teiserver/protocols/spring/spring_party_in.ex
@@ -263,6 +263,7 @@ defmodule Teiserver.Protocols.Spring.PartyIn do
     # invited players also receive this message, but this shouldn't force them to
     # leave the party they are in
     state = if state.user.id == userid, do: Map.put(state, :party_id, nil), else: state
+    :ok = PubSub.unsubscribe(Teiserver.PubSub, "teiserver_party:#{party_id}")
 
     # chobby would like to receive a member_left message when the last member leaves
     case Teiserver.Account.get_user_by_id(userid) do

--- a/lib/teiserver/protocols/spring/spring_party_in.ex
+++ b/lib/teiserver/protocols/spring/spring_party_in.ex
@@ -226,6 +226,19 @@ defmodule Teiserver.Protocols.Spring.PartyIn do
     end
   end
 
+  def handle_event(
+        %{event: :updated_values, party_id: party_id, operation: {:invite_created, userid}},
+        state
+      ) do
+    case Teiserver.Account.get_user_by_id(userid) do
+      nil ->
+        state
+
+      user ->
+        SpringOut.reply(:party, :invited_to_party, {party_id, user.name}, message_id(), state)
+    end
+  end
+
   def handle_event(%{event: :closed, party_id: party_id, last_member: userid}, state) do
     # invited players also receive this message, but this shouldn't force them to
     # leave the party they are in

--- a/lib/teiserver/protocols/spring/spring_party_out.ex
+++ b/lib/teiserver/protocols/spring/spring_party_out.ex
@@ -2,6 +2,10 @@ defmodule Teiserver.Protocols.Spring.PartyOut do
   require Logger
 
   @spec do_reply(atom(), nil | String.t() | tuple() | list(), map()) :: String.t()
+  def do_reply(:invited_to_party, {party_id, username}, _state) do
+    "s.party.invited_to_party #{party_id} #{username}\n"
+  end
+
   def do_reply(:invited_to_party, party_id, state) do
     "s.party.invited_to_party #{party_id} #{state.user.name}\n"
   end

--- a/test/teiserver/protocols/spring/spring_party_test.exs
+++ b/test/teiserver/protocols/spring/spring_party_test.exs
@@ -250,6 +250,9 @@ defmodule Teiserver.Protocols.Spring.SpringPartyTest do
 
     invite_to_party!(socket1, user3.name)
 
+    assert [{"s.party.invited_to_party", _, _}] =
+             _recv_until(socket2) |> parse_in_messages()
+
     assert [{"s.party.invited_to_party", _, _}, {"s.party.joined_party", _, _}] =
              _recv_until(socket3) |> parse_in_messages()
 
@@ -307,7 +310,9 @@ defmodule Teiserver.Protocols.Spring.SpringPartyTest do
 
   defp invite_to_party!(socket, username) do
     invite_to_party(socket, username)
-    assert {"OK", _, _} = _recv_until(socket) |> parse_in_message()
+    [ok, invited] = _recv_until(socket) |> parse_in_messages()
+    assert {"OK", _, _} = ok
+    assert {"s.party.invited_to_party", [_, ^username], _} = invited
   end
 
   defp accept_invite(socket, party_id) do

--- a/test/teiserver/protocols/spring/spring_party_test.exs
+++ b/test/teiserver/protocols/spring/spring_party_test.exs
@@ -258,7 +258,12 @@ defmodule Teiserver.Protocols.Spring.SpringPartyTest do
     assert [{"s.party.invited_to_party", _, _}] =
              _recv_until(socket2) |> parse_in_messages()
 
-    assert [{"s.party.invited_to_party", _, _}, {"s.party.joined_party", _, _}] =
+    assert [
+             {"s.party.invited_to_party", _, _},
+             {"s.party.joined_party", _, _},
+             # also get the message about user2 being invited
+             {"s.party.invited_to_party", [_, ^username2], _}
+           ] =
              _recv_until(socket3) |> parse_in_messages()
 
     # player 3 accepts the invite

--- a/test/teiserver/protocols/spring/spring_party_test.exs
+++ b/test/teiserver/protocols/spring/spring_party_test.exs
@@ -137,6 +137,11 @@ defmodule Teiserver.Protocols.Spring.SpringPartyTest do
 
       cancelled = _recv_until(ctx.socket2) |> parse_in_message()
       assert {"s.party.invite_cancelled", [^party_id, ^username2], _} = cancelled
+
+      invite_to_party!(ctx.socket1, username2)
+      [invited, joined] = _recv_until(ctx.socket2) |> parse_in_messages()
+      assert {"s.party.invited_to_party", _, _} = invited
+      assert {"s.party.joined_party", _, _} = joined
     end
 
     test "cancel invite via web", ctx do


### PR DESCRIPTION
bugs [reported by masterbel](https://discord.com/channels/549281623154229250/1341480967063339110/1354083844340322315)

I think I've found a server bug in the parties implementation, where a player receives an incorrect command when a party they are invited to is destroyed.

Steps to reproduce:

    testacc200 logs on and creates a party
    testacc201 logs on and creates a party
    testacc201 invites testacc200 to their party
    testacc201 leaves their party


testacc201 incorrectly receives s.party.left_party 01JQ6PVVF3265QFC3R5VXP76D6 testacc200 rather than either s.party.left_party 01JQ6PVVF3265QFC3R5VXP76D6 testacc201 or s.party.invite_cancelled 01JQ6PVVF3265QFC3R5VXP76D6 testacc200

This occurs only when the last member of the party leaves, and regardless of how many invites there are to that party.
There's another potential issue where players are not told about invites to a party made by another player. I'd like other players to be told about any current invites to the party when joining the party, and whenever a player makes a new invite.