### PR TITLE
Fix a race condition when closing a party.

### DIFF
--- a/lib/teiserver/account/servers/party_server.ex
+++ b/lib/teiserver/account/servers/party_server.ex
@@ -123,10 +123,10 @@ defmodule Teiserver.Account.PartyServer do
             "teiserver_party:#{party.id}",
             %{
               channel: "teiserver_party:#{party.id}",
-              event: :closed,
+              event: :updated_values,
               party_id: party.id,
-              reason: "No members",
-              last_member: userid
+              new_values: %{pending_invites: []},
+              operation: {:invite_cancelled, party.pending_invites}
             }
           )
 
@@ -135,10 +135,10 @@ defmodule Teiserver.Account.PartyServer do
             "teiserver_party:#{party.id}",
             %{
               channel: "teiserver_party:#{party.id}",
-              event: :updated_values,
+              event: :closed,
               party_id: party.id,
-              new_values: %{pending_invites: []},
-              operation: {:invite_cancelled, party.pending_invites}
+              reason: "No members",
+              last_member: userid
             }
           )
 

--- a/test/teiserver/protocols/spring/spring_party_test.exs
+++ b/test/teiserver/protocols/spring/spring_party_test.exs
@@ -226,7 +226,11 @@ defmodule Teiserver.Protocols.Spring.SpringPartyTest do
     assert {"s.party.invited_to_party", [^party1, ^username2], _} = invited
     assert {"s.party.joined_party", [^party1, ^username1], _} = joined
     leave_party!(socket1)
-    [left, cancelled] = _recv_until(socket2) |> parse_in_messages()
+
+    [cancelled, left] =
+      _recv_until(socket2) |> IO.inspect(label: "sock2 go stuff") |> parse_in_messages()
+
+    assert {"s.party.invite_cancelled", [^party1, ^username2], _} = cancelled
     assert {"s.party.left_party", [^party1, ^username1], _} = left
     assert {"s.party.invite_cancelled", [^party1, ^username2], _} = cancelled
   end


### PR DESCRIPTION
It was possible that subscriber would receive the `close` message and unsubscribe from the party topic before the message about cancel invite is sent. Now, unsubscribing from the topic is only done after no more message is sent on the topic.