### PR TITLE
Asset mm restart

### DIFF
--- a/lib/teiserver/matchmaking.ex
+++ b/lib/teiserver/matchmaking.ex
@@ -61,4 +61,11 @@ defmodule Teiserver.Matchmaking do
   """
   @spec ready(pid(), ready_data()) :: :ok | {:error, term()}
   defdelegate ready(room_pid, user_id), to: Matchmaking.PairingRoom
+
+  @doc """
+  Kill and restart all matchmaking queues. This can be used to reset the
+  matchmaking state, for example when a new asset (game/engine) is set
+  It is a bit brutal but simple
+  """
+  defdelegate restart_queues(), to: Matchmaking.QueueSupervisor
 end

--- a/lib/teiserver/matchmaking.ex
+++ b/lib/teiserver/matchmaking.ex
@@ -5,6 +5,7 @@ defmodule Teiserver.Matchmaking do
   @type queue :: Matchmaking.QueueServer.queue()
   @type queue_id :: Matchmaking.QueueServer.id()
   @type member :: Matchmaking.QueueServer.member()
+  @type join_error :: Matchmaking.QueueServer.join_error()
   @type join_result :: Matchmaking.QueueServer.join_result()
   @type leave_result :: Matchmaking.QueueServer.leave_result()
   @type lost_reason :: Matchmaking.PairingRoom.lost_reason()

--- a/lib/teiserver/matchmaking/queue_server.ex
+++ b/lib/teiserver/matchmaking/queue_server.ex
@@ -118,15 +118,15 @@ defmodule Teiserver.Matchmaking.QueueServer do
     QueueRegistry.via_tuple(queue_id, queue)
   end
 
-  @type join_result ::
-          :ok
-          | {:error,
-             :invalid_queue
-             | :already_queued
-             | :too_many_players
-             | :missing_engines
-             | :missing_games
-             | :missing_maps}
+  @type join_error ::
+          {:error,
+           :invalid_queue
+           | :already_queued
+           | :too_many_players
+           | :missing_engines
+           | :missing_games
+           | :missing_maps}
+  @type join_result :: {:ok, queue_pid :: pid()} | join_error()
 
   @doc """
   Join the specified queue
@@ -231,7 +231,7 @@ defmodule Teiserver.Matchmaking.QueueServer do
           end)
           |> Enum.filter(fn {x, _} -> x != nil end)
 
-        {:reply, :ok,
+        {:reply, {:ok, self()},
          %{state | members: [new_member | state.members], monitors: monitors ++ state.monitors}}
 
       true ->

--- a/lib/teiserver/matchmaking/queue_server.ex
+++ b/lib/teiserver/matchmaking/queue_server.ex
@@ -185,7 +185,6 @@ defmodule Teiserver.Matchmaking.QueueServer do
 
   @impl true
   def handle_continue(:init_engines_games_maps, state) do
-    # TODO Get engines and games from somewhere else
     engines = state.queue.engines
     games = state.queue.games
     maps = Asset.get_maps_for_queue(state.id)

--- a/lib/teiserver/matchmaking/queue_supervisor.ex
+++ b/lib/teiserver/matchmaking/queue_supervisor.ex
@@ -3,6 +3,7 @@ defmodule Teiserver.Matchmaking.QueueSupervisor do
   cluster wide supervisor for all matchmaking queues
   """
 
+  require Logger
   use Horde.DynamicSupervisor
   alias Teiserver.Matchmaking.QueueServer
   alias Teiserver.Asset
@@ -38,6 +39,16 @@ defmodule Teiserver.Matchmaking.QueueSupervisor do
         games: games
       })
     ]
+  end
+
+  def restart_queues() do
+    Logger.info("Restarting all matchmaking queues")
+
+    Horde.DynamicSupervisor.stop(__MODULE__, :shutdown)
+    :ok
+  catch
+    :exit, {:noproc, _} ->
+      :ok
   end
 
   def start_queue!(state) do

--- a/lib/teiserver/matchmaking/system.ex
+++ b/lib/teiserver/matchmaking/system.ex
@@ -16,6 +16,15 @@ defmodule Teiserver.Matchmaking.System do
       Teiserver.Matchmaking.QueueSupervisor
     ]
 
-    Supervisor.init(children, strategy: :one_for_one)
+    # there are some matchmaking tests interacting with assets that stop the
+    # QueueSupervisor. So when running tests with --repeat-until-failure xxx
+    # it will start restarting this supervisor as well if using the default
+    # restart parameter.
+    # Setting it to an absurd number ensure we keep the restart isolated
+    # Another way would be to restart the entire application supervisor for
+    # each test, but that's a lot bigger change, maybe another day.
+    restarts = if Mix.env() == :test, do: 10000, else: 3
+
+    Supervisor.init(children, strategy: :rest_for_one, max_restarts: restarts)
   end
 end

--- a/test/teiserver/matchmaking/queue_test.exs
+++ b/test/teiserver/matchmaking/queue_test.exs
@@ -36,7 +36,7 @@ defmodule Teiserver.Matchmaking.QueueTest do
 
   describe "joining" do
     test "works", %{user: user, queue_id: queue_id} do
-      assert :ok = Matchmaking.join_queue(queue_id, user.id)
+      assert {:ok, _pid} = Matchmaking.join_queue(queue_id, user.id)
 
       assert {:error, :already_queued} == Matchmaking.join_queue(queue_id, user.id)
     end
@@ -60,8 +60,8 @@ defmodule Teiserver.Matchmaking.QueueTest do
 
     test "paired user still in queue", %{user: user, queue_id: queue_id, queue_pid: queue_pid} do
       user2 = Central.Helpers.GeneralTestLib.make_user(%{"data" => %{"roles" => ["Verified"]}})
-      assert :ok = Matchmaking.join_queue(queue_id, user.id)
-      assert :ok = Matchmaking.join_queue(queue_id, user2.id)
+      assert {:ok, ^queue_pid} = Matchmaking.join_queue(queue_id, user.id)
+      assert {:ok, ^queue_pid} = Matchmaking.join_queue(queue_id, user2.id)
       send(queue_pid, :tick)
       assert {:error, :already_queued} == Matchmaking.join_queue(queue_id, user.id)
     end
@@ -74,7 +74,7 @@ defmodule Teiserver.Matchmaking.QueueTest do
       assert {:error, :invalid_queue} =
                Matchmaking.leave_queue("lolnope that't not a queue", user.id)
 
-      :ok = Matchmaking.join_queue(queue_id, user.id)
+      {:ok, _pid} = Matchmaking.join_queue(queue_id, user.id)
       assert :ok = Matchmaking.leave_queue(queue_id, user.id)
     end
   end


### PR DESCRIPTION
This ties some lose ends:

* robust matchmaking: when a queue dies, the player's state will be accordingly reset
* restart queues when asset changes. This also has the effect that queuing player will get kicked out, which is what we want. Maybe later we can add some additional logic to avoid too many restarts, but I'm not sure how important it's going to be, and this simpler version will work fine for now.