### PR TITLE
User subscription events

### DIFF
--- a/lib/teiserver/account.ex
+++ b/lib/teiserver/account.ex
@@ -32,6 +32,9 @@ defmodule Teiserver.Account do
   @spec get_user(non_neg_integer(), list) :: User.t() | nil
   defdelegate get_user(user_id, args), to: UserLib
 
+  @spec query_users(list) :: [User.t()]
+  defdelegate query_users(query_args), to: UserLib
+
   @spec query_user(list) :: User.t() | nil
   defdelegate query_user(query_args), to: UserLib
 

--- a/lib/teiserver/account/libs/user_lib.ex
+++ b/lib/teiserver/account/libs/user_lib.ex
@@ -92,6 +92,12 @@ defmodule Teiserver.Account.UserLib do
     |> Repo.one()
   end
 
+  @spec query_users(list) :: [User.t()]
+  def query_users(query_args \\ []) do
+    UserQueries.query_users(query_args)
+    |> Repo.all()
+  end
+
   @spec query_user(list) :: User.t() | nil
   def query_user(query_args \\ []) do
     UserQueries.query_users(query_args)

--- a/lib/teiserver/player/session.ex
+++ b/lib/teiserver/player/session.ex
@@ -80,6 +80,8 @@ defmodule Teiserver.Player.Session do
       }
     }
 
+    broadcast_user_update!(user, :menu)
+
     Logger.debug("init session #{inspect(self())}")
     Logger.info("session started")
 
@@ -290,6 +292,8 @@ defmodule Teiserver.Player.Session do
       _ ->
         nil
     end
+
+    broadcast_user_update!(state.user, :offline)
 
     {:stop, :normal, :ok, %{state | matchmaking: initial_matchmaking_state()}}
   end

--- a/lib/teiserver/player/session.ex
+++ b/lib/teiserver/player/session.ex
@@ -14,8 +14,9 @@ defmodule Teiserver.Player.Session do
   require Logger
 
   alias Teiserver.Data.Types, as: T
-  alias Teiserver.{Player, Matchmaking, Messaging}
+  alias Teiserver.{Player, Matchmaking, Messaging, Account}
   alias Teiserver.Helpers.BoundedQueue, as: BQ
+  alias Phoenix.PubSub
 
   @type conn_state :: :connected | :reconnecting | :disconnected
 
@@ -247,6 +248,15 @@ defmodule Teiserver.Player.Session do
       :died
   end
 
+  @doc """
+  Subscribe the session process to user updates. This will also ensure the first
+  message processed from these channel is the full user state
+  """
+  @spec subscribe_updates(T.userid(), [T.userid()]) :: :ok | {:error, {:invalid_ids, [integer()]}}
+  def subscribe_updates(originator_id, user_ids) do
+    GenServer.call(via_tuple(originator_id), {:user, {:subscribe_updates, user_ids}})
+  end
+
   ################################################################################
   #                                                                              #
   #                       INTERNAL MESSAGE HANDLERS                              #
@@ -382,6 +392,21 @@ defmodule Teiserver.Player.Session do
       end
 
     {:reply, {:ok, has_missed_messages, msg_to_send}, state}
+  end
+
+  def handle_call({:user, {:subscribe_updates, user_ids}}, _from, state) do
+    users = Account.query_users(where: [id_in: user_ids])
+
+    if Enum.count(users) != Enum.count(user_ids) do
+      diff =
+        MapSet.difference(MapSet.new(user_ids), MapSet.new(Enum.map(users, & &1.id)))
+        |> MapSet.to_list()
+
+      {:reply, {:error, {:invalid_ids, diff}}, state}
+    else
+      Enum.each(users, &do_subscribe_updates/1)
+      {:reply, :ok, state}
+    end
   end
 
   @impl true
@@ -532,6 +557,11 @@ defmodule Teiserver.Player.Session do
     {:noreply, state}
   end
 
+  def handle_cast({:user, :get_subscribe_state}, state) do
+    broadcast_user_update!(state.user, :menu)
+    {:noreply, state}
+  end
+
   @impl true
   def handle_info({:DOWN, ref, :process, _, _reason}, state) when ref == state.mon_ref do
     # we don't care about cancelling the timer if the player reconnects since reconnection
@@ -576,6 +606,15 @@ defmodule Teiserver.Player.Session do
     end
   end
 
+  def handle_info(
+        %{channel: "tachyon:user:" <> _user_id, event: :user_updated, state: user_state},
+        state
+      ) do
+    # TODO: before sending to a player, make sure we’re still subscribed
+    state = send_to_player({:user, {:user_updated, user_state}}, state)
+    {:noreply, state}
+  end
+
   defp via_tuple(user_id) do
     Player.SessionRegistry.via_tuple(user_id)
   end
@@ -617,5 +656,53 @@ defmodule Teiserver.Player.Session do
     end
 
     state
+  end
+
+  defp do_subscribe_updates(user) do
+    topic = user_topic(user.id)
+    :ok = PubSub.subscribe(Teiserver.PubSub, topic)
+
+    case Player.SessionRegistry.lookup(user.id) do
+      # player is offline, simulate the broadcast ourselves
+      nil ->
+        broadcast_user_update!(user, :offline)
+
+      # TODO: needs to store a monitor in the state to handle the case where the
+      # session dies before it can process this message.
+      pid ->
+        GenServer.cast(pid, {:user, :get_subscribe_state})
+    end
+  end
+
+  defp user_topic(%{id: id}), do: user_topic(id)
+  defp user_topic(user_id), do: "tachyon:user:#{user_id}"
+
+  defp broadcast_user_update!(user, status) do
+    topic = user_topic(user)
+
+    state = %{
+      user_id: user.id,
+      username: user.name,
+      clan_id: user.clan_id,
+      # the user struct is a giant mess, where a bunch of stuff is added from
+      # "user stats data" and whatnot. We should refactor user access so that
+      # we get the same struct every time, possibly with nil values for some keys
+      # but in the meantime, just defensively get the country
+      country: Map.get(user, :country, "??"),
+      status: status
+    }
+
+    PubSub.broadcast!(
+      Teiserver.PubSub,
+      topic,
+      # for now(?) we don't surface the `reconnecting` status. I think we'll revisit
+      # that because it's not a transparent state in term of capabilities:
+      # the player is "online" but cannot vote, reply, or anything really
+      %{
+        channel: topic,
+        event: :user_updated,
+        state: state
+      }
+    )
   end
 end

--- a/priv/tachyon/schema/user/subscribeUpdates/request.json
+++ b/priv/tachyon/schema/user/subscribeUpdates/request.json
@@ -1,0 +1,34 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/user/subscribeUpdates/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "UserSubscribeUpdatesRequest",
+    "tachyon": {
+        "source": "user",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "user/subscribeUpdates" },
+        "data": {
+            "title": "UserSubscribeUpdatesRequestData",
+            "type": "object",
+            "properties": {
+                "userIds": {
+                    "type": "array",
+                    "items": {
+                        "$id": "userId",
+                        "type": "string",
+                        "examples": ["351"]
+                    },
+                    "minItems": 1,
+                    "maxItems": 100
+                }
+            },
+            "required": ["userIds"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/user/subscribeUpdates/response.json
+++ b/priv/tachyon/schema/user/subscribeUpdates/response.json
@@ -1,0 +1,44 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/user/subscribeUpdates/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "UserSubscribeUpdatesResponse",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "UserSubscribeUpdatesOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "user/subscribeUpdates" },
+                "status": { "const": "success" }
+            },
+            "required": ["type", "messageId", "commandId", "status"]
+        },
+        {
+            "title": "UserSubscribeUpdatesFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "user/subscribeUpdates" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "subscription_limit_reached",
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}

--- a/priv/tachyon/schema/user/unsubscribeUpdates/request.json
+++ b/priv/tachyon/schema/user/unsubscribeUpdates/request.json
@@ -1,0 +1,34 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/user/unsubscribeUpdates/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "UserUnsubscribeUpdatesRequest",
+    "tachyon": {
+        "source": "user",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "user/unsubscribeUpdates" },
+        "data": {
+            "title": "UserUnsubscribeUpdatesRequestData",
+            "type": "object",
+            "properties": {
+                "userIds": {
+                    "type": "array",
+                    "items": {
+                        "$id": "userId",
+                        "type": "string",
+                        "examples": ["351"]
+                    },
+                    "minItems": 1,
+                    "maxItems": 100
+                }
+            },
+            "required": ["userIds"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/user/unsubscribeUpdates/response.json
+++ b/priv/tachyon/schema/user/unsubscribeUpdates/response.json
@@ -1,0 +1,43 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/user/unsubscribeUpdates/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "UserUnsubscribeUpdatesResponse",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "UserUnsubscribeUpdatesOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "user/unsubscribeUpdates" },
+                "status": { "const": "success" }
+            },
+            "required": ["type", "messageId", "commandId", "status"]
+        },
+        {
+            "title": "UserUnsubscribeUpdatesFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "user/unsubscribeUpdates" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -338,4 +338,10 @@ defmodule Teiserver.Support.Tachyon do
     {:ok, resp} = recv_message(client)
     resp
   end
+
+  def unsubscribe_updates!(client, user_ids) do
+    :ok = send_request(client, "user/unsubscribeUpdates", %{userIds: user_ids})
+    {:ok, resp} = recv_message(client)
+    resp
+  end
 end

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -187,10 +187,12 @@ defmodule Teiserver.Support.Tachyon do
           {:ok, decoded}
         else
           {:error, %JsonXema.ValidationError{} = err} ->
-            IO.inspect(Jason.decode!(resp))
+            IO.inspect(Jason.decode!(resp), label: "schema validation failed on")
             {:error, err}
 
           err ->
+            IO.inspect(Jason.decode!(resp), label: "schema validation failed on")
+            IO.inspect(err, label: "unknown error")
             err
         end
 
@@ -329,5 +331,11 @@ defmodule Teiserver.Support.Tachyon do
   def remove_friend!(client, friend_id) do
     :ok = send_request(client, "friend/remove", %{userId: to_string(friend_id)})
     recv_message!(client)
+  end
+
+  def subscribe_updates!(client, user_ids) do
+    :ok = send_request(client, "user/subscribeUpdates", %{userIds: user_ids})
+    {:ok, resp} = recv_message(client)
+    resp
   end
 end

--- a/test/teiserver/player/session_test.exs
+++ b/test/teiserver/player/session_test.exs
@@ -1,0 +1,25 @@
+defmodule Teiserver.Player.SessionTest do
+  use Teiserver.DataCase, async: false
+  alias Teiserver.Player
+
+  def setup_session(_) do
+    user = Central.Helpers.GeneralTestLib.make_user(%{"data" => %{"roles" => ["Verified"]}})
+    {:ok, sess_pid} = Player.SessionSupervisor.start_session(user)
+    {:ok, user: user, sess_pid: sess_pid}
+  end
+
+  describe "user updates" do
+    setup [:setup_session]
+
+    test "ignore updates if not subscribed", %{sess_pid: sess_pid} do
+      send(sess_pid, %{
+        channel: "tachyon:user:123",
+        user_id: 123,
+        event: :user_updated,
+        state: :irrelevant
+      })
+
+      refute_receive _
+    end
+  end
+end

--- a/test/teiserver_web/tachyon/user_test.exs
+++ b/test/teiserver_web/tachyon/user_test.exs
@@ -46,4 +46,64 @@ defmodule TeiserverWeb.Tachyon.UserTest do
       assert userdata["status"] == "menu"
     end
   end
+
+  describe "subscribeUpdates" do
+    setup [{Tachyon, :setup_client}]
+
+    test "must pass valid user ids", %{client: client} do
+      assert %{"status" => "failed", "reason" => "invalid_request"} =
+               Tachyon.subscribe_updates!(client, ["invalid-user-id"])
+    end
+
+    test "must pass id for existing users", %{client: client} do
+      # negative integer are valid int, but guaranteed to be invalid postgres
+      # primary key, so guaranteed no user behind that
+      assert %{"status" => "failed", "reason" => "invalid_request"} =
+               Tachyon.subscribe_updates!(client, ["-87931"])
+    end
+
+    test "for offline user", %{client: client} do
+      other_user =
+        Central.Helpers.GeneralTestLib.make_user(%{"data" => %{"roles" => ["Verified"]}})
+
+      assert %{"status" => "success"} =
+               Tachyon.subscribe_updates!(client, [to_string(other_user.id)])
+
+      # subscribing should also be followed by an updated event to get the full state
+      assert {:ok,
+              %{
+                "status" => "success",
+                "commandId" => "user/updated",
+                "data" => %{"users" => [user_data]}
+              }} =
+               Tachyon.recv_message(client)
+
+      assert user_data["userId"] == to_string(other_user.id)
+      assert user_data["username"] == other_user.name
+      assert user_data["clanId"] == other_user.clan_id
+      assert user_data["status"] == "offline"
+    end
+
+    test "for online user", %{client: client} do
+      {:ok, ctx} = Tachyon.setup_client()
+      other_user = ctx[:user]
+
+      assert %{"status" => "success"} =
+               Tachyon.subscribe_updates!(client, [to_string(other_user.id)])
+
+      # subscribing should also be followed by an updated event to get the full state
+      assert {:ok,
+              %{
+                "status" => "success",
+                "commandId" => "user/updated",
+                "data" => %{"users" => [user_data]}
+              }} =
+               Tachyon.recv_message(client)
+
+      assert user_data["userId"] == to_string(other_user.id)
+      assert user_data["username"] == other_user.name
+      assert user_data["clanId"] == other_user.clan_id
+      assert user_data["status"] == "menu"
+    end
+  end
 end


### PR DESCRIPTION
Basics for [user/updated](https://github.com/beyond-all-reason/tachyon/blob/master/docs/schema/user.md#updated) events. For now, only supports the `status: menu | offline` bits. 