### PR TITLE
Add max_heap_size to balancer_server and fix it for spring_tcp_server

### DIFF
--- a/lib/teiserver/game/servers/balancer_server.ex
+++ b/lib/teiserver/game/servers/balancer_server.ex
@@ -336,6 +336,9 @@ defmodule Teiserver.Game.BalancerServer do
       lobby_id
     )
 
+    # 50 MB = 50 * 1024 * 1024 / 8 words = 6_553_600 words (1 word = 8 bytes)
+    Process.flag(:max_heap_size, 6_553_600)
+
     :timer.send_interval(@tick_interval, :tick)
     send(self(), :startup)
     {:ok, empty_state(lobby_id)}


### PR DESCRIPTION
Reverts https://github.com/beyond-all-reason/teiserver/pull/660/files as it was doing it incorrectly.
Sets 50 MB max heap size limit to balancer server and 20 MB for Spring TCP server.