### PR TITLE
Add pagination to phoenix UI pages

### DIFF
--- a/lib/teiserver/account.ex
+++ b/lib/teiserver/account.ex
@@ -22,6 +22,12 @@ defmodule Teiserver.Account do
   @spec list_users(list) :: [User]
   defdelegate list_users(args), to: UserLib
 
+  @spec count_users() :: integer
+  defdelegate count_users(), to: UserLib
+
+  @spec count_users(list) :: integer
+  defdelegate count_users(args), to: UserLib
+
   @spec get_user!(non_neg_integer()) :: User.t()
   defdelegate get_user!(user_id), to: UserLib
 

--- a/lib/teiserver/account/libs/user_lib.ex
+++ b/lib/teiserver/account/libs/user_lib.ex
@@ -64,6 +64,18 @@ defmodule Teiserver.Account.UserLib do
     |> Repo.all()
   end
 
+  @spec count_users() :: integer
+  def count_users() do
+    count_users([])
+  end
+
+  @spec count_users(list) :: integer
+  def count_users(args) do
+    args
+    |> UserQueries.count_users()
+    |> Repo.aggregate(:count, :id)
+  end
+
   @doc """
   Gets a single user.
 

--- a/lib/teiserver/account/queries/user_queries.ex
+++ b/lib/teiserver/account/queries/user_queries.ex
@@ -16,6 +16,22 @@ defmodule Teiserver.Account.UserQueries do
     |> do_order_by(args[:order_by])
     |> query_select(args[:select])
     |> limit_query(args[:limit] || 50)
+    |> offset_query(args[:offset])
+  end
+
+  @spec count_users(list) :: Ecto.Query.t()
+  def count_users(args) do
+    query = from(users in User)
+
+    query
+    |> do_where(id: args[:id])
+    |> do_where(args[:where])
+    |> do_where(args[:search])
+    |> do_preload(args[:preload])
+    |> do_order_by(args[:order_by])
+    |> query_select(args[:select])
+
+    # No limit or offset for counting
   end
 
   @spec do_where(Ecto.Query.t(), list | map | nil) :: Ecto.Query.t()

--- a/lib/teiserver/battle.ex
+++ b/lib/teiserver/battle.ex
@@ -32,6 +32,7 @@ defmodule Teiserver.Battle do
     |> MatchLib.order_by(args[:order_by])
     |> QueryHelpers.query_select(args[:select])
     |> QueryHelpers.limit_query(args[:limit])
+    |> QueryHelpers.offset_query(args[:offset])
   end
 
   @doc """
@@ -47,7 +48,26 @@ defmodule Teiserver.Battle do
   def list_matches(args \\ []) do
     match_query(args)
     |> QueryHelpers.limit_query(args[:limit] || 50)
+    |> QueryHelpers.offset_query(args[:offset])
     |> Repo.all()
+  end
+
+  @doc """
+  Returns the count of matches matching the given criteria.
+
+  ## Examples
+
+      iex> count_matches()
+      42
+
+      iex> count_matches(search: [has_started: true])
+      35
+
+  """
+  @spec count_matches(List.t()) :: integer()
+  def count_matches(args \\ []) do
+    match_query(args)
+    |> Repo.aggregate(:count, :id)
   end
 
   @doc """

--- a/lib/teiserver/battle/libs/match_lib.ex
+++ b/lib/teiserver/battle/libs/match_lib.ex
@@ -244,6 +244,15 @@ defmodule Teiserver.Battle.MatchLib do
       preload: [members: members]
   end
 
+  def _search(query, :username, username) do
+    from matches in query,
+      join: members in assoc(matches, :members),
+      join: users in assoc(members, :user),
+      where: ilike(users.name, ^"%#{username}%"),
+      distinct: true,
+      preload: [members: members]
+  end
+
   def _search(query, :user_id_in, user_ids) do
     from matches in query,
       join: members in assoc(matches, :members),

--- a/lib/teiserver/game.ex
+++ b/lib/teiserver/game.ex
@@ -537,7 +537,26 @@ defmodule Teiserver.Game do
   def list_rating_logs(args \\ []) do
     rating_log_query(args)
     |> QueryHelpers.limit_query(args[:limit] || 50)
+    |> QueryHelpers.offset_query(args[:offset])
     |> Repo.all()
+  end
+
+  @doc """
+  Returns the count of rating_logs matching the given criteria.
+
+  ## Examples
+
+      iex> count_rating_logs()
+      42
+
+      iex> count_rating_logs(search: [user_id: 123])
+      15
+
+  """
+  @spec count_rating_logs(List.t()) :: integer()
+  def count_rating_logs(args \\ []) do
+    rating_log_query(args)
+    |> Repo.aggregate(:count, :id)
   end
 
   @doc """

--- a/lib/teiserver/moderation.ex
+++ b/lib/teiserver/moderation.ex
@@ -49,7 +49,23 @@ defmodule Teiserver.Moderation do
   def list_reports(args \\ []) do
     report_query(args)
     |> QueryHelpers.limit_query(args[:limit] || 50)
+    |> QueryHelpers.offset_query(args[:offset])
     |> Repo.all()
+  end
+
+  @doc """
+  Returns the count of reports.
+
+  ## Examples
+
+      iex> count_reports()
+      42
+
+  """
+  @spec count_reports(List.t()) :: integer()
+  def count_reports(args \\ []) do
+    report_query(args)
+    |> Repo.aggregate(:count, :id)
   end
 
   @doc """
@@ -255,6 +271,9 @@ defmodule Teiserver.Moderation do
 
   @spec list_report_groups(list) :: [ComplexServerEventType.t()]
   defdelegate list_report_groups(args), to: ReportGroupLib
+
+  @spec count_report_groups(list) :: integer()
+  defdelegate count_report_groups(args), to: ReportGroupLib
 
   @spec get_report_group!(non_neg_integer) :: ComplexServerEventType.t()
   defdelegate get_report_group!(id), to: ReportGroupLib
@@ -502,7 +521,23 @@ defmodule Teiserver.Moderation do
   def list_actions(args \\ []) do
     action_query(args)
     |> QueryHelpers.limit_query(args[:limit] || 50)
+    |> QueryHelpers.offset_query(args[:offset])
     |> Repo.all()
+  end
+
+  @doc """
+  Returns the count of actions.
+
+  ## Examples
+
+      iex> count_actions()
+      42
+
+  """
+  @spec count_actions(List.t()) :: integer()
+  def count_actions(args \\ []) do
+    action_query(args)
+    |> Repo.aggregate(:count, :id)
   end
 
   @doc """
@@ -964,7 +999,23 @@ defmodule Teiserver.Moderation do
   def list_bans(args \\ []) do
     ban_query(args)
     |> QueryHelpers.limit_query(args[:limit] || 50)
+    |> QueryHelpers.offset_query(args[:offset])
     |> Repo.all()
+  end
+
+  @doc """
+  Returns the count of bans.
+
+  ## Examples
+
+      iex> count_bans()
+      42
+
+  """
+  @spec count_bans(List.t()) :: integer()
+  def count_bans(args \\ []) do
+    ban_query(args)
+    |> Repo.aggregate(:count, :id)
   end
 
   @doc """

--- a/lib/teiserver/moderation/libs/ban_lib.ex
+++ b/lib/teiserver/moderation/libs/ban_lib.ex
@@ -79,6 +79,12 @@ defmodule Teiserver.Moderation.BanLib do
       where: bans.inserted_at < ^dt
   end
 
+  def _search(query, :name, name) do
+    from bans in query,
+      left_join: sources in assoc(bans, :source),
+      where: ilike(sources.name, ^"%#{name}%")
+  end
+
   @spec order_by(Ecto.Query.t(), String.t() | nil) :: Ecto.Query.t()
   def order_by(query, nil), do: query
 

--- a/lib/teiserver/moderation/libs/report_group_lib.ex
+++ b/lib/teiserver/moderation/libs/report_group_lib.ex
@@ -41,6 +41,13 @@ defmodule Teiserver.Moderation.ReportGroupLib do
     |> Repo.all()
   end
 
+  @spec count_report_groups(list) :: integer()
+  def count_report_groups(args \\ []) do
+    args
+    |> ReportGroupQueries.query_report_groups()
+    |> Repo.aggregate(:count, :id)
+  end
+
   @doc """
   Gets a single report_group.
 

--- a/lib/teiserver/moderation/libs/report_lib.ex
+++ b/lib/teiserver/moderation/libs/report_lib.ex
@@ -177,14 +177,24 @@ defmodule Teiserver.Moderation.ReportLib do
 
   def _search(query, :state, "Any"), do: query
 
-  def _search(query, :state, "Open") do
+  def _search(query, :state, "open") do
     from reports in query,
       where: is_nil(reports.result_id) and not reports.closed
   end
 
-  def _search(query, :state, "Resolved") do
+  def _search(query, :state, "resolved") do
     from reports in query,
       where: reports.closed or not is_nil(reports.result_id)
+  end
+
+  def _search(query, :type, "chat") do
+    from reports in query,
+      where: reports.type == "chat"
+  end
+
+  def _search(query, :type, "actions") do
+    from reports in query,
+      where: reports.type == "actions"
   end
 
   @spec order_by(Ecto.Query.t(), String.t() | nil) :: Ecto.Query.t()

--- a/lib/teiserver/moderation/queries/report_group_queries.ex
+++ b/lib/teiserver/moderation/queries/report_group_queries.ex
@@ -14,7 +14,8 @@ defmodule Teiserver.Moderation.ReportGroupQueries do
     |> do_preload(args[:preload])
     |> do_order_by(args[:order_by])
     |> query_select(args[:select])
-    |> limit_query(args[:limit] || 50)
+    |> limit_query(args[:limit])
+    |> offset_query(args[:offset])
   end
 
   @spec do_where(Ecto.Query.t(), list | map | nil) :: Ecto.Query.t()

--- a/lib/teiserver/telemetry.ex
+++ b/lib/teiserver/telemetry.ex
@@ -939,6 +939,12 @@ defmodule Teiserver.Telemetry do
     |> Repo.all()
   end
 
+  @spec count_infologs(List.t()) :: non_neg_integer()
+  def count_infologs(args \\ []) do
+    infolog_query(args)
+    |> Repo.aggregate(:count, :id)
+  end
+
   @spec get_infolog(Integer.t(), List.t()) :: List.t()
   def get_infolog(id, args \\ []) do
     infolog_query(id, args)

--- a/lib/teiserver_web/components/pagination_components.ex
+++ b/lib/teiserver_web/components/pagination_components.ex
@@ -1,0 +1,423 @@
+defmodule TeiserverWeb.PaginationComponents do
+  @moduledoc """
+  Pagination components and utilities.
+  """
+  use Phoenix.Component
+
+  @doc """
+  Renders a pagination component with page numbers, navigation, and search parameter preservation.
+
+  ## Examples
+      
+      # Basic pagination
+      <.pagination
+        page={@page}
+        total_pages={@total_pages}
+        base_url="/admin/users"
+        class="mt-3"
+      />
+      
+      # Full pagination with search parameter preservation (Controller)
+      <.pagination
+        page={@page}
+        total_pages={@total_pages}
+        base_url="/admin/users"
+        limit={@limit}
+        total_count={@total_count}
+        current_count={@current_count}
+        include_params={["search", "limit", "name", "order"]}
+        current_params={@conn.params}
+        show_go_to={@total_pages > 5}
+        class="mt-3"
+      />
+      
+      # Full pagination with search parameter preservation (LiveView)
+      <.pagination
+        page={@page}
+        total_pages={@total_pages}
+        base_url="/moderation/overwatch"
+        limit={@limit}
+        total_count={@total_count}
+        current_count={@current_count}
+        include_params={["actioned-filter", "closed-filter", "kind-filter", "timeframe-filter", "target_id", "limit"]}
+        current_params={@filters}
+        show_go_to={@total_pages > 5}
+        class="mt-3"
+      />
+      
+  ## Options
+      
+  * `:page` - Current page number (0-based)
+  * `:total_pages` - Total number of pages (required for page number display)
+  * `:base_url` - Base URL for pagination links
+  * `:class` - Additional CSS classes
+  * `:limit` - Number of items per page (for display and limit dropdown)
+  * `:total_count` - Total number of items (for display purposes)
+  * `:current_count` - Number of items on current page
+  * `:show_go_to` - Whether to show "go to page" input (default: true)
+  * `:show_limit_dropdown` - Whether to show limit dropdown (default: true)
+  * `:max_pages` - Maximum number of page links to show (default: 7)
+  * `:include_params` - List of parameter names to preserve in pagination (e.g., ["search", "limit", "name"])
+  * `:current_params` - Map of current parameters to preserve (typically @conn.params for controllers or @filters for LiveViews)
+
+  ## Features
+
+  * **Search Parameter Preservation**: Automatically preserves search filters, sort orders, and other parameters when navigating between pages
+  * **Smart Pagination**: Shows ellipsis (...) for large page ranges to keep navigation clean
+  * **Limit Dropdown**: Allows users to change items per page (10, 25, 50, 100, 500)
+  * **Go to Page**: Direct page navigation input for large datasets
+  * **Responsive Design**: Adapts to different screen sizes
+
+  ## Usage Patterns
+
+  ### Controllers
+  Use `current_params={@conn.params}` to preserve URL parameters from the request:
+
+      current_params={@conn.params}
+      include_params={["search", "limit", "name", "order"]}
+
+  ### LiveViews  
+  Use `current_params={@filters}` to preserve LiveView filter state:
+
+      current_params={@filters}
+      include_params={["actioned-filter", "closed-filter", "kind-filter", "limit"]}
+
+  ### Special Cases
+  Some controllers merge additional parameters:
+
+      current_params={Map.merge(@conn.params, %{"limit" => @limit})}
+  """
+  attr :page, :integer, required: true
+  attr :total_pages, :integer, required: true
+  attr :base_url, :string, required: true
+  attr :class, :string, default: ""
+  attr :limit, :integer, default: nil
+  attr :total_count, :integer, default: nil
+  attr :current_count, :integer, default: nil
+  attr :show_go_to, :boolean, default: true
+  attr :show_limit_dropdown, :boolean, default: true
+  attr :max_pages, :integer, default: 7
+  attr :include_params, :list, default: []
+  attr :current_params, :map, default: %{}
+
+  def pagination(assigns) do
+    assigns =
+      assign(
+        assigns,
+        :page_range,
+        build_page_range(assigns.page, assigns.total_pages, assigns.max_pages)
+      )
+
+    ~H"""
+    <div class={"row mt-3 #{@class}"}>
+      <div class="col-md-6">
+        <!-- Info Section -->
+        <%= if @limit != nil and @total_count != nil and @current_count != nil do %>
+          <div class="text-muted">
+            Showing {@page * @limit + 1}-{@page * @limit + @current_count} of {@total_count}
+          </div>
+        <% end %>
+      </div>
+
+      <div class="col-md-6">
+        <div class="d-flex justify-content-end align-items-center">
+          <!-- Limit Dropdown -->
+          <%= if @show_limit_dropdown and @limit != nil do %>
+            <div class="me-3">
+              <div class="input-group input-group-sm" style="width: 130px;">
+                <span class="input-group-text">Show</span>
+                <div class="dropdown">
+                  <button
+                    class="btn btn-outline-secondary dropdown-toggle"
+                    type="button"
+                    data-bs-toggle="dropdown"
+                  >
+                    {@limit}
+                  </button>
+                  <ul class="dropdown-menu">
+                    <li>
+                      <a
+                        class="dropdown-item"
+                        href={
+                          build_pagination_url(@base_url, @current_params, @include_params, %{
+                            "page" => "1",
+                            "limit" => "10"
+                          })
+                        }
+                      >
+                        10
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        class="dropdown-item"
+                        href={
+                          build_pagination_url(@base_url, @current_params, @include_params, %{
+                            "page" => "1",
+                            "limit" => "25"
+                          })
+                        }
+                      >
+                        25
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        class="dropdown-item"
+                        href={
+                          build_pagination_url(@base_url, @current_params, @include_params, %{
+                            "page" => "1",
+                            "limit" => "50"
+                          })
+                        }
+                      >
+                        50
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        class="dropdown-item"
+                        href={
+                          build_pagination_url(@base_url, @current_params, @include_params, %{
+                            "page" => "1",
+                            "limit" => "100"
+                          })
+                        }
+                      >
+                        100
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        class="dropdown-item"
+                        href={
+                          build_pagination_url(@base_url, @current_params, @include_params, %{
+                            "page" => "1",
+                            "limit" => "500"
+                          })
+                        }
+                      >
+                        500
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          <% end %>
+          
+    <!-- Go to Page Input -->
+          <%= if @show_go_to and @total_pages > 5 do %>
+            <div class="me-3">
+              <div class="input-group input-group-sm" style="width: 160px;">
+                <span class="input-group-text">Go to</span>
+                <input
+                  type="number"
+                  class="form-control"
+                  placeholder="Page"
+                  min="1"
+                  max={@total_pages}
+                  id="go-to-page-input"
+                />
+                <button
+                  class="btn btn-outline-secondary"
+                  type="button"
+                  onclick={"var url = '#{build_pagination_url(@base_url, @current_params, @include_params, %{"page" => "PAGE_PLACEHOLDER"}, []) |> String.replace("'", "\\'")}'; window.location.href = url.replace('PAGE_PLACEHOLDER', document.getElementById('go-to-page-input').value);"}
+                >
+                  <Fontawesome.icon icon="arrow-right" style="solid" />
+                </button>
+              </div>
+            </div>
+          <% end %>
+          
+    <!-- Pagination Navigation -->
+          <%= if @total_pages > 1 do %>
+            <nav aria-label="Page navigation">
+              <ul class="pagination pagination-sm mb-0">
+                <!-- Previous Button -->
+                <li class={"page-item #{if @page == 0, do: "disabled"}"}>
+                  <%= if @page > 0 do %>
+                    <.link
+                      navigate={
+                        build_pagination_url(
+                          @base_url,
+                          @current_params,
+                          @include_params,
+                          %{"page" => @page + 1},
+                          []
+                        )
+                      }
+                      class="page-link"
+                    >
+                      <Fontawesome.icon icon="chevron-left" style="solid" />
+                    </.link>
+                  <% else %>
+                    <span class="page-link">
+                      <Fontawesome.icon icon="chevron-left" style="solid" />
+                    </span>
+                  <% end %>
+                </li>
+                
+    <!-- Page Numbers -->
+                <%= for page_num <- @page_range do %>
+                  <%= if page_num == :ellipsis do %>
+                    <li class="page-item disabled">
+                      <span class="page-link">…</span>
+                    </li>
+                  <% else %>
+                    <li class={"page-item #{if page_num == @page, do: "active"}"}>
+                      <%= if page_num == @page do %>
+                        <span class="page-link">
+                          {page_num + 1}
+                          <span class="visually-hidden">(current)</span>
+                        </span>
+                      <% else %>
+                        <.link
+                          navigate={
+                            build_pagination_url(
+                              @base_url,
+                              @current_params,
+                              @include_params,
+                              %{"page" => page_num + 1},
+                              []
+                            )
+                          }
+                          class="page-link"
+                        >
+                          {page_num + 1}
+                        </.link>
+                      <% end %>
+                    </li>
+                  <% end %>
+                <% end %>
+                
+    <!-- Next Button -->
+                <li class={"page-item #{if @page >= @total_pages - 1, do: "disabled"}"}>
+                  <%= if @page < @total_pages - 1 do %>
+                    <.link
+                      navigate={
+                        build_pagination_url(
+                          @base_url,
+                          @current_params,
+                          @include_params,
+                          %{"page" => @page + 2},
+                          []
+                        )
+                      }
+                      class="page-link"
+                    >
+                      <Fontawesome.icon icon="chevron-right" style="solid" />
+                    </.link>
+                  <% else %>
+                    <span class="page-link">
+                      <Fontawesome.icon icon="chevron-right" style="solid" />
+                    </span>
+                  <% end %>
+                </li>
+              </ul>
+            </nav>
+          <% end %>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  @doc """
+  Builds a pagination URL with specified parameters and optional overrides.
+  This function is used internally by the pagination component and can also be used
+  directly for custom pagination logic.
+
+  ## Options
+
+  * `base_url` - Base URL or connection (string or Plug.Conn)
+  * `params` - All available parameters (typically @conn.params or similar)
+  * `include_params` - List of parameter names to include in the URL
+  * `overrides` - Map of parameters to override (e.g., %{"page" => 5})
+  * `exclusions` - List of parameter names to exclude (e.g., ["page", "limit"])
+
+  ## Examples
+
+      # Build URL with page override
+      build_pagination_url("/admin/users", params, ["limit", "kind"], %{"page" => 5})
+
+      # Build URL with page override and exclude limit
+      build_pagination_url("/admin/users", params, ["limit", "kind"], %{"page" => 1}, ["limit"])
+
+      # Build URL with no overrides or exclusions
+      build_pagination_url("/admin/users", params, ["limit", "kind"])
+      
+      # Build URL for LiveView push_patch (preserving all search parameters)
+      build_pagination_url("/moderation/overwatch", filters, 
+        ["actioned-filter", "closed-filter", "kind-filter", "timeframe-filter", "target_id", "limit"], 
+        %{"page" => "1"})
+
+  ## Behavior
+
+  * **Parameter Preservation**: Only includes parameters specified in `include_params`
+  * **Overrides**: Parameters in `overrides` take precedence over existing params
+  * **Exclusions**: Parameters in `exclusions` are removed from the final URL
+  * **Empty Values**: Automatically filters out empty strings and nil values
+  * **URL Encoding**: Properly encodes parameter values for safe URLs
+  """
+  def build_pagination_url(base_url, params, include_params, overrides \\ %{}, exclusions \\ []) do
+    # Use centralized parameter preparation with exclusions
+    search_params = prepare_params(params, include_params, overrides, exclusions)
+
+    if Enum.empty?(search_params) do
+      get_base_path(base_url)
+    else
+      query_string = build_query_string(search_params)
+      "#{get_base_path(base_url)}?#{query_string}"
+    end
+  end
+
+  # Helper function for building query strings consistently
+  defp build_query_string(params) do
+    params
+    |> Enum.map(fn {k, v} -> "#{k}=#{URI.encode_www_form(to_string(v))}" end)
+    |> Enum.join("&")
+  end
+
+  # Centralized parameter preparation with overrides and exclusions
+  defp prepare_params(params, include_params, overrides, exclusions) do
+    params
+    |> Map.take(include_params)
+    |> Map.merge(overrides)
+    |> Map.drop(exclusions)
+    |> Enum.reject(fn {_k, v} -> v == "" or v == nil end)
+  end
+
+  # Extract base path from URL or connection
+  defp get_base_path(base_url) when is_binary(base_url), do: base_url
+  defp get_base_path(conn) when is_map(conn), do: conn.request_path
+
+  # Helper function to build the page range for pagination
+  # Returns a list like [0, 1, :ellipsis, 5, 6, 7] for smart pagination
+  defp build_page_range(_current_page, total_pages, max_pages) when total_pages <= max_pages do
+    # If total pages is small, show all pages
+    Enum.to_list(0..(total_pages - 1))
+  end
+
+  defp build_page_range(current_page, total_pages, max_pages) do
+    # Smart pagination with ellipsis
+    # Reserve space for first, last, and ellipsis
+    half = div(max_pages - 3, 2)
+
+    cond do
+      # Near the beginning: [0, 1, 2, 3, ..., last]
+      current_page < half + 2 ->
+        Enum.to_list(0..(max_pages - 3)) ++ [:ellipsis, total_pages - 1]
+
+      # Near the end: [0, ..., n-3, n-2, n-1]
+      current_page > total_pages - half - 3 ->
+        [0, :ellipsis] ++ Enum.to_list((total_pages - max_pages + 2)..(total_pages - 1))
+
+      # In the middle: [0, ..., current-1, current, current+1, ..., last]
+      true ->
+        [0, :ellipsis] ++
+          Enum.to_list((current_page - half)..(current_page + half)) ++
+          [:ellipsis, total_pages - 1]
+    end
+  end
+end

--- a/lib/teiserver_web/live/admin/admin_components.ex
+++ b/lib/teiserver_web/live/admin/admin_components.ex
@@ -29,7 +29,7 @@ defmodule TeiserverWeb.Admin.AdminComponents do
         bsname={@view_colour}
         icon={Teiserver.Battle.MatchLib.icon()}
         active={@active == "matches"}
-        url={~p"/teiserver/admin/matches/search"}
+        url={~p"/teiserver/admin/matches"}
       >
         Matches
       </.sub_menu_button>

--- a/lib/teiserver_web/live/battles/match/index.ex
+++ b/lib/teiserver_web/live/battles/match/index.ex
@@ -1,6 +1,7 @@
 defmodule TeiserverWeb.Battle.MatchLive.Index do
   use TeiserverWeb, :live_view
   alias Teiserver.{Account, Battle}
+  import TeiserverWeb.PaginationComponents, only: [pagination: 1, build_pagination_url: 4]
 
   @impl true
   def mount(_params, _session, socket) do
@@ -11,11 +12,45 @@ defmodule TeiserverWeb.Battle.MatchLive.Index do
       |> assign(:site_menu_active, "match")
       |> assign(:view_colour, Teiserver.Battle.MatchLib.colours())
       |> assign(:game_types, game_types)
-      |> add_breadcrumb(name: "Matches", url: "/battle/matches")
+      |> add_breadcrumb(name: "Matches", url: "/battle")
       |> default_filters()
-      |> update_match_list()
+      |> assign(:page, 0)
+      |> assign(:limit, 100)
+      |> assign(:total_count, 0)
+      |> assign(:total_pages, 1)
+      |> assign(:current_count, 0)
 
     {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
+    validated = TeiserverWeb.Validators.PaginationParams.validate_params(params)
+
+    params =
+      Map.merge(params, %{
+        "limit" => to_string(validated.limit),
+        "page" => to_string(validated.page)
+      })
+
+    page = (params["page"] || "1") |> String.to_integer() |> max(1) |> then(&(&1 - 1))
+    limit = (params["limit"] || "100") |> String.to_integer() |> max(1)
+
+    # Update filters from URL params
+    updated_filters =
+      socket.assigns.filters
+      |> Map.put("game-type", params["game-type"] || socket.assigns.filters["game-type"])
+      |> Map.put("opponent", params["opponent"] || socket.assigns.filters["opponent"])
+      |> Map.put("ally", params["ally"] || socket.assigns.filters["ally"])
+
+    socket =
+      socket
+      |> assign(:page, page)
+      |> assign(:limit, limit)
+      |> assign(:filters, updated_filters)
+      |> update_match_list()
+
+    {:noreply, socket}
   end
 
   @impl true
@@ -25,27 +60,52 @@ defmodule TeiserverWeb.Battle.MatchLive.Index do
 
     new_filters = Map.put(filters, key, value)
 
+    # Reset to first page when filters change and update URL
     socket =
       socket
+      |> assign(:page, 0)
       |> assign(:filters, new_filters)
-      |> update_match_list
+      |> push_patch(
+        to:
+          build_pagination_url(
+            "/battle",
+            %{"limit" => socket.assigns.limit},
+            ["limit"],
+            new_filters
+          )
+      )
+      |> update_match_list()
 
     {:noreply, socket}
   end
 
-  defp update_match_list(%{assigns: %{filters: filters, current_user: current_user}} = socket) do
+  defp update_match_list(
+         %{assigns: %{filters: filters, current_user: current_user, page: page, limit: limit}} =
+           socket
+       ) do
     if connected?(socket) do
-      matches = run_match_query(filters, current_user)
+      case run_match_query(filters, current_user, page, limit) do
+        {matches, total_count} when is_list(matches) and is_integer(total_count) ->
+          socket
+          |> assign(:matches, matches)
+          |> assign(:total_count, total_count)
+          |> assign(:total_pages, max(1, div(total_count - 1, limit) + 1))
+          |> assign(:current_count, Enum.count(matches))
 
-      if matches != nil do
-        socket
-        |> assign(:matches, matches)
-      else
-        socket
+        _ ->
+          # Fallback if query fails
+          socket
+          |> assign(:matches, [])
+          |> assign(:total_count, 0)
+          |> assign(:total_pages, 1)
+          |> assign(:current_count, 0)
       end
     else
       socket
       |> assign(:matches, [])
+      |> assign(:total_count, 0)
+      |> assign(:total_pages, 1)
+      |> assign(:current_count, 0)
     end
   end
 
@@ -53,7 +113,7 @@ defmodule TeiserverWeb.Battle.MatchLive.Index do
     socket
   end
 
-  defp run_match_query(filters, user) do
+  defp run_match_query(filters, user, page, limit) do
     opponent_id =
       if filters["opponent"] != "" do
         Account.get_userid_from_name(filters["opponent"]) || -1
@@ -68,21 +128,24 @@ defmodule TeiserverWeb.Battle.MatchLive.Index do
         nil
       end
 
+    search_criteria = [
+      has_started: true,
+      game_type: filters["game-type"],
+      ally_opponent: {user.id, ally_id, opponent_id}
+    ]
+
+    total_count = Battle.count_matches(search: search_criteria)
+
     matches =
       Battle.list_matches(
-        search: [
-          has_started: true,
-          # user_id: user.id,
-          game_type: filters["game-type"],
-          ally_opponent: {user.id, ally_id, opponent_id}
-        ],
-        preload: [
-          :queue
-        ],
-        order_by: "Newest first"
+        search: search_criteria,
+        preload: [:queue],
+        order_by: "Newest first",
+        limit: limit,
+        offset: page * limit
       )
 
-    matches
+    {matches, total_count}
   end
 
   defp default_filters(socket) do

--- a/lib/teiserver_web/live/battles/match/index.html.heex
+++ b/lib/teiserver_web/live/battles/match/index.html.heex
@@ -88,6 +88,28 @@
             </div>
           </:col>
         </.table>
+
+        <%= if assigns[:total_pages] do %>
+          <.pagination
+            page={@page}
+            total_pages={@total_pages}
+            base_url="/battle"
+            limit={@limit}
+            total_count={@total_count}
+            current_count={@current_count}
+            show_go_to={@total_pages > 5}
+            class="mt-3"
+            include_params={["limit", "game-type", "opponent", "ally"]}
+            current_params={
+              %{
+                "limit" => @limit,
+                "game-type" => @filters["game-type"],
+                "opponent" => @filters["opponent"],
+                "ally" => @filters["ally"]
+              }
+            }
+          />
+        <% end %>
       </div>
     </div>
   </div>

--- a/lib/teiserver_web/live/battles/match/ratings.html.heex
+++ b/lib/teiserver_web/live/battles/match/ratings.html.heex
@@ -136,5 +136,24 @@
         <% end %>
       </tbody>
     </table>
+
+    <%= if assigns[:total_pages] do %>
+      <.pagination
+        page={@page}
+        total_pages={@total_pages}
+        base_url={
+          if @rating_type == "Large Team",
+            do: "/battle/ratings",
+            else: "/battle/ratings/#{@rating_type}"
+        }
+        limit={@limit}
+        total_count={@total_count}
+        current_count={@current_count}
+        show_go_to={@total_pages > 5}
+        class="mt-3"
+        include_params={["limit"]}
+        current_params={%{"limit" => @limit}}
+      />
+    <% end %>
   </div>
 </div>

--- a/lib/teiserver_web/live/moderation/overwatch/index.html.heex
+++ b/lib/teiserver_web/live/moderation/overwatch/index.html.heex
@@ -159,3 +159,25 @@
     </.link>
   </:col>
 </.table>
+
+<div class="mt-3">
+  <.pagination
+    page={@page}
+    total_pages={@total_pages}
+    base_url="/moderation/overwatch"
+    limit={@limit}
+    total_count={@total_count}
+    current_count={@current_count}
+    show_go_to={@total_pages > 5}
+    class="mt-3"
+    include_params={[
+      "actioned-filter",
+      "closed-filter",
+      "kind-filter",
+      "timeframe-filter",
+      "target_id",
+      "limit"
+    ]}
+    current_params={@filters}
+  />
+</div>

--- a/lib/teiserver_web/live/moderation/report/report_components.ex
+++ b/lib/teiserver_web/live/moderation/report/report_components.ex
@@ -37,11 +37,10 @@ defmodule TeiserverWeb.Moderation.ReportComponents do
     </.section_menu_button>
 
     <.section_menu_button
-      :if={@active == "show"}
       bsname={@view_colour}
       icon={StylingHelper.icon(:search)}
-      active={true}
-      url={~p"/moderation/report/search"}
+      active={@active == "search"}
+      url={~p"/moderation/report?search=true"}
     >
       Search
     </.section_menu_button>

--- a/lib/teiserver_web/plugs/validate_pagination_params.ex
+++ b/lib/teiserver_web/plugs/validate_pagination_params.ex
@@ -1,0 +1,22 @@
+defmodule TeiserverWeb.Plugs.ValidatePaginationParams do
+  @moduledoc """
+  Plug to automatically validate pagination parameters (limit, page) before they reach controllers.
+  This prevents abuse and ensures consistent pagination behavior across all controllers.
+  """
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    # Use centralized validation logic
+    validated = TeiserverWeb.Validators.PaginationParams.validate_params(conn.params)
+
+    # Update the params with validated values
+    updated_params =
+      conn.params
+      |> Map.put("limit", to_string(validated.limit))
+      |> Map.put("page", to_string(validated.page))
+
+    # Update the connection with validated params
+    %{conn | params: updated_params}
+  end
+end

--- a/lib/teiserver_web/router.ex
+++ b/lib/teiserver_web/router.ex
@@ -20,6 +20,7 @@ defmodule TeiserverWeb.Router do
     plug(Teiserver.Account.AuthPipeline)
     plug(Teiserver.Account.AuthPlug)
     plug(Teiserver.Plugs.CachePlug)
+    plug(TeiserverWeb.Plugs.ValidatePaginationParams)
   end
 
   pipeline :live_browser do
@@ -383,8 +384,6 @@ defmodule TeiserverWeb.Router do
 
     # Infologs
     get("/infolog/download/:id", InfologController, :download)
-    get("/infolog/search", InfologController, :index)
-    post("/infolog/search", InfologController, :search)
     resources("/infolog", InfologController, only: [:index, :show, :delete])
   end
 
@@ -492,8 +491,6 @@ defmodule TeiserverWeb.Router do
 
     get("/", GeneralController, :index)
 
-    get("/report/search", ReportController, :search)
-    post("/report/search", ReportController, :search)
     get("/report/user/:id", ReportController, :user)
     resources("/report", ReportController, only: [:index, :show, :delete])
     post("/report/:id/respond", ReportController, :respond)
@@ -502,7 +499,6 @@ defmodule TeiserverWeb.Router do
     put("/report/:id/open", ReportController, :open)
 
     get("/action/search", ActionController, :search)
-    post("/action/search", ActionController, :search)
     get("/action/new_with_user", ActionController, :new_with_user)
     put("/action/halt/:id", ActionController, :halt)
     put("/action/re-post/:id", ActionController, :re_post)
@@ -661,8 +657,6 @@ defmodule TeiserverWeb.Router do
     get("/accolades/user/:user_id", AccoladeController, :user_show)
 
     get("/matches/by_server/:uuid", MatchController, :server_index)
-    get("/matches/search", MatchController, :index)
-    post("/matches/search", MatchController, :search)
     get("/matches/user/:user_id", MatchController, :user_show)
     resources("/matches", MatchController, only: [:index, :show, :delete])
 

--- a/lib/teiserver_web/templates/admin/match/index.html.heex
+++ b/lib/teiserver_web/templates/admin/match/index.html.heex
@@ -82,6 +82,21 @@
             <% end %>
           </tbody>
         </table>
+
+        <div class="mt-3">
+          <.pagination
+            page={@page}
+            total_pages={@total_pages}
+            base_url="/teiserver/admin/matches"
+            limit={@limit}
+            total_count={@total_count}
+            current_count={@current_count}
+            show_go_to={@total_pages > 5}
+            class="mt-3"
+            include_params={["account_user", "queue", "game_type", "search", "limit"]}
+            current_params={@params}
+          />
+        </div>
       </div>
     </div>
   </div>

--- a/lib/teiserver_web/templates/admin/match/search.html.heex
+++ b/lib/teiserver_web/templates/admin/match/search.html.heex
@@ -18,12 +18,6 @@
 <script src={Routes.static_path(@conn, "/js/select2.js")}>
 </script>
 
-{central_component("picker_script",
-  module: Teiserver.Account.UserLib,
-  name: "account_user",
-  title: "User search"
-)}
-
 <div class="row">
   <div class="col-md-12">
     <div class={"card border-#{bsname} page-card"}>
@@ -33,27 +27,31 @@
         </div>
 
         <form
-          action={Routes.ts_admin_match_path(@conn, :search)}
-          method="post"
+          action={Routes.ts_admin_match_path(@conn, :index)}
+          method="get"
           class="form-horizontal"
           id="search-box"
           style="display: none;"
         >
-          <input type="hidden" name="_csrf_token" value={get_csrf_token()} />
+          <input type="hidden" name="search" value="true" />
 
           <div class="row">
             <div class="col-md-4 col-lg-3 col-xl-2 my-2">
-              <label for="teiserver-user-search" class="control-label">User: </label>
-              {render(TeiserverWeb.Account.UserView, "picker.html",
-                input_name: "search[account_user]",
-                value: @params["account_user"]
-              )}
+              <label for="account_user" class="control-label">User: </label>
+              <input
+                type="text"
+                name="account_user"
+                id="account_user"
+                value={@params["account_user"]}
+                placeholder="Username (partial OK, e.g., SomePlayer or Some)"
+                class="form-control"
+              />
             </div>
 
             <div class="col-md-4 col-lg-3 col-xl-2 my-2">
               <label for="search_action" class="control-label">Game type: </label>
               {central_component("icon_dropdown", %{
-                name: "search[game_type]",
+                name: "game_type",
                 id: "search_game_type",
                 selected: @params["game_type"] || "Any",
                 enumerable: [
@@ -97,12 +95,7 @@
 
             <div class="offset-md-8 col-md-4 offset-xl-10 col-xl-2">
               &nbsp;<br />
-              <input
-                type="submit"
-                value="Search"
-                name="form.submitted"
-                class={"btn btn-#{bsname} btn-block"}
-              />
+              <input type="submit" value="Search" class={"btn btn-#{bsname} btn-block"} />
             </div>
           </div>
         </form>

--- a/lib/teiserver_web/templates/admin/match/user_index.html.heex
+++ b/lib/teiserver_web/templates/admin/match/user_index.html.heex
@@ -104,6 +104,21 @@
             <% end %>
           </tbody>
         </table>
+
+        <%= if assigns[:total_pages] do %>
+          <.pagination
+            page={@page}
+            total_pages={@total_pages}
+            base_url={Routes.ts_admin_match_path(@conn, :user_show, @user.id)}
+            limit={@limit}
+            total_count={@total_count}
+            current_count={@current_count}
+            show_go_to={@total_pages > 5}
+            class="mt-3"
+            include_params={["limit"]}
+            current_params={%{"limit" => @limit}}
+          />
+        <% end %>
       </div>
     </div>
   </div>

--- a/lib/teiserver_web/templates/admin/user/index.html.heex
+++ b/lib/teiserver_web/templates/admin/user/index.html.heex
@@ -131,6 +131,21 @@ is_moderator = allow?(@conn, "Moderator") %>
             <% end %>
           </tbody>
         </table>
+
+        <%= if assigns[:total_pages] do %>
+          <.pagination
+            page={@page}
+            total_pages={@total_pages}
+            base_url="/teiserver/admin/user"
+            limit={@limit}
+            total_count={@total_count}
+            current_count={@current_count}
+            show_go_to={@total_pages > 5}
+            class="mt-3"
+            include_params={["s", "limit"]}
+            current_params={Map.merge(@conn.params, %{"limit" => @limit})}
+          />
+        <% end %>
       </div>
     </div>
   </div>

--- a/lib/teiserver_web/templates/admin/user/ratings.html.heex
+++ b/lib/teiserver_web/templates/admin/user/ratings.html.heex
@@ -22,15 +22,6 @@
         <hr />
 
         <div class="float-end">
-          {central_component("section_menu_button",
-            name: "all_games",
-            label: "500 games",
-            active: @filter,
-            url: "?filter=#{@filter}&limit=500",
-            icon: "",
-            bsname: bsname
-          )}
-
           <a
             class={"btn btn-outline-#{bsname}"}
             href={Routes.ts_admin_user_path(@conn, :ratings_form, @user)}
@@ -195,6 +186,21 @@
             <% end %>
           </tbody>
         </table>
+
+        <%= if assigns[:total_pages] do %>
+          <.pagination
+            page={@page}
+            total_pages={@total_pages}
+            base_url={Routes.ts_admin_user_path(@conn, :ratings, @user.id)}
+            limit={@limit}
+            total_count={@total_count}
+            current_count={@current_count}
+            show_go_to={@total_pages > 5}
+            class="mt-3"
+            include_params={["filter", "limit"]}
+            current_params={Map.merge(@conn.params, %{"limit" => @limit})}
+          />
+        <% end %>
       </div>
     </div>
   </div>

--- a/lib/teiserver_web/templates/battle/match/ratings.html.heex
+++ b/lib/teiserver_web/templates/battle/match/ratings.html.heex
@@ -28,7 +28,7 @@
                   name: rt,
                   label: raw("#{rt} &nbsp;&nbsp;&nbsp; #{@ratings[rt].rating_value |> round(2)}"),
                   active: @filter,
-                  url: "?filter=#{rt}",
+                  url: "?filter=#{rt}&limit=#{@limit}",
                   icon: "",
                   bsname: bsname
                 )}

--- a/lib/teiserver_web/templates/moderation/action/index.html.heex
+++ b/lib/teiserver_web/templates/moderation/action/index.html.heex
@@ -87,6 +87,21 @@
             <% end %>
           </tbody>
         </table>
+
+        <%= if assigns[:total_pages] do %>
+          <.pagination
+            page={@page}
+            total_pages={@total_pages}
+            base_url="/moderation/action"
+            limit={@limit}
+            total_count={@total_count}
+            current_count={@current_count}
+            show_go_to={@total_pages > 5}
+            class="mt-3"
+            include_params={["search", "target_id", "reporter_id", "expiry", "limit"]}
+            current_params={@conn.params}
+          />
+        <% end %>
       </div>
     </div>
   </div>

--- a/lib/teiserver_web/templates/moderation/action/search.html.heex
+++ b/lib/teiserver_web/templates/moderation/action/search.html.heex
@@ -20,19 +20,18 @@
 
 <div class="search-row">
   <form
-    action={Routes.moderation_action_path(@conn, :search)}
-    method="post"
+    action={Routes.moderation_action_path(@conn, :index)}
+    method="get"
     class="form-horizontal"
     id="search-box"
   >
-    <input type="hidden" name="_csrf_token" value={get_csrf_token()} />
     <input type="hidden" name="search" value="true" />
 
     <div class="row">
       <div class="col-md-4 col-xl-2 search-form-input">
         <label for="search_order" class="control-label">Expiry: </label>
         {central_component("icon_dropdown", %{
-          name: "search[expiry]",
+          name: "expiry",
           id: "search_expiry",
           selected: @params["expiry"] || "All",
           enumerable: [
@@ -49,7 +48,7 @@
       <div class="col-md-4 col-xl-2 search-form-input">
         <label for="search_order" class="control-label">Order by: </label>
         {central_component("icon_dropdown", %{
-          name: "search[order]",
+          name: "order",
           id: "search_order",
           selected: @params["order"] || "Newest first",
           enumerable: [
@@ -65,12 +64,7 @@
     <div class="row">
       <div class="offset-md-8 col-md-4 offset-xl-10 col-xl-2">
         &nbsp;<br />
-        <input
-          type="submit"
-          value="Search"
-          name="form.submitted"
-          class={"btn btn-#{bsname} btn-block"}
-        />
+        <input type="submit" value="Search" class={"btn btn-#{bsname} btn-block"} />
       </div>
     </div>
   </form>

--- a/lib/teiserver_web/templates/moderation/ban/index.html.heex
+++ b/lib/teiserver_web/templates/moderation/ban/index.html.heex
@@ -67,6 +67,21 @@
             <% end %>
           </tbody>
         </table>
+
+        <%= if assigns[:total_pages] do %>
+          <.pagination
+            page={@page}
+            total_pages={@total_pages}
+            base_url="/moderation/ban"
+            limit={@limit}
+            total_count={@total_count}
+            current_count={@current_count}
+            show_go_to={@total_pages > 5}
+            class="mt-3"
+            include_params={["search", "limit", "name", "order"]}
+            current_params={@conn.params}
+          />
+        <% end %>
       </div>
     </div>
   </div>

--- a/lib/teiserver_web/templates/moderation/ban/search.html.heex
+++ b/lib/teiserver_web/templates/moderation/ban/search.html.heex
@@ -21,11 +21,10 @@
 <div class="search-row">
   <form
     action={Routes.moderation_ban_path(@conn, :index)}
-    method="post"
+    method="get"
     class="form-horizontal"
     id="search-box"
   >
-    <input type="hidden" name="_csrf_token" value={get_csrf_token()} />
     <input type="hidden" name="search" value="true" />
 
     <div class="row">
@@ -33,7 +32,7 @@
         <label for="search_name" class="control-label">Name: </label>
         <input
           type="text"
-          name="search[name]"
+          name="name"
           id="search_name"
           value={@conn.params["name"]}
           placeholder=""
@@ -42,21 +41,9 @@
       </div>
 
       <div class="col-md-4 col-xl-2 search-form-input">
-        <label for="search_limit" class="control-label">Limit: </label>
-        <input
-          type="text"
-          name="search[limit]"
-          id="search_limit"
-          value={@conn.params["limit"]}
-          placeholder=""
-          class="form-control"
-        />
-      </div>
-
-      <div class="col-md-4 col-xl-2 search-form-input">
         <label for="search_order" class="control-label">Order by: </label>
         {central_component("icon_dropdown", %{
-          name: "search[order]",
+          name: "order",
           id: "search_order",
           selected: @conn.params["order"] || "Newest first",
           enumerable: [
@@ -72,12 +59,7 @@
     <div class="row">
       <div class="offset-md-8 col-md-4 offset-xl-10 col-xl-2">
         &nbsp;<br />
-        <input
-          type="submit"
-          value="Search"
-          name="form.submitted"
-          class={"btn btn-#{bsname} btn-block"}
-        />
+        <input type="submit" value="Search" class={"btn btn-#{bsname} btn-block"} />
       </div>
     </div>
   </form>

--- a/lib/teiserver_web/templates/moderation/ban/section_menu.html.heex
+++ b/lib/teiserver_web/templates/moderation/ban/section_menu.html.heex
@@ -11,6 +11,15 @@
       url: Routes.moderation_ban_path(@conn, :index)
     )}
 
+    {central_component("section_menu_button",
+      name: "search",
+      label: "Search",
+      active: @active,
+      icon: StylingHelper.icon(:search),
+      bsname: bsname,
+      url: Routes.moderation_ban_path(@conn, :index) <> "?search=true"
+    )}
+
     <%= if allow?(@conn, "Moderator") do %>
       {central_component("section_menu_button",
         name: "new",

--- a/lib/teiserver_web/templates/moderation/report/index.html.heex
+++ b/lib/teiserver_web/templates/moderation/report/index.html.heex
@@ -7,132 +7,164 @@
 
 <div class="row section-menu">
   <div class="col-md-12">
-    <%= if @target_id do %>
-      <div class="float-end">
-        <%= if allow?(@conn, "teiserver.staff.moderator") do %>
-          <a
-            class={"btn btn-outline-#{Teiserver.Account.UserLib.colour()}"}
-            href={~p"/teiserver/admin/user/#{@target_id}"}
-          >
-            <Fontawesome.icon icon={Teiserver.Account.UserLib.icon()} style="solid" /> &nbsp;
-            View user
-          </a>
-        <% end %>
+    <div class={"card border-#{bsname}"}>
+      <div class="card-body">
+        <TeiserverWeb.Moderation.ReportComponents.section_menu
+          active={if @conn.params["search"] == "true", do: "search", else: "index"}
+          view_colour={view_colour()}
+          current_user={@current_user}
+        />
+        <br /><br />
 
-        <a
-          class={"btn btn-outline-#{Teiserver.Moderation.ActionLib.colour()}"}
-          href={"#{Routes.moderation_action_path(@conn, :new_with_user)}?teiserver_user=%23#{@target_id}_"}
-        >
-          <Fontawesome.icon icon={Teiserver.Moderation.ActionLib.icon()} style="solid" /> &nbsp;
-          Action user
-        </a>
-      </div>
-      <br /><br />
-    <% end %>
-
-    <%= if @target && @target.smurf_of_id do %>
-      <div class="alert alert-primary">
-        {@target.name} has been flagged as a smurf, these reports are not worth acting on.
-      </div>
-    <% end %>
-
-    {render(TeiserverWeb.Moderation.ReportView, "search.html", assigns)}
-
-    <h4>Listing Reports</h4>
-
-    <table class="table table-sm">
-      <thead>
-        <tr>
-          <th>&nbsp;</th>
-          <th>Target</th>
-          <th>Type</th>
-          <th>Extra text</th>
-
-          <th>Reporter</th>
-          <th>Datetime</th>
-          <th>Responses</th>
-
-          <th colspan="3">&nbsp;</th>
-        </tr>
-      </thead>
-      <tbody>
-        <%= for report <- @reports do %>
-          <tr>
-            <td style="width: 30px;">
-              <%= if report.result_id do %>
-                <a
-                  href={Routes.moderation_action_path(@conn, :show, report.result_id)}
-                  class={"btn btn-sm btn-#{Teiserver.Moderation.ActionLib.colour()}"}
-                >
-                  <Fontawesome.icon icon={Teiserver.Moderation.ActionLib.icon()} style="solid" />
-                </a>
-              <% end %>
-
-              <%= if report.closed do %>
-                <span class={"btn btn-sm btn-#{bsname}"}>
-                  <Fontawesome.icon icon="folder-closed" style="solid" />
-                </span>
-              <% end %>
-            </td>
-
-            <td>
+        <%= if @target_id do %>
+          <div class="float-end">
+            <%= if allow?(@conn, "teiserver.staff.moderator") do %>
               <a
-                href={~p"/moderation/report/user/#{report.target_id}"}
-                class={"btn btn-sm btn-#{Teiserver.Account.UserLib.colour()}"}
+                class={"btn btn-outline-#{Teiserver.Account.UserLib.colour()}"}
+                href={~p"/teiserver/admin/user/#{@target_id}"}
               >
-                <Fontawesome.icon
-                  icon={Teiserver.Helper.StylingHelper.icon(:user)}
-                  style="regular"
-                />
+                <Fontawesome.icon icon={Teiserver.Account.UserLib.icon()} style="solid" /> &nbsp;
+                View user
               </a>
-              &nbsp; {report.target.name}
-            </td>
-
-            <td>{report.type}/{report.sub_type}</td>
-            <td>{String.slice(report.extra_text || "", 0..40)}</td>
-
-            <td>
-              <a href={Routes.moderation_report_path(@conn, :user, report.reporter_id)}>
-                {report.reporter.name}
-              </a>
-            </td>
-
-            <td>{date_to_str(report.inserted_at, format: :hms_or_ymd)}</td>
-
-            <td>{Enum.count(report.responses)}</td>
-
-            <td>
-              <a
-                href={Routes.moderation_report_path(@conn, :show, report.id)}
-                class="btn btn-secondary btn-sm"
-              >
-                Details
-              </a>
-            </td>
-
-            <%= if report.match_id do %>
-              <td>
-                <a href={~p"/battle/#{report.match_id}"} class="btn btn-secondary btn-sm">
-                  Match
-                </a>
-              </td>
-              <td>
-                <a
-                  href={
-                    ~p"/battle/chat/#{report.match_id}/#{report.target_id}/#{report.reporter_id}"
-                  }
-                  class="btn btn-secondary btn-sm"
-                >
-                  Chat
-                </a>
-              </td>
-            <% else %>
-              <td>&nbsp;</td>
-              <td>&nbsp;</td>
             <% end %>
-          </tr>
+
+            <a
+              class={"btn btn-outline-#{Teiserver.Moderation.ActionLib.icon()}"}
+              href={"#{Routes.moderation_action_path(@conn, :new_with_user)}?teiserver_user=%23#{@target_id}_"}
+            >
+              <Fontawesome.icon icon={Teiserver.Moderation.ActionLib.icon()} style="solid" />
+              &nbsp;
+              Action user
+            </a>
+          </div>
+          <br /><br />
         <% end %>
-      </tbody>
-    </table>
+
+        <%= if @target && @target.smurf_of_id do %>
+          <div class="alert alert-primary">
+            {@target.name} has been flagged as a smurf, these reports are not worth acting on.
+          </div>
+        <% end %>
+
+        <%= if @conn.params["search"] == "true" do %>
+          {render(TeiserverWeb.Moderation.ReportView, "search.html", assigns)}
+        <% end %>
+
+        <h4>Listing Reports</h4>
+
+        <table class="table table-sm">
+          <thead>
+            <tr>
+              <th>&nbsp;</th>
+              <th>Target</th>
+              <th>Type</th>
+              <th>Extra text</th>
+
+              <th>Reporter</th>
+              <th>Datetime</th>
+              <th>Responses</th>
+
+              <th colspan="3">&nbsp;</th>
+            </tr>
+          </thead>
+          <tbody>
+            <%= for report <- @reports do %>
+              <tr>
+                <td style="width: 30px;">
+                  <%= if report.result_id do %>
+                    <a
+                      href={Routes.moderation_action_path(@conn, :show, report.result_id)}
+                      class={"btn btn-sm btn-#{Teiserver.Moderation.ActionLib.colour()}"}
+                    >
+                      <Fontawesome.icon
+                        icon={Teiserver.Moderation.ActionLib.icon()}
+                        style="solid"
+                      />
+                    </a>
+                  <% end %>
+
+                  <%= if report.closed do %>
+                    <span class={"btn btn-sm btn-#{bsname}"}>
+                      <Fontawesome.icon icon="folder-closed" style="solid" />
+                    </span>
+                  <% end %>
+                </td>
+
+                <td>
+                  <a
+                    href={~p"/moderation/report/user/#{report.target_id}"}
+                    class={"btn btn-sm btn-#{Teiserver.Account.UserLib.colour()}"}
+                  >
+                    <Fontawesome.icon
+                      icon={Teiserver.Helper.StylingHelper.icon(:user)}
+                      style="regular"
+                    />
+                  </a>
+                  &nbsp; {report.target.name}
+                </td>
+
+                <td>{report.type}/{report.sub_type}</td>
+                <td>{String.slice(report.extra_text || "", 0..40)}</td>
+
+                <td>
+                  <a href={Routes.moderation_report_path(@conn, :user, report.reporter_id)}>
+                    {report.reporter.name}
+                  </a>
+                </td>
+
+                <td>{date_to_str(report.inserted_at, format: :hms_or_ymd)}</td>
+
+                <td>{Enum.count(report.responses)}</td>
+
+                <td>
+                  <a
+                    href={Routes.moderation_report_path(@conn, :show, report.id)}
+                    class="btn btn-secondary btn-sm"
+                  >
+                    Details
+                  </a>
+                </td>
+
+                <%= if report.match_id do %>
+                  <td>
+                    <a href={~p"/battle/#{report.match_id}"} class="btn btn-secondary btn-sm">
+                      Match
+                    </a>
+                  </td>
+                  <td>
+                    <a
+                      href={
+                        ~p"/battle/chat/#{report.match_id}/#{report.target_id}/#{report.reporter_id}"
+                      }
+                      class="btn btn-secondary btn-sm"
+                    >
+                      Chat
+                    </a>
+                  </td>
+                <% else %>
+                  <td>&nbsp;</td>
+                  <td>&nbsp;</td>
+                <% end %>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+
+        <%= if assigns[:total_pages] do %>
+          <.pagination
+            page={@page}
+            total_pages={@total_pages}
+            base_url="/moderation/report"
+            limit={@limit}
+            total_count={@total_count}
+            current_count={@current_count}
+            show_go_to={@total_pages > 5}
+            class="mt-3"
+            include_params={["target_id", "reporter_id", "limit", "kind", "state", "order"]}
+            current_params={@conn.params}
+          />
+        <% end %>
+      </div>
+    </div>
   </div>
 </div>

--- a/lib/teiserver_web/templates/moderation/report/search.html.heex
+++ b/lib/teiserver_web/templates/moderation/report/search.html.heex
@@ -20,19 +20,16 @@
 
 <div class="search-row">
   <form
-    action={Routes.moderation_report_path(@conn, :search)}
-    method="post"
+    action={Routes.moderation_report_path(@conn, :index)}
+    method="get"
     class="form-horizontal"
     id="search-box"
   >
-    <input type="hidden" name="_csrf_token" value={get_csrf_token()} />
-    <input type="hidden" name="search" value="true" />
-
     <div class="row">
       <div class="col-md-4 col-lg-3 col-xl-2 mt-2">
         <label for="search_state" class="control-label">State: </label>
         {central_component("icon_dropdown", %{
-          name: "search[state]",
+          name: "state",
           id: "search_state",
           selected: @params["state"] || "Open",
           enumerable: [
@@ -46,7 +43,7 @@
       <div class="col-md-4 col-lg-3 col-xl-2 mt-2">
         <label for="search_state" class="control-label">Kind: </label>
         {central_component("icon_dropdown", %{
-          name: "search[kind]",
+          name: "kind",
           id: "search_kind",
           selected: @params["kind"] || "Any",
           enumerable: [
@@ -60,7 +57,7 @@
       <div class="col-md-4 col-lg-3 col-xl-2 mt-2">
         <label for="search_order" class="control-label">Order by: </label>
         {central_component("icon_dropdown", %{
-          name: "search[order]",
+          name: "order",
           id: "search_order",
           selected: @params["order"] || "Newest first",
           enumerable: [
@@ -76,12 +73,7 @@
     <div class="row">
       <div class="offset-md-8 col-md-4 offset-xl-10 col-xl-2">
         &nbsp;<br />
-        <input
-          type="submit"
-          value="Search"
-          name="form.submitted"
-          class={"btn btn-#{bsname} btn-block"}
-        />
+        <input type="submit" value="Search" class={"btn btn-#{bsname} btn-block"} />
       </div>
     </div>
   </form>

--- a/lib/teiserver_web/templates/telemetry/infolog/index.html.heex
+++ b/lib/teiserver_web/templates/telemetry/infolog/index.html.heex
@@ -106,6 +106,21 @@
             <% end %>
           </tbody>
         </table>
+
+        <div class="mt-3">
+          <.pagination
+            page={@page}
+            total_pages={@total_pages}
+            base_url="/telemetry/infolog"
+            limit={@limit}
+            total_count={@total_count}
+            current_count={@current_count}
+            show_go_to={@total_pages > 5}
+            class="mt-3"
+            include_params={["search", "limit", "type", "engine", "game", "shorterror", "order"]}
+            current_params={@conn.params}
+          />
+        </div>
       </div>
     </div>
   </div>

--- a/lib/teiserver_web/templates/telemetry/infolog/search.html.heex
+++ b/lib/teiserver_web/templates/telemetry/infolog/search.html.heex
@@ -20,19 +20,17 @@
   </div>
 
   <form
-    action={~p"/telemetry/infolog/search"}
-    method="post"
+    action={~p"/telemetry/infolog"}
+    method="get"
     class="form-horizontal"
     id="search-box"
     style="display: none;"
   >
-    <input type="hidden" name="_csrf_token" value={get_csrf_token()} />
-
     <div class="row">
       <div class="col-md-4 col-lg-3 col-xl-2 my-2">
         <label for="search_order" class="control-label">Type: </label>
         {central_component("icon_dropdown", %{
-          name: "search[type]",
+          name: "type",
           id: "search_type",
           selected: @params["type"] || "Any",
           enumerable: [
@@ -51,7 +49,7 @@
       <div class="col-md-4 col-lg-3 col-xl-2 my-2">
         <label for="search_order" class="control-label">Order by: </label>
         {central_component("icon_dropdown", %{
-          name: "search[order]",
+          name: "order",
           id: "search_order",
           selected: @params["order"] || "Newest first",
           enumerable: [
@@ -67,7 +65,7 @@
         <label for="search_engine" class="control-label">Engine: </label>
         <input
           type="text"
-          name="search[engine]"
+          name="engine"
           id="search_engine"
           value={@params["engine"]}
           placeholder=""
@@ -79,7 +77,7 @@
         <label for="search_game" class="control-label">Game: </label>
         <input
           type="text"
-          name="search[game]"
+          name="game"
           id="search_game"
           value={@params["game"]}
           placeholder=""
@@ -91,7 +89,7 @@
         <label for="search_shorterror" class="control-label">Errorcode: </label>
         <input
           type="text"
-          name="search[shorterror]"
+          name="shorterror"
           id="search_shorterror"
           value={@params["shorterror"]}
           placeholder=""
@@ -103,12 +101,7 @@
     <div class="row">
       <div class="offset-md-8 col-md-4 offset-xl-10 col-xl-2">
         &nbsp;<br />
-        <input
-          type="submit"
-          value="Search"
-          name="form.submitted"
-          class={"btn btn-#{bsname} btn-block"}
-        />
+        <input type="submit" value="Search" class={"btn btn-#{bsname} btn-block"} />
       </div>
     </div>
   </form>

--- a/lib/teiserver_web/templates/telemetry/infolog/section_menu.html.heex
+++ b/lib/teiserver_web/templates/telemetry/infolog/section_menu.html.heex
@@ -17,16 +17,3 @@
   bsname: bsname,
   url: ~p"/telemetry/infolog?search=true"
 )}
-
-<%= case @active do %>
-  <% "index" -> %>
-    &nbsp;&nbsp;&nbsp;
-    <a href={~p"/telemetry/infolog/?page=#{@page - 1}"} class="btn btn-secondary">
-      Prev
-    </a>
-
-    <a href={~p"/telemetry/infolog/?page=#{@page + 1}"} class="btn btn-secondary">
-      Next
-    </a>
-  <% _ -> %>
-<% end %>

--- a/lib/teiserver_web/validators/pagination_params.ex
+++ b/lib/teiserver_web/validators/pagination_params.ex
@@ -1,0 +1,49 @@
+defmodule TeiserverWeb.Validators.PaginationParams do
+  @moduledoc """
+  Centralized pagination parameter validation.
+  Used by both the plug and LiveViews to ensure consistent validation logic.
+  """
+
+  # Maximum allowed limit to prevent abuse
+  @max_limit 500
+
+  @doc """
+  Validates and clamps a limit value to prevent abuse.
+  Returns a safe limit value between 1 and @max_limit.
+
+    ## Examples
+
+      validate_limit("100")  # => 100
+      validate_limit("5000") # => 500 (clamped to max)
+      validate_limit("0")    # => 50 (default)
+      validate_limit(nil)    # => 50 (default)
+  """
+  def validate_limit(limit) when is_binary(limit) do
+    case Integer.parse(limit) do
+      {int_limit, ""} -> validate_limit(int_limit)
+      # Default if parsing fails
+      _ -> 50
+    end
+  end
+
+  def validate_limit(limit) when is_integer(limit) do
+    cond do
+      limit <= 0 -> 50
+      limit > @max_limit -> @max_limit
+      true -> limit
+    end
+  end
+
+  def validate_limit(_), do: 50
+
+  @doc """
+  Validates limit parameter and returns a map with validated values.
+  This is the main function that should be used by both plugs and LiveViews.
+  """
+  def validate_params(params) do
+    %{
+      limit: validate_limit(params["limit"] || "50"),
+      page: (params["page"] || "1") |> String.to_integer() |> max(1)
+    }
+  end
+end

--- a/lib/teiserver_web/views/admin/match_view.ex
+++ b/lib/teiserver_web/views/admin/match_view.ex
@@ -1,5 +1,6 @@
 defmodule TeiserverWeb.Admin.MatchView do
   use TeiserverWeb, :view
+  import TeiserverWeb.PaginationComponents, only: [pagination: 1]
 
   def view_colour(), do: Teiserver.Battle.MatchLib.colours()
   def icon(), do: Teiserver.Battle.MatchLib.icon()

--- a/lib/teiserver_web/views/admin/user_view.ex
+++ b/lib/teiserver_web/views/admin/user_view.ex
@@ -1,5 +1,6 @@
 defmodule TeiserverWeb.Admin.UserView do
   use TeiserverWeb, :view
+  import TeiserverWeb.PaginationComponents, only: [pagination: 1]
 
   @spec view_colour :: atom()
   def view_colour(), do: Teiserver.Account.UserLib.colours()

--- a/lib/teiserver_web/views/moderation/action_view.ex
+++ b/lib/teiserver_web/views/moderation/action_view.ex
@@ -1,6 +1,7 @@
 defmodule TeiserverWeb.Moderation.ActionView do
   @moduledoc false
   use TeiserverWeb, :view
+  import TeiserverWeb.PaginationComponents, only: [pagination: 1]
 
   @spec view_colour() :: atom
   def view_colour, do: Teiserver.Moderation.ActionLib.colour()

--- a/lib/teiserver_web/views/moderation/ban_view.ex
+++ b/lib/teiserver_web/views/moderation/ban_view.ex
@@ -1,6 +1,7 @@
 defmodule TeiserverWeb.Moderation.BanView do
   @moduledoc false
   use TeiserverWeb, :view
+  import TeiserverWeb.PaginationComponents, only: [pagination: 1]
 
   @spec view_colour() :: atom
   def view_colour, do: Teiserver.Moderation.BanLib.colour()

--- a/lib/teiserver_web/views/moderation/report_view.ex
+++ b/lib/teiserver_web/views/moderation/report_view.ex
@@ -1,5 +1,6 @@
 defmodule TeiserverWeb.Moderation.ReportView do
   use TeiserverWeb, :view
+  import TeiserverWeb.PaginationComponents, only: [pagination: 1]
 
   @spec view_colour() :: atom
   def view_colour, do: Teiserver.Moderation.ReportLib.colour()

--- a/lib/teiserver_web/views/telemetry/infolog_view.ex
+++ b/lib/teiserver_web/views/telemetry/infolog_view.ex
@@ -1,5 +1,6 @@
 defmodule TeiserverWeb.Telemetry.InfologView do
   use TeiserverWeb, :view
+  import TeiserverWeb.PaginationComponents, only: [pagination: 1]
 
   @spec view_colour :: atom
   def view_colour(), do: Teiserver.Telemetry.InfologLib.colours()


### PR DESCRIPTION
Added pagination to various pages listed below using a reusable pagination component defined in the new file `lib/teiserver_web/components/pagination_components.ex`

Additionally I needed to convert/normalize a number of the search forms from using POST to GET so that their results could be properly paginated.  This seemed inconsistent across the application anyway - GET was already being used in places.


Admin:
- admin/user list
- admin/user/matches/{id} list
- admin/user/ratings/{id} list
- admin/matches/search list
  - Converted route to `admin/matches` (since `admin/matches/search?search=true` is redundant) and updated links to this page
  - Converted search form from POST to GET to enable pagination on search results
  - Replaced (from what I could tell broken) user picker with a standard input field that searches on partial username match

Matches
- matches (/battle)
- ratings (/battle/ratings)

Moderation:
- Overwatch
  - Pagination
  - All filtering will re-query data to give a full data set based on the current filters and limit set, resetting to page 1
- Reports 
  - Pagination
  - Converted search form from POST to GET to enable pagination on search results
  - Normalized the search routing to use `search=true` like is done for actions and various other places
  - Added the section menu showing List and Search to maintain consistency with actions and bans
  - Added `type` to search clause as it was not filtering the search on this before
- Actions 
  - Pagination
  - Converted search form from POST to GET to enable pagination on search results
- Bans
  - Pagination
  - Added Search to the section menu
  - Converted search form from POST to GET to enable pagination on search results
  - Added new _search/3 function to make the existing (but unseen) search form work

Telemetry
- Infologs
  - Pagination
  - Converted search form from POST to GET to enable pagination on search results

Added in a validator which is called via a plug for non-liveview pages, or called directly in liveviews to clamp limit and page parameters to a max limit of 500, and a max page of 10,000.