### PR TITLE
Add configuration for SpringTCPServer max_heap_size

### DIFF
--- a/lib/teiserver/libs/teiserver_configs.ex
+++ b/lib/teiserver/libs/teiserver_configs.ex
@@ -246,6 +246,16 @@ defmodule Teiserver.TeiserverConfigs do
         "The time in milliseconds to wait until doing something when a user logs in (e.g. sending a message)",
       default: 2500
     })
+
+    add_site_config_type(%{
+      key: "teiserver.Sprint TCP Server max heap size",
+      section: "Legacy protocol",
+      type: "integer",
+      permissions: ["Server"],
+      description:
+        "Max heap size in words for the TCP server used by the legacy protocol. Default is 13_107_200 words or 100 MB = 100 * 1024 * 1024 / 8 words = 13_107_200 words (1 word = 8 bytes)",
+      default: 13_107_200
+    })
   end
 
   defp login_configs() do

--- a/lib/teiserver/tcp/spring/spring_tcp_server.ex
+++ b/lib/teiserver/tcp/spring/spring_tcp_server.ex
@@ -78,8 +78,10 @@ defmodule Teiserver.SpringTcpServer do
   end
 
   def init(ref, socket, transport) do
-    # 50 MB = 50 * 1024 * 1024 / 8 words = 6_553_600 words (1 word = 8 bytes)
-    Process.flag(:max_heap_size, 6_553_600)
+    Process.flag(
+      :max_heap_size,
+      Config.get_site_config_cache("teiserver.Sprint TCP Server max heap size")
+    )
 
     # If we've not started up yet, lets just delay for a moment
     # for some of the stuff to get sorted


### PR DESCRIPTION
Added config for `max_heap_size` on spring TCP server, increased default to 100 MB for now.