### PR TITLE
Add team stat totals to match results display

### DIFF
--- a/lib/teiserver/mix_tasks/fake_data.ex
+++ b/lib/teiserver/mix_tasks/fake_data.ex
@@ -377,12 +377,12 @@ defmodule Mix.Tasks.Teiserver.Fakedata do
               team_id: 0,
               win: match.winning_team == 0,
               stats: %{
-                "damage_done" => :rand.uniform(1000) * 10,
-                "damage_taken" => :rand.uniform(1000) * 10,
-                "metal_produced" => :rand.uniform(1000) * 100,
-                "metal_used" => :rand.uniform(1000) * 100,
-                "energy_produced" => :rand.uniform(1000) * 1000,
-                "energy_used" => :rand.uniform(1000) * 1000
+                "damageDealt" => :rand.uniform(1000) * 10,
+                "damageReceived" => :rand.uniform(1000) * 10,
+                "metalProduced" => :rand.uniform(1000) * 100,
+                "metalUsed" => :rand.uniform(1000) * 100,
+                "energyProduced" => :rand.uniform(1000) * 1000,
+                "energyUsed" => :rand.uniform(1000) * 1000
               },
               party_id: get_party_id(num_players),
               user_id: userid,
@@ -397,12 +397,12 @@ defmodule Mix.Tasks.Teiserver.Fakedata do
               team_id: 1,
               win: match.winning_team == 1,
               stats: %{
-                "damage_done" => :rand.uniform(1000) * 10,
-                "damage_taken" => :rand.uniform(1000) * 10,
-                "metal_produced" => :rand.uniform(1000) * 100,
-                "metal_used" => :rand.uniform(1000) * 100,
-                "energy_produced" => :rand.uniform(1000) * 1000,
-                "energy_used" => :rand.uniform(1000) * 1000
+                "damageDealt" => :rand.uniform(1000) * 10,
+                "damageReceived" => :rand.uniform(1000) * 10,
+                "metalProduced" => :rand.uniform(1000) * 100,
+                "metalUsed" => :rand.uniform(1000) * 100,
+                "energyProduced" => :rand.uniform(1000) * 1000,
+                "energyUsed" => :rand.uniform(1000) * 1000
               },
               party_id: get_party_id(num_players),
               user_id: userid,

--- a/lib/teiserver/mix_tasks/fake_data.ex
+++ b/lib/teiserver/mix_tasks/fake_data.ex
@@ -376,7 +376,14 @@ defmodule Mix.Tasks.Teiserver.Fakedata do
             %{
               team_id: 0,
               win: match.winning_team == 0,
-              stats: %{},
+              stats: %{
+                "damage_done" => :rand.uniform(1000) * 10,
+                "damage_taken" => :rand.uniform(1000) * 10,
+                "metal_produced" => :rand.uniform(1000) * 100,
+                "metal_used" => :rand.uniform(1000) * 100,
+                "energy_produced" => :rand.uniform(1000) * 1000,
+                "energy_used" => :rand.uniform(1000) * 1000
+              },
               party_id: get_party_id(num_players),
               user_id: userid,
               match_id: match.id
@@ -389,7 +396,14 @@ defmodule Mix.Tasks.Teiserver.Fakedata do
             %{
               team_id: 1,
               win: match.winning_team == 1,
-              stats: %{},
+              stats: %{
+                "damage_done" => :rand.uniform(1000) * 10,
+                "damage_taken" => :rand.uniform(1000) * 10,
+                "metal_produced" => :rand.uniform(1000) * 100,
+                "metal_used" => :rand.uniform(1000) * 100,
+                "energy_produced" => :rand.uniform(1000) * 1000,
+                "energy_used" => :rand.uniform(1000) * 1000
+              },
               party_id: get_party_id(num_players),
               user_id: userid,
               match_id: match.id

--- a/lib/teiserver_web/live/battles/match/show.ex
+++ b/lib/teiserver_web/live/battles/match/show.ex
@@ -671,22 +671,21 @@ defmodule TeiserverWeb.Battle.MatchLive.Show do
           Enum.reduce(
             team_members,
             %{
-              "damage_done" => 0,
-              "damage_taken" => 0,
-              "metal_produced" => 0,
-              "metal_used" => 0,
-              "energy_produced" => 0,
-              "energy_used" => 0
+              "damageDealt" => 0,
+              "damageReceived" => 0,
+              "metalProduced" => 0,
+              "metalUsed" => 0,
+              "energyProduced" => 0,
+              "energyUsed" => 0
             },
             fn member, acc ->
               %{
-                "damage_done" => acc["damage_done"] + (member.stats["damage_done"] || 0),
-                "damage_taken" => acc["damage_taken"] + (member.stats["damage_taken"] || 0),
-                "metal_produced" => acc["metal_produced"] + (member.stats["metal_produced"] || 0),
-                "metal_used" => acc["metal_used"] + (member.stats["metal_used"] || 0),
-                "energy_produced" =>
-                  acc["energy_produced"] + (member.stats["energy_produced"] || 0),
-                "energy_used" => acc["energy_used"] + (member.stats["energy_used"] || 0)
+                "damageDealt" => acc["damageDealt"] + (member.stats["damageDealt"] || 0),
+                "damageReceived" => acc["damageReceived"] + (member.stats["damageReceived"] || 0),
+                "metalProduced" => acc["metalProduced"] + (member.stats["metalProduced"] || 0),
+                "metalUsed" => acc["metalUsed"] + (member.stats["metalUsed"] || 0),
+                "energyProduced" => acc["energyProduced"] + (member.stats["energyProduced"] || 0),
+                "energyUsed" => acc["energyUsed"] + (member.stats["energyUsed"] || 0)
               }
             end
           )

--- a/lib/teiserver_web/live/battles/match/show.ex
+++ b/lib/teiserver_web/live/battles/match/show.ex
@@ -684,7 +684,8 @@ defmodule TeiserverWeb.Battle.MatchLive.Show do
                 "damage_taken" => acc["damage_taken"] + (member.stats["damage_taken"] || 0),
                 "metal_produced" => acc["metal_produced"] + (member.stats["metal_produced"] || 0),
                 "metal_used" => acc["metal_used"] + (member.stats["metal_used"] || 0),
-                "energy_produced" => acc["energy_produced"] + (member.stats["energy_produced"] || 0),
+                "energy_produced" =>
+                  acc["energy_produced"] + (member.stats["energy_produced"] || 0),
                 "energy_used" => acc["energy_used"] + (member.stats["energy_used"] || 0)
               }
             end

--- a/lib/teiserver_web/live/battles/match/show.html.heex
+++ b/lib/teiserver_web/live/battles/match/show.html.heex
@@ -232,14 +232,14 @@
                   <% end %>
                 </td>
 
-                <td>{normalize(m.stats["damageDealt"])}</td>
-                <td>{normalize(m.stats["damageReceived"])}</td>
+                <td>{normalize(m.stats["damage_done"])}</td>
+                <td>{normalize(m.stats["damage_taken"])}</td>
 
-                <td>{normalize(m.stats["metalProduced"])}</td>
-                <td>{normalize(m.stats["metalUsed"])}</td>
+                <td>{normalize(m.stats["metal_produced"])}</td>
+                <td>{normalize(m.stats["metal_used"])}</td>
 
-                <td>{normalize(m.stats["energyProduced"])}</td>
-                <td>{normalize(m.stats["energyUsed"])}</td>
+                <td>{normalize(m.stats["energy_produced"])}</td>
+                <td>{normalize(m.stats["energy_used"])}</td>
 
                 <td>
                   <div :if={m.user_id != @current_user.id} style="display: flex;">
@@ -271,6 +271,21 @@
                   </div>
                 </td>
               </tr>
+
+              <%= if should_show_team_total?(@members, m) do %>
+                <% team_totals = @team_totals[m.team_id] %>
+                <tr style="background-color: rgba(0,0,0,0.05);">
+                  <td colspan="4"><strong>Team {m.team_id + 1} Totals ({team_totals.players} players)</strong></td>
+                  <td colspan="4">&nbsp;</td>
+                  <td><strong>{normalize(team_totals.stats["damage_done"])}</strong></td>
+                  <td><strong>{normalize(team_totals.stats["damage_taken"])}</strong></td>
+                  <td><strong>{normalize(team_totals.stats["metal_produced"])}</strong></td>
+                  <td><strong>{normalize(team_totals.stats["metal_used"])}</strong></td>
+                  <td><strong>{normalize(team_totals.stats["energy_produced"])}</strong></td>
+                  <td><strong>{normalize(team_totals.stats["energy_used"])}</strong></td>
+                  <td>&nbsp;</td>
+                </tr>
+              <% end %>
             <% end %>
           </tbody>
         </table>

--- a/lib/teiserver_web/live/battles/match/show.html.heex
+++ b/lib/teiserver_web/live/battles/match/show.html.heex
@@ -275,7 +275,9 @@
               <%= if should_show_team_total?(@members, m) do %>
                 <% team_totals = @team_totals[m.team_id] %>
                 <tr style="background-color: rgba(0,0,0,0.05);">
-                  <td colspan="4"><strong>Team {m.team_id + 1} Totals ({team_totals.players} players)</strong></td>
+                  <td colspan="4">
+                    <strong>Team {m.team_id + 1} Totals ({team_totals.players} players)</strong>
+                  </td>
                   <td colspan="4">&nbsp;</td>
                   <td><strong>{normalize(team_totals.stats["damage_done"])}</strong></td>
                   <td><strong>{normalize(team_totals.stats["damage_taken"])}</strong></td>

--- a/lib/teiserver_web/live/battles/match/show.html.heex
+++ b/lib/teiserver_web/live/battles/match/show.html.heex
@@ -232,14 +232,14 @@
                   <% end %>
                 </td>
 
-                <td>{normalize(m.stats["damage_done"])}</td>
-                <td>{normalize(m.stats["damage_taken"])}</td>
+                <td>{normalize(m.stats["damageDealt"])}</td>
+                <td>{normalize(m.stats["damageReceived"])}</td>
 
-                <td>{normalize(m.stats["metal_produced"])}</td>
-                <td>{normalize(m.stats["metal_used"])}</td>
+                <td>{normalize(m.stats["metalProduced"])}</td>
+                <td>{normalize(m.stats["metalUsed"])}</td>
 
-                <td>{normalize(m.stats["energy_produced"])}</td>
-                <td>{normalize(m.stats["energy_used"])}</td>
+                <td>{normalize(m.stats["energyProduced"])}</td>
+                <td>{normalize(m.stats["energyUsed"])}</td>
 
                 <td>
                   <div :if={m.user_id != @current_user.id} style="display: flex;">
@@ -279,12 +279,12 @@
                     <strong>Team {m.team_id + 1} Totals ({team_totals.players} players)</strong>
                   </td>
                   <td colspan="4">&nbsp;</td>
-                  <td><strong>{normalize(team_totals.stats["damage_done"])}</strong></td>
-                  <td><strong>{normalize(team_totals.stats["damage_taken"])}</strong></td>
-                  <td><strong>{normalize(team_totals.stats["metal_produced"])}</strong></td>
-                  <td><strong>{normalize(team_totals.stats["metal_used"])}</strong></td>
-                  <td><strong>{normalize(team_totals.stats["energy_produced"])}</strong></td>
-                  <td><strong>{normalize(team_totals.stats["energy_used"])}</strong></td>
+                  <td><strong>{normalize(team_totals.stats["damageDealt"])}</strong></td>
+                  <td><strong>{normalize(team_totals.stats["damageReceived"])}</strong></td>
+                  <td><strong>{normalize(team_totals.stats["metalProduced"])}</strong></td>
+                  <td><strong>{normalize(team_totals.stats["metalUsed"])}</strong></td>
+                  <td><strong>{normalize(team_totals.stats["energyProduced"])}</strong></td>
+                  <td><strong>{normalize(team_totals.stats["energyUsed"])}</strong></td>
                   <td>&nbsp;</td>
                 </tr>
               <% end %>

--- a/lib/teiserver_web/templates/battle/match/tab_players.html.heex
+++ b/lib/teiserver_web/templates/battle/match/tab_players.html.heex
@@ -53,17 +53,17 @@
 
         <td>{m.team_id + 1}</td>
 
-        <td>{normalize(m.stats["damage_done"])}</td>
-        <td>{normalize(m.stats["damage_taken"])}</td>
+        <td>{normalize(m.stats["damageDealt"])}</td>
+        <td>{normalize(m.stats["damageReceived"])}</td>
 
-        <td>{normalize(m.stats["units_killed"])}</td>
-        <td>{normalize(m.stats["units_produced"])}</td>
+        <td>{normalize(m.stats["unitsKilled"])}</td>
+        <td>{normalize(m.stats["unitsProduced"])}</td>
 
-        <td>{normalize(m.stats["metal_produced"])}</td>
-        <td>{normalize(m.stats["metal_used"])}</td>
+        <td>{normalize(m.stats["metalProduced"])}</td>
+        <td>{normalize(m.stats["metalUsed"])}</td>
 
-        <td>{normalize(m.stats["energy_produced"])}</td>
-        <td>{normalize(m.stats["energy_used"])}</td>
+        <td>{normalize(m.stats["energyProduced"])}</td>
+        <td>{normalize(m.stats["energyUsed"])}</td>
 
         <td>{if rating, do: rating.value["rating_value"] |> round(2)}</td>
 

--- a/lib/teiserver_web/templates/battle/match/tab_players.html.heex
+++ b/lib/teiserver_web/templates/battle/match/tab_players.html.heex
@@ -53,17 +53,17 @@
 
         <td>{m.team_id + 1}</td>
 
-        <td>{normalize(m.stats["damageDealt"])}</td>
-        <td>{normalize(m.stats["damageReceived"])}</td>
+        <td>{normalize(m.stats["damage_done"])}</td>
+        <td>{normalize(m.stats["damage_taken"])}</td>
 
-        <td>{normalize(m.stats["unitsKilled"])}</td>
-        <td>{normalize(m.stats["unitsProduced"])}</td>
+        <td>{normalize(m.stats["units_killed"])}</td>
+        <td>{normalize(m.stats["units_produced"])}</td>
 
-        <td>{normalize(m.stats["metalProduced"])}</td>
-        <td>{normalize(m.stats["metalUsed"])}</td>
+        <td>{normalize(m.stats["metal_produced"])}</td>
+        <td>{normalize(m.stats["metal_used"])}</td>
 
-        <td>{normalize(m.stats["energyProduced"])}</td>
-        <td>{normalize(m.stats["energyUsed"])}</td>
+        <td>{normalize(m.stats["energy_produced"])}</td>
+        <td>{normalize(m.stats["energy_used"])}</td>
 
         <td>{if rating, do: rating.value["rating_value"] |> round(2)}</td>
 

--- a/test/teiserver_web/live/battles/match/show_live_test.exs
+++ b/test/teiserver_web/live/battles/match/show_live_test.exs
@@ -4,36 +4,36 @@ defmodule TeiserverWeb.Battle.MatchLive.ShowTest do
 
   @player_stats %{
     team1_player1: %{
-      "damage_done" => 100,
-      "damage_taken" => 50,
-      "metal_produced" => 200,
-      "metal_used" => 150,
-      "energy_produced" => 300,
-      "energy_used" => 250
+      "damageDealt" => 100,
+      "damageReceived" => 50,
+      "metalProduced" => 200,
+      "metalUsed" => 150,
+      "energyProduced" => 300,
+      "energyUsed" => 250
     },
     team1_player2: %{
-      "damage_done" => 200,
-      "damage_taken" => 100,
-      "metal_produced" => 300,
-      "metal_used" => 250,
-      "energy_produced" => 400,
-      "energy_used" => 350
+      "damageDealt" => 200,
+      "damageReceived" => 100,
+      "metalProduced" => 300,
+      "metalUsed" => 250,
+      "energyProduced" => 400,
+      "energyUsed" => 350
     },
     team2_player1: %{
-      "damage_done" => 150,
-      "damage_taken" => 75,
-      "metal_produced" => 250,
-      "metal_used" => 200,
-      "energy_produced" => 350,
-      "energy_used" => 300
+      "damageDealt" => 150,
+      "damageReceived" => 75,
+      "metalProduced" => 250,
+      "metalUsed" => 200,
+      "energyProduced" => 350,
+      "energyUsed" => 300
     },
     team2_player2: %{
-      "damage_done" => 250,
-      "damage_taken" => 125,
-      "metal_produced" => 350,
-      "metal_used" => 300,
-      "energy_produced" => 450,
-      "energy_used" => 400
+      "damageDealt" => 250,
+      "damageReceived" => 125,
+      "metalProduced" => 350,
+      "metalUsed" => 300,
+      "energyProduced" => 450,
+      "energyUsed" => 400
     }
   }
 
@@ -76,12 +76,12 @@ defmodule TeiserverWeb.Battle.MatchLive.ShowTest do
 
   defp assert_team_totals(totals, team_id, expected) do
     assert totals[team_id].players == expected.players
-    assert totals[team_id].stats["damage_done"] == expected.damage_done
-    assert totals[team_id].stats["damage_taken"] == expected.damage_taken
-    assert totals[team_id].stats["metal_produced"] == expected.metal_produced
-    assert totals[team_id].stats["metal_used"] == expected.metal_used
-    assert totals[team_id].stats["energy_produced"] == expected.energy_produced
-    assert totals[team_id].stats["energy_used"] == expected.energy_used
+    assert totals[team_id].stats["damageDealt"] == expected.damage_done
+    assert totals[team_id].stats["damageReceived"] == expected.damage_taken
+    assert totals[team_id].stats["metalProduced"] == expected.metal_produced
+    assert totals[team_id].stats["metalUsed"] == expected.metal_used
+    assert totals[team_id].stats["energyProduced"] == expected.energy_produced
+    assert totals[team_id].stats["energyUsed"] == expected.energy_used
   end
 
   test "get team id" do

--- a/test/teiserver_web/live/battles/match/show_live_test.exs
+++ b/test/teiserver_web/live/battles/match/show_live_test.exs
@@ -1,6 +1,88 @@
 defmodule TeiserverWeb.Battle.MatchLive.ShowTest do
   alias TeiserverWeb.Battle.MatchLive.Show
-  use ExUnit.Case
+  use Teiserver.DataCase, async: true
+
+  @player_stats %{
+    team1_player1: %{
+      "damage_done" => 100,
+      "damage_taken" => 50,
+      "metal_produced" => 200,
+      "metal_used" => 150,
+      "energy_produced" => 300,
+      "energy_used" => 250
+    },
+    team1_player2: %{
+      "damage_done" => 200,
+      "damage_taken" => 100,
+      "metal_produced" => 300,
+      "metal_used" => 250,
+      "energy_produced" => 400,
+      "energy_used" => 350
+    },
+    team2_player1: %{
+      "damage_done" => 150,
+      "damage_taken" => 75,
+      "metal_produced" => 250,
+      "metal_used" => 200,
+      "energy_produced" => 350,
+      "energy_used" => 300
+    },
+    team2_player2: %{
+      "damage_done" => 250,
+      "damage_taken" => 125,
+      "metal_produced" => 350,
+      "metal_used" => 300,
+      "energy_produced" => 450,
+      "energy_used" => 400
+    }
+  }
+
+  # Expected team total stat values for tests
+  @team_totals %{
+    empty_team: %{
+      players: 2,
+      damage_done: 0,
+      damage_taken: 0,
+      metal_produced: 0,
+      metal_used: 0,
+      energy_produced: 0,
+      energy_used: 0
+    },
+    team1: %{
+      players: 2,
+      damage_done: 300,
+      damage_taken: 150,
+      metal_produced: 500,
+      metal_used: 400,
+      energy_produced: 700,
+      energy_used: 600
+    },
+    team2: %{
+      players: 2,
+      damage_done: 400,
+      damage_taken: 200,
+      metal_produced: 600,
+      metal_used: 500,
+      energy_produced: 800,
+      energy_used: 700
+    }
+  }
+
+  defp player_stats(player_key), do: @player_stats[player_key]
+
+  defp make_player(user_id, team_id, stats \\ %{}) do
+    %{team_id: team_id, user_id: user_id, stats: stats}
+  end
+
+  defp assert_team_totals(totals, team_id, expected) do
+    assert totals[team_id].players == expected.players
+    assert totals[team_id].stats["damage_done"] == expected.damage_done
+    assert totals[team_id].stats["damage_taken"] == expected.damage_taken
+    assert totals[team_id].stats["metal_produced"] == expected.metal_produced
+    assert totals[team_id].stats["metal_used"] == expected.metal_used
+    assert totals[team_id].stats["energy_produced"] == expected.energy_produced
+    assert totals[team_id].stats["energy_used"] == expected.energy_used
+  end
 
   test "get team id" do
     team_players = %{1 => [1, 4], 2 => [2, 3]}
@@ -11,5 +93,127 @@ defmodule TeiserverWeb.Battle.MatchLive.ShowTest do
     player_id = 3
     result = Show.get_team_id(player_id, team_players)
     assert result == 1
+  end
+
+  describe "should_show_team_total?/2" do
+    test "duel matches never show team totals" do
+      members = [
+        make_player(1, 0),
+        make_player(2, 1)
+      ]
+
+      refute Show.should_show_team_total?(members, hd(members))
+      refute Show.should_show_team_total?(members, List.last(members))
+    end
+
+    test "shows team total stats after last player in each team in team games" do
+      members = [
+        make_player(1, 0),
+        make_player(2, 0),
+        make_player(3, 1),
+        make_player(4, 1)
+      ]
+
+      refute Show.should_show_team_total?(members, Enum.at(members, 0))
+      assert Show.should_show_team_total?(members, Enum.at(members, 1))
+      refute Show.should_show_team_total?(members, Enum.at(members, 2))
+      assert Show.should_show_team_total?(members, Enum.at(members, 3))
+    end
+
+    test "shows team totals for uneven teams (2v1)" do
+      members = [
+        make_player(1, 0),
+        make_player(2, 0),
+        make_player(3, 1)
+      ]
+
+      refute Show.should_show_team_total?(members, Enum.at(members, 0))
+      assert Show.should_show_team_total?(members, Enum.at(members, 1))
+      # Teams with only one player should not show team stat totals
+      refute Show.should_show_team_total?(members, Enum.at(members, 2))
+    end
+
+    test "never shows team totals in free-for-all games (1v1v1)" do
+      members = [
+        make_player(1, 0),
+        make_player(2, 1),
+        make_player(3, 2)
+      ]
+
+      refute Show.should_show_team_total?(members, Enum.at(members, 0))
+      refute Show.should_show_team_total?(members, Enum.at(members, 1))
+      refute Show.should_show_team_total?(members, Enum.at(members, 2))
+    end
+  end
+
+  describe "calculate_team_totals/1" do
+    test "handles empty stats" do
+      members = [
+        make_player(1, 0, %{}),
+        make_player(2, 0, %{}),
+        make_player(3, 1, %{}),
+        make_player(4, 1, %{})
+      ]
+
+      totals = Show.calculate_team_totals(members)
+
+      assert_team_totals(totals, 0, @team_totals.empty_team)
+      assert_team_totals(totals, 1, @team_totals.empty_team)
+    end
+
+    test "calculates totals for 2v2 teams" do
+      members = [
+        make_player(1, 0, player_stats(:team1_player1)),
+        make_player(2, 0, player_stats(:team1_player2)),
+        make_player(3, 1, player_stats(:team2_player1)),
+        make_player(4, 1, player_stats(:team2_player2))
+      ]
+
+      totals = Show.calculate_team_totals(members)
+
+      assert_team_totals(totals, 0, @team_totals.team1)
+      assert_team_totals(totals, 1, @team_totals.team2)
+    end
+
+    test "calculates totals for uneven teams (2v1)" do
+      members = [
+        make_player(1, 0, player_stats(:team1_player1)),
+        make_player(2, 0, player_stats(:team1_player2)),
+        make_player(3, 1, player_stats(:team2_player1))
+      ]
+
+      totals = Show.calculate_team_totals(members)
+
+      # Team 0 has multiple players, so should have total stats
+      assert_team_totals(totals, 0, @team_totals.team1)
+
+      # Team 1 has only one player, so should not have total stats
+      refute Map.has_key?(totals, 1)
+    end
+
+    test "skips totals for teams with only one player" do
+      members = [
+        make_player(1, 0, player_stats(:team1_player1)),
+        make_player(2, 1, player_stats(:team2_player1))
+      ]
+
+      totals = Show.calculate_team_totals(members)
+
+      # Both teams have only one player, so no total stats should be calculated
+      assert totals == %{}
+    end
+
+    test "skips totals for free-for-all games (1v1v1)" do
+      members = [
+        make_player(1, 0, player_stats(:team1_player1)),
+        make_player(2, 1, player_stats(:team1_player2)),
+        make_player(3, 2, player_stats(:team2_player1))
+      ]
+
+      totals = Show.calculate_team_totals(members)
+
+      # Free-for-all games have no team total stats since each player is their own team
+      assert totals == %{}
+    end
   end
 end


### PR DESCRIPTION
### Add the calculation and display of team stat totals in match results
Issue: [#583](https://github.com/beyond-all-reason/teiserver/issues/583)

Features:
- Now shows team totals for damage, metal, and energy when teams have multiple players

Tests cover team games (2v2), uneven teams (2v1), duels (1v1), and free-for-all games (1v1v1).


![image](https://github.com/user-attachments/assets/1592f9ec-6015-4ef9-a953-d82136d6e31c)

No team stats shown for single player teams:
<img width="1991" alt="image" src="https://github.com/user-attachments/assets/aa08c532-23eb-4ed5-a078-55c575ebed14" />
