### PR TITLE
Messaging for parties

### DIFF
--- a/lib/teiserver/messaging.ex
+++ b/lib/teiserver/messaging.ex
@@ -8,9 +8,11 @@ defmodule Teiserver.Messaging do
   defdelegate new(message, source, marker), to: Message
 
   @spec send(message(), entity()) :: :ok | {:error, :invalid_recipient}
-  def send(message, {:player, player_id}) do
-    Teiserver.Player.Session.send_dm(player_id, message)
-  end
+  def send(message, {:player, player_id}),
+    do: Teiserver.Player.Session.send_dm(player_id, message)
+
+  def send(message, {:party, party_id, player_id}),
+    do: Teiserver.Party.send_message(party_id, player_id, message)
 
   def send(_, _), do: {:error, :invalid_recipient}
 end

--- a/lib/teiserver/messaging/message.ex
+++ b/lib/teiserver/messaging/message.ex
@@ -2,7 +2,9 @@ defmodule Teiserver.Messaging.Message do
   @enforce_keys [:content, :source, :timestamp, :marker]
   defstruct [:content, :source, :timestamp, :marker]
 
-  @type entity :: {:player, Teiserver.Data.Types.userid()}
+  @type entity ::
+          {:player, Teiserver.Data.Types.userid()}
+          | {:party, Teiserver.Party.id(), Teiserver.Data.Types.userid()}
   @type t :: %__MODULE__{
           content: String.t(),
           source: entity(),

--- a/lib/teiserver/party.ex
+++ b/lib/teiserver/party.ex
@@ -63,6 +63,10 @@ defmodule Teiserver.Party do
   @spec matchmaking_notify_cancel(id()) :: :ok
   defdelegate matchmaking_notify_cancel(party_id), to: Party.Server
 
+  @spec send_message(id(), T.userid(), String.t()) ::
+          :ok | {:error, :invalid_request, reason :: term()}
+  defdelegate send_message(party_id, from_id, msg_content), to: Party.Server
+
   def setup_site_configs() do
     Config.add_site_config_type(%{
       key: Party.Server.max_size_key(),

--- a/priv/tachyon/schema/messaging/received/event.json
+++ b/priv/tachyon/schema/messaging/received/event.json
@@ -18,12 +18,31 @@
             "properties": {
                 "message": { "type": "string" },
                 "source": {
-                    "type": "object",
-                    "properties": {
-                        "type": { "const": "player" },
-                        "userId": { "$ref": "../../definitions/userId.json" }
-                    },
-                    "required": ["type", "userId"]
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "type": { "const": "player" },
+                                "userId": {
+                                    "$ref": "../../definitions/userId.json"
+                                }
+                            },
+                            "required": ["type", "userId"]
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "type": { "const": "party" },
+                                "partyId": {
+                                    "$ref": "../../definitions/partyId.json"
+                                },
+                                "userId": {
+                                    "$ref": "../../definitions/userId.json"
+                                }
+                            },
+                            "required": ["type", "partyId", "userId"]
+                        }
+                    ]
                 },
                 "timestamp": {
                     "$ref": "../../definitions/unixTime.json",

--- a/priv/tachyon/schema/messaging/send/request.json
+++ b/priv/tachyon/schema/messaging/send/request.json
@@ -17,12 +17,23 @@
             "type": "object",
             "properties": {
                 "target": {
-                    "type": "object",
-                    "properties": {
-                        "type": { "const": "player" },
-                        "userId": { "$ref": "../../definitions/userId.json" }
-                    },
-                    "required": ["type", "userId"]
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "type": { "const": "player" },
+                                "userId": {
+                                    "$ref": "../../definitions/userId.json"
+                                }
+                            },
+                            "required": ["type", "userId"]
+                        },
+                        {
+                            "type": "object",
+                            "properties": { "type": { "const": "party" } },
+                            "required": ["type"]
+                        }
+                    ]
                 },
                 "message": { "type": "string", "maxLength": 512 }
             },

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -295,6 +295,10 @@ defmodule Teiserver.Support.Tachyon do
     send_message!(client, message, %{type: "player", userId: to_string(player_id)})
   end
 
+  def send_party_message(client, message) do
+    send_message!(client, message, %{type: :party})
+  end
+
   def subscribe_messaging!(client, opts \\ []) do
     since = Keyword.get(opts, :since, %{type: "latest"})
     :ok = send_request(client, "messaging/subscribeReceived", %{since: since})


### PR DESCRIPTION
Add support for the target `party` for messaging. Send the message to all other member of the sender's current party.