### PR TITLE
Fix email validation in tests and bot accounts after PR #709

### DIFF
--- a/lib/teiserver/account/accolades/accolade_bot_server.ex
+++ b/lib/teiserver/account/accolades/accolade_bot_server.ex
@@ -172,7 +172,7 @@ defmodule Teiserver.Account.AccoladeBotServer do
     user =
       Account.get_user(nil,
         search: [
-          email: "accolades_bot@teiserver"
+          email: "accolades_bot@teiserver.local"
         ]
       )
 
@@ -182,7 +182,7 @@ defmodule Teiserver.Account.AccoladeBotServer do
         {:ok, account} =
           Account.script_create_user(%{
             name: "AccoladesBot",
-            email: "accolades_bot@teiserver",
+            email: "accolades_bot@teiserver.local",
             icon:
               "fa-solid #{Teiserver.Account.AccoladeLib.icon()}" |> String.replace(" far ", " "),
             colour: "#0066AA",

--- a/lib/teiserver/account/libs/account_test_lib.ex
+++ b/lib/teiserver/account/libs/account_test_lib.ex
@@ -12,7 +12,7 @@ defmodule Teiserver.Account.AccountTestLib do
       %User{},
       %{
         name: data["name"] || "name_#{r}",
-        email: data["email"] || "email_#{r}",
+        email: data["email"] || "email_#{r}@test.local",
         colour: data["colour"] || "colour",
         icon: data["icon"] || "icon",
         password: data["password"] || Teiserver.Account.spring_md5_password("password"),

--- a/lib/teiserver/battle/servers/match_monitor_server.ex
+++ b/lib/teiserver/battle/servers/match_monitor_server.ex
@@ -413,7 +413,7 @@ defmodule Teiserver.Battle.MatchMonitorServer do
     user =
       Account.get_user(nil,
         search: [
-          email: "match_monitor@teiserver"
+          email: "match_monitor@teiserver.local"
         ]
       )
 
@@ -423,7 +423,7 @@ defmodule Teiserver.Battle.MatchMonitorServer do
         {:ok, account} =
           Account.create_user(%{
             name: "AutohostMonitor",
-            email: "match_monitor@teiserver",
+            email: "match_monitor@teiserver.local",
             icon: "fa-solid fa-camera-cctv",
             colour: "#00AA66",
             password: Account.make_bot_password(),

--- a/lib/teiserver/bridge/bridge_server.ex
+++ b/lib/teiserver/bridge/bridge_server.ex
@@ -404,7 +404,7 @@ defmodule Teiserver.Bridge.BridgeServer do
     user =
       Account.get_user(nil,
         search: [
-          email: "bridge@teiserver"
+          email: "bridge@teiserver.local"
         ]
       )
 
@@ -414,7 +414,7 @@ defmodule Teiserver.Bridge.BridgeServer do
         {:ok, account} =
           Account.script_create_user(%{
             name: bot_name(),
-            email: "bridge@teiserver",
+            email: "bridge@teiserver.local",
             icon: "fa-brands fa-discord",
             colour: "#0066AA",
             password: Account.make_bot_password(),

--- a/lib/teiserver/coordinator/coordinator_server.ex
+++ b/lib/teiserver/coordinator/coordinator_server.ex
@@ -320,7 +320,7 @@ defmodule Teiserver.Coordinator.CoordinatorServer do
     user =
       Account.get_user(nil,
         search: [
-          email: "coordinator@teiserver"
+          email: "coordinator@teiserver.local"
         ]
       )
 
@@ -330,7 +330,7 @@ defmodule Teiserver.Coordinator.CoordinatorServer do
         {:ok, account} =
           Account.script_create_user(%{
             name: "Coordinator",
-            email: "coordinator@teiserver",
+            email: "coordinator@teiserver.local",
             icon: "fa-solid fa-sitemap",
             colour: "#AA00AA",
             password: Account.make_bot_password(),

--- a/test/teiserver_web/controllers/admin/user_controller_test.exs
+++ b/test/teiserver_web/controllers/admin/user_controller_test.exs
@@ -78,7 +78,7 @@ defmodule TeiserverWeb.Admin.UserControllerTest do
     test "redirects when data is valid", %{conn: conn} do
       user =
         GeneralTestLib.make_user(%{
-          "email" => "tsuser2@tsuser2",
+          "email" => "tsuser2@test.local",
           "data" => %{}
         })
 
@@ -101,7 +101,7 @@ defmodule TeiserverWeb.Admin.UserControllerTest do
     test "redirects when data is valid", %{conn: conn} do
       user =
         GeneralTestLib.make_user(%{
-          "email" => "tsuser_rename@tsuser_rename",
+          "email" => "tsuser_rename@test.local",
           "data" => %{}
         })
 
@@ -119,7 +119,7 @@ defmodule TeiserverWeb.Admin.UserControllerTest do
     test "renders errors when data is invalid", %{conn: conn} do
       user =
         GeneralTestLib.make_user(%{
-          "email" => "tsuser_rename_bad@tsuser_rename_bad",
+          "email" => "tsuser_rename_bad@test.local",
           "data" => %{}
         })
 


### PR DESCRIPTION
Working on #713, @geekingfrog noticed a bunch of non-flakey test failures.  I _think_ this resolves that issue without rolling back the change introduced to add email validation to the user schema in #709 

- Update AccountTestLib.user_fixture() to use valid email addresses with @test.local domain
- Fix admin user controller tests to use valid email addresses
- Fix all bot account emails to use valid domains:
  - Coordinator: coordinator@teiserver.local
  - Bridge: bridge@teiserver.local
  - Match Monitor: match_monitor@teiserver.local
  - Accolade: accolades_bot@teiserver.local
- This resolves test failures caused by email validation introduced in PR #709