### PR TITLE
Simple matchmaking queue statistics

### DIFF
--- a/lib/teiserver/matchmaking.ex
+++ b/lib/teiserver/matchmaking.ex
@@ -14,6 +14,7 @@ defmodule Teiserver.Matchmaking do
   @type lost_reason :: Matchmaking.PairingRoom.lost_reason()
   @type cancelled_reason :: Matchmaking.QueueServer.cancelled_reason()
   @type ready_data :: Matchmaking.PairingRoom.ready_data()
+  @type stats :: Matchmaking.QueueServer.stats()
 
   @spec lookup_queue(Matchmaking.QueueServer.id()) :: pid() | nil
   def lookup_queue(queue_id) do
@@ -53,6 +54,12 @@ defmodule Teiserver.Matchmaking do
   """
   @spec ready(pid(), ready_data()) :: :ok | {:error, term()}
   defdelegate ready(room_pid, user_id), to: Matchmaking.PairingRoom
+
+  @doc """
+  Get statistics for a specific queue
+  """
+  @spec get_stats(queue_id :: String.t()) :: {:ok, stats()} | {:error, :not_found}
+  defdelegate get_stats(queue_id), to: Matchmaking.QueueServer
 
   @doc """
   Kill and restart all matchmaking queues. This can be used to reset the


### PR DESCRIPTION
Added simple incremental matchmaking stats which closes #683 

Added some basic unit tests to make sure it increments as intended. I didn't go too deep into trying to increment large party sizes and just implemented the logic for a "party of 1"

`total_wait_time_s` is a total aggregate of time waited, not an average.  If this is incorrect I can swap it.