### PR TITLE
Increase error log truncuation limit

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -105,7 +105,8 @@ config :logger, LoggerBackends.Console,
 config :logger, :error_log,
   format: "$date $time [$level] $metadata $message\n",
   metadata: metadata,
-  level: :error
+  level: :error,
+  truncate: 16384
 
 config :logger, :notice_log,
   format: "$date $time [$level] $metadata $message\n",


### PR DESCRIPTION
Some larger error logs are getting truncated before the important part or the entire error is outputted. This doubles the default limit.