### PR TITLE
Fix script update user

### DIFF
--- a/lib/teiserver/account/libs/user_lib.ex
+++ b/lib/teiserver/account/libs/user_lib.ex
@@ -125,7 +125,7 @@ defmodule Teiserver.Account.UserLib do
 
   def script_create_user(attrs \\ %{}) do
     %User{}
-    |> User.changeset(attrs, :script)
+    |> User.changeset(attrs, :script_create)
     |> Repo.insert()
     |> broadcast_create_user()
   end


### PR DESCRIPTION
Smurf linking used `script_update_user` resulting in smurf linked user's data being overwritten by default values.
Affecting colors and `user.data` values.