### PR TITLE
Send roles to Client

### DIFF
--- a/lib/teiserver/player/session.ex
+++ b/lib/teiserver/player/session.ex
@@ -1305,7 +1305,8 @@ defmodule Teiserver.Player.Session do
       # we get the same struct every time, possibly with nil values for some keys
       # but in the meantime, just defensively get the country
       country: Map.get(user, :country, "??"),
-      status: status
+      status: status,
+      roles: Teiserver.Player.TachyonHandler.convert_teiserver_roles_to_tachyon(user.roles)
     }
 
     PubSub.broadcast!(

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -67,7 +67,8 @@ defmodule Teiserver.Player.TachyonHandler do
         friendIds: Enum.map(friends, fn %{userId: uid} -> uid end),
         outgoingFriendRequest: outgoing,
         incomingFriendRequest: incoming,
-        ignoreIds: []
+        ignoreIds: [],
+        roles: convert_teiserver_roles_to_tachyon(user.roles)
       }
     }
 
@@ -158,7 +159,8 @@ defmodule Teiserver.Player.TachyonHandler do
           username: user_state.username,
           clanId: user_state.clan_id,
           country: user_state.country,
-          status: user_state.status
+          status: user_state.status,
+          roles: user_state.roles
         }
       ]
     }
@@ -348,7 +350,8 @@ defmodule Teiserver.Player.TachyonHandler do
           displayName: user.name,
           clanId: user.clan_id,
           countryCode: user.country,
-          status: status
+          status: status,
+          roles: convert_teiserver_roles_to_tachyon(user.roles)
         }
 
       {:response, resp, state}
@@ -712,5 +715,24 @@ defmodule Teiserver.Player.TachyonHandler do
           }
         end)
     }
+  end
+
+  @doc """
+  Converts Teiserver role names to Tachyon role names.
+  Only roles that have Tachyon equivalents are included.
+  """
+  def convert_teiserver_roles_to_tachyon(teiserver_roles) when is_list(teiserver_roles) do
+    teiserver_roles
+    |> Enum.map(fn role ->
+      case role do
+        "Contributor" -> "contributor"
+        "Admin" -> "admin"
+        "Moderator" -> "moderator"
+        "Caster" -> "tournament_caster"
+        "Tournament winner" -> "tournament_winner"
+        _ -> nil
+      end
+    end)
+    |> Enum.reject(&is_nil/1)
   end
 end

--- a/priv/tachyon/schema/definitions/user.json
+++ b/priv/tachyon/schema/definitions/user.json
@@ -8,7 +8,30 @@
         "displayName": { "type": "string" },
         "clanId": { "anyOf": [{ "type": "string" }, { "type": "null" }] },
         "countryCode": { "type": "string" },
-        "status": { "enum": ["offline", "menu", "playing", "lobby"] }
+        "status": { "enum": ["offline", "menu", "playing", "lobby"] },
+        "rating": {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "description": "Key is omitted when the player isn't rated yet.",
+                    "type": "number"
+                }
+            },
+            "required": ["value"]
+        },
+        "roles": {
+            "type": "array",
+            "items": {
+                "enum": [
+                    "contributor",
+                    "admin",
+                    "moderator",
+                    "tournament_winner",
+                    "tournament_caster"
+                ]
+            },
+            "uniqueItems": true
+        }
     },
     "required": ["userId", "username", "displayName", "clanId", "status"]
 }


### PR DESCRIPTION
Added conversion function to map and convert tachyon roles.  These are the roles sent in `user/self`, 'user/info`, `user/updated` (https://github.com/beyond-all-reason/tachyon/issues/60)

Closes #675 