### PR TITLE
Fix s.battle.teams crashes

### DIFF
--- a/lib/teiserver/application.ex
+++ b/lib/teiserver/application.ex
@@ -27,6 +27,7 @@ defmodule Teiserver.Application do
 
         # Start phoenix pubsub
         {Phoenix.PubSub, name: Teiserver.PubSub},
+        {Task.Supervisor, name: Teiserver.TaskSupervisor},
         TeiserverWeb.Telemetry,
 
         # Start the Ecto repository

--- a/lib/teiserver/coordinator.ex
+++ b/lib/teiserver/coordinator.ex
@@ -119,15 +119,15 @@ defmodule Teiserver.Coordinator do
     end
   end
 
-  @spec call_consul(pid() | T.lobby_id(), any) :: any
-  def call_consul(lobby_id, msg) when is_integer(lobby_id) do
+  @spec call_consul(pid() | T.lobby_id(), any, timeout()) :: any
+  def call_consul(lobby_id, msg, timeout \\ 5_000) when is_integer(lobby_id) do
     case get_consul_pid(lobby_id) do
       nil ->
         nil
 
       pid ->
         try do
-          GenServer.call(pid, msg)
+          GenServer.call(pid, msg, timeout)
 
           # If the process has somehow died, we just return nil
         catch
@@ -291,9 +291,9 @@ defmodule Teiserver.Coordinator do
     CacheUser.send_direct_message(get_coordinator_userid(), userid, msg)
   end
 
-  @spec get_team_config(integer()) :: map()
-  def get_team_config(lobby_id) do
-    call_consul(lobby_id, :get_team_config)
+  @spec get_team_config(integer(), timeout()) :: map()
+  def get_team_config(lobby_id, timeout \\ 5_000) do
+    call_consul(lobby_id, :get_team_config, timeout)
   end
 
   # Debug stuff

--- a/lib/teiserver/protocols/spring/spring_battle_out.ex
+++ b/lib/teiserver/protocols/spring/spring_battle_out.ex
@@ -61,6 +61,8 @@ defmodule Teiserver.Protocols.Spring.BattleOut do
 
   def do_reply(:extra_data, _, _state), do: ""
 
+  def do_reply(:battle_teams, nil, _state), do: ""
+
   def do_reply(:battle_teams, data, _state) do
     encoded_data =
       data

--- a/lib/teiserver/protocols/spring/spring_out.ex
+++ b/lib/teiserver/protocols/spring/spring_out.ex
@@ -738,11 +738,16 @@ defmodule Teiserver.Protocols.SpringOut do
     end)
 
     # Send BATTLETEAMS message
-    teams_data = Teiserver.Battle.get_team_config(:all)
+    # Make this async to avoid blocking login
+    current_process = self()
 
-    if teams_data do
-      send(self(), {:battle_teams, teams_data})
-    end
+    Task.Supervisor.start_child(Teiserver.TaskSupervisor, fn ->
+      teams_data = Teiserver.Battle.get_team_config(:all)
+
+      if teams_data do
+        send(current_process, {:battle_teams, teams_data})
+      end
+    end)
 
     # CLIENTSTATUS entries
     clients


### PR DESCRIPTION
Fix for crashes related to #705 

Discord convo: https://discord.com/channels/549281623154229250/564591092360675328/1402703973617635481

## Problem
Error logs showed KeyError crashes when accessing `:host_teamsize` from nil values:

```
(KeyError) key :host_teamsize not found in: nil
(teiserver 0.1.0) lib/teiserver/lobby/libs/lobby_lib.ex:554: Teiserver.Lobby.LobbyLib.get_team_config/1
```

Also found login timeouts due to blocking `get_team_config(:all)` calls.

## Solution

### 1. Added nil checks in `get_team_config/1`
- Added `case` blocks to handle nil returns from `Teiserver.Coordinator.get_team_config/1`
- Prevents KeyError when consul servers don't exist

### 2. Made battle teams login bulk broadcast asynchronous
- Moved `get_team_config(:all)` call to async task in `spring_out.ex`
- Prevents login timeouts

### 3. Added nil checks in downstream functions
- Added nil check in `spring_tcp_server.ex` before calling `SpringOut.reply`
- Added nil guard in `spring_battle_out.ex` to prevent Jason.encode! crashes
