### PR TITLE
Kill battle with `!stop`

### DIFF
--- a/lib/teiserver/autohost.ex
+++ b/lib/teiserver/autohost.ex
@@ -82,4 +82,8 @@ defmodule Teiserver.Autohost do
           :ok | {:error, reason :: term()}
   defdelegate send_message(autohost, payload),
     to: Teiserver.Autohost.TachyonHandler
+
+  @spec kill_battle(pid(), TachyonBattle.id()) :: :ok
+  defdelegate kill_battle(autohost, battle_id),
+    to: Teiserver.Autohost.TachyonHandler
 end

--- a/lib/teiserver/autohost.ex
+++ b/lib/teiserver/autohost.ex
@@ -3,6 +3,7 @@ defmodule Teiserver.Autohost do
   alias Teiserver.Autohost.TachyonHandler
   alias Teiserver.Bot.Bot
   alias Teiserver.BotQueries
+  alias Teiserver.TachyonBattle
 
   @type id :: Teiserver.Bot.Bot.id()
   @type reg_value :: Registry.reg_value()
@@ -75,5 +76,10 @@ defmodule Teiserver.Autohost do
   @spec start_battle(Bot.id(), start_script()) ::
           {:ok, start_response()} | {:error, term()}
   defdelegate start_battle(bot_id, start_script),
+    to: Teiserver.Autohost.TachyonHandler
+
+  @spec send_message(pid(), %{battle_id: TachyonBattle.id(), message: String.t()}) ::
+          :ok | {:error, reason :: term()}
+  defdelegate send_message(autohost, payload),
     to: Teiserver.Autohost.TachyonHandler
 end

--- a/lib/teiserver/autohost/tachyon_handler.ex
+++ b/lib/teiserver/autohost/tachyon_handler.ex
@@ -212,6 +212,12 @@ defmodule Teiserver.Autohost.TachyonHandler do
           | {:engine_message, %{message: String.t()}}
           | {:engine_warning, %{message: String.t()}}
           | {:engine_crash, %{details: String.t() | nil}}
+          | {:player_chat_broadcast,
+             %{
+               destination: :allies | :all | :spectators,
+               message: String.t(),
+               user_id: T.userid()
+             }}
           | :engine_quit
           | {:luamsg,
              %{
@@ -256,6 +262,21 @@ defmodule Teiserver.Autohost.TachyonHandler do
               end
 
             {:player_left, %{user_id: user_id, reason: reason}}
+
+          "player_chat" ->
+            if update["destination"] == "player" do
+              {:error, "unimplement, player destination for player_chat event"}
+            else
+              dest =
+                case update["destination"] do
+                  "allies" -> :allies
+                  "all" -> :all
+                  "spectators" -> :spectators
+                end
+
+              {:player_chat_broadcast,
+               %{destination: dest, message: update["message"], user_id: user_id}}
+            end
 
           "player_defeated" ->
             {:player_defeated, %{user_id: user_id}}

--- a/lib/teiserver/autohost/tachyon_handler.ex
+++ b/lib/teiserver/autohost/tachyon_handler.ex
@@ -191,6 +191,7 @@ defmodule Teiserver.Autohost.TachyonHandler do
                message: String.t(),
                user_id: T.userid()
              }}
+          | {:player_chat_dm, %{message: String.t(), user_id: T.userid(), to_user_id: T.userid()}}
           | :engine_quit
           | {:luamsg,
              %{
@@ -239,7 +240,17 @@ defmodule Teiserver.Autohost.TachyonHandler do
 
         "player_chat" ->
           if update["destination"] == "player" do
-            {:error, "unimplement, player destination for player_chat event"}
+            case TachyonParser.parse_user_id(update["toUserId"]) do
+              {:ok, id} ->
+                update =
+                  {:player_chat_dm,
+                   %{message: update["message"], user_id: user_id, to_user_id: id}}
+
+                {:ok, %{battle_id: data["battleId"], time: time, update: update}}
+
+              err ->
+                err
+            end
           else
             dest =
               case update["destination"] do

--- a/lib/teiserver/autohost/tachyon_handler.ex
+++ b/lib/teiserver/autohost/tachyon_handler.ex
@@ -81,6 +81,24 @@ defmodule Teiserver.Autohost.TachyonHandler do
     end
   end
 
+  @spec kill_battle(pid(), TachyonBattle.id()) :: :ok
+  def kill_battle(autohost, battle_id) when is_pid(autohost) do
+    response = Transport.call_client(autohost, "autohost/kill", %{battleId: battle_id})
+
+    case response["status"] do
+      "success" ->
+        :ok
+
+      "failed" ->
+        err = response["reason"]
+
+        case Map.get(response, "details") do
+          nil -> {:error, err}
+          details -> {:error, "#{err} - #{details}"}
+        end
+    end
+  end
+
   @impl Handler
   def connect(conn) do
     autohost = conn.assigns[:token].bot
@@ -94,7 +112,7 @@ defmodule Teiserver.Autohost.TachyonHandler do
      %{since: DateTime.utc_now() |> DateTime.to_unix(:microsecond)}, [], state}
   end
 
-  @impl Handler
+  @impl true
   def handle_info(_msg, state) do
     {:ok, state}
   end

--- a/lib/teiserver/autohost/tachyon_handler.ex
+++ b/lib/teiserver/autohost/tachyon_handler.ex
@@ -21,13 +21,7 @@ defmodule Teiserver.Autohost.TachyonHandler do
           state: :handshaking | {:connected, connected_state()}
         }
 
-  @type start_response :: %{
-          ips: [String.t()],
-          port: integer(),
-          engine: %{version: String.t()},
-          game: %{springName: String.t()},
-          map: %{springName: String.t()}
-        }
+  @type start_response :: %{ips: [String.t()], port: integer()}
 
   # TODO: there should be some kind of retry here
   @spec start_battle(Bot.id(), Teiserver.Autohost.start_script()) ::

--- a/lib/teiserver/player.ex
+++ b/lib/teiserver/player.ex
@@ -82,10 +82,12 @@ defmodule Teiserver.Player do
   @spec matchmaking_leave_queues(T.userid()) :: Matchmaking.leave_result()
   defdelegate matchmaking_leave_queues(user_id), to: Player.Session, as: :leave_queues
 
+  @type start_data :: Player.Session.start_data()
+
   @doc """
   It's go time! the player should join a game
   """
-  @spec battle_start(T.userid(), {TachyonBattle.id(), pid()}, Teiserver.Autohost.start_response()) ::
+  @spec battle_start(T.userid(), {TachyonBattle.id(), pid()}, start_data()) ::
           :ok
   defdelegate battle_start(user_id, battle_id, battle_start_data), to: Player.Session
 

--- a/lib/teiserver/player/session.ex
+++ b/lib/teiserver/player/session.ex
@@ -192,10 +192,18 @@ defmodule Teiserver.Player.Session do
     GenServer.cast(via_tuple(user_id), {:matchmaking, {:found_update, ready_count, room_pid}})
   end
 
+  @type start_data :: %{
+          ips: [String.t()],
+          port: integer(),
+          engine: %{version: String.t()},
+          game: %{springName: String.t()},
+          map: %{springName: String.t()}
+        }
+
   @doc """
   Let the player know that they are now in a battle
   """
-  @spec battle_start(T.userid(), {TachyonBattle.id(), pid()}, Teiserver.Autohost.start_response()) ::
+  @spec battle_start(T.userid(), {TachyonBattle.id(), pid()}, start_data()) ::
           :ok
   def battle_start(user_id, battle_data, battle_start_data) do
     GenServer.cast(via_tuple(user_id), {:battle, {:start, battle_data, battle_start_data}})

--- a/lib/teiserver/tachyon/system.ex
+++ b/lib/teiserver/tachyon/system.ex
@@ -11,8 +11,8 @@ defmodule Teiserver.Tachyon.System do
   def init(_) do
     children = [
       Teiserver.Tachyon.Schema.cache_spec(),
-      Teiserver.TachyonBattle.System,
       Teiserver.Autohost.System,
+      Teiserver.TachyonBattle.System,
       Teiserver.Matchmaking.System,
       Teiserver.Party.System,
       Teiserver.Player.System

--- a/lib/teiserver/tachyon/transport.ex
+++ b/lib/teiserver/tachyon/transport.ex
@@ -36,6 +36,7 @@ defmodule Teiserver.Tachyon.Transport do
   and
   :gen.call (https://github.com/erlang/otp/blob/OTP-28.0.2/lib/stdlib/src/gen.erl#L221-L227)
   """
+  @spec call_client(pid(), Schema.command_id(), term(), timeout() | nil) :: term()
   def call_client(pid, cmd_id, payload, timeout \\ 5_000) when is_pid(pid) do
     req_id = Process.monitor(pid, alias: :reply_demonitor)
     send(pid, {:call_client, cmd_id, payload, req_id})

--- a/lib/teiserver/tachyon/transport.ex
+++ b/lib/teiserver/tachyon/transport.ex
@@ -26,6 +26,43 @@ defmodule Teiserver.Tachyon.Transport do
     )
   end
 
+  @doc """
+  This is similar to GenServer.call but targets a tachyon client. It sends
+  a request with the given command id and payload, then wait for a response
+  from the client and returns it "synchronously"
+
+  The code is heavily inspired from
+  https://www.erlang.org/doc/apps/erts/erlang.html#monitor/3
+  and
+  :gen.call (https://github.com/erlang/otp/blob/OTP-28.0.2/lib/stdlib/src/gen.erl#L221-L227)
+  """
+  def call_client(pid, cmd_id, payload, timeout \\ 5_000) when is_pid(pid) do
+    req_id = Process.monitor(pid, alias: :reply_demonitor)
+    send(pid, {:call_client, cmd_id, payload, req_id})
+
+    receive do
+      {^req_id, reply} ->
+        Process.demonitor(req_id, [:flush])
+        reply
+
+      {:DOWN, ^req_id, _, _, :noconnection} ->
+        node = node(pid)
+        exit({{:nodedown, node}, {__MODULE__, :call_client, [pid, cmd_id, payload, timeout]}})
+
+      {:DOWN, ^req_id, _, _, reason} ->
+        exit({reason, {__MODULE__, :call_client, [pid, cmd_id, payload, timeout]}})
+    after
+      timeout ->
+        Process.demonitor(req_id, [:flush])
+
+        receive do
+          {^req_id, reply} -> reply
+        after
+          0 -> exit({:timeout, {__MODULE__, :call_client, [pid, cmd_id, payload, timeout]}})
+        end
+    end
+  end
+
   # dummy handle_in for now
   @impl true
   def handle_in({"test_ping\n", opcode: :text}, state) do
@@ -69,6 +106,11 @@ defmodule Teiserver.Tachyon.Transport do
     {:stop, :timeout,
      {1008, "Response to request with message id #{message_id} not received in time."},
      %{state | pending_responses: pendings}}
+  end
+
+  def handle_info({:call_client, cmd_id, payload, req_id}, state) do
+    opts = [cb_state: {:call_client_resp, req_id}]
+    handle_result({:request, cmd_id, payload, opts, state.handler_state}, state)
   end
 
   def handle_info(msg, state) do
@@ -146,13 +188,20 @@ defmodule Teiserver.Tachyon.Transport do
         :erlang.cancel_timer(tref)
         state = Map.replace!(state, :pending_responses, new_pendings)
 
-        if function_exported?(state.handler, :handle_response, 4) do
-          result =
-            state.handler.handle_response(command_id, cb_state, message, state.handler_state)
+        case cb_state do
+          {:call_client_resp, req_id} ->
+            send(req_id, {req_id, message})
+            {:ok, state}
 
-          handle_result(result, command_id, message_id, state)
-        else
-          {:ok, state}
+          cb_state ->
+            if function_exported?(state.handler, :handle_response, 4) do
+              result =
+                state.handler.handle_response(command_id, cb_state, message, state.handler_state)
+
+              handle_result(result, command_id, message_id, state)
+            else
+              {:ok, state}
+            end
         end
     end
   end

--- a/lib/teiserver/tachyon_battle.ex
+++ b/lib/teiserver/tachyon_battle.ex
@@ -60,6 +60,9 @@ defmodule Teiserver.TachyonBattle do
   @spec send_message(T.id(), String.t()) :: :ok | {:error, reason :: term()}
   defdelegate send_message(battle_id, message), to: TachyonBattle.Battle
 
+  @spec kill(T.id()) :: :ok | {:error, reason :: term()}
+  defdelegate kill(battle_id), to: TachyonBattle.Battle
+
   # keep this function private to dissuade caller to misuse the API.
   # Generating a battle id is meaningless unless the corresponding
   # Battle genserver is also started and connected to an autohost

--- a/lib/teiserver/tachyon_battle.ex
+++ b/lib/teiserver/tachyon_battle.ex
@@ -57,6 +57,9 @@ defmodule Teiserver.TachyonBattle do
   @spec send_update_event(Teiserver.Autohost.update_event()) :: :ok
   defdelegate send_update_event(event), to: TachyonBattle.Battle
 
+  @spec send_message(T.id(), String.t()) :: :ok | {:error, reason :: term()}
+  defdelegate send_message(battle_id, message), to: TachyonBattle.Battle
+
   # keep this function private to dissuade caller to misuse the API.
   # Generating a battle id is meaningless unless the corresponding
   # Battle genserver is also started and connected to an autohost

--- a/priv/tachyon/schema/autohost/kill/request.json
+++ b/priv/tachyon/schema/autohost/kill/request.json
@@ -1,0 +1,25 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/kill/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "AutohostKillRequest",
+    "tachyon": {
+        "source": "server",
+        "target": "autohost",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "autohost/kill" },
+        "data": {
+            "title": "AutohostKillRequestData",
+            "type": "object",
+            "properties": {
+                "battleId": { "type": "string", "format": "uuid" }
+            },
+            "required": ["battleId"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/autohost/kill/response.json
+++ b/priv/tachyon/schema/autohost/kill/response.json
@@ -1,0 +1,43 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/kill/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "AutohostKillResponse",
+    "tachyon": {
+        "source": "autohost",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "AutohostKillOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "autohost/kill" },
+                "status": { "const": "success" }
+            },
+            "required": ["type", "messageId", "commandId", "status"]
+        },
+        {
+            "title": "AutohostKillFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "autohost/kill" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}

--- a/priv/tachyon/schema/autohost/sendMessage/request.json
+++ b/priv/tachyon/schema/autohost/sendMessage/request.json
@@ -1,0 +1,26 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/sendMessage/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "AutohostSendMessageRequest",
+    "tachyon": {
+        "source": "server",
+        "target": "autohost",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "autohost/sendMessage" },
+        "data": {
+            "title": "AutohostSendMessageRequestData",
+            "type": "object",
+            "properties": {
+                "battleId": { "type": "string", "format": "uuid" },
+                "message": { "type": "string", "maxLength": 127 }
+            },
+            "required": ["battleId", "message"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/autohost/sendMessage/response.json
+++ b/priv/tachyon/schema/autohost/sendMessage/response.json
@@ -1,0 +1,43 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/autohost/sendMessage/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "AutohostSendMessageResponse",
+    "tachyon": {
+        "source": "autohost",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "AutohostSendMessageOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "autohost/sendMessage" },
+                "status": { "const": "success" }
+            },
+            "required": ["type", "messageId", "commandId", "status"]
+        },
+        {
+            "title": "AutohostSendMessageFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "autohost/sendMessage" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -196,6 +196,9 @@ defmodule Teiserver.Support.Tachyon do
           nil -> resp
           x -> Map.put(resp, :details, x)
         end
+
+      true ->
+        Map.put(resp, :status, :success)
     end
   end
 

--- a/test/teiserver/autohost/autohost_test.exs
+++ b/test/teiserver/autohost/autohost_test.exs
@@ -76,5 +76,31 @@ defmodule Teiserver.Autohost.AutohostTest do
 
       assert TH.parse_update_event(msg["data"]) == {:ok, expected}
     end
+
+    test "player chat broadcast" do
+      msg = %{
+        "commandId" => "autohost/update",
+        "data" => %{
+          "battleId" => "d9eff7cb-ab31-4070-8bd8-376acf9c5095",
+          "time" => 1_748_191_573_075_000,
+          "update" => %{
+            "destination" => "all",
+            "message" => "blah",
+            "type" => "player_chat",
+            "userId" => "5"
+          }
+        },
+        "messageId" => "46dc384f-1ffe-4cac-8a77-1fd1927f0437",
+        "type" => "event"
+      }
+
+      expected = %{
+        battle_id: "d9eff7cb-ab31-4070-8bd8-376acf9c5095",
+        time: DateTime.from_unix!(1_748_191_573_075_000, :microsecond),
+        update: {:player_chat_broadcast, %{destination: :all, message: "blah", user_id: 5}}
+      }
+
+      assert TH.parse_update_event(msg["data"]) == {:ok, expected}
+    end
   end
 end

--- a/test/teiserver/autohost/autohost_test.exs
+++ b/test/teiserver/autohost/autohost_test.exs
@@ -102,5 +102,53 @@ defmodule Teiserver.Autohost.AutohostTest do
 
       assert TH.parse_update_event(msg["data"]) == {:ok, expected}
     end
+
+    test "player chat dm" do
+      msg = %{
+        "commandId" => "autohost/update",
+        "data" => %{
+          "battleId" => "d9eff7cb-ab31-4070-8bd8-376acf9c5095",
+          "time" => 1_748_191_573_075_000,
+          "update" => %{
+            "destination" => "player",
+            "message" => "blah",
+            "type" => "player_chat",
+            "userId" => "5",
+            "toUserId" => "42"
+          }
+        },
+        "messageId" => "46dc384f-1ffe-4cac-8a77-1fd1927f0437",
+        "type" => "event"
+      }
+
+      expected = %{
+        battle_id: "d9eff7cb-ab31-4070-8bd8-376acf9c5095",
+        time: DateTime.from_unix!(1_748_191_573_075_000, :microsecond),
+        update: {:player_chat_dm, %{to_user_id: 42, message: "blah", user_id: 5}}
+      }
+
+      assert TH.parse_update_event(msg["data"]) == {:ok, expected}
+    end
+
+    test "player chat dm, invalid target" do
+      msg = %{
+        "commandId" => "autohost/update",
+        "data" => %{
+          "battleId" => "d9eff7cb-ab31-4070-8bd8-376acf9c5095",
+          "time" => 1_748_191_573_075_000,
+          "update" => %{
+            "destination" => "player",
+            "message" => "blah",
+            "type" => "player_chat",
+            "userId" => "5",
+            "toUserId" => "not-a-number"
+          }
+        },
+        "messageId" => "46dc384f-1ffe-4cac-8a77-1fd1927f0437",
+        "type" => "event"
+      }
+
+      assert {:error, _} = TH.parse_update_event(msg["data"])
+    end
   end
 end

--- a/test/teiserver/tachyon_battle/battle_test.exs
+++ b/test/teiserver/tachyon_battle/battle_test.exs
@@ -1,13 +1,13 @@
 defmodule Teiserver.TachyonBattle.BattleTest do
   use Teiserver.DataCase
-  import Teiserver.Support.Polling, only: [poll_until_some: 1]
+  import Teiserver.Support.Polling, only: [poll_until_some: 1, poll_until: 2]
   alias Teiserver.TachyonBattle, as: Battle
 
   @moduletag :tachyon
 
   describe "start battle" do
     test "happy path" do
-      autohost_id = 123
+      autohost_id = :rand.uniform(10_000_000)
       Teiserver.Autohost.Registry.register(%{id: autohost_id})
       {:ok, battle_id, _pid} = Battle.start_battle(autohost_id)
       poll_until_some(fn -> Battle.lookup(battle_id) end)
@@ -17,7 +17,7 @@ defmodule Teiserver.TachyonBattle.BattleTest do
   describe "send message" do
     test "autohost is there" do
       battle_id = to_string(UUID.uuid4())
-      autohost_id = :rand.uniform(1..10000000)
+      autohost_id = :rand.uniform(10_000_000)
       Teiserver.Autohost.Registry.register(%{id: autohost_id})
 
       {:ok, _battle_pid} =
@@ -31,5 +31,20 @@ defmodule Teiserver.TachyonBattle.BattleTest do
       send(from, {from, %{"status" => "success"}})
       assert Task.await(task) == :ok
     end
+  end
+
+  test "kill battle" do
+    battle_id = to_string(UUID.uuid4())
+    autohost_id = :rand.uniform(10_000_000)
+    Teiserver.Autohost.Registry.register(%{id: autohost_id})
+
+    {:ok, battle_pid} =
+      Battle.Battle.start_link(%{battle_id: battle_id, autohost_id: autohost_id})
+
+    task = Task.async(fn -> Battle.kill(battle_id) end)
+    assert_receive {:call_client, "autohost/kill", %{battleId: battle_id}, from}
+    resp = %{"status" => "success"}
+    send(from, {from, resp})
+    assert Task.await(task) == :ok
   end
 end


### PR DESCRIPTION
This is the start of handling commands from players and relay them to autohost.
It requires https://github.com/beyond-all-reason/recoil-autohost/issues/21 to be fixed to actually work.

Couple of points here:

* I've refactored the way to issue request from server to client and block until client responds. I think it'll require a bit more work to handle error response, but we can see when we start copy/pasting too much code.
* I changed the order of startup between autohost and battles. That means battle can freely `call` into autohosts, but autohosts should only `cast` to battle. Following this rule (based on init order in the supervision tree) should prevent deadlocks.
* I added the `send_message` logic. Turn out it's irrelevant when it comes to stopping a battle, but we'll need that anyway, so might as well leave it there.


The next big piece is going to figure out voting (and tracking players in battle).