### PR TITLE
Change the link for iso country codes

### DIFF
--- a/lib/teiserver_web/live/account/profile/contributor.html.heex
+++ b/lib/teiserver_web/live/account/profile/contributor.html.heex
@@ -17,8 +17,8 @@
     <h4>User flag</h4>
     <%= if @show_flag_config do %>
       You can enter any
-      <a href="https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes">
-        ISO Country code <Fontawesome.icon icon="arrow-up-right-from-square" style="solid" />
+      <a href="https://github.com/beyond-all-reason/BYAR-Chobby/blob/master/LuaMenu/configs/countryShortname.lua">
+        ISO Country code or one of the BAR-specific flags<Fontawesome.icon icon="arrow-up-right-from-square" style="solid" />
       </a>
       and even a few extra ones. <br /><br />
       Your current country code is: "<span class="monospace"><%= @country_code %></span>".

--- a/lib/teiserver_web/live/account/profile/contributor.html.heex
+++ b/lib/teiserver_web/live/account/profile/contributor.html.heex
@@ -18,7 +18,7 @@
     <%= if @show_flag_config do %>
       You can enter any
       <a href="https://github.com/beyond-all-reason/BYAR-Chobby/blob/master/LuaMenu/configs/countryShortname.lua">
-               ISO Country code or one of the BAR-specific flags<Fontawesome.icon icon="arrow-up-right-from-square" style="solid" />
+        ISO Country code or one of the BAR-specific flags<Fontawesome.icon icon="arrow-up-right-from-square" style="solid" />
       </a>
       and even a few extra ones. <br /><br />
       Your current country code is: "<span class="monospace"><%= @country_code %></span>".

--- a/lib/teiserver_web/live/account/profile/contributor.html.heex
+++ b/lib/teiserver_web/live/account/profile/contributor.html.heex
@@ -18,7 +18,7 @@
     <%= if @show_flag_config do %>
       You can enter any
       <a href="https://github.com/beyond-all-reason/BYAR-Chobby/blob/master/LuaMenu/configs/countryShortname.lua">
-        ISO Country code or one of the BAR-specific flags<Fontawesome.icon icon="arrow-up-right-from-square" style="solid" />
+               ISO Country code or one of the BAR-specific flags<Fontawesome.icon icon="arrow-up-right-from-square" style="solid" />
       </a>
       and even a few extra ones. <br /><br />
       Your current country code is: "<span class="monospace"><%= @country_code %></span>".


### PR DESCRIPTION
since the flag changing feature for contributors also allows certain BAR specific flags such as raptor, scav, moon etc. this pr changes the link from https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes to https://github.com/beyond-all-reason/BYAR-Chobby/blob/master/LuaMenu/configs/countryShortname.lua and also changes the description to reflect this