### PR TITLE
change curve algorihm for rating graph to curveCatmullRom to fix visual glitches

### DIFF
--- a/lib/teiserver_web/templates/battle/match/ratings_graph.html.heex
+++ b/lib/teiserver_web/templates/battle/match/ratings_graph.html.heex
@@ -137,7 +137,7 @@
         .x(function(d) { return x(dateFormat(d.date)) })
         .y0(function(d) { return y(d.skill) })
         .y1(function(d) { return y(d.skill + d.uncertainty) })
-        .curve(d3.curveCardinal)
+        .curve(d3.curveMonotoneX)
         )
 
     // Show bottom part of confidence interval
@@ -149,20 +149,7 @@
         .x(function(d) { return x(dateFormat(d.date)) })
         .y0(function(d) { return y(d.skill - d.uncertainty) })
         .y1(function(d) { return y(d.skill) })
-        .curve(d3.curveCardinal)
-        )
-
-    // Add skill value line (in middle of uncertainty)
-    g
-      .append("path")
-      .datum(data)
-      .attr("fill", "none")
-      .attr("stroke", colors.skillValueLine)
-      .attr("stroke-width", 1.5)
-      .attr("d", d3.line()
-        .x(function(d) { return x(dateFormat(d.date)) })
-        .y(function(d) { return y(d.skill) })
-        .curve(d3.curveCardinal)
+        .curve(d3.curveMonotoneX)
         )
 
     // Add skill value line (minimum of uncertainty)
@@ -175,7 +162,7 @@
       .attr("d", d3.line()
         .x(function(d) { return x(dateFormat(d.date)) })
         .y(function(d) { return y(d.rating_value) })
-        .curve(d3.curveCardinal)
+        .curve(d3.curveMonotoneX)
         )
 
     // Add X and Y axis


### PR DESCRIPTION
`curveCatmullRom` was chosen over `curveMonotoneX`.
`curveMonotoneX` give better looking curve, however it introduces a minor visual glitch where the "middle of uncertainty" skill line doesn't follow the edge of "bottom part of confidence interval" and leaves a little gap, see image.
If we wanna use the nicer looking `curveMonotoneX`, we could also omit the "middle of uncertainty" skill line, since it is barely visible anyway and the edge of the two areas accomplishes the same visual feat.

![gap](https://github.com/user-attachments/assets/86f29dac-a725-483a-b3c2-d04ea7ce4962)
