### PR TITLE
simple matchmaking admin dashboard

### DIFF
--- a/lib/teiserver_web/live/admin/admin_components.ex
+++ b/lib/teiserver_web/live/admin/admin_components.ex
@@ -53,6 +53,16 @@ defmodule TeiserverWeb.Admin.AdminComponents do
       >
         Moderation
       </.sub_menu_button>
+
+      <.sub_menu_button
+        :if={allow?(@current_user, "Admin")}
+        bsname={@view_colour}
+        icon="fa-solid fa-users"
+        active={@active == "matchmaking"}
+        url={~p"/admin/matchmaking"}
+      >
+        Matchmaking
+      </.sub_menu_button>
     </div>
     """
   end

--- a/lib/teiserver_web/live/admin/matchmaking/index.ex
+++ b/lib/teiserver_web/live/admin/matchmaking/index.ex
@@ -1,0 +1,66 @@
+defmodule TeiserverWeb.Admin.MatchmakingLive.Index do
+  use TeiserverWeb, :live_view
+  alias Teiserver.Matchmaking
+
+  @impl true
+  def mount(_params, _session, socket) do
+    case allow?(socket.assigns[:current_user], "Admin") do
+      true ->
+        socket =
+          socket
+          |> assign(:site_menu_active, "matchmaking")
+          |> assign(:view_colour, Teiserver.Battle.MatchLib.colours())
+          |> assign(:queues, [])
+          |> add_breadcrumb(name: "Admin", url: "/teiserver/admin")
+          |> add_breadcrumb(name: "Matchmaking", url: "/admin/matchmaking")
+
+        Matchmaking.subscribe_to_queue_updates()
+
+        {:ok, get_queues(socket)}
+
+      false ->
+        {:ok,
+         socket
+         |> redirect(to: ~p"/")}
+    end
+  end
+
+  @impl true
+  def handle_params(_params, _url, socket) do
+    {:noreply, get_queues(socket)}
+  end
+
+  @impl true
+  def handle_info(
+        %{
+          channel: "matchmaking_queues",
+          event: :queue_updated,
+          queue_id: queue_id,
+          stats: stats
+        },
+        socket
+      ) do
+    queues = socket.assigns.queues
+
+    updated_queues =
+      Enum.map(queues, fn {id, queue} ->
+        if id == queue_id do
+          {id,
+           Map.merge(queue, %{
+             stats: stats
+           })}
+        else
+          {id, queue}
+        end
+      end)
+
+    {:noreply, assign(socket, :queues, updated_queues)}
+  end
+
+  defp get_queues(socket) do
+    queues = Matchmaking.list_queues_with_stats()
+
+    socket
+    |> assign(:queues, queues)
+  end
+end

--- a/lib/teiserver_web/live/admin/matchmaking/index.html.heex
+++ b/lib/teiserver_web/live/admin/matchmaking/index.html.heex
@@ -1,0 +1,60 @@
+<TeiserverWeb.Admin.AdminComponents.sub_menu
+  active="matchmaking"
+  view_colour={@view_colour}
+  current_user={@current_user}
+/>
+
+<div class="row section-menu">
+  <div class="col-md-12">
+    <h2>Matchmaking Queues</h2>
+
+    <table class="table table-sm table-hover">
+      <thead>
+        <tr>
+          <th>Queue ID</th>
+          <th>Name</th>
+          <th>Team Size</th>
+          <th>Team Count</th>
+          <th>Total Players</th>
+          <th>Total Joined</th>
+          <th>Total Left</th>
+          <th>Total Matched</th>
+          <th>Total Wait Time (s)</th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= if Enum.empty?(@queues) do %>
+          <tr>
+            <td colspan="9" class="text-center">
+              No active matchmaking queues found.
+            </td>
+          </tr>
+        <% else %>
+          <%= for {queue_id, queue} <- @queues do %>
+            <tr>
+              <td>{queue_id}</td>
+              <td>{queue.name}</td>
+              <td>{queue.team_size}</td>
+              <td>{queue.team_count}</td>
+              <td>
+                {queue.stats.player_count}
+              </td>
+              <td>
+                {queue.stats.total_joined}
+              </td>
+              <td>
+                {queue.stats.total_left}
+              </td>
+              <td>
+                {queue.stats.total_matched}
+              </td>
+              <td>
+                {queue.stats.total_wait_time_s}
+              </td>
+            </tr>
+          <% end %>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/lib/teiserver_web/router.ex
+++ b/lib/teiserver_web/router.ex
@@ -608,6 +608,14 @@ defmodule TeiserverWeb.Router do
       ] do
       live "/chat", ChatLive.Index, :index
     end
+
+    live_session :admin_matchmaking_liveview,
+      on_mount: [
+        {Teiserver.Account.AuthPlug, :ensure_authenticated},
+        {Teiserver.Account.AuthPlug, {:authorise, "Admin"}}
+      ] do
+      live "/matchmaking", MatchmakingLive.Index, :index
+    end
   end
 
   scope "/teiserver/admin", TeiserverWeb.Admin, as: :ts_admin do

--- a/lib/teiserver_web/templates/admin/general/index.html.heex
+++ b/lib/teiserver_web/templates/admin/general/index.html.heex
@@ -92,6 +92,15 @@
   </.menu_card>
 
   <.menu_card
+    :if={allow_any?(@current_user, ~w(Admin))}
+    icon="fa-solid fa-users"
+    url={~p"/admin/matchmaking"}
+    size={:small}
+  >
+    Matchmaking
+  </.menu_card>
+
+  <.menu_card
     :if={allow_any?(@conn, ~w(Contributor Overwatch))}
     icon={Teiserver.Communication.TextCallbackLib.icon()}
     url={~p"/admin/text_callbacks"}

--- a/test/teiserver/matchmaking/queue_test.exs
+++ b/test/teiserver/matchmaking/queue_test.exs
@@ -71,23 +71,51 @@ defmodule Teiserver.Matchmaking.QueueTest do
     test "initial stats are zero", %{queue_id: queue_id} do
       # Initially stats should be zero
       {:ok, stats} = Matchmaking.get_stats(queue_id)
-      assert stats == %{total_joined: 0, total_left: 0, total_matched: 0, total_wait_time_s: 0}
+
+      assert stats == %{
+               total_joined: 0,
+               total_left: 0,
+               total_matched: 0,
+               total_wait_time_s: 0,
+               player_count: 0
+             }
     end
 
     test "tracks joins and leaves", %{user: user, queue_id: queue_id} do
       # Initially stats should be zero
       {:ok, stats} = Matchmaking.get_stats(queue_id)
-      assert stats == %{total_joined: 0, total_left: 0, total_matched: 0, total_wait_time_s: 0}
+
+      assert stats == %{
+               total_joined: 0,
+               total_left: 0,
+               total_matched: 0,
+               total_wait_time_s: 0,
+               player_count: 0
+             }
 
       # Join the queue
       {:ok, _pid} = Matchmaking.join_queue(queue_id, user.id)
       {:ok, stats} = Matchmaking.get_stats(queue_id)
-      assert stats == %{total_joined: 1, total_left: 0, total_matched: 0, total_wait_time_s: 0}
+
+      assert stats == %{
+               total_joined: 1,
+               total_left: 0,
+               total_matched: 0,
+               total_wait_time_s: 0,
+               player_count: 1
+             }
 
       # Leave the queue
       :ok = Matchmaking.leave_queue(queue_id, user.id)
       {:ok, stats} = Matchmaking.get_stats(queue_id)
-      assert stats == %{total_joined: 1, total_left: 1, total_matched: 0, total_wait_time_s: 0}
+
+      assert stats == %{
+               total_joined: 1,
+               total_left: 1,
+               total_matched: 0,
+               total_wait_time_s: 0,
+               player_count: 0
+             }
     end
 
     test "tracks party joins", %{queue_id: queue_id} do
@@ -98,13 +126,25 @@ defmodule Teiserver.Matchmaking.QueueTest do
       {:ok, _pid} = Matchmaking.party_join_queue(queue_id, party_id, [user1])
       {:ok, stats} = Matchmaking.get_stats(queue_id)
       # No stats updated yet, party is pending
-      assert stats == %{total_joined: 0, total_left: 0, total_matched: 0, total_wait_time_s: 0}
+      assert stats == %{
+               total_joined: 0,
+               total_left: 0,
+               total_matched: 0,
+               total_wait_time_s: 0,
+               player_count: 0
+             }
 
       # Now actually join the queue with the party
       {:ok, _pid} = Matchmaking.join_queue(queue_id, user1.id, party_id)
       {:ok, stats} = Matchmaking.get_stats(queue_id)
       # Now the player has joined
-      assert stats == %{total_joined: 1, total_left: 0, total_matched: 0, total_wait_time_s: 0}
+      assert stats == %{
+               total_joined: 1,
+               total_left: 0,
+               total_matched: 0,
+               total_wait_time_s: 0,
+               player_count: 1
+             }
     end
 
     test "tracks wait time when matches are created", %{queue_id: queue_id} do
@@ -114,7 +154,14 @@ defmodule Teiserver.Matchmaking.QueueTest do
       # Join first user
       {:ok, _pid} = Matchmaking.join_queue(queue_id, user1.id)
       {:ok, stats} = Matchmaking.get_stats(queue_id)
-      assert stats == %{total_joined: 1, total_left: 0, total_matched: 0, total_wait_time_s: 0}
+
+      assert stats == %{
+               total_joined: 1,
+               total_left: 0,
+               total_matched: 0,
+               total_wait_time_s: 0,
+               player_count: 1
+             }
 
       # Join second user (this should trigger a match)
       {:ok, _pid} = Matchmaking.join_queue(queue_id, user2.id)

--- a/test/teiserver_web/live/admin/matchmaking/index_test.exs
+++ b/test/teiserver_web/live/admin/matchmaking/index_test.exs
@@ -1,0 +1,49 @@
+defmodule TeiserverWeb.Admin.MatchmakingLive.IndexTest do
+  use TeiserverWeb.ConnCase, async: true
+
+  alias Central.Helpers.GeneralTestLib
+
+  test "cannot access admin matchmaking without authenticating" do
+    {:ok, kw} = GeneralTestLib.conn_setup([], [:no_login])
+    {:ok, conn} = Keyword.fetch(kw, :conn)
+    conn = get(conn, ~p"/admin/matchmaking")
+    assert redirected_to(conn) == ~p"/login"
+  end
+
+  test "cannot access admin matchmaking when unauthorized" do
+    {:ok, kw} = GeneralTestLib.conn_setup()
+    {:ok, conn} = Keyword.fetch(kw, :conn)
+    conn = get(conn, ~p"/admin/matchmaking")
+    assert redirected_to(conn) == ~p"/"
+  end
+
+  test "can access admin matchmaking when authorized" do
+    {:ok, kw} = GeneralTestLib.conn_setup(["Admin"])
+    {:ok, conn} = Keyword.fetch(kw, :conn)
+    conn = get(conn, ~p"/admin/matchmaking")
+    html_response(conn, 200)
+  end
+
+  test "displays queue stats table structure" do
+    {:ok, kw} = GeneralTestLib.conn_setup(["Admin"])
+    {:ok, conn} = Keyword.fetch(kw, :conn)
+
+    # Access the admin page
+    conn = get(conn, ~p"/admin/matchmaking")
+    html = html_response(conn, 200)
+
+    # Verify the page contains the expected table headers
+    assert html =~ "Queue ID"
+    assert html =~ "Name"
+    assert html =~ "Team Size"
+    assert html =~ "Team Count"
+    assert html =~ "Total Players"
+    assert html =~ "Total Joined"
+    assert html =~ "Total Left"
+    assert html =~ "Total Matched"
+    assert html =~ "Total Wait Time (s)"
+
+    # Verify the page contains the matchmaking queues section
+    assert html =~ "Matchmaking Queues"
+  end
+end


### PR DESCRIPTION
Adding a simple admin dashboard for viewing matchmaking queues at `/admin/matchmaking`

<img width="1073" height="342" alt="image" src="https://github.com/user-attachments/assets/7fe0033c-eae7-47a1-8808-e511a8a71cbe" />


Closes #684 