### PR TITLE
More generic logger metadata

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -98,7 +98,7 @@ config :teiserver, Teiserver,
 
 config :logger, :default_handler, false
 
-metadata = [:request_id, :user_id, :queue_id, :pid]
+metadata = [:request_id, :user_id, :pid, :actor_type, :actor_id]
 
 config :logger, LoggerBackends.Console,
   format: "$date $time [$level] $metadata $message\n",

--- a/lib/teiserver/matchmaking/pairing_room.ex
+++ b/lib/teiserver/matchmaking/pairing_room.ex
@@ -63,7 +63,7 @@ defmodule Teiserver.Matchmaking.PairingRoom do
 
   @impl true
   def init({queue_id, queue, teams, timeout}) do
-    Logger.metadata(queue_id: queue_id)
+    Logger.metadata(actor_type: :pairing_room)
 
     initial_state =
       %{
@@ -84,7 +84,7 @@ defmodule Teiserver.Matchmaking.PairingRoom do
           end
       }
 
-    Logger.debug("Pairing room for players " <> Enum.join(initial_state.awaiting, ","))
+    Logger.info("Pairing room for players " <> Enum.join(initial_state.awaiting, ","))
 
     {:ok, initial_state, {:continue, {:notify_players, timeout}}}
   end

--- a/lib/teiserver/matchmaking/queue_server.ex
+++ b/lib/teiserver/matchmaking/queue_server.ex
@@ -198,7 +198,7 @@ defmodule Teiserver.Matchmaking.QueueServer do
 
   @impl true
   def init(state) do
-    Logger.metadata(queue_id: state.id)
+    Logger.metadata(actor_type: :mm_queue, actor_id: state.id)
 
     if state.settings.tick_interval_ms != :manual do
       :timer.send_interval(state.settings.tick_interval_ms, :tick)

--- a/lib/teiserver/player/session.ex
+++ b/lib/teiserver/player/session.ex
@@ -86,7 +86,7 @@ defmodule Teiserver.Player.Session do
 
   @impl true
   def init({conn_pid, user}) do
-    Logger.metadata(user_id: user.id)
+    Logger.metadata(actor_type: :session, user_id: user.id)
     monitors = MC.monitor(MC.new(), conn_pid, :connection)
 
     state = %{

--- a/lib/teiserver/tachyon_battle/battle.ex
+++ b/lib/teiserver/tachyon_battle/battle.ex
@@ -38,7 +38,7 @@ defmodule Teiserver.TachyonBattle.Battle do
 
   @impl true
   def init(%{battle_id: battle_id, autohost_id: autohost_id} = args) do
-    Logger.metadata(battle_id: battle_id)
+    Logger.metadata(actor_type: :battle, actor_id: battle_id)
 
     state = %{
       id: battle_id,


### PR DESCRIPTION
To avoid having to add more and more keywords to the list of metadata to log, unify them under a tuple (type, id) that can be used across different systems.


@L-e-x-o-n do you think I should also modify the other metadata across the code? There are about 20 total, things like:
```elixir
Logger.metadata(request_id: "PartyServer##{id}")
# could be turned into
Logger.metadata(actor_type: :party, actor_id: id)
```

I don't use or even have access to these logs, so I haven't touched anything outside tachyon.