### PR TITLE
Add default icon and colour to user registration

### DIFF
--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -112,6 +112,8 @@ defmodule Teiserver.CacheUser do
                "name" => String.trim(name),
                "email" => String.trim(email),
                "password" => md5_password,
+               "icon" => @default_icon,
+               "colour" => @default_colour,
                # hack so that we can use the same code for web and chobby registration
                # chobby does its own confirmation check
                "password_confirmation" => md5_password


### PR DESCRIPTION
New registration improvements from #637 use random colour and icon if nothing is set specifically. This sets the previous default icon and colour and makes it easier to notice special users like contributors or moderators.