### PR TITLE
Add user/self event broadcast when roles are changed

### DIFF
--- a/lib/teiserver/player.ex
+++ b/lib/teiserver/player.ex
@@ -114,4 +114,10 @@ defmodule Teiserver.Player do
   """
   @spec party_notify_join_queues(T.userid(), [Matchmaking.queue_id()], Party.state()) :: :ok
   defdelegate party_notify_join_queues(user_id, queues, party_state), to: Player.Session
+
+  @doc """
+  Sends a user/self event to a user when their roles are updated
+  """
+  @spec update_user_roles(T.userid(), [String.t()]) :: :ok
+  defdelegate update_user_roles(user_id, roles), to: Player.Session
 end

--- a/lib/teiserver_web/controllers/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/admin/user_controller.ex
@@ -265,6 +265,8 @@ defmodule TeiserverWeb.Admin.UserController do
       |> Enum.reject(&(&1 == nil))
       |> Enum.uniq()
 
+    roles_changed = MapSet.new(new_roles) != MapSet.new(user.roles)
+
     permissions =
       new_roles
       |> Enum.map(fn role_name ->
@@ -306,6 +308,10 @@ defmodule TeiserverWeb.Admin.UserController do
         case change_result do
           {:ok, user} ->
             Account.decache_user(user.id)
+
+            if roles_changed do
+              Teiserver.Player.update_user_roles(user.id, user.roles)
+            end
 
             conn
             |> put_flash(:info, "User updated successfully.")


### PR DESCRIPTION
- Added role change detection to user_controller.ex
- Added `send_admin_role_update/1` function to session.ex to communicate with connected users
- Added `admin_role_update` handler and extracted `build_user_self_event/2` from `init/1` for reusability

Closes #723