### PR TITLE
Tachyon party

### DIFF
--- a/lib/teiserver/config.ex
+++ b/lib/teiserver/config.ex
@@ -292,15 +292,20 @@ defmodule Teiserver.Config do
   @spec get_site_config_cache(String.t()) :: any
   def get_site_config_cache(key) do
     Teiserver.cache_get_or_store(:config_site_cache, key, fn ->
-      case get_site_config(key) do
-        nil ->
-          default = get_site_config_default(key)
-          cast_site_config_value(key, default)
-
-        config ->
-          cast_site_config_value(key, config.value)
-      end
+      get_site_config_val(key)
     end)
+  end
+
+  @spec get_site_config_val(String.t()) :: any()
+  def get_site_config_val(key) do
+    case get_site_config(key) do
+      nil ->
+        default = get_site_config_default(key)
+        cast_site_config_value(key, default)
+
+      config ->
+        cast_site_config_value(key, config.value)
+    end
   end
 
   @spec get_site_config(String.t()) :: SiteConfig.t() | nil

--- a/lib/teiserver/config/schemas/site_config.ex
+++ b/lib/teiserver/config/schemas/site_config.ex
@@ -2,6 +2,11 @@ defmodule Teiserver.Config.SiteConfig do
   @moduledoc false
   use TeiserverWeb, :schema
 
+  @type t :: %__MODULE__{
+          key: String.t(),
+          value: String.t()
+        }
+
   @primary_key false
   schema "config_site" do
     field :key, :string, primary_key: true

--- a/lib/teiserver/libs/teiserver_configs.ex
+++ b/lib/teiserver/libs/teiserver_configs.ex
@@ -14,6 +14,8 @@ defmodule Teiserver.TeiserverConfigs do
     debugging_configs()
     profile_configs()
     rating_configs()
+    tachyon_configs()
+    :ok
   end
 
   @spec site_configs :: any
@@ -671,5 +673,10 @@ defmodule Teiserver.TeiserverConfigs do
       description: "Active season",
       default: 1
     })
+  end
+
+  defp tachyon_configs do
+    Teiserver.Party.setup_site_configs()
+    :ok
   end
 end

--- a/lib/teiserver/party.ex
+++ b/lib/teiserver/party.ex
@@ -30,4 +30,7 @@ defmodule Teiserver.Party do
 
   @spec get_state(id()) :: state() | nil
   defdelegate get_state(party_id), to: Party.Server
+
+  @spec leave_party(id(), T.userid()) :: :ok | {:error, :invalid_party | :not_a_member}
+  defdelegate leave_party(party_id, user_id), to: Party.Server
 end

--- a/lib/teiserver/party.ex
+++ b/lib/teiserver/party.ex
@@ -43,4 +43,8 @@ defmodule Teiserver.Party do
           {:ok, state()} | {:error, :invalid_party | :not_invited}
   defdelegate accept_invite(party_id, user_id), to: Party.Server
 
+  @spec decline_invite(id(), T.userid()) ::
+          {:ok, state()} | {:error, :invalid_party | :not_invited}
+  defdelegate decline_invite(party_id, user_id), to: Party.Server
+
 end

--- a/lib/teiserver/party.ex
+++ b/lib/teiserver/party.ex
@@ -65,6 +65,15 @@ defmodule Teiserver.Party do
       description: "Maximum number of member + invited for parties",
       default: 3
     })
+
+    Config.add_site_config_type(%{
+      key: Party.Server.invite_valid_duration_key(),
+      section: "Tachyon",
+      type: "integer",
+      permissions: ["Admin"],
+      description: "How long a party invite should be valid for (in seconds)",
+      default: 60 * 5
+    })
   end
 
   @spec update_max_size(integer()) :: :ok

--- a/lib/teiserver/party.ex
+++ b/lib/teiserver/party.ex
@@ -50,4 +50,8 @@ defmodule Teiserver.Party do
   @spec cancel_invite(id(), T.userid()) ::
           {:ok, state()} | {:error, :invalid_party | :not_in_party | :not_invited}
   defdelegate cancel_invite(party_id, user_id), to: Party.Server
+
+  @spec kick_user(id(), user_kicking :: T.userid(), kicked_user :: T.userid()) ::
+          {:ok, state()} | {:error, :invalid_party | :invalid_target | :not_a_member}
+  defdelegate kick_user(party_id, actor_id, target_id), to: Party.Server
 end

--- a/lib/teiserver/party.ex
+++ b/lib/teiserver/party.ex
@@ -38,4 +38,9 @@ defmodule Teiserver.Party do
   @spec create_invite(id(), T.userid()) ::
           {:ok, state()} | {:error, :invalid_party | :already_invited}
   defdelegate create_invite(party_id, user_id), to: Party.Server
+
+  @spec accept_invite(id(), T.userid()) ::
+          {:ok, state()} | {:error, :invalid_party | :not_invited}
+  defdelegate accept_invite(party_id, user_id), to: Party.Server
+
 end

--- a/lib/teiserver/party.ex
+++ b/lib/teiserver/party.ex
@@ -9,14 +9,15 @@ defmodule Teiserver.Party do
   """
 
   alias Teiserver.Party
+  alias Teiserver.Data.Types, as: T
 
   @type id :: Party.Server.id()
 
-  @spec create_party() :: {:ok, id()} | {:error, reason :: term()}
-  def create_party() do
+  @spec create_party(T.userid()) :: {:ok, id()} | {:error, reason :: term()}
+  def create_party(user_id) do
     party_id = Party.Server.gen_party_id()
 
-    case Party.Supervisor.start_party(party_id) do
+    case Party.Supervisor.start_party(party_id, user_id) do
       {:ok, _pid} -> {:ok, party_id}
       {:ok, _pid, _info} -> {:ok, party_id}
       :ignore -> {:error, :ignore}
@@ -26,4 +27,7 @@ defmodule Teiserver.Party do
 
   @spec lookup(id()) :: pid() | nil
   defdelegate lookup(party_id), to: Party.Registry
+
+  @spec get_state(id()) :: state() | nil
+  defdelegate get_state(party_id), to: Party.Server
 end

--- a/lib/teiserver/party.ex
+++ b/lib/teiserver/party.ex
@@ -12,6 +12,7 @@ defmodule Teiserver.Party do
   alias Teiserver.Data.Types, as: T
 
   @type id :: Party.Server.id()
+  @type state :: Party.Server.state()
 
   @spec create_party(T.userid()) :: {:ok, id()} | {:error, reason :: term()}
   def create_party(user_id) do
@@ -33,4 +34,8 @@ defmodule Teiserver.Party do
 
   @spec leave_party(id(), T.userid()) :: :ok | {:error, :invalid_party | :not_a_member}
   defdelegate leave_party(party_id, user_id), to: Party.Server
+
+  @spec create_invite(id(), T.userid()) ::
+          {:ok, state()} | {:error, :invalid_party | :already_invited}
+  defdelegate create_invite(party_id, user_id), to: Party.Server
 end

--- a/lib/teiserver/party.ex
+++ b/lib/teiserver/party.ex
@@ -8,6 +8,7 @@ defmodule Teiserver.Party do
   with regard to invites.
   """
 
+  alias Teiserver.Config
   alias Teiserver.Party
   alias Teiserver.Data.Types, as: T
 
@@ -36,7 +37,7 @@ defmodule Teiserver.Party do
   defdelegate leave_party(party_id, user_id), to: Party.Server
 
   @spec create_invite(id(), T.userid()) ::
-          {:ok, state()} | {:error, :invalid_party | :already_invited}
+          {:ok, state()} | {:error, :invalid_party | :already_invited | :party_at_capacity}
   defdelegate create_invite(party_id, user_id), to: Party.Server
 
   @spec accept_invite(id(), T.userid()) ::
@@ -54,4 +55,21 @@ defmodule Teiserver.Party do
   @spec kick_user(id(), user_kicking :: T.userid(), kicked_user :: T.userid()) ::
           {:ok, state()} | {:error, :invalid_party | :invalid_target | :not_a_member}
   defdelegate kick_user(party_id, actor_id, target_id), to: Party.Server
+
+  def setup_site_configs() do
+    Config.add_site_config_type(%{
+      key: Party.Server.max_size_key(),
+      section: "Tachyon",
+      type: "integer",
+      permissions: ["Admin"],
+      description: "Maximum number of member + invited for parties",
+      default: 3
+    })
+  end
+
+  @spec update_max_size(integer()) :: :ok
+  def update_max_size(new_max_size) do
+    Config.update_site_config(Party.Server.max_size_key(), new_max_size)
+    :ok
+  end
 end

--- a/lib/teiserver/party.ex
+++ b/lib/teiserver/party.ex
@@ -12,11 +12,16 @@ defmodule Teiserver.Party do
 
   @type id :: Party.Server.id()
 
-  @spec create_party() :: {id(), DynamicSupervisor.on_start_child()}
+  @spec create_party() :: {:ok, id()} | {:error, reason :: term()}
   def create_party() do
     party_id = Party.Server.gen_party_id()
-    res = Party.Supervisor.start_party(party_id)
-    {party_id, res}
+
+    case Party.Supervisor.start_party(party_id) do
+      {:ok, _pid} -> {:ok, party_id}
+      {:ok, _pid, _info} -> {:ok, party_id}
+      :ignore -> {:error, :ignore}
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   @spec lookup(id()) :: pid() | nil

--- a/lib/teiserver/party.ex
+++ b/lib/teiserver/party.ex
@@ -47,4 +47,7 @@ defmodule Teiserver.Party do
           {:ok, state()} | {:error, :invalid_party | :not_invited}
   defdelegate decline_invite(party_id, user_id), to: Party.Server
 
+  @spec cancel_invite(id(), T.userid()) ::
+          {:ok, state()} | {:error, :invalid_party | :not_in_party | :not_invited}
+  defdelegate cancel_invite(party_id, user_id), to: Party.Server
 end

--- a/lib/teiserver/party.ex
+++ b/lib/teiserver/party.ex
@@ -1,0 +1,24 @@
+defmodule Teiserver.Party do
+  @moduledoc """
+  Anything party related. These are only tachyon related parties, and don't
+  have anything shared with the existing parties under Teiserver.Account
+
+  The main reason is that the logic to tie parties with matchmaking is
+  completely different and there are also a few other semantic differences
+  with regard to invites.
+  """
+
+  alias Teiserver.Party
+
+  @type id :: Party.Server.id()
+
+  @spec create_party() :: {id(), DynamicSupervisor.on_start_child()}
+  def create_party() do
+    party_id = Party.Server.gen_party_id()
+    res = Party.Supervisor.start_party(party_id)
+    {party_id, res}
+  end
+
+  @spec lookup(id()) :: pid() | nil
+  defdelegate lookup(party_id), to: Party.Registry
+end

--- a/lib/teiserver/party/registry.ex
+++ b/lib/teiserver/party/registry.ex
@@ -1,0 +1,30 @@
+defmodule Teiserver.Party.Registry do
+  @moduledoc """
+  Tracks tachyon parties
+  """
+
+  alias Teiserver.Party
+
+  @spec lookup(Party.Server.id()) :: pid() | nil
+  def lookup(party_id) do
+    case Horde.Registry.lookup(__MODULE__, party_id) do
+      [{pid, _}] -> pid
+      _ -> nil
+    end
+  end
+
+  def start_link() do
+    Horde.Registry.start_link(keys: :unique, name: __MODULE__)
+  end
+
+  def child_spec(_) do
+    Supervisor.child_spec(Horde.Registry,
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, []}
+    )
+  end
+
+  def via_tuple(party_id) do
+    {:via, Horde.Registry, {__MODULE__, party_id}}
+  end
+end

--- a/lib/teiserver/party/server.ex
+++ b/lib/teiserver/party/server.ex
@@ -1,0 +1,28 @@
+defmodule Teiserver.Party.Server do
+  @moduledoc """
+  transient genserver to hold a party state and mediate player interactions
+  """
+
+  alias Teiserver.Party
+
+  use GenServer
+
+  @opaque id :: String.t()
+
+  @spec gen_party_id() :: id()
+  def gen_party_id(), do: UUID.uuid4()
+
+  def start_link(party_id) do
+    GenServer.start_link(__MODULE__, party_id, name: via_tuple(party_id))
+  end
+
+  @impl true
+  def init(party_id) do
+    state = %{id: party_id}
+    {:ok, state}
+  end
+
+  def via_tuple(party_id) do
+    Party.Registry.via_tuple(party_id)
+  end
+end

--- a/lib/teiserver/party/server.ex
+++ b/lib/teiserver/party/server.ex
@@ -4,22 +4,44 @@ defmodule Teiserver.Party.Server do
   """
 
   alias Teiserver.Party
+  alias Teiserver.Data.Types, as: T
 
   use GenServer
 
-  @opaque id :: String.t()
+  @type id :: String.t()
+  @type state :: %{
+          # versionning of the state to avoid races between call and cast
+          version: integer(),
+          id: id(),
+          members: [%{id: T.userid(), joined_at: DateTime.t()}]
+        }
 
   @spec gen_party_id() :: id()
   def gen_party_id(), do: UUID.uuid4()
 
-  def start_link(party_id) do
-    GenServer.start_link(__MODULE__, party_id, name: via_tuple(party_id))
+  def start_link({party_id, _user_id} = args) do
+    GenServer.start_link(__MODULE__, args, name: via_tuple(party_id))
+  end
+
+  @doc """
+  Get the party state
+  """
+  @spec get_state(id()) :: state() | nil
+  def get_state(party_id) do
+    GenServer.call(via_tuple(party_id), :get_state)
+  catch
+    :exit, {:noproc, _} -> nil
   end
 
   @impl true
-  def init(party_id) do
-    state = %{id: party_id}
+  def init({party_id, user_id}) do
+    state = %{version: 0, id: party_id, members: [%{id: user_id, joined_at: DateTime.utc_now()}]}
     {:ok, state}
+  end
+
+  @impl true
+  def handle_call(:get_state, _from, state) do
+    {:reply, state, state}
   end
 
   def via_tuple(party_id) do

--- a/lib/teiserver/party/supervisor.ex
+++ b/lib/teiserver/party/supervisor.ex
@@ -6,13 +6,15 @@ defmodule Teiserver.Party.Supervisor do
   use DynamicSupervisor
 
   alias Teiserver.Party
+  alias Teiserver.Data.Types, as: T
 
   @doc """
   Create a new party
   """
-  @spec start_party(Party.Server.id()) :: DynamicSupervisor.on_start_child()
-  def start_party(party_id) do
-    DynamicSupervisor.start_child(__MODULE__, {Teiserver.Party.Server, party_id})
+  @spec start_party(Party.Server.id(), T.userid()) ::
+          DynamicSupervisor.on_start_child()
+  def start_party(party_id, user_id) do
+    DynamicSupervisor.start_child(__MODULE__, {Teiserver.Party.Server, {party_id, user_id}})
   end
 
   def start_link(init_arg) do

--- a/lib/teiserver/party/supervisor.ex
+++ b/lib/teiserver/party/supervisor.ex
@@ -1,0 +1,26 @@
+defmodule Teiserver.Party.Supervisor do
+  @moduledoc """
+  Supervise player's parties
+  """
+
+  use DynamicSupervisor
+
+  alias Teiserver.Party
+
+  @doc """
+  Create a new party
+  """
+  @spec start_party(Party.Server.id()) :: DynamicSupervisor.on_start_child()
+  def start_party(party_id) do
+    DynamicSupervisor.start_child(__MODULE__, {Teiserver.Party.Server, party_id})
+  end
+
+  def start_link(init_arg) do
+    DynamicSupervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+end

--- a/lib/teiserver/party/system.ex
+++ b/lib/teiserver/party/system.ex
@@ -1,0 +1,17 @@
+defmodule Teiserver.Party.System do
+  use Supervisor
+
+  def start_link(init_arg) do
+    Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_) do
+    children = [
+      Teiserver.Party.Registry,
+      Teiserver.Party.Supervisor
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end

--- a/lib/teiserver/player.ex
+++ b/lib/teiserver/player.ex
@@ -77,4 +77,16 @@ defmodule Teiserver.Player do
   """
   @spec battle_start(T.userid(), Teiserver.Autohost.start_response()) :: :ok
   defdelegate battle_start(user_id, battle_start_data), to: Player.Session
+
+  @doc """
+  Let the player know they've been invited to a party
+  """
+  defdelegate party_notify_invited(user_id, party_state), to: Player.Session
+
+  @doc """
+  Let the player know about the new state of a party they're a member of, or
+  have been invited to.
+  """
+  defdelegate party_notify_updated(user_id, party_state), to: Player.Session
+
 end

--- a/lib/teiserver/player.ex
+++ b/lib/teiserver/player.ex
@@ -10,7 +10,7 @@ defmodule Teiserver.Player do
   """
 
   alias Teiserver.Data.Types, as: T
-  alias Teiserver.{Player, Matchmaking}
+  alias Teiserver.{Player, Matchmaking, Party}
 
   @doc """
   Returns the pid of the session registered with a given user id
@@ -89,4 +89,9 @@ defmodule Teiserver.Player do
   """
   defdelegate party_notify_updated(user_id, party_state), to: Player.Session
 
+  @doc """
+  Let the player know that they are no longer invited/member of the party
+  """
+  @spec party_notify_removed(T.userid(), Party.state()) :: :ok
+  defdelegate party_notify_removed(user_id, party_state), to: Player.Session
 end

--- a/lib/teiserver/player.ex
+++ b/lib/teiserver/player.ex
@@ -32,7 +32,7 @@ defmodule Teiserver.Player do
   """
   @spec monitor_session(T.userid()) :: reference() | nil
   def monitor_session(user_id) do
-    pid = lookup_connection(user_id)
+    pid = lookup_session(user_id)
 
     if is_nil(pid) do
       nil

--- a/lib/teiserver/player/session_registry.ex
+++ b/lib/teiserver/player/session_registry.ex
@@ -25,6 +25,13 @@ defmodule Teiserver.Player.SessionRegistry do
     end
   end
 
+  @doc """
+  Used only for test (for now), not sure if there's a case outside tests
+  """
+  def register(key, value) do
+    Horde.Registry.register(Teiserver.Player.SessionRegistry, key, value)
+  end
+
   def unregister(user_id) do
     Horde.Registry.unregister(__MODULE__, via_tuple(user_id))
   end

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -452,6 +452,20 @@ defmodule Teiserver.Player.TachyonHandler do
     end
   end
 
+  def handle_command("party/create", "request", _message_id, _msg, state) do
+    case Player.Session.create_party(state.user.id) do
+      {:ok, party_id} ->
+        data = %{partyId: party_id}
+        {:response, data, state}
+
+      {:error, :already_in_party} ->
+        {:error_response, :invalid_request, "Already in a party", state}
+
+      {:error, reason} ->
+        {:error_response, :internal_error, to_string(reason), state}
+    end
+  end
+
   def handle_command(_command_id, _message_type, _message_id, _message, state) do
     {:error_response, :command_unimplemented, state}
   end

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -514,6 +514,18 @@ defmodule Teiserver.Player.TachyonHandler do
     end
   end
 
+  def handle_command("party/declineInvite", "request", _message_id, msg, state) do
+    party_id = msg["data"]["partyId"]
+
+    case Player.Session.decline_invite_to_party(state.user.id, party_id) do
+      :ok ->
+        {:response, state}
+
+      {:error, reason} ->
+        {:error_response, :invalid_request, to_string(reason), state}
+    end
+  end
+
   def handle_command(_command_id, _message_type, _message_id, _message, state) do
     {:error_response, :command_unimplemented, state}
   end

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -62,7 +62,7 @@ defmodule Teiserver.Player.TachyonHandler do
         countryCode: user.country,
         status: :menu,
         party: party_state_to_tachyon(sess_state.party),
-        invitedToParties: [],
+        invitedToParties: Enum.map(sess_state.invited_to_parties, &party_state_to_tachyon/1),
         friendIds: Enum.map(friends, fn %{userId: uid} -> uid end),
         outgoingFriendRequest: outgoing,
         incomingFriendRequest: incoming,
@@ -518,7 +518,7 @@ defmodule Teiserver.Player.TachyonHandler do
     case Player.SessionSupervisor.start_session(user) do
       {:ok, session_pid} ->
         {:ok, _} = Player.Registry.register_and_kill_existing(user.id)
-        {:ok, session_pid, %{party: nil}}
+        {:ok, session_pid, %{party: nil, invited_to_parties: []}}
 
       {:error, {:already_started, pid}} ->
         case Player.Session.replace_connection(pid, self()) do

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -502,6 +502,18 @@ defmodule Teiserver.Player.TachyonHandler do
     end
   end
 
+  def handle_command("party/acceptInvite", "request", _message_id, msg, state) do
+    party_id = msg["data"]["partyId"]
+
+    case Player.Session.accept_invite_to_party(state.user.id, party_id) do
+      :ok ->
+        {:response, state}
+
+      {:error, reason} ->
+        {:error_response, :invalid_request, to_string(reason), state}
+    end
+  end
+
   def handle_command(_command_id, _message_type, _message_id, _message, state) do
     {:error_response, :command_unimplemented, state}
   end

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -541,6 +541,16 @@ defmodule Teiserver.Player.TachyonHandler do
     end
   end
 
+  def handle_command("party/kickMember", "request", _message_id, msg, state) do
+    with {:ok, target_id} <- parse_user_id(msg["data"]["userId"]),
+         :ok <- Player.Session.kick_party_member(state.user.id, target_id) do
+      {:response, state}
+    else
+      {:error, reason} ->
+        {:error_response, :invalid_request, to_string(reason), state}
+    end
+  end
+
   def handle_command(_command_id, _message_type, _message_id, _message, state) do
     {:error_response, :command_unimplemented, state}
   end

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -485,6 +485,14 @@ defmodule Teiserver.Player.TachyonHandler do
     end
   end
 
+  def handle_command("party/leave", "request", _message_id, _msg, state) do
+    case Player.Session.leave_party(state.user.id) do
+      :ok -> {:response, state}
+      {:error, :not_in_party} -> {:error_response, :invalid_request, "Not in a party", state}
+      {:error, reason} -> {:error_response, :internal_error, to_string(reason), state}
+    end
+  end
+
   def handle_command(_command_id, _message_type, _message_id, _message, state) do
     {:error_response, :command_unimplemented, state}
   end

--- a/lib/teiserver/tachyon/handler.ex
+++ b/lib/teiserver/tachyon/handler.ex
@@ -19,6 +19,7 @@ defmodule Teiserver.Tachyon.Handler do
   """
   @type tachyon_result ::
           {:event, Schema.command_id(), payload :: term(), state :: term()}
+          | {:response, state :: term()}
           | {:response, payload :: term(), state :: term()}
           | {:error_response, reason :: String.t() | atom(), state :: term()}
           | {:error_response, reason :: String.t() | atom(), details :: String.t(),

--- a/lib/teiserver/tachyon/system.ex
+++ b/lib/teiserver/tachyon/system.ex
@@ -14,6 +14,7 @@ defmodule Teiserver.Tachyon.System do
       Teiserver.TachyonBattle.System,
       Teiserver.Autohost.System,
       Teiserver.Matchmaking.System,
+      Teiserver.Party.System,
       Teiserver.Player.System
     ]
 

--- a/priv/tachyon/schema/definitions/partyId.json
+++ b/priv/tachyon/schema/definitions/partyId.json
@@ -1,0 +1,6 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/definitions/partyId.json",
+    "title": "PartyId",
+    "type": "string",
+    "examples": ["1882f6b2e3a4d14f24acb7aa"]
+}

--- a/priv/tachyon/schema/definitions/partyState.json
+++ b/priv/tachyon/schema/definitions/partyState.json
@@ -1,0 +1,31 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/definitions/partyState.json",
+    "title": "PartyState",
+    "type": "object",
+    "properties": {
+        "id": { "$ref": "../definitions/partyId.json" },
+        "members": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "userId": { "$ref": "../definitions/userId.json" },
+                    "joinedAt": { "$ref": "../definitions/unixTime.json" }
+                },
+                "required": ["userId", "joinedAt"]
+            }
+        },
+        "invited": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "userId": { "$ref": "../definitions/userId.json" },
+                    "invitedAt": { "$ref": "../definitions/unixTime.json" }
+                },
+                "required": ["userId", "invitedAt"]
+            }
+        }
+    },
+    "required": ["id", "members", "invited"]
+}

--- a/priv/tachyon/schema/definitions/privateUser.json
+++ b/priv/tachyon/schema/definitions/privateUser.json
@@ -6,8 +6,15 @@
         {
             "type": "object",
             "properties": {
-                "partyId": {
-                    "anyOf": [{ "type": "string" }, { "type": "null" }]
+                "party": {
+                    "anyOf": [
+                        { "$ref": "../definitions/partyState.json" },
+                        { "type": "null" }
+                    ]
+                },
+                "invitedToParties": {
+                    "type": "array",
+                    "items": { "$ref": "../definitions/partyState.json" }
                 },
                 "friendIds": { "type": "array", "items": { "type": "string" } },
                 "outgoingFriendRequest": {
@@ -36,7 +43,8 @@
                 "currentBattle": { "$ref": "../definitions/privateBattle.json" }
             },
             "required": [
-                "partyId",
+                "party",
+                "invitedToParties",
                 "friendIds",
                 "outgoingFriendRequest",
                 "incomingFriendRequest",

--- a/priv/tachyon/schema/party/acceptInvite/request.json
+++ b/priv/tachyon/schema/party/acceptInvite/request.json
@@ -1,0 +1,25 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/acceptInvite/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "PartyAcceptInviteRequest",
+    "tachyon": {
+        "source": "user",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "party/acceptInvite" },
+        "data": {
+            "title": "PartyAcceptInviteRequestData",
+            "type": "object",
+            "properties": {
+                "partyId": { "$ref": "../../definitions/partyId.json" }
+            },
+            "required": ["partyId"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/party/acceptInvite/response.json
+++ b/priv/tachyon/schema/party/acceptInvite/response.json
@@ -1,0 +1,43 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/acceptInvite/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "PartyAcceptInviteResponse",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "PartyAcceptInviteOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "party/acceptInvite" },
+                "status": { "const": "success" }
+            },
+            "required": ["type", "messageId", "commandId", "status"]
+        },
+        {
+            "title": "PartyAcceptInviteFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "party/acceptInvite" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}

--- a/priv/tachyon/schema/party/cancelInvite/request.json
+++ b/priv/tachyon/schema/party/cancelInvite/request.json
@@ -1,0 +1,25 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/cancelInvite/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "PartyCancelInviteRequest",
+    "tachyon": {
+        "source": "user",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "party/cancelInvite" },
+        "data": {
+            "title": "PartyCancelInviteRequestData",
+            "type": "object",
+            "properties": {
+                "userId": { "$ref": "../../definitions/userId.json" }
+            },
+            "required": ["userId"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/party/cancelInvite/response.json
+++ b/priv/tachyon/schema/party/cancelInvite/response.json
@@ -1,0 +1,45 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/cancelInvite/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "PartyCancelInviteResponse",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "PartyCancelInviteOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "party/cancelInvite" },
+                "status": { "const": "success" }
+            },
+            "required": ["type", "messageId", "commandId", "status"]
+        },
+        {
+            "title": "PartyCancelInviteFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "party/cancelInvite" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "not_in_party",
+                        "invalid_invite",
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}

--- a/priv/tachyon/schema/party/create/request.json
+++ b/priv/tachyon/schema/party/create/request.json
@@ -1,0 +1,17 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/create/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "PartyCreateRequest",
+    "tachyon": {
+        "source": "user",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "party/create" }
+    },
+    "required": ["type", "messageId", "commandId"]
+}

--- a/priv/tachyon/schema/party/create/response.json
+++ b/priv/tachyon/schema/party/create/response.json
@@ -1,0 +1,51 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/create/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "PartyCreateResponse",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "PartyCreateOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "party/create" },
+                "status": { "const": "success" },
+                "data": {
+                    "title": "PartyCreateOkResponseData",
+                    "type": "object",
+                    "properties": {
+                        "partyId": { "$ref": "../../definitions/partyId.json" }
+                    },
+                    "required": ["partyId"]
+                }
+            },
+            "required": ["type", "messageId", "commandId", "status", "data"]
+        },
+        {
+            "title": "PartyCreateFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "party/create" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}

--- a/priv/tachyon/schema/party/declineInvite/request.json
+++ b/priv/tachyon/schema/party/declineInvite/request.json
@@ -1,0 +1,25 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/declineInvite/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "PartyDeclineInviteRequest",
+    "tachyon": {
+        "source": "user",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "party/declineInvite" },
+        "data": {
+            "title": "PartyDeclineInviteRequestData",
+            "type": "object",
+            "properties": {
+                "partyId": { "$ref": "../../definitions/partyId.json" }
+            },
+            "required": ["partyId"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/party/declineInvite/response.json
+++ b/priv/tachyon/schema/party/declineInvite/response.json
@@ -1,0 +1,43 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/declineInvite/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "PartyDeclineInviteResponse",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "PartyDeclineInviteOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "party/declineInvite" },
+                "status": { "const": "success" }
+            },
+            "required": ["type", "messageId", "commandId", "status"]
+        },
+        {
+            "title": "PartyDeclineInviteFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "party/declineInvite" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}

--- a/priv/tachyon/schema/party/invite/request.json
+++ b/priv/tachyon/schema/party/invite/request.json
@@ -1,0 +1,25 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/invite/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "PartyInviteRequest",
+    "tachyon": {
+        "source": "user",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "party/invite" },
+        "data": {
+            "title": "PartyInviteRequestData",
+            "type": "object",
+            "properties": {
+                "userId": { "$ref": "../../definitions/userId.json" }
+            },
+            "required": ["userId"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/party/invite/response.json
+++ b/priv/tachyon/schema/party/invite/response.json
@@ -1,0 +1,43 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/invite/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "PartyInviteResponse",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "PartyInviteOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "party/invite" },
+                "status": { "const": "success" }
+            },
+            "required": ["type", "messageId", "commandId", "status"]
+        },
+        {
+            "title": "PartyInviteFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "party/invite" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}

--- a/priv/tachyon/schema/party/invited/event.json
+++ b/priv/tachyon/schema/party/invited/event.json
@@ -1,0 +1,25 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/invited/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "PartyInvitedEvent",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "event" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "party/invited" },
+        "data": {
+            "title": "PartyInvitedEventData",
+            "type": "object",
+            "properties": {
+                "party": { "$ref": "../../definitions/partyState.json" }
+            },
+            "required": ["party"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/party/kickMember/request.json
+++ b/priv/tachyon/schema/party/kickMember/request.json
@@ -1,0 +1,25 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/kickMember/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "PartyKickMemberRequest",
+    "tachyon": {
+        "source": "user",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "party/kickMember" },
+        "data": {
+            "title": "PartyKickMemberRequestData",
+            "type": "object",
+            "properties": {
+                "userId": { "$ref": "../../definitions/userId.json" }
+            },
+            "required": ["userId"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/party/kickMember/response.json
+++ b/priv/tachyon/schema/party/kickMember/response.json
@@ -1,0 +1,43 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/kickMember/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "PartyKickMemberResponse",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "PartyKickMemberOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "party/kickMember" },
+                "status": { "const": "success" }
+            },
+            "required": ["type", "messageId", "commandId", "status"]
+        },
+        {
+            "title": "PartyKickMemberFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "party/kickMember" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}

--- a/priv/tachyon/schema/party/leave/request.json
+++ b/priv/tachyon/schema/party/leave/request.json
@@ -1,0 +1,17 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/leave/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "PartyLeaveRequest",
+    "tachyon": {
+        "source": "user",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "party/leave" }
+    },
+    "required": ["type", "messageId", "commandId"]
+}

--- a/priv/tachyon/schema/party/leave/response.json
+++ b/priv/tachyon/schema/party/leave/response.json
@@ -1,0 +1,43 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/leave/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "PartyLeaveResponse",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "PartyLeaveOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "party/leave" },
+                "status": { "const": "success" }
+            },
+            "required": ["type", "messageId", "commandId", "status"]
+        },
+        {
+            "title": "PartyLeaveFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "party/leave" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}

--- a/priv/tachyon/schema/party/removed/event.json
+++ b/priv/tachyon/schema/party/removed/event.json
@@ -1,0 +1,25 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/removed/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "PartyRemovedEvent",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "event" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "party/removed" },
+        "data": {
+            "title": "PartyRemovedEventData",
+            "type": "object",
+            "properties": {
+                "partyId": { "$ref": "../../definitions/partyId.json" }
+            },
+            "required": ["partyId"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/party/updated/event.json
+++ b/priv/tachyon/schema/party/updated/event.json
@@ -1,0 +1,21 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/party/updated/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "PartyUpdatedEvent",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "event" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "party/updated" },
+        "data": {
+            "$ref": "../../definitions/partyState.json",
+            "title": "PartyUpdatedEventData"
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -40,6 +40,12 @@ defmodule TeiserverWeb.ConnCase do
 
     unless tags[:async] do
       Ecto.Adapters.SQL.Sandbox.mode(Teiserver.Repo, {:shared, self()})
+
+      :ok =
+        Supervisor.terminate_child(Teiserver.Supervisor, Teiserver.Config.SiteConfigTypes.Cache)
+
+      {:ok, _pid} =
+        Supervisor.restart_child(Teiserver.Supervisor, Teiserver.Config.SiteConfigTypes.Cache)
     end
 
     Teiserver.Support.Tachyon.tachyon_case_setup(tags)

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -360,4 +360,10 @@ defmodule Teiserver.Support.Tachyon do
     {:ok, resp} = recv_message(client)
     resp
   end
+
+  def cancel_party_invite!(client, user_id) do
+    :ok = send_request(client, "party/cancelInvite", %{userId: to_string(user_id)})
+    {:ok, resp} = recv_message(client)
+    resp
+  end
 end

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -336,4 +336,10 @@ defmodule Teiserver.Support.Tachyon do
     {:ok, resp} = recv_message(client)
     resp
   end
+
+  def leave_party!(client) do
+    :ok = send_request(client, "party/leave")
+    {:ok, resp} = recv_message(client)
+    resp
+  end
 end

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -354,4 +354,10 @@ defmodule Teiserver.Support.Tachyon do
     {:ok, resp} = recv_message(client)
     resp
   end
+
+  def decline_party_invite!(client, party_id) do
+    :ok = send_request(client, "party/declineInvite", %{partyId: party_id})
+    {:ok, resp} = recv_message(client)
+    resp
+  end
 end

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -332,4 +332,10 @@ defmodule Teiserver.Support.Tachyon do
     {:ok, resp} = recv_message(client)
     resp
   end
+
+  def create_party!(client) do
+    :ok = send_request(client, "party/create")
+    {:ok, resp} = recv_message(client)
+    resp
+  end
 end

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -17,8 +17,6 @@ defmodule Teiserver.Support.Tachyon do
   def setup_client() do
     user = create_user()
     %{client: client, token: token} = connect(user)
-
-    ExUnit.Callbacks.on_exit(fn -> cleanup_connection(client, token) end)
     {:ok, user: user, client: client, token: token}
   end
 

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -348,4 +348,10 @@ defmodule Teiserver.Support.Tachyon do
     {:ok, resp} = recv_message(client)
     resp
   end
+
+  def accept_party_invite!(client, party_id) do
+    :ok = send_request(client, "party/acceptInvite", %{partyId: party_id})
+    {:ok, resp} = recv_message(client)
+    resp
+  end
 end

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -366,4 +366,10 @@ defmodule Teiserver.Support.Tachyon do
     {:ok, resp} = recv_message(client)
     resp
   end
+
+  def kick_player_from_party!(client, target_id) do
+    :ok = send_request(client, "party/kickMember", %{userId: to_string(target_id)})
+    {:ok, resp} = recv_message(client)
+    resp
+  end
 end

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -342,4 +342,10 @@ defmodule Teiserver.Support.Tachyon do
     {:ok, resp} = recv_message(client)
     resp
   end
+
+  def invite_to_party!(client, user_id) do
+    :ok = send_request(client, "party/invite", %{userId: to_string(user_id)})
+    {:ok, resp} = recv_message(client)
+    resp
+  end
 end

--- a/test/teiserver/party/party_test.exs
+++ b/test/teiserver/party/party_test.exs
@@ -7,7 +7,7 @@ defmodule Teiserver.Party.PartyTest do
   alias Teiserver.Support.Polling
 
   test "create party" do
-    assert {:ok, party_id} = Party.create_party()
+    assert {:ok, party_id} = Party.create_party(123)
     Polling.poll_until_some(fn -> Party.lookup(party_id) end)
   end
 end

--- a/test/teiserver/party/party_test.exs
+++ b/test/teiserver/party/party_test.exs
@@ -1,0 +1,13 @@
+defmodule Teiserver.Party.PartyTest do
+  use Teiserver.DataCase
+
+  @moduletag :tachyon
+
+  alias Teiserver.Party
+  alias Teiserver.Support.Polling
+
+  test "create party" do
+    assert {party_id, {:ok, _pid}} = Party.create_party()
+    Polling.poll_until_some(fn -> Party.lookup(party_id) end)
+  end
+end

--- a/test/teiserver/party/party_test.exs
+++ b/test/teiserver/party/party_test.exs
@@ -7,6 +7,7 @@ defmodule Teiserver.Party.PartyTest do
   alias Teiserver.Support.Polling
 
   test "create party" do
+    {:ok, _} = Horde.Registry.register(Teiserver.Player.SessionRegistry, 123, nil)
     assert {:ok, party_id} = Party.create_party(123)
     Polling.poll_until_some(fn -> Party.lookup(party_id) end)
   end

--- a/test/teiserver/party/party_test.exs
+++ b/test/teiserver/party/party_test.exs
@@ -7,7 +7,7 @@ defmodule Teiserver.Party.PartyTest do
   alias Teiserver.Support.Polling
 
   test "create party" do
-    assert {party_id, {:ok, _pid}} = Party.create_party()
+    assert {:ok, party_id} = Party.create_party()
     Polling.poll_until_some(fn -> Party.lookup(party_id) end)
   end
 end

--- a/test/teiserver_web/tachyon/party_test.exs
+++ b/test/teiserver_web/tachyon/party_test.exs
@@ -1,0 +1,19 @@
+defmodule TeiserverWeb.Tachyon.PartyTest do
+  use TeiserverWeb.ConnCase, async: false
+  alias Teiserver.Support.Tachyon
+
+  describe "create" do
+    setup [{Tachyon, :setup_client}]
+
+    test "works", %{client: client} do
+      assert %{"status" => "success"} = Tachyon.create_party!(client)
+    end
+
+    test "cannot join 2 parties", %{client: client} do
+      assert %{"status" => "success"} = Tachyon.create_party!(client)
+
+      assert %{"status" => "failed", "reason" => "invalid_request"} =
+               Tachyon.create_party!(client)
+    end
+  end
+end

--- a/test/teiserver_web/tachyon/party_test.exs
+++ b/test/teiserver_web/tachyon/party_test.exs
@@ -91,6 +91,75 @@ defmodule TeiserverWeb.Tachyon.PartyTest do
       expected = MapSet.new([to_string(ctx2.user.id), to_string(ctx3.user.id)])
       assert invited == expected
     end
+
+    test "must be invited to accept", ctx do
+      ctx2 = setup_client()
+
+      assert %{"status" => "failed", "reason" => "invalid_request"} =
+               Tachyon.accept_party_invite!(ctx2.client, "not-a-party-id")
+
+      assert %{"status" => "failed", "reason" => "invalid_request"} =
+               Tachyon.accept_party_invite!(ctx2.client, ctx.party_id)
+    end
+
+    test "accept invite works", ctx do
+      ctx2 = setup_client()
+      assert %{"status" => "success"} = Tachyon.invite_to_party!(ctx.client, ctx2.user.id)
+
+      assert %{"commandId" => "party/invited", "data" => %{"party" => %{"id" => party_id}}} =
+               Tachyon.recv_message!(ctx2.client)
+
+      assert %{"commandId" => "party/updated"} = Tachyon.recv_message!(ctx.client)
+
+      assert %{"status" => "success"} = Tachyon.accept_party_invite!(ctx2.client, party_id)
+      assert %{"commandId" => "party/updated", "data" => data} = Tachyon.recv_message!(ctx.client)
+
+      assert %{"commandId" => "party/updated", "data" => data2} =
+               Tachyon.recv_message!(ctx2.client)
+
+      assert data["id"] == party_id
+      members = Enum.map(data["members"], fn m -> m["userId"] end) |> MapSet.new()
+      assert members == MapSet.new([to_string(ctx.user.id), to_string(ctx2.user.id)])
+      assert data["invited"] == []
+
+      assert data == data2
+    end
+
+    test "cannot accept invite twice", ctx do
+      ctx2 = setup_client()
+      party_id = invite_and_accept([ctx.client], ctx2.client, ctx2.user.id)
+
+      assert %{"status" => "failed", "reason" => "invalid_request"} =
+               Tachyon.accept_party_invite!(ctx.client, party_id)
+    end
+
+    test "accepting invite doesn't revoke other invites", ctx do
+      ctx2 = setup_client()
+      target = setup_client()
+
+      assert %{"status" => "success", "data" => %{"partyId" => party2_id}} =
+               Tachyon.create_party!(ctx2.client)
+
+      # invite `target` to both parties
+      assert %{"status" => "success"} = Tachyon.invite_to_party!(ctx.client, target.user.id)
+      assert %{"status" => "success"} = Tachyon.invite_to_party!(ctx2.client, target.user.id)
+
+      assert %{"commandId" => "party/invited"} = Tachyon.recv_message!(target.client)
+      assert %{"commandId" => "party/invited"} = Tachyon.recv_message!(target.client)
+      assert %{"commandId" => "party/updated"} = Tachyon.recv_message!(ctx.client)
+      assert %{"commandId" => "party/updated"} = Tachyon.recv_message!(ctx2.client)
+
+      # accept one invite
+      Tachyon.accept_party_invite!(target.client, ctx.party_id)
+      assert %{"commandId" => "party/updated"} = Tachyon.recv_message!(target.client)
+      assert %{"status" => "success"} = Tachyon.leave_party!(target.client)
+
+      # can still accept the other invite
+      Tachyon.accept_party_invite!(target.client, party2_id)
+
+      assert %{"commandId" => "party/updated", "data" => %{"id" => ^party2_id}} =
+               Tachyon.recv_message!(target.client)
+    end
   end
 
   describe "self event" do
@@ -141,5 +210,26 @@ defmodule TeiserverWeb.Tachyon.PartyTest do
   defp setup_client() do
     {:ok, args} = Tachyon.setup_client()
     Map.new(args)
+  end
+
+  # convenient function to have a player invited to a party, it assumes
+  # everything works fine.
+  defp invite_and_accept([client | _] = in_party, client_to_invite, user_id) do
+    assert %{"status" => "success"} = Tachyon.invite_to_party!(client, user_id)
+
+    assert %{"commandId" => "party/invited", "data" => %{"party" => %{"id" => party_id}}} =
+             Tachyon.recv_message!(client_to_invite)
+
+    for c <- in_party do
+      assert %{"commandId" => "party/updated"} = Tachyon.recv_message!(c)
+    end
+
+    assert %{"status" => "success"} = Tachyon.accept_party_invite!(client_to_invite, party_id)
+
+    for c <- [client_to_invite | in_party] do
+      assert %{"commandId" => "party/updated"} = Tachyon.recv_message!(c)
+    end
+
+    party_id
   end
 end

--- a/test/teiserver_web/tachyon/party_test.exs
+++ b/test/teiserver_web/tachyon/party_test.exs
@@ -224,6 +224,18 @@ defmodule TeiserverWeb.Tachyon.PartyTest do
       assert %{"commandId" => "party/updated", "data" => data} = Tachyon.recv_message!(ctx.client)
       assert data["invited"] == []
     end
+
+    test "max size enforced", ctx do
+      Teiserver.Party.update_max_size(2)
+      ok_client = setup_client()
+      assert %{"status" => "success"} = Tachyon.invite_to_party!(ctx.client, ok_client.user.id)
+      assert %{"commandId" => "party/updated"} = Tachyon.recv_message!(ctx.client)
+
+      at_capacity_ctx = setup_client()
+
+      assert %{"status" => "failed", "reason" => "invalid_request"} =
+               Tachyon.invite_to_party!(ctx.client, at_capacity_ctx.user.id)
+    end
   end
 
   describe "kick player" do

--- a/test/teiserver_web/tachyon/party_test.exs
+++ b/test/teiserver_web/tachyon/party_test.exs
@@ -16,4 +16,27 @@ defmodule TeiserverWeb.Tachyon.PartyTest do
                Tachyon.create_party!(client)
     end
   end
+
+  describe "self event" do
+    test "has the correct data" do
+      user = Tachyon.create_user()
+      %{client: client} = Tachyon.connect(user, swallow_first_event: false)
+      %{"commandId" => "user/self", "data" => %{"user" => event}} = Tachyon.recv_message!(client)
+      assert %{"party" => nil} = event
+    end
+
+    test "works after reconnection" do
+      user = Tachyon.create_user()
+      %{client: client} = Tachyon.connect(user)
+
+      assert %{"status" => "success", "data" => %{"partyId" => party_id}} =
+               Tachyon.create_party!(client)
+
+      Tachyon.abrupt_disconnect!(client)
+      %{client: client} = Tachyon.connect(user, swallow_first_event: false)
+
+      %{"commandId" => "user/self", "data" => %{"user" => event}} = Tachyon.recv_message!(client)
+      assert %{"party" => %{"id" => ^party_id}} = event
+    end
+  end
 end

--- a/test/teiserver_web/tachyon/party_test.exs
+++ b/test/teiserver_web/tachyon/party_test.exs
@@ -32,6 +32,67 @@ defmodule TeiserverWeb.Tachyon.PartyTest do
     end
   end
 
+  describe "invite lifecycle" do
+    setup [{Tachyon, :setup_client}, :setup_party]
+
+    test "must be valid player", ctx do
+      assert %{"status" => "failed", "reason" => "invalid_request"} =
+               Tachyon.invite_to_party!(ctx.client, "not-a-user-id")
+    end
+
+    test "must be online", ctx do
+      user2 = Tachyon.create_user()
+
+      assert %{"status" => "failed", "reason" => "invalid_request"} =
+               Tachyon.invite_to_party!(ctx.client, user2.id)
+    end
+
+    test "must be in party", ctx do
+      %{client: client} = setup_client()
+
+      assert %{"status" => "failed", "reason" => "invalid_request"} =
+               Tachyon.invite_to_party!(client, ctx.user.id)
+    end
+
+    test "cannot invite twice", ctx do
+      %{user: user2} = setup_client()
+      assert %{"status" => "success"} = Tachyon.invite_to_party!(ctx.client, user2.id)
+      assert %{"commandId" => "party/updated"} = Tachyon.recv_message!(ctx.client)
+
+      assert %{"status" => "failed", "reason" => "invalid_request"} =
+               Tachyon.invite_to_party!(ctx.client, user2.id)
+    end
+
+    test "works", %{party_id: party_id} = ctx do
+      ctx2 = setup_client()
+
+      assert %{"status" => "success"} = Tachyon.invite_to_party!(ctx.client, ctx2.user.id)
+
+      assert %{"commandId" => "party/invited", "data" => %{"party" => data}} =
+               Tachyon.recv_message!(ctx2.client)
+
+      assert %{"id" => ^party_id, "members" => [m1]} = data
+      assert m1["userId"] == to_string(ctx.user.id)
+
+      assert %{"commandId" => "party/updated", "data" => ^data} =
+               Tachyon.recv_message!(ctx.client)
+
+      # make sure updates are also sent to other invited ppl
+      ctx3 = setup_client()
+      assert %{"status" => "success"} = Tachyon.invite_to_party!(ctx.client, ctx3.user.id)
+
+      assert %{"commandId" => "party/updated", "data" => data2} =
+               Tachyon.recv_message!(ctx.client)
+
+      assert %{"commandId" => "party/updated", "data" => ^data2} =
+               Tachyon.recv_message!(ctx2.client)
+
+      invited = Enum.map(data2["invited"], fn i -> i["userId"] end) |> MapSet.new()
+      expected = MapSet.new([to_string(ctx2.user.id), to_string(ctx3.user.id)])
+      assert invited == expected
+    end
+  end
+
   describe "self event" do
     test "has the correct data" do
       user = Tachyon.create_user()
@@ -62,5 +123,10 @@ defmodule TeiserverWeb.Tachyon.PartyTest do
              Tachyon.create_party!(client)
 
     {:ok, party_id: party_id}
+  end
+
+  defp setup_client() do
+    {:ok, args} = Tachyon.setup_client()
+    Map.new(args)
   end
 end


### PR DESCRIPTION
Most of the party features. Missing: joining matchmaking queues as a party (hard) and messaging (easy). These can be tackled independently later on.

It's a bit of a massive change, reviewing commit per commit should help, the accept/decline/cancel invite is all very similar to each others.
There are minor changes to the tachyon specs going along this change at https://github.com/beyond-all-reason/tachyon/pull/55 but since schema are vendored merging this doesn't depend on the tachyon repo.

One thing not handled is that invited players don't get notified when the last member of the party leaves.
I'd rather wait for https://github.com/beyond-all-reason/teiserver/pull/643 to be merged since it require setting up some monitor of the session to also handle the case when the party process disappears. And I'll take this opportunity to refactor a bit how sessions handle monitors since it's getting a bit out of hand.