### PR TITLE
Limit grouped balancing to 16 players

### DIFF
--- a/lib/teiserver_web/controllers/api/spads_controller.ex
+++ b/lib/teiserver_web/controllers/api/spads_controller.ex
@@ -142,7 +142,10 @@ defmodule TeiserverWeb.API.SpadsController do
 
       balance_enabled == true ->
         opts = [
-          allow_groups: params["balanceMode"] != "skill"
+          # Balancing with parties in lobbies with large player counts can lead to OOM issues
+          # Balancing algorithmss in these conditions can generate a large number of combinations
+          # which can quickly fill up all available memory
+          allow_groups: Enum.count(player_data) <= 16 and params["balanceMode"] != "skill"
         ]
 
         balance_result =


### PR DESCRIPTION
Balancing with parties in lobbies with large player counts can lead to OOM issues due to large number of combinations that balance algorithms generate and put in memory in these conditions.
Specifically the issue is in the way [`loser_picks`](https://github.com/beyond-all-reason/teiserver/blob/8abd7ffbf7f953203b0af4b22eb3507d84e5b94a/lib/teiserver/battle/libs/balance_lib.ex#L838) algorithm and tries to find a counter party to balance against an existing party.