### PR TITLE
Restart tachyon system between sync tests

### DIFF
--- a/lib/teiserver/application.ex
+++ b/lib/teiserver/application.ex
@@ -164,7 +164,7 @@ defmodule Teiserver.Application do
 
         # this must be before Endpoint. Endpoint takes care of ws connection upgrade
         # and makes use of the tachyon systems spawned under this module.
-        tachyon_system(),
+        Teiserver.Tachyon.System,
 
         # Start the endpoint after the rest of the systems are up
         TeiserverWeb.Endpoint,
@@ -251,9 +251,5 @@ defmodule Teiserver.Application do
     )
 
     state
-  end
-
-  defp tachyon_system() do
-    if Mix.env() != :test, do: Teiserver.Tachyon.System, else: nil
   end
 end

--- a/lib/teiserver/matchmaking.ex
+++ b/lib/teiserver/matchmaking.ex
@@ -1,6 +1,7 @@
 defmodule Teiserver.Matchmaking do
   alias Teiserver.Matchmaking
   alias Teiserver.Data.Types, as: T
+  require Logger
 
   @type queue :: Matchmaking.QueueServer.queue()
   @type queue_id :: Matchmaking.QueueServer.id()
@@ -67,5 +68,15 @@ defmodule Teiserver.Matchmaking do
   matchmaking state, for example when a new asset (game/engine) is set
   It is a bit brutal but simple
   """
-  defdelegate restart_queues(), to: Matchmaking.QueueSupervisor
+  def restart_queues() do
+    Logger.info("Restarting all matchmaking queues")
+
+    :ok =
+      Supervisor.terminate_child(Matchmaking.System, Matchmaking.QueueSupervisor)
+
+    {:ok, _pid} =
+      Supervisor.restart_child(Matchmaking.System, Matchmaking.QueueSupervisor)
+
+    :ok
+  end
 end

--- a/lib/teiserver/matchmaking/queue_supervisor.ex
+++ b/lib/teiserver/matchmaking/queue_supervisor.ex
@@ -3,7 +3,6 @@ defmodule Teiserver.Matchmaking.QueueSupervisor do
   cluster wide supervisor for all matchmaking queues
   """
 
-  require Logger
   use Horde.DynamicSupervisor
   alias Teiserver.Matchmaking.QueueServer
   alias Teiserver.Asset
@@ -39,16 +38,6 @@ defmodule Teiserver.Matchmaking.QueueSupervisor do
         games: games
       })
     ]
-  end
-
-  def restart_queues() do
-    Logger.info("Restarting all matchmaking queues")
-
-    Horde.DynamicSupervisor.stop(__MODULE__, :shutdown)
-    :ok
-  catch
-    :exit, {:noproc, _} ->
-      :ok
   end
 
   def start_queue!(state) do

--- a/lib/teiserver/matchmaking/system.ex
+++ b/lib/teiserver/matchmaking/system.ex
@@ -16,15 +16,6 @@ defmodule Teiserver.Matchmaking.System do
       Teiserver.Matchmaking.QueueSupervisor
     ]
 
-    # there are some matchmaking tests interacting with assets that stop the
-    # QueueSupervisor. So when running tests with --repeat-until-failure xxx
-    # it will start restarting this supervisor as well if using the default
-    # restart parameter.
-    # Setting it to an absurd number ensure we keep the restart isolated
-    # Another way would be to restart the entire application supervisor for
-    # each test, but that's a lot bigger change, maybe another day.
-    restarts = if Mix.env() == :test, do: 10000, else: 3
-
-    Supervisor.init(children, strategy: :rest_for_one, max_restarts: restarts)
+    Supervisor.init(children, strategy: :rest_for_one)
   end
 end

--- a/test/support/server_case.ex
+++ b/test/support/server_case.ex
@@ -32,12 +32,9 @@ defmodule Teiserver.ServerCase do
     # all the tests that have side effects, this is a stopgap measure to avoid
     # more false failures.
     Teiserver.TeiserverTestLib.clear_all_con_caches()
+    Teiserver.Support.Tachyon.tachyon_case_setup(tags)
     Teiserver.DataCase.setup_sandbox(tags)
     Teiserver.Config.update_site_config("system.Use geoip", false)
-
-    unless tags[:async] do
-      ExUnit.Callbacks.start_supervised!(Teiserver.Tachyon.System)
-    end
 
     on_exit(&Teiserver.TeiserverTestLib.clear_all_con_caches/0)
     :ok

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -4,7 +4,8 @@ defmodule Teiserver.Support.Tachyon do
 
   def tachyon_case_setup(tags) do
     if String.contains?(to_string(tags[:module]), "Tachyon") || tags[:tachyon] do
-      ExUnit.Callbacks.start_supervised!(Teiserver.Tachyon.System)
+      :ok = Supervisor.terminate_child(Teiserver.Supervisor, Teiserver.Tachyon.System)
+      {:ok, _pid} = Supervisor.restart_child(Teiserver.Supervisor, Teiserver.Tachyon.System)
     end
   end
 

--- a/test/teiserver/asset/engine_test.exs
+++ b/test/teiserver/asset/engine_test.exs
@@ -1,8 +1,9 @@
 defmodule Teiserver.Asset.EngineTest do
-  use Teiserver.DataCase, async: true
+  use Teiserver.DataCase
   alias Teiserver.Asset
   alias Teiserver.AssetFixtures
 
+  @moduletag :tachyon
   describe "engine queries" do
     test "get" do
       AssetFixtures.create_engine(%{name: "engine1"})

--- a/test/teiserver/asset/game_test.exs
+++ b/test/teiserver/asset/game_test.exs
@@ -1,8 +1,9 @@
 defmodule Teiserver.Asset.GameTest do
-  use Teiserver.DataCase, async: true
+  use Teiserver.DataCase
   alias Teiserver.Asset
   alias Teiserver.AssetFixtures
 
+  @moduletag :tachyon
   describe "game queries" do
     test "get" do
       AssetFixtures.create_game(%{name: "game1"})


### PR DESCRIPTION
Instead of relying on different configuration of the app for test vs the rest, always start the same app, and restart the trees between tests. Ideally, we would restart then entire application tree, but last time I checked, there was some issues with the tcp servers.