### PR TITLE
Monitors

### DIFF
--- a/lib/teiserver/helpers/bimap.ex
+++ b/lib/teiserver/helpers/bimap.ex
@@ -1,0 +1,88 @@
+defmodule Teiserver.Helpers.Bimap do
+  @moduledoc """
+  A wrapper aroud a map where each value has 2 keys.
+  Ensure that both keys are kept in sync.
+  When storing another value and one of the key overlaps with an existing key,
+  it deletes the previous keys before storing the new value.
+
+  Typical usage: storing a reference from Process.monitor with some data
+  about what the reference is about.
+
+  bimap = Bimap.put(Bimap.new(), key1, key2, val)
+  Bimap.get(bimap, key1) == val
+  Bimap.get(bimap, key2) == val
+
+  Bimap.delete(key1) == Bimap.new()
+  Bimap.delete(key2) == Bimap.new()
+  """
+
+  @opaque t :: map()
+
+  def new(), do: Map.new()
+
+  def put(map, key1, key2, value) do
+    case {Map.has_key?(map, key1), Map.has_key?(map, key2)} do
+      {false, false} ->
+        map |> Map.put(key2, {:key2, key1}) |> Map.put(key1, {:val, key2, value})
+
+      {true, true} ->
+        map |> Map.put(key2, {:key2, key1}) |> Map.put(key1, {:val, key2, value})
+
+      {false, true} ->
+        case Map.get(map, key2) do
+          {:val, k2, _} ->
+            map
+            |> Map.delete(k2)
+            |> Map.put(key2, {:key2, key1})
+            |> Map.put(key1, {:val, key2, value})
+
+          {:key2, k1} ->
+            map
+            |> Map.delete(k1)
+            |> Map.put(key2, {:key2, key1})
+            |> Map.put(key1, {:val, key2, value})
+        end
+
+      {true, false} ->
+        case Map.get(map, key1) do
+          {:val, k2, _} ->
+            map
+            |> Map.delete(k2)
+            |> Map.put(key2, {:key2, key1})
+            |> Map.put(key1, {:val, key2, value})
+
+          {:key2, k1} ->
+            map
+            |> Map.delete(k1)
+            |> Map.put(key2, {:key2, key1})
+            |> Map.put(key1, {:val, key2, value})
+        end
+    end
+  end
+
+  def get(map, key) do
+    case Map.get(map, key) do
+      nil -> nil
+      {:val, _, val} -> val
+      {:key2, k} -> get(map, k)
+    end
+  end
+
+  def get_other_key(map, key) do
+    case Map.get(map, key) do
+      nil -> nil
+      {:val, k, _val} -> k
+      {:key2, k} -> k
+    end
+  end
+
+  def delete(map, key) do
+    case Map.get(map, key) do
+      nil -> map
+      {:val, k, _v} -> Map.delete(map, k) |> Map.delete(key)
+      {:key2, key1} -> Map.delete(map, key1) |> Map.delete(key)
+    end
+  end
+
+  defdelegate has_key?(map, key), to: Map
+end

--- a/lib/teiserver/helpers/monitor_collection.ex
+++ b/lib/teiserver/helpers/monitor_collection.ex
@@ -1,0 +1,64 @@
+defmodule Teiserver.Helpers.MonitorCollection do
+  @moduledoc """
+  An opaque collection of monitor references with keys attached to them
+  """
+
+  alias Teiserver.Helpers.Bimap
+
+  @opaque t :: Bimap.t()
+
+  @spec new() :: t()
+  def new(), do: Bimap.new()
+
+  @doc """
+  Start monitoring the given pid from the calling process. Same as
+  `Process.Monitor`.
+  Store the returned reference with the given value and return the updated
+  collection
+  """
+  @spec monitor(t(), pid(), term()) :: t()
+  def monitor(mc, pid, val) do
+    ref = Process.monitor(pid)
+    Bimap.put(mc, ref, val, nil)
+  end
+
+  @doc """
+  Similar to `Process.demonitor` but uses the value associated with the reference.
+  Has no effect if there is no reference for the given value, otherwise
+  removes the ref and the value from the collection
+  """
+  @spec demonitor_by_val(t(), term(), options :: [:flush | :info]) :: t()
+  def demonitor_by_val(mc, val, opts \\ []) do
+    case Bimap.get_other_key(mc, val) do
+      nil ->
+        mc
+
+      ref ->
+        Process.demonitor(ref, opts)
+        Bimap.delete(mc, ref)
+    end
+  end
+
+  @doc """
+  Return the stored reference for the given value
+  """
+  @spec get_ref(t(), term()) :: reference() | nil
+  def get_ref(mc, v), do: Bimap.get_other_key(mc, v)
+
+  @doc """
+  Return the stored reference for the given reference
+  """
+  @spec get_val(t(), reference()) :: term()
+  def get_val(mc, r), do: Bimap.get_other_key(mc, r)
+
+  @doc """
+  update the value without touching the associated reference. Raises if
+  `old_val` is not in the collection
+  """
+  def replace_val!(mc, old_val, new_val) do
+    case Bimap.get_other_key(mc, old_val) do
+      nil -> raise "key to replace not found"
+      ref -> Bimap.put(mc, ref, new_val, nil)
+    end
+  end
+end

--- a/lib/teiserver/party.ex
+++ b/lib/teiserver/party.ex
@@ -15,13 +15,13 @@ defmodule Teiserver.Party do
   @type id :: Party.Server.id()
   @type state :: Party.Server.state()
 
-  @spec create_party(T.userid()) :: {:ok, id()} | {:error, reason :: term()}
+  @spec create_party(T.userid()) :: {:ok, id(), pid()} | {:error, reason :: term()}
   def create_party(user_id) do
     party_id = Party.Server.gen_party_id()
 
     case Party.Supervisor.start_party(party_id, user_id) do
-      {:ok, _pid} -> {:ok, party_id}
-      {:ok, _pid, _info} -> {:ok, party_id}
+      {:ok, pid} -> {:ok, party_id, pid}
+      {:ok, pid, _info} -> {:ok, party_id, pid}
       :ignore -> {:error, :ignore}
       {:error, reason} -> {:error, reason}
     end

--- a/lib/teiserver/party/server.ex
+++ b/lib/teiserver/party/server.ex
@@ -6,6 +6,7 @@ defmodule Teiserver.Party.Server do
   alias Teiserver.Party
   alias Teiserver.Player
   alias Teiserver.Data.Types, as: T
+  alias Teiserver.Helpers.MonitorCollection, as: MC
 
   use GenServer, restart: :transient
   alias Teiserver.Data.Types, as: T
@@ -16,12 +17,12 @@ defmodule Teiserver.Party.Server do
           version: integer(),
           id: id(),
           pid: pid(),
-          members: [%{id: T.userid(), joined_at: DateTime.t(), mon_ref: reference()}],
+          monitors: MC.t(),
+          members: [%{id: T.userid(), joined_at: DateTime.t()}],
           invited: [
             %{
               id: T.userid(),
               invited_at: DateTime.t(),
-              mon_ref: reference(),
               valid_until: DateTime.t(),
               timeout_ref: :timer.tref()
             }
@@ -114,13 +115,16 @@ defmodule Teiserver.Party.Server do
 
   @impl true
   def init({party_id, user_id}) do
-    state = %{
-      version: 0,
-      id: party_id,
-      pid: self(),
-      members: add_member([], user_id),
-      invited: []
-    }
+    state =
+      %{
+        version: 0,
+        id: party_id,
+        pid: self(),
+        monitors: MC.new(),
+        members: [],
+        invited: []
+      }
+      |> add_member(user_id)
 
     {:ok, state}
   end
@@ -157,12 +161,9 @@ defmodule Teiserver.Party.Server do
         valid_until = DateTime.add(DateTime.utc_now(), valid_duration, :second)
         tref = :timer.send_after(valid_duration * 1000, {:invite_timeout, user_id})
 
-        monitor = Player.monitor_session(user_id)
-
         invite = %{
           id: user_id,
           invited_at: DateTime.utc_now(),
-          mon_ref: monitor,
           valid_until: valid_until,
           timeout_ref: tref
         }
@@ -170,6 +171,9 @@ defmodule Teiserver.Party.Server do
         new_state =
           state
           |> Map.put(:invited, [invite | state.invited])
+          |> Map.update!(:monitors, fn m ->
+            Player.add_session_monitor(m, user_id, {:invite, user_id})
+          end)
           |> bump()
 
         # don't send the updated event to the newly invited player
@@ -186,12 +190,12 @@ defmodule Teiserver.Party.Server do
       {[], _} ->
         {:reply, {:error, :not_invited}, state}
 
-      {[invited], rest} ->
+      {[_invited], rest} ->
         state =
           state
           |> bump()
           |> Map.put(:invited, rest)
-          |> Map.update!(:members, &add_member(&1, user_id, invited.mon_ref))
+          |> add_member(user_id)
 
         notify_updated(state)
         {:reply, {:ok, state}, state}
@@ -204,11 +208,13 @@ defmodule Teiserver.Party.Server do
         {:reply, {:error, :not_invited}, state}
 
       {[invited], rest} ->
-        Process.demonitor(invited.mon_ref)
         :timer.cancel(invited.timeout_ref)
 
         state =
           state
+          |> Map.update!(:monitors, fn mc ->
+            MC.demonitor_by_val(mc, {:invite, user_id})
+          end)
           |> bump()
           |> Map.put(:invited, rest)
 
@@ -240,9 +246,13 @@ defmodule Teiserver.Party.Server do
       {_, {[], _}} ->
         {:reply, {:error, :invalid_target}, state}
 
-      {true, {[member], rest}} ->
-        Process.demonitor(member.mon_ref)
-        state = state |> bump() |> Map.put(:members, rest)
+      {true, {[_member], rest}} ->
+        state =
+          state
+          |> bump()
+          |> Map.update!(:monitors, &MC.demonitor_by_val(&1, {:member, target_id}))
+          |> Map.put(:members, rest)
+
         Player.party_notify_removed(target_id, state)
         notify_updated(state)
         {:reply, {:ok, state}, state}
@@ -251,21 +261,25 @@ defmodule Teiserver.Party.Server do
 
   @impl true
   def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
-    in_members = Enum.split_with(state.members, &(&1.mon_ref == ref))
-    in_invited = Enum.split_with(state.invited, &(&1.mon_ref == ref))
+    val = MC.get_val(state.monitors, ref)
+    state = Map.update!(state, :monitors, &MC.demonitor_by_val(&1, val))
 
     state =
-      case {in_members, in_invited} do
-        {{[_], rest}, _} ->
-          Map.put(state, :members, rest)
-          |> notify_updated()
-
-        {_, {[_], rest}} ->
-          Map.put(state, :invited, rest)
-          |> notify_updated()
-
-        _ ->
+      case val do
+        nil ->
           state
+
+        {:invite, user_id} ->
+          Map.update!(state, :invited, fn invites ->
+            Enum.filter(invites, fn i -> i.id != user_id end)
+          end)
+          |> notify_updated()
+
+        {:member, user_id} ->
+          Map.update!(state, :members, fn members ->
+            Enum.filter(members, fn m -> m.id != user_id end)
+          end)
+          |> notify_updated()
       end
 
     {:noreply, state}
@@ -296,20 +310,35 @@ defmodule Teiserver.Party.Server do
 
   defp bump(state), do: Map.update!(state, :version, &(&1 + 1))
 
-  defp add_member(members, user_id) do
-    monitor = Player.monitor_session(user_id)
-    if monitor == nil, do: raise("member not connected")
-    add_member(members, user_id, monitor)
-  end
+  defp add_member(state, user_id) do
+    state =
+      state
+      |> Map.update!(:members, fn members ->
+        [%{id: user_id, joined_at: DateTime.utc_now()} | members]
+      end)
 
-  defp add_member(members, user_id, monitor) do
-    [%{id: user_id, joined_at: DateTime.utc_now(), mon_ref: monitor} | members]
+    case MC.get_ref(state.monitors, {:invite, user_id}) do
+      nil ->
+        Map.update!(state, :monitors, fn mc ->
+          Player.add_session_monitor(mc, user_id, {:member, user_id})
+        end)
+
+      _ref ->
+        Map.update!(state, :monitors, fn mc ->
+          MC.replace_val!(mc, {:invite, user_id}, {:member, user_id})
+        end)
+    end
   end
 
   defp cancel_invite_internal(invite, other_invites, state) do
-    Process.demonitor(invite.mon_ref)
     :timer.cancel(invite.timeout_ref)
-    state = state |> bump() |> Map.put(:invited, other_invites)
+
+    state =
+      state
+      |> bump()
+      |> Map.put(:invited, other_invites)
+      |> Map.update!(:monitors, &MC.demonitor_by_val(&1, {:invite, invite.id}))
+
     Player.party_notify_removed(invite.id, state)
     notify_updated(state)
     state

--- a/lib/teiserver/party/server.ex
+++ b/lib/teiserver/party/server.ex
@@ -15,6 +15,7 @@ defmodule Teiserver.Party.Server do
           # versionning of the state to avoid races between call and cast
           version: integer(),
           id: id(),
+          pid: pid(),
           members: [%{id: T.userid(), joined_at: DateTime.t(), mon_ref: reference()}],
           invited: [
             %{
@@ -116,6 +117,7 @@ defmodule Teiserver.Party.Server do
     state = %{
       version: 0,
       id: party_id,
+      pid: self(),
       members: add_member([], user_id),
       invited: []
     }

--- a/lib/teiserver/player.ex
+++ b/lib/teiserver/player.ex
@@ -11,6 +11,7 @@ defmodule Teiserver.Player do
 
   alias Teiserver.Data.Types, as: T
   alias Teiserver.{Player, Matchmaking, Party}
+  alias Teiserver.Helpers.MonitorCollection, as: MC
 
   @doc """
   Returns the pid of the session registered with a given user id
@@ -39,6 +40,14 @@ defmodule Teiserver.Player do
     else
       Process.monitor(pid)
     end
+  end
+
+  @doc """
+  Same as `monitor_session` but meant to be used with a `Teiserver.Helpers.MonitorCollection`
+  """
+  def add_session_monitor(monitors, user_id, key) do
+    pid = lookup_session(user_id)
+    MC.monitor(monitors, pid, key)
   end
 
   @spec conn_state(T.userid()) :: Player.Session.conn_state()

--- a/test/teiserver/helpers/bimap_test.exs
+++ b/test/teiserver/helpers/bimap_test.exs
@@ -1,0 +1,81 @@
+defmodule Teiserver.Helper.BimapTest do
+  use ExUnit.Case, async: true
+
+  alias Teiserver.Helpers.Bimap
+
+  test "store a value with 2 keys" do
+    m = Bimap.new() |> Bimap.put(1, :key, :value)
+    assert Bimap.get(m, :key) == :value
+    assert Bimap.get(m, 1) == :value
+  end
+
+  test "handle two identical keys" do
+    m = Bimap.new() |> Bimap.put(1, 1, :value)
+    assert Bimap.get(m, 1) == :value
+    assert Bimap.delete(m, 1) == Bimap.new()
+  end
+
+  test "store several distinct values" do
+    m = Bimap.new() |> Bimap.put(1, :key1, :value1) |> Bimap.put(2, :key2, :value2)
+    assert Bimap.get(m, :key1) == :value1
+    assert Bimap.get(m, 1) == :value1
+    assert Bimap.get(m, :key2) == :value2
+    assert Bimap.get(m, 2) == :value2
+  end
+
+  test "storing a value with key1 overlap" do
+    m = Bimap.new() |> Bimap.put(1, :key1, :value1) |> Bimap.put(1, :key2, :value2)
+    assert Bimap.get(m, 1) == :value2
+    assert Bimap.get(m, :key2) == :value2
+    assert Bimap.get(m, :key1) == nil
+  end
+
+  test "storing a value with key2 overlap" do
+    m = Bimap.new() |> Bimap.put(1, :key1, :value1) |> Bimap.put(2, :key1, :value2)
+    assert Bimap.get(m, 1) == nil
+    assert Bimap.get(m, 2) == :value2
+    assert Bimap.get(m, :key1) == :value2
+  end
+
+  test "store nil with key1 overlap" do
+    m = Bimap.new() |> Bimap.put(1, :key1, :value1) |> Bimap.put(1, :key2, nil)
+    assert Bimap.has_key?(m, :key1) == false
+    assert Bimap.get(m, 1) == nil
+    assert Bimap.get(m, :key2) == nil
+    assert Bimap.has_key?(m, 1) == true
+    assert Bimap.has_key?(m, :key2) == true
+  end
+
+  test "store nil with key2 overlap" do
+    m = Bimap.new() |> Bimap.put(1, :key1, :value1) |> Bimap.put(2, :key1, nil)
+    assert Bimap.has_key?(m, 1) == false
+    assert Bimap.get(m, 2) == nil
+    assert Bimap.get(m, :key1) == nil
+    assert Bimap.has_key?(m, 2) == true
+    assert Bimap.has_key?(m, :key1) == true
+  end
+
+  test "overwrite value" do
+    m = Bimap.new() |> Bimap.put(1, :key1, :value1) |> Bimap.put(1, :key1, :value2)
+    assert Bimap.get(m, 1) == :value2
+    assert Bimap.get(m, :key1) == :value2
+  end
+
+  test "overwrite value, the other way around" do
+    m = Bimap.new() |> Bimap.put(1, :key1, :value1) |> Bimap.put(:key1, 1, :value2)
+    assert Bimap.get(m, 1) == :value2
+    assert Bimap.get(m, :key1) == :value2
+  end
+
+  test "get value and sibling key" do
+    m = Bimap.new() |> Bimap.put(1, :key1, :value)
+    assert Bimap.get_other_key(m, 1) == :key1
+    assert Bimap.get_other_key(m, :key1) == 1
+  end
+
+  test "delete both keys" do
+    m = Bimap.new() |> Bimap.put(1, :key1, :value1)
+    assert Bimap.delete(m, 1) == Bimap.new()
+    assert Bimap.delete(m, :key1) == Bimap.new()
+  end
+end

--- a/test/teiserver/helpers/monitor_collection_test.exs
+++ b/test/teiserver/helpers/monitor_collection_test.exs
@@ -1,0 +1,56 @@
+defmodule Teiserver.Helper.MonitorCollectionTest do
+  use ExUnit.Case, async: true
+
+  defmodule GenServerTest do
+    use GenServer
+
+    def start_link(arg), do: GenServer.start_link(__MODULE__, arg)
+
+    @impl true
+    def init(_args), do: {:ok, nil}
+
+    @impl true
+    def handle_call(:stop, _from, state), do: {:stop, :normal, :stopped, state}
+  end
+
+  alias Teiserver.Helpers.MonitorCollection, as: MC
+  import ExUnit.Callbacks, only: [start_supervised!: 1]
+
+  test "can monitor a single process" do
+    pid = start_supervised!(GenServerTest)
+    mc = MC.new() |> MC.monitor(pid, :val)
+
+    GenServer.call(pid, :stop)
+    assert_receive {:DOWN, ref, :process, _, _}, 10
+
+    assert MC.get_val(mc, ref) == :val
+    assert MC.get_ref(mc, :val) == ref
+  end
+
+  test "can demonitor by val" do
+    pid = start_supervised!(GenServerTest)
+    mc = MC.new() |> MC.monitor(pid, :val) |> MC.demonitor_by_val(:val)
+    assert MC.get_ref(mc, :val) == nil
+
+    GenServer.call(pid, :stop)
+
+    refute_receive {:DOWN, _, :process, _, _}, 10
+  end
+
+  test "can update value without losing ref" do
+    pid = start_supervised!(GenServerTest)
+
+    mc =
+      MC.new()
+      |> MC.monitor(pid, :val)
+      |> MC.replace_val!(:val, :newval)
+
+    assert MC.get_ref(mc, :val) == nil
+    assert is_reference(MC.get_ref(mc, :newval))
+
+    MC.demonitor_by_val(mc, :newval)
+    GenServer.call(pid, :stop)
+
+    refute_receive {:DOWN, _, :process, _, _}, 10
+  end
+end

--- a/test/teiserver/party/party_test.exs
+++ b/test/teiserver/party/party_test.exs
@@ -8,7 +8,7 @@ defmodule Teiserver.Party.PartyTest do
 
   test "create party" do
     {:ok, _} = Horde.Registry.register(Teiserver.Player.SessionRegistry, 123, nil)
-    assert {:ok, party_id} = Party.create_party(123)
+    assert {:ok, party_id, _pid} = Party.create_party(123)
     Polling.poll_until_some(fn -> Party.lookup(party_id) end)
   end
 end

--- a/test/teiserver/protocols/spring/spring_party_test.exs
+++ b/test/teiserver/protocols/spring/spring_party_test.exs
@@ -227,8 +227,7 @@ defmodule Teiserver.Protocols.Spring.SpringPartyTest do
     assert {"s.party.joined_party", [^party1, ^username1], _} = joined
     leave_party!(socket1)
 
-    [cancelled, left] =
-      _recv_until(socket2) |> IO.inspect(label: "sock2 go stuff") |> parse_in_messages()
+    [cancelled, left] = _recv_until(socket2) |> parse_in_messages()
 
     assert {"s.party.invite_cancelled", [^party1, ^username2], _} = cancelled
     assert {"s.party.left_party", [^party1, ^username1], _} = left

--- a/test/teiserver_web/tachyon/party_test.exs
+++ b/test/teiserver_web/tachyon/party_test.exs
@@ -369,6 +369,18 @@ defmodule TeiserverWeb.Tachyon.PartyTest do
     assert %{"commandId" => "party/removed"} = Tachyon.recv_message!(ctx2.client)
   end
 
+  test "handle session death" do
+    ctx = setup_client()
+    setup_party(ctx.client)
+    ctx2 = setup_client()
+    party_id = invite_and_accept([ctx.client], ctx2.client, ctx2.user.id)
+
+    Process.exit(Teiserver.Player.SessionRegistry.lookup(ctx2.user.id), :kill)
+    assert %{"commandId" => "party/updated", "data" => data} = Tachyon.recv_message!(ctx.client)
+    assert length(data["members"]) == 1
+    assert hd(data["members"])["userId"] == to_string(ctx.user.id)
+  end
+
   describe "self event" do
     test "has the correct data" do
       user = Tachyon.create_user()


### PR DESCRIPTION
This ties some lose ends in several places to make sure that when a process goes down, other process that depend on the dead process state adjust accordingly.
For example, a queue going down mean that anyone in that queue should exit it. Similar for parties, if the genserver holding the party state dies, all member and invited players should consider themselves out of this party.

The first 2 commits introduce a data structure to reference a monitor by an arbitrary value or a reference.
I did that because it was getting cumbersome to track down what to do when a `:DOWN` event comes in. For matchmaking and sessions especially, the reference could be in several places, so having a way to immediately know where to look is helpful.