### PR TITLE
Add .githooks with mix format pre commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -eo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+# Get all staged files that have been added, copied, or modified
+FILES=$(git diff --cached --name-only --diff-filter=ACM)
+
+if [ -n "$FILES" ]; then
+  echo "Running mix format on staged files..."
+  # Format all staged files
+  echo "$FILES" | xargs mix format
+
+  # Re-stage formatted files
+  echo "$FILES" | xargs git add
+fi

--- a/documents/guides/local_setup.md
+++ b/documents/guides/local_setup.md
@@ -181,5 +181,16 @@ The attached `.git-blame-ignore-revs` file contains a list of commit hashes whic
 
 See [this blog post by Stefan Judis](https://www.stefanjudis.com/today-i-learned/how-to-exclude-commits-from-git-blame/) for reference.
 
+### Git hooks
+The `.githooks` directory contains a `pre-commit` Git hook that will run `mix format` on staged files before they get commited.
+To use this (and other Git hooks) you have to first make them executable with
+```
+chmod +x .githooks/pre-commit
+```
+then use the following command to change the location where Git looks for hook scripts (from the default `.git/hooks`) to the `.githooks` directory
+```
+git config core.hooksPath .githooks
+```
+
 ### Next Steps
 If you want to develop features that interact with the lobby, then you will need to [set up SPADS](/documents/guides/spads_install.md).


### PR DESCRIPTION
The `.githooks` directory contains a `pre-commit` Git hook that will run `mix format` on staged files before they get commited.
To use this (and other Git hooks) you have to first make them executable with
```
chmod +x .githooks/pre-commit
```
then use the following command to change the location where Git looks for hook scripts (from the default `.git/hooks`) to the `.githooks` directory
```
git config core.hooksPath .githooks
```