### PR TITLE
Add max heap size to SpringTcpServer

### DIFF
--- a/lib/teiserver/tcp/spring/spring_tcp_server.ex
+++ b/lib/teiserver/tcp/spring/spring_tcp_server.ex
@@ -42,7 +42,8 @@ defmodule Teiserver.SpringTcpServer do
     mode = if opts[:ssl], do: :ranch_ssl, else: :ranch_tcp
 
     # https://www.erlang.org/docs/23/man/erlang#process_flag_max_heap_size
-    max_heap_size = 2_620_000
+    # 20 MB = 20 * 1024 * 1024 / 8 words = 2_621_440 words (1 word = 8 bytes)
+    max_heap_size = 2_621_440
 
     # start_listener(Ref, Transport, TransOpts0, Protocol, ProtoOpts)
     if mode == :ranch_ssl do

--- a/lib/teiserver/tcp/spring/spring_tcp_server.ex
+++ b/lib/teiserver/tcp/spring/spring_tcp_server.ex
@@ -41,6 +41,9 @@ defmodule Teiserver.SpringTcpServer do
   def start_link(opts) do
     mode = if opts[:ssl], do: :ranch_ssl, else: :ranch_tcp
 
+    # https://www.erlang.org/docs/23/man/erlang#process_flag_max_heap_size
+    max_heap_size = 2_620_000
+
     # start_listener(Ref, Transport, TransOpts0, Protocol, ProtoOpts)
     if mode == :ranch_ssl do
       ssl_opts = get_ssl_opts()
@@ -54,7 +57,7 @@ defmodule Teiserver.SpringTcpServer do
             port: Application.get_env(:teiserver, Teiserver)[:ports][:tls]
           ],
         __MODULE__,
-        []
+        max_heap_size: max_heap_size
       )
     else
       :ranch.start_listener(
@@ -65,7 +68,7 @@ defmodule Teiserver.SpringTcpServer do
             port: Application.get_env(:teiserver, Teiserver)[:ports][:tcp]
           ],
         __MODULE__,
-        []
+        max_heap_size: max_heap_size
       )
     end
   end


### PR DESCRIPTION
Sets [max_heap_size](https://www.erlang.org/docs/23/man/erlang#process_flag_max_heap_size) for SpringTcpServer to ~20 MB

For info on how Elixir's GC works https://www.erlang.org/doc/apps/erts/garbagecollection. 
If my understanding is correct, GC will attempt to collect when the process reaches the `max_heap_size` and if it isn't successful in reducing the heap size, the process will be killed (configurable as well, default true).