### PR TITLE
Fix GDPR clean not updating user due to invalid email

### DIFF
--- a/lib/teiserver_web/controllers/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/admin/user_controller.ex
@@ -1063,7 +1063,7 @@ defmodule TeiserverWeb.Admin.UserController do
         new_user =
           Map.merge(user, %{
             name: Ecto.UUID.generate(),
-            email: "#{user.id}@#{user.id}",
+            email: "#{user.id}@#{user.id}.#{user.id}",
             password: UserLib.make_bot_password(),
             country: "??"
           })


### PR DESCRIPTION
GDPR clean was not updating user with new randomised name and email due to email validation failing,
Specifically, user `:script` changeset, `Teiserver.CacheUser.valid_email?` was returning false because the GDPR clean email didn't contain a dot.