### PR TITLE
Fix admin api to create tokens

### DIFF
--- a/lib/teiserver/o_auth.ex
+++ b/lib/teiserver/o_auth.ex
@@ -185,7 +185,8 @@ defmodule Teiserver.OAuth do
             :scopes => Application.scopes(),
             optional(:original_scopes) => Application.scopes()
           },
-          create_refresh: boolean() | options()
+          create_refresh: boolean() | options(),
+          scopes: Application.scopes()
         ) ::
           {:ok, Token.t()} | {:error, :invalid_scope | Ecto.Changeset.t()}
   def create_token(user_id, application, opts \\ [])

--- a/lib/teiserver_web/controllers/api/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/api/admin/user_controller.ex
@@ -91,7 +91,8 @@ defmodule TeiserverWeb.API.Admin.UserController do
         id: app.id,
         scopes: app.scopes
       },
-      create_refresh: true
+      create_refresh: true,
+      scopes: app.scopes
     )
   end
 


### PR DESCRIPTION
Turn out the @spec for create token was incorrect.

That wasn't caught earlier because other call sites used `Keyword.put` on the options, and dialyzer doesn't understand that.