### PR TITLE
address "Application can't start when discord is unavailable"

### DIFF
--- a/lib/teiserver/application.ex
+++ b/lib/teiserver/application.ex
@@ -126,7 +126,7 @@ defmodule Teiserver.Application do
         {DynamicSupervisor, strategy: :one_for_one, name: Teiserver.Throttles.Supervisor},
 
         # Bridge
-        Teiserver.Bridge.BridgeServer,
+        Teiserver.Bridge.DiscordSystem,
         concache_sup(:discord_bridge_dm_cache),
         concache_perm_sup(:discord_channel_cache),
         concache_sup(:discord_bridge_account_codes, global_ttl: 300_000),
@@ -178,7 +178,7 @@ defmodule Teiserver.Application do
           id: Teiserver.RawSpringTcpServer,
           start: {Teiserver.SpringTcpServer, :start_link, [[]]}
         }
-      ] ++ discord_start()
+      ]
 
     children = Enum.filter(children, fn x -> not is_nil(x) end)
 
@@ -194,17 +194,6 @@ defmodule Teiserver.Application do
     startup_sub_functions(start_result)
 
     start_result
-  end
-
-  defp discord_start do
-    if Teiserver.Communication.use_discord?() do
-      [
-        Nostrum.Application,
-        {Teiserver.Bridge.DiscordBridgeBot, name: Teiserver.Bridge.DiscordBridgeBot}
-      ]
-    else
-      []
-    end
   end
 
   def startup_sub_functions({:error, _}), do: :error

--- a/lib/teiserver/application.ex
+++ b/lib/teiserver/application.ex
@@ -126,7 +126,6 @@ defmodule Teiserver.Application do
         {DynamicSupervisor, strategy: :one_for_one, name: Teiserver.Throttles.Supervisor},
 
         # Bridge
-        Teiserver.Bridge.BridgeServer,
         Teiserver.Bridge.DiscordSystem,
         concache_sup(:discord_bridge_dm_cache),
         concache_perm_sup(:discord_channel_cache),

--- a/lib/teiserver/application.ex
+++ b/lib/teiserver/application.ex
@@ -126,6 +126,7 @@ defmodule Teiserver.Application do
         {DynamicSupervisor, strategy: :one_for_one, name: Teiserver.Throttles.Supervisor},
 
         # Bridge
+        Teiserver.Bridge.BridgeServer,
         Teiserver.Bridge.DiscordSystem,
         concache_sup(:discord_bridge_dm_cache),
         concache_perm_sup(:discord_channel_cache),

--- a/lib/teiserver/bridge/discord_supervisor.ex
+++ b/lib/teiserver/bridge/discord_supervisor.ex
@@ -6,8 +6,7 @@ defmodule Teiserver.Bridge.DiscordSupervisor do
   end
 
   def init(_) do
-    Supervisor.init([{Nostrum.Application, []}, {Teiserver.Bridge.DiscordBridgeBot, []}],
-      restart: :temporary,
+    Supervisor.init([Nostrum.Application, Teiserver.Bridge.DiscordBridgeBot],
       strategy: :rest_for_one
     )
   end

--- a/lib/teiserver/bridge/discord_supervisor.ex
+++ b/lib/teiserver/bridge/discord_supervisor.ex
@@ -6,7 +6,8 @@ defmodule Teiserver.Bridge.DiscordSupervisor do
   end
 
   def init(_) do
-    Supervisor.init([Nostrum.Application, Teiserver.Bridge.DiscordBridgeBot],
+    Supervisor.init(
+      [Nostrum.Application, Teiserver.Bridge.BridgeServer, Teiserver.Bridge.DiscordBridgeBot],
       strategy: :rest_for_one
     )
   end

--- a/lib/teiserver/bridge/discord_supervisor.ex
+++ b/lib/teiserver/bridge/discord_supervisor.ex
@@ -1,0 +1,14 @@
+defmodule Teiserver.Bridge.DiscordSupervisor do
+  use Supervisor
+
+  def start_link(init_arg) do
+    Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  def init(_) do
+    Supervisor.init([{Nostrum.Application, []}, {Teiserver.Bridge.DiscordBridgeBot, []}],
+      restart: :temporary,
+      strategy: :rest_for_one
+    )
+  end
+end

--- a/lib/teiserver/bridge/discord_system.ex
+++ b/lib/teiserver/bridge/discord_system.ex
@@ -10,12 +10,14 @@ defmodule Teiserver.Bridge.DiscordSystem do
   def init(_) do
     pid = DynamicSupervisor.init(strategy: :one_for_one)
 
-    Task.async(fn ->
-      DynamicSupervisor.start_child(
-        Teiserver.Bridge.DiscordSystem,
-        Supervisor.child_spec(Teiserver.Bridge.DiscordSupervisor, restart: :temporary)
-      )
-    end)
+    if Teiserver.Communication.use_discord?() do
+      Task.async(fn ->
+        DynamicSupervisor.start_child(
+          __MODULE__,
+          Supervisor.child_spec(Teiserver.Bridge.DiscordSupervisor, restart: :temporary)
+        )
+      end)
+    end
 
     pid
   end

--- a/lib/teiserver/bridge/discord_system.ex
+++ b/lib/teiserver/bridge/discord_system.ex
@@ -8,7 +8,7 @@ defmodule Teiserver.Bridge.DiscordSystem do
 
   @impl true
   def init(_) do
-    pid = DynamicSupervisor.init(strategy: :one_for_one)
+    {:ok, sup_flags} = DynamicSupervisor.init(strategy: :one_for_one)
 
     if Teiserver.Communication.use_discord?() do
       Task.async(fn ->
@@ -19,6 +19,6 @@ defmodule Teiserver.Bridge.DiscordSystem do
       end)
     end
 
-    pid
+    {:ok, sup_flags}
   end
 end

--- a/lib/teiserver/bridge/discord_system.ex
+++ b/lib/teiserver/bridge/discord_system.ex
@@ -1,0 +1,22 @@
+defmodule Teiserver.Bridge.DiscordSystem do
+  use Supervisor
+
+  def start_link(init_arg) do
+    Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_) do
+    children =
+      if Teiserver.Communication.use_discord?() do
+        [Teiserver.Bridge.DiscordSupervisor]
+      else
+        []
+      end
+
+    Supervisor.init(children,
+      restart: :temporary,
+      strategy: :rest_for_one
+    )
+  end
+end

--- a/lib/teiserver/chat/chat_room_cache.ex
+++ b/lib/teiserver/chat/chat_room_cache.ex
@@ -166,6 +166,10 @@ defmodule Teiserver.Room do
     CacheUser.send_direct_message(from_id, Coordinator.get_coordinator_userid(), "$" <> msg)
   end
 
+  def send_message(from_id, room_name, messages) when is_list(messages) do
+    Enum.map(messages, fn msg -> send_message(from_id, room_name, msg) end)
+  end
+
   def send_message(from_id, room_name, msg) do
     user = Account.get_user_by_id(from_id)
 


### PR DESCRIPTION
Should address the startup issue in #237 

 - Moves Nostrum.Application / API into a DynamicSupervisor that basically just logs any Nostrum errors or crashes
 - This allows Teiserver to start despite Discord API failure
    - (I simulated that by manually induced failure by using an invalid access token)
    - This would make Discord integration a one-shot attempt. After teiserver startup Discord connection would not be re-attempted until the next teiserver restart. 
 - Connection appears to succeed as expected when Nostrum is provided correct Discord credential information: 
    >  ![image](https://github.com/user-attachments/assets/4026521c-3cad-40ea-a6b3-4884c5ff016a)

 - Does not retain a deliberate queue of messages to eventually send to discord, but _could_ be a source of slow memory leaks or something as messages for Nostrum pile up in a process message queue. Nonetheless, I assume this could limp for several hours. possibly days (unsure of memory growth rate), until someone is online to investigate or restart the server to allow another discord connection attempt.

 - _note that this code was written by me in heavy consultation with Microsoft Copilot. I think I understand it, I would vouch that it appears to be straightforward, but (a) it lacks true tests and (b) I am a novice in the world of Elixir, so it could have subtle bugs that I am just blind to._




---------------------------------


Example output on invalid Discord token (which previously crashed Teiserver):

> 2025-04-26 00:24:21.997 [error] pid=<0.612.0>  Nostrum failed: {%RuntimeError{message: "Invalid token format. Copy it again from the \"Bot\" tab of your Application in the Discord Developer Portal."}, [{Nostrum.Token, :check_token!, 1, [file: ~c"lib/nostrum/token.ex", line: 46, error_info: %{module: Exception}]}, {Nostrum.Application, :start, 2, [file: ~c"lib/nostrum/application.ex", line: 24]}, {DynamicSupervisor, :start_child, 3, [file: ~c"lib/dynamic_supervisor.ex", line: 800]}, {DynamicSupervisor, :handle_start_child, 2, [file: ~c"lib/dynamic_supervisor.ex", line: 786]}, {:gen_server, :try_handle_call, 4, [file: ~c"gen_server.erl", line: 1131]}, {:gen_server, :handle_msg, 6, [file: ~c"gen_server.erl", line: 1160]}, {:proc_lib, :init_p_do_apply, 3, [file: ~c"proc_lib.erl", line: 241]}]}. DiscordBridgeBot will NOT start.


----------------------------------


Example internal log output on failing to send a chat message from `#main` to Discord `#main` (because Nostrum Application / API is unavailable): 



```
 
2025-04-26 00:30:40.854 [error] request_id=BridgeServer pid=<0.3802.0>  GenServer #PID<0.3802.0> terminating
** (ArgumentError) errors were found at the given arguments:

  * 1st argument: out of range

    (erts 14.2.5.2) :erlang.phash2("/channels/1361893231796813955/messages", 0)
    (nostrum 0.10.1) lib/nostrum/api/ratelimiter_group.ex:44: Nostrum.Api.RatelimiterGroup.limiter_for_bucket/1
    (nostrum 0.10.1) lib/nostrum/api/ratelimiter.ex:982: Nostrum.Api.Ratelimiter.queue/1
    (nostrum 0.10.1) lib/nostrum/api/message.ex:110: Nostrum.Api.Message.create/2
    (teiserver 0.1.0) lib/teiserver/bridge/bridge_server.ex:188: Teiserver.Bridge.BridgeServer.handle_info/2
    (stdlib 5.2.3.1) gen_server.erl:1095: :gen_server.try_handle_info/3
    (stdlib 5.2.3.1) gen_server.erl:1183: :gen_server.handle_msg/6
    (stdlib 5.2.3.1) proc_lib.erl:241: :proc_lib.init_p_do_apply/3
Last message: {:new_message, 16, "main", "tharp test"}
State: %{user: %{rank: 0, id: 792, lobby_hash: "IC", last_played: nil, email: "bridge@teiserver", clan_id: nil, discord_id: nil, icon: "fa-brands fa-discord", colour: "#0066AA", last_login_timex: ~U[2025-04-26 05:30:37.551000Z], last_login_mins: 29094091, inserted_at: ~N[2025-04-24 02:49:59], spring_password: false, restricted_until: nil, last_login: 29094091, chobby_hash: nil, permissions: [], name: "DiscordBridgeBot", verified: true, country: "GB", email_change_code: nil, moderator: false, bot: true, shadowbanned: false, steam_id: nil, print_client_messages: false, hw_hash: nil, restrictions: [], discord_dm_channel: nil, lobby_client: "Teiserver Internal Client", password_hash: nil, discord_dm_channel_id: nil, smurf_of_id: nil, roles: [], print_server_messages: false, last_logout: nil}, ip: "127.0.0.1", username: "DiscordBridgeBot", client: %{rank: 0, team_colour: "0", in_game: false, unready_at: nil, lobby_host: false, role: "spectator", ip: "127.0.0.1", ready: false, temp_mute_count: 0, awaiting_warn_ack: false, muted: false, player_number: 0, sync: %{map: 0, engine: 0, game: 0}, token_id: nil, userid: 792, lobby_id: nil, clan_tag: nil, party_id: nil, name: "DiscordBridgeBot", warned: false, country: "GB", moderator: false, player: false, bot: false, queues: [], shadowbanned: false, print_client_messages: false, tcp_pid: #PID<0.3802.0>, chat_times: [], protocol: :internal, lobby_client: "Teiserver Internal Client", handicap: 0, away: false, side: 0, connected: true, team_number: 0, app_status: nil, print_server_messages: false, restricted: false}, userid: 792, channel_lookup: %{"gdt-discussion" => 0, "gdt-voting" => 0, "main" => 1361893231796813955, "moderation-actions" => 0, "moderation-reports" => 0, "newbies" => 0, "promote" => 0, "server-updates" => 1361895967955353721, "telemetry-infologs" => 0}, room_lookup: %{0 => "promote", 1361893231796813955 => "main"}, lobby_host: false, recent_bridged_messages: %{}}

```



