### PR TITLE
Fix last_login db field being null

### DIFF
--- a/lib/teiserver/account/caches/user_cache_lib.ex
+++ b/lib/teiserver/account/caches/user_cache_lib.ex
@@ -239,20 +239,6 @@ defmodule Teiserver.Account.UserCacheLib do
     data =
       CacheUser.data_keys()
       |> Map.new(fn k -> {to_string(k), Map.get(user, k, Account.default_data()[k])} end)
-      |> Map.put(
-        "last_login",
-        case Map.get(user, :last_login) do
-          dt when is_map(dt) ->
-            try do
-              div(Timex.to_unix(dt), 60)
-            rescue
-              _ -> Map.get(user, :last_login)
-            end
-
-          _ ->
-            Map.get(user, :last_login)
-        end
-      )
 
     obj_attrs =
       CacheUser.keys()

--- a/lib/teiserver/account/caches/user_cache_lib.ex
+++ b/lib/teiserver/account/caches/user_cache_lib.ex
@@ -239,23 +239,20 @@ defmodule Teiserver.Account.UserCacheLib do
     data =
       CacheUser.data_keys()
       |> Map.new(fn k -> {to_string(k), Map.get(user, k, Account.default_data()[k])} end)
-      |> Map.put("last_login", 
-          case Map.get(user, :last_login) do
-            dt when is_map(dt) -> 
-              # Try to convert to Unix timestamp, if it fails, keep original
-              try do
-                unix_mins = div(Timex.to_unix(dt), 60)
-                Logger.info("persist_user: Converting last_login datetime #{inspect(dt)} to Unix minutes: #{unix_mins}")
-                unix_mins
-              rescue
-                _ -> 
-                  Logger.info("persist_user: last_login is not a convertible datetime: #{inspect(dt)}")
-                  dt
-              end
-            other -> 
-              Logger.info("persist_user: last_login is not a map: #{inspect(other)}")
-              other
-          end)
+      |> Map.put(
+        "last_login",
+        case Map.get(user, :last_login) do
+          dt when is_map(dt) ->
+            try do
+              div(Timex.to_unix(dt), 60)
+            rescue
+              _ -> Map.get(user, :last_login)
+            end
+
+          _ ->
+            Map.get(user, :last_login)
+        end
+      )
 
     obj_attrs =
       CacheUser.keys()

--- a/lib/teiserver/account/libs/account_test_lib.ex
+++ b/lib/teiserver/account/libs/account_test_lib.ex
@@ -16,7 +16,7 @@ defmodule Teiserver.Account.AccountTestLib do
         colour: data["colour"] || "colour",
         icon: data["icon"] || "icon",
         password: data["password"] || Teiserver.Account.spring_md5_password("password"),
-        last_login_timex: data["last_login_timex"] || Timex.now()
+        last_login: data["last_login"] || Timex.now()
       },
       :script
     )

--- a/lib/teiserver/account/libs/relationship_lib.ex
+++ b/lib/teiserver/account/libs/relationship_lib.ex
@@ -397,8 +397,8 @@ defmodule Teiserver.Account.RelationshipLib do
       using account_users au
       where au.id = ar.to_user_id
       and ar.from_user_id = $1
-      and (au.last_login_timex is null OR
-      abs(DATE_PART('day', (now()- au.last_login_timex ))) > $2);
+      and (au.last_login is null OR
+      abs(DATE_PART('day', (now()- au.last_login ))) > $2);
     """
 
     results =
@@ -419,8 +419,8 @@ defmodule Teiserver.Account.RelationshipLib do
       join account_users au
       on au.id = ar.to_user_id
       and ar.from_user_id = $1
-      and (au.last_login_timex is null OR
-      abs(DATE_PART('day', (now()- au.last_login_timex ))) > $2);
+      and (au.last_login is null OR
+      abs(DATE_PART('day', (now()- au.last_login ))) > $2);
       """
 
     result =

--- a/lib/teiserver/account/reports/retention_report.ex
+++ b/lib/teiserver/account/reports/retention_report.ex
@@ -51,8 +51,7 @@ defmodule Teiserver.Account.RetentionReport do
         limit: :infinity
       )
       |> Enum.map(fn user ->
-        last_login_secs = user.data["last_login"] * 60
-        last_login = Timex.from_unix(last_login_secs)
+        last_login = user.data["last_login"]
 
         last_played =
           day_logs
@@ -70,7 +69,7 @@ defmodule Teiserver.Account.RetentionReport do
             end
           end)
 
-        if last_played != nil do
+        if last_played != nil and last_login != nil do
           %{
             last_login: Timex.diff(user.inserted_at, last_login, :days) |> abs,
             last_played: Timex.diff(user.inserted_at, last_played, :days) |> abs

--- a/lib/teiserver/account/schemas/user.ex
+++ b/lib/teiserver/account/schemas/user.ex
@@ -28,7 +28,6 @@ defmodule Teiserver.Account.User do
 
     # Start time of their last match
     field :last_login, :utc_datetime
-    field :last_login_timex, :utc_datetime
     field :last_played, :utc_datetime
     field :last_logout, :utc_datetime
 
@@ -57,7 +56,6 @@ defmodule Teiserver.Account.User do
       email_change_code: nil,
       last_login: nil,
       last_login_mins: nil,
-      last_login_timex: nil,
       restrictions: [],
       restricted_until: nil,
       shadowbanned: false,
@@ -84,7 +82,7 @@ defmodule Teiserver.Account.User do
     user
     |> cast(
       attrs,
-      ~w(name email password icon colour data roles permissions restrictions restricted_until shadowbanned last_login_timex last_login last_played last_logout discord_id discord_dm_channel_id steam_id smurf_of_id clan_id)a
+      ~w(name email password icon colour data roles permissions restrictions restricted_until shadowbanned last_login last_played last_logout discord_id discord_dm_channel_id steam_id smurf_of_id clan_id)a
     )
     |> validate_required([:name, :email, :password, :permissions])
     |> unique_constraint(:email)
@@ -100,7 +98,7 @@ defmodule Teiserver.Account.User do
     user
     |> cast(
       attrs,
-      ~w(name email password icon colour data roles permissions restrictions restricted_until shadowbanned last_login_timex last_login last_played last_logout discord_id discord_dm_channel_id steam_id smurf_of_id clan_id)a
+      ~w(name email password icon colour data roles permissions restrictions restricted_until shadowbanned last_login last_played last_logout discord_id discord_dm_channel_id steam_id smurf_of_id clan_id)a
     )
     |> validate_required([:name, :email, :password, :permissions])
     |> unique_constraint(:email)

--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -27,7 +27,7 @@ defmodule Teiserver.CacheUser do
   @spec keys() :: [atom]
   def keys(),
     do:
-      ~w(id name password email inserted_at clan_id permissions colour icon smurf_of_id last_login_timex last_played last_logout roles discord_id)a
+      ~w(id name password email inserted_at clan_id permissions colour icon smurf_of_id last_login_timex last_login last_played last_logout roles discord_id)a
 
   # This is the version of keys with the extra fields we're going to be moving from data to the object itself
   # def keys(),
@@ -946,7 +946,7 @@ defmodule Teiserver.CacheUser do
 
     user = %{
       user
-      | last_login: round(System.system_time(:second) / 60),
+      | last_login: Timex.now(),  # Set as proper datetime
         last_login_timex: Timex.now(),
         last_login_mins: round(System.system_time(:second) / 60),
         country: country,

--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -945,8 +945,7 @@ defmodule Teiserver.CacheUser do
 
     user = %{
       user
-      | # Set as proper datetime
-        last_login: Timex.now(),
+      | last_login: Timex.now(),
         last_login_mins: round(System.system_time(:second) / 60),
         country: country,
         rank: rank,

--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -27,7 +27,7 @@ defmodule Teiserver.CacheUser do
   @spec keys() :: [atom]
   def keys(),
     do:
-      ~w(id name password email inserted_at clan_id permissions colour icon smurf_of_id last_login_timex last_login last_played last_logout roles discord_id)a
+      ~w(id name password email inserted_at clan_id permissions colour icon smurf_of_id last_login last_played last_logout roles discord_id)a
 
   # This is the version of keys with the extra fields we're going to be moving from data to the object itself
   # def keys(),
@@ -41,7 +41,6 @@ defmodule Teiserver.CacheUser do
     :email_change_code,
     :last_login,
     :last_login_mins,
-    :last_login_timex,
     :restrictions,
     :restricted_until,
     :shadowbanned,
@@ -946,8 +945,8 @@ defmodule Teiserver.CacheUser do
 
     user = %{
       user
-      | last_login: Timex.now(),  # Set as proper datetime
-        last_login_timex: Timex.now(),
+      | # Set as proper datetime
+        last_login: Timex.now(),
         last_login_mins: round(System.system_time(:second) / 60),
         country: country,
         rank: rank,

--- a/lib/teiserver_web/controllers/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/admin/user_controller.ex
@@ -626,7 +626,7 @@ defmodule TeiserverWeb.Admin.UserController do
           |> Enum.map(fn {_, user} -> user end)
           |> Enum.sort_by(
             fn user ->
-              user.data["last_login"]
+              user.last_login
             end,
             &>=/2
           )

--- a/lib/teiserver_web/live/account/relationship/index.ex
+++ b/lib/teiserver_web/live/account/relationship/index.ex
@@ -534,7 +534,7 @@ defmodule TeiserverWeb.Account.RelationshipLive.Index do
 
   def get_inactive_friends(friends, days_cutoff) do
     Enum.filter(friends, fn friend ->
-      last_login = friend.other_user.last_login_timex
+      last_login = friend.other_user.last_login
       days = get_days_diff(last_login, Timex.now())
       days > days_cutoff
     end)

--- a/lib/teiserver_web/templates/admin/user/smurf_list.html.heex
+++ b/lib/teiserver_web/templates/admin/user/smurf_list.html.heex
@@ -160,7 +160,7 @@ is_moderator = allow?(@conn, "Moderator") %>
                   <% end %>
 
                   <td>
-                    {date_to_str(((@user.data["last_login"] || 0) * 60) |> Timex.from_unix(),
+                    {date_to_str(@user.last_login,
                       format: :hms_or_ymd,
                       tz: @tz
                     )}
@@ -228,7 +228,7 @@ is_moderator = allow?(@conn, "Moderator") %>
                     <% end %>
 
                     <td>
-                      {date_to_str(((user.data["last_login"] || 0) * 60) |> Timex.from_unix(),
+                      {date_to_str(user.last_login,
                         format: :hms_or_ymd,
                         tz: @tz
                       )}

--- a/lib/teiserver_web/templates/admin/user/tab_details.html.heex
+++ b/lib/teiserver_web/templates/admin/user/tab_details.html.heex
@@ -17,7 +17,7 @@
     {central_component("detail_line",
       label: "Last login",
       value:
-        date_to_str(@user.last_login_timex,
+        date_to_str(@user.last_login,
           format: :hms_or_hms_ymd,
           tz: @tz
         )

--- a/lib/teiserver_web/templates/report/report/ban_evasion.html.heex
+++ b/lib/teiserver_web/templates/report/report/ban_evasion.html.heex
@@ -93,7 +93,7 @@
                 </td>
 
                 <td>
-                  {date_to_str(((user.data["last_login_mins"] || 0) * 60) |> Timex.from_unix(),
+                  {date_to_str(user.data["last_login"],
                     format: :hms_or_ymd,
                     tz: @tz
                   )}

--- a/lib/teiserver_web/templates/report/report/new_smurf.html.heex
+++ b/lib/teiserver_web/templates/report/report/new_smurf.html.heex
@@ -102,7 +102,7 @@
                 </td>
 
                 <td>
-                  {date_to_str(((user.data["last_login"] || 0) * 60) |> Timex.from_unix(),
+                  {date_to_str(user.data["last_login"],
                     format: :hms_or_ymd,
                     tz: @tz
                   )}

--- a/priv/repo/migrations/20250821211457_remove_last_login_timex_column.exs
+++ b/priv/repo/migrations/20250821211457_remove_last_login_timex_column.exs
@@ -2,6 +2,19 @@ defmodule Teiserver.Repo.Migrations.RemoveLastLoginTimexColumn do
   use Ecto.Migration
 
   def change do
+    # First, migrate data from last_login_timex to last_login for ALL users
+    # This ensures all users have consistent last_login data before we remove the old column
+    # We overwrite last_login regardless of its current value to prevent format inconsistencies
+    execute """
+            UPDATE account_users 
+            SET last_login = last_login_timex 
+            WHERE last_login_timex IS NOT NULL
+            """,
+            """
+            -- No rollback needed for data migration
+            """
+
+    # Now remove the redundant column
     alter table(:account_users) do
       remove :last_login_timex
     end

--- a/priv/repo/migrations/20250821211457_remove_last_login_timex_column.exs
+++ b/priv/repo/migrations/20250821211457_remove_last_login_timex_column.exs
@@ -1,0 +1,9 @@
+defmodule Teiserver.Repo.Migrations.RemoveLastLoginTimexColumn do
+  use Ecto.Migration
+
+  def change do
+    alter table(:account_users) do
+      remove :last_login_timex
+    end
+  end
+end

--- a/test/teiserver/account/relationship_lib_test.exs
+++ b/test/teiserver/account/relationship_lib_test.exs
@@ -13,7 +13,7 @@ defmodule Teiserver.Account.RelationshipLibTest do
 
     user3 =
       AccountTestLib.user_fixture(%{
-        "last_login_timex" => old_login
+        "last_login" => old_login
       })
 
     assert user1.id != nil


### PR DESCRIPTION
Fixes #543

Fixing `last_login` field always being null in DB,  also unravelling some duplication of data.

Originally we had:

DB (ie. `user.last_login`):

`last_login` :datetime  - always null
`last_login_timex` :datetime - set correctly


Cache (ie. `user.data['last_login']`:

`last_login` - unix timestamp
`last_login_timex` - datetime
`last_login_mins` - unix timestamp (same value as `last_login`)

In the new state, `last_login` populates correctly, and the data duplication is reduced

DB:
`last_login` :datettime - correctly populates
~~last_login_timex~~ - removed from all code references and replaced with `last_login`, and there is a database migration to purge it

Cache:
`last_login` - datettime
~~last_login_timex~~ removed, references updated to `last_login`
`last_login_mins` - untouched

This could be further reduced by blowing away the `last_login_mins` field and quickly computing that where needed, but I didn't go that far.

I also found a weird column mismatch in smurf_search I fixed while I was fixing the templates that used this data.


Note: as mentioned this includes a database migration to remove `last_login_timex` but if you don't run it everything should be fine as no code touches it anymore as far as I was able to grep

I'll squash commits once this is reviewed