### PR TITLE
Change issue template labels to types

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Create a report to describe a bug
 title: '[Bug]: '
-labels: ['bug']
+type: bug
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/2-feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature request
 description: Create a feature request
 title: '[Feature]: '
-labels: ['feature request']
+type: feature
 
 body:
   - type: markdown


### PR DESCRIPTION
Uses Github `types` instead of `label` for classifying issues.