### PR TITLE
Fix boss restriction not working with new unboss commmand

### DIFF
--- a/lib/teiserver/coordinator/consul_server.ex
+++ b/lib/teiserver/coordinator/consul_server.ex
@@ -468,7 +468,7 @@ defmodule Teiserver.Coordinator.ConsulServer do
           state.lobby_id
         )
 
-        ChatLib.say(userid, "!boss", state.lobby_id)
+        ChatLib.say(userid, "!unboss #{username}", state.lobby_id)
       end)
 
       # Broadcast team configuration changes to lobby server


### PR DESCRIPTION
`!boss` command was changed some time ago. Without arguments it used to unboss the user if they were a boss already, after the changes it no longer does that, a new command `!unboss` was added for that purpose. As a result boss restriction was ineffective.