### PR TITLE
Fix leaderboard activity for previous seasons

### DIFF
--- a/lib/teiserver/account.ex
+++ b/lib/teiserver/account.ex
@@ -6,7 +6,7 @@ defmodule Teiserver.Account do
   alias Teiserver.Data.Types, as: T
   alias Phoenix.PubSub
   alias Teiserver.Helper.QueryHelpers
-  alias Teiserver.Config
+  alias Teiserver.Game.MatchRatingLib
   alias Teiserver.Account.UserLib
 
   @type t :: UserLib.t()
@@ -932,7 +932,7 @@ defmodule Teiserver.Account do
 
   def get_rating(user_id, rating_type_id)
       when is_integer(user_id) and is_integer(rating_type_id) do
-    get_rating(user_id, rating_type_id, Config.get_site_config_cache("rating.Season"))
+    get_rating(user_id, rating_type_id, MatchRatingLib.active_season())
   end
 
   def get_rating(user_id, rating_type_id, season)
@@ -952,7 +952,7 @@ defmodule Teiserver.Account do
 
   @spec get_player_highest_leaderboard_rating(T.userid()) :: number()
   def get_player_highest_leaderboard_rating(user_id) do
-    get_player_highest_leaderboard_rating(user_id, Config.get_site_config_cache("rating.Season"))
+    get_player_highest_leaderboard_rating(user_id, MatchRatingLib.active_season())
   end
 
   @spec get_player_highest_leaderboard_rating(T.userid(), integer()) :: number()

--- a/lib/teiserver/account/libs/rating_lib.ex
+++ b/lib/teiserver/account/libs/rating_lib.ex
@@ -108,6 +108,16 @@ defmodule Teiserver.Account.RatingLib do
       order_by: [asc: ratings.uncertainty]
   end
 
+  def order_by(query, "Last updated new to old") do
+    from ratings in query,
+      order_by: [desc: ratings.last_updated]
+  end
+
+  def order_by(query, "Last updated old to new") do
+    from ratings in query,
+      order_by: [asc: ratings.last_updated]
+  end
+
   @spec preload(Ecto.Query.t(), List.t() | nil) :: Ecto.Query.t()
   def preload(query, nil), do: query
 

--- a/lib/teiserver_web/controllers/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/admin/user_controller.ex
@@ -536,7 +536,7 @@ defmodule TeiserverWeb.Admin.UserController do
                     uncertainty: new_uncertainty,
                     leaderboard_rating: new_leaderboard_rating,
                     last_updated: Timex.now(),
-                    season: active_season()
+                    season: MatchRatingLib.active_season()
                   })
 
                 existing ->
@@ -546,7 +546,7 @@ defmodule TeiserverWeb.Admin.UserController do
                     uncertainty: new_uncertainty,
                     leaderboard_rating: new_leaderboard_rating,
                     last_updated: Timex.now(),
-                    season: active_season()
+                    season: MatchRatingLib.active_season()
                   })
               end
 
@@ -555,7 +555,7 @@ defmodule TeiserverWeb.Admin.UserController do
               rating_type_id: rating_type_id,
               match_id: nil,
               inserted_at: Timex.now(),
-              season: active_season(),
+              season: MatchRatingLib.active_season(),
               value: %{
                 reason: "Manual adjustment",
                 rating_value: new_rating_value,
@@ -1128,9 +1128,5 @@ defmodule TeiserverWeb.Admin.UserController do
         |> put_flash(:danger, "Unable to access this user")
         |> redirect(to: ~p"/teiserver/admin/user")
     end
-  end
-
-  defp active_season() do
-    Teiserver.Config.get_site_config_cache("rating.Season")
   end
 end

--- a/lib/teiserver_web/controllers/api/public_controller.ex
+++ b/lib/teiserver_web/controllers/api/public_controller.ex
@@ -1,6 +1,7 @@
 defmodule TeiserverWeb.API.PublicController do
   use TeiserverWeb, :controller
   alias Teiserver.Account
+  alias Teiserver.Game.MatchRatingLib
 
   @rating_types [
     "Small Team",
@@ -11,52 +12,50 @@ defmodule TeiserverWeb.API.PublicController do
 
   @spec leaderboard(Plug.Conn.t(), map) :: Plug.Conn.t()
   def leaderboard(conn, %{"season" => season_param}) do
-    activity_time =
-      Timex.today()
-      |> Timex.shift(days: -35)
-      |> Timex.to_datetime()
-
     case Integer.parse(season_param) do
       {season, ""} ->
-        rating_type_lookup = Teiserver.Game.MatchRatingLib.rating_type_name_lookup()
+        active_season = MatchRatingLib.active_season()
 
-        ratings =
-          @rating_types
-          |> Enum.map(fn rating_type ->
-            {rating_type, rating_type_lookup[rating_type]}
-          end)
-          |> Enum.filter(fn {_, type_id} -> not is_nil(type_id) end)
-          |> Enum.map(fn {rating_type, type_id} ->
-            players =
+        cond do
+          season == active_season ->
+            activity_time =
+              Timex.today()
+              |> Timex.shift(days: -35)
+              |> Timex.to_datetime()
+
+            ratings = leaderboard_ratings(season, activity_time)
+
+            conn
+            |> put_status(200)
+            |> json(ratings)
+
+          season < active_season ->
+            # 35 days before last match of the season for older seasons
+            activity_time =
               Account.list_ratings(
                 search: [
-                  updated_after: activity_time,
-                  season: season,
-                  rating_type_id: type_id
+                  season: season
                 ],
-                order_by: "Leaderboard rating high to low",
-                preload: [:user],
-                limit: 100
+                order_by: "Last updated new to old",
+                limit: 1
               )
-              |> Enum.sort_by(&(-&1.leaderboard_rating))
-              |> Enum.take(100)
-              |> Enum.map(fn r ->
-                %{
-                  id: r.user_id,
-                  name: r.user.name,
-                  rating: r.leaderboard_rating
-                }
-              end)
+              |> List.first()
+              |> Map.get(:last_updated)
+              |> Timex.to_datetime()
+              |> Timex.shift(days: -35)
+              |> Timex.to_datetime()
 
-            %{
-              name: rating_type,
-              players: players
-            }
-          end)
+            ratings = leaderboard_ratings(season, activity_time)
 
-        conn
-        |> put_status(200)
-        |> json(ratings)
+            conn
+            |> put_status(200)
+            |> json(ratings)
+
+          true ->
+            conn
+            |> put_status(400)
+            |> json(%{error: "Invalid season parameter"})
+        end
 
       _ ->
         conn
@@ -67,7 +66,7 @@ defmodule TeiserverWeb.API.PublicController do
 
   @spec leaderboard(Plug.Conn.t(), map) :: Plug.Conn.t()
   def leaderboard(conn, _params) do
-    active_season = Teiserver.Config.get_site_config_cache("rating.Season")
+    active_season = MatchRatingLib.active_season()
 
     # For every active season from 1 to active_season create a map containing season and game type
     seasons =
@@ -81,5 +80,40 @@ defmodule TeiserverWeb.API.PublicController do
     conn
     |> put_status(200)
     |> json(seasons)
+  end
+
+  defp leaderboard_ratings(season, activity_time) do
+    rating_type_lookup = Teiserver.Game.MatchRatingLib.rating_type_name_lookup()
+
+    @rating_types
+    |> Enum.map(fn rating_type ->
+      {rating_type, rating_type_lookup[rating_type]}
+    end)
+    |> Enum.filter(fn {_, type_id} -> not is_nil(type_id) end)
+    |> Enum.map(fn {rating_type, type_id} ->
+      players =
+        Account.list_ratings(
+          search: [
+            updated_after: activity_time,
+            season: season,
+            rating_type_id: type_id
+          ],
+          order_by: "Leaderboard rating high to low",
+          preload: [:user],
+          limit: 100
+        )
+        |> Enum.map(fn r ->
+          %{
+            id: r.user_id,
+            name: r.user.name,
+            rating: r.leaderboard_rating
+          }
+        end)
+
+      %{
+        name: rating_type,
+        players: players
+      }
+    end)
   end
 end


### PR DESCRIPTION
Unfortunately I missed an important bug - leaderboards for previous seasons were stil using activity time relative to today and so after 35 days no matches would be shown. This PR fixes the bug by first finding the time of the newest rating in the older season and then calculating 35 days from that to use as the activity time. 