### PR TITLE
Kill party on disconnect

### DIFF
--- a/lib/teiserver/party.ex
+++ b/lib/teiserver/party.ex
@@ -20,7 +20,7 @@ defmodule Teiserver.Party do
   def create_party(user_id) do
     party_id = Party.Server.gen_party_id()
 
-    case Party.Supervisor.start_party(party_id, user_id) do
+    case Party.Supervisor.start_party(party_id, user_id, self()) do
       {:ok, pid} -> {:ok, party_id, pid}
       {:ok, pid, _info} -> {:ok, party_id, pid}
       :ignore -> {:error, :ignore}

--- a/lib/teiserver/party/server.ex
+++ b/lib/teiserver/party/server.ex
@@ -420,7 +420,9 @@ defmodule Teiserver.Party.Server do
           %{state | matchmaking: nil}
       end
 
-    {:noreply, state}
+    if state.members == [],
+      do: {:stop, :normal, state},
+      else: {:noreply, state}
   end
 
   def handle_info({:invite_timeout, user_id}, state) do

--- a/lib/teiserver/party/supervisor.ex
+++ b/lib/teiserver/party/supervisor.ex
@@ -11,10 +11,10 @@ defmodule Teiserver.Party.Supervisor do
   @doc """
   Create a new party
   """
-  @spec start_party(Party.Server.id(), T.userid()) ::
+  @spec start_party(Party.Server.id(), T.userid(), pid()) ::
           DynamicSupervisor.on_start_child()
-  def start_party(party_id, user_id) do
-    DynamicSupervisor.start_child(__MODULE__, {Teiserver.Party.Server, {party_id, user_id}})
+  def start_party(party_id, user_id, creator_pid) do
+    DynamicSupervisor.start_child(__MODULE__, {Teiserver.Party.Server, {party_id, user_id, creator_pid}})
   end
 
   def start_link(init_arg) do

--- a/lib/teiserver/party/supervisor.ex
+++ b/lib/teiserver/party/supervisor.ex
@@ -14,7 +14,10 @@ defmodule Teiserver.Party.Supervisor do
   @spec start_party(Party.Server.id(), T.userid(), pid()) ::
           DynamicSupervisor.on_start_child()
   def start_party(party_id, user_id, creator_pid) do
-    DynamicSupervisor.start_child(__MODULE__, {Teiserver.Party.Server, {party_id, user_id, creator_pid}})
+    DynamicSupervisor.start_child(
+      __MODULE__,
+      {Teiserver.Party.Server, {party_id, user_id, creator_pid}}
+    )
   end
 
   def start_link(init_arg) do

--- a/lib/teiserver/player.ex
+++ b/lib/teiserver/player.ex
@@ -11,7 +11,6 @@ defmodule Teiserver.Player do
 
   alias Teiserver.Data.Types, as: T
   alias Teiserver.{Player, Matchmaking, Party, TachyonBattle}
-  alias Teiserver.Helpers.MonitorCollection, as: MC
 
   @doc """
   Returns the pid of the session registered with a given user id
@@ -40,14 +39,6 @@ defmodule Teiserver.Player do
     else
       Process.monitor(pid)
     end
-  end
-
-  @doc """
-  Same as `monitor_session` but meant to be used with a `Teiserver.Helpers.MonitorCollection`
-  """
-  def add_session_monitor(monitors, user_id, key) do
-    pid = lookup_session(user_id)
-    MC.monitor(monitors, pid, key)
   end
 
   @spec conn_state(T.userid()) :: Player.Session.conn_state()

--- a/test/teiserver_web/tachyon/party_test.exs
+++ b/test/teiserver_web/tachyon/party_test.exs
@@ -369,6 +369,11 @@ defmodule TeiserverWeb.Tachyon.PartyTest do
       assert %{"status" => "success"} = Tachyon.leave_party!(ctx.client)
       assert %{"commandId" => "party/removed"} = Tachyon.recv_message!(invited.client)
     end
+
+    test "last member disconnecting terminates party", ctx do
+      Tachyon.disconnect!(ctx.client)
+      Polling.poll_until_nil(fn -> Teiserver.Party.lookup(ctx.party_id) end)
+    end
   end
 
   test "handle party server going down" do


### PR DESCRIPTION
Small refactoring before fixing a bug: the party process would never exit if the last remaining member did not cleanly leave and instead disconnected.