### PR TITLE
Added arrows and backling pointing to first report for a match

### DIFF
--- a/lib/teiserver/bridge/discord_bridge_bot.ex
+++ b/lib/teiserver/bridge/discord_bridge_bot.ex
@@ -327,18 +327,28 @@ defmodule Teiserver.Bridge.DiscordBridgeBot do
           msg
         end
 
+# Version of the link adding, using "with". Currently giving compiler errors `missing closing delimiter (expected "end")`
+#      msg =
+#        with true <- length(reports) > 1,
+#             first_report <- hd(reports),
+#             false <- is_nil(first_report.discord_message_id) do
+#          first_report_link = "https://discord.com/channels/#{Communication.get_guild_id()}/#{channel}/#{first_report.discord_message_id}"
+#          msg ++ ["**First report:** #{first_report_link}"]
+#        else
+#          _ -> msg
+#        end
+
       msg = msg ++ ["#{outstanding_msg}"]
       |> Enum.join("\n")
 
       {status, message_data} = Teiserver.Communication.new_discord_message(channel, msg)
-      message_id = message_data.id
       if status == :ok do
+        message_id = message_data.id
         Moderation.update_report(report, %{discord_message_id: message_id})
 
         if length(reports) > 1 do
           first_report = hd(reports)
-          icon = "🔼"
-          Teiserver.Communication.create_discord_reaction(channel, message_id, icon)
+          Teiserver.Communication.create_discord_reaction(channel, message_id, "🔼")
         end
       end
     end

--- a/lib/teiserver/bridge/discord_bridge_bot.ex
+++ b/lib/teiserver/bridge/discord_bridge_bot.ex
@@ -329,40 +329,18 @@ defmodule Teiserver.Bridge.DiscordBridgeBot do
           msg
         end
 
-      IO.inspect(msg)
       msg = msg ++ ["#{outstanding_msg}"]
       |> Enum.join("\n")
 
       {status, message_data} = Teiserver.Communication.new_discord_message(channel, msg)
       message_id = message_data.id
       if status == :ok do
-        #IO.inspect("before")
         Moderation.update_report(report, %{discord_message_id: message_id})
-        #IO.inspect("after")
-
 
         if length(reports) > 1 do
           first_report = hd(reports)
-
-          reports =
-            from(r in Teiserver.Moderation.Report,
-              where: r.type == ^report.type and r.id > ^first_report.id and r.id <= ^report.id
-            )
-            |> Repo.all()
-
-          #IO.inspect(reports, pretty: true, limit: :infinity)
-          #IO.inspect(length(reports), label: "count")
-
-          count =
-            from(r in Teiserver.Moderation.Report,
-              where: r.type == ^report.type and r.id > ^first_report.id and r.id <= ^report.id
-            )
-            |> Repo.aggregate(:count, :id)
-
-          icon = if count > 4, do: "⏫", else: "🔼"
+          icon = "🔼"
           Teiserver.Communication.create_discord_reaction(channel, message_id, icon)
-        else
-          IO.puts("less than 2 reports")
         end
       end
     end

--- a/lib/teiserver/bridge/discord_bridge_bot.ex
+++ b/lib/teiserver/bridge/discord_bridge_bot.ex
@@ -317,10 +317,8 @@ defmodule Teiserver.Bridge.DiscordBridgeBot do
       msg =
         if length(reports) > 1 do
           first_report = hd(reports)
-          IO.inspect(first_report.discord_message_id)
           if not is_nil(first_report.discord_message_id) do
             first_report_link = "https://discord.com/channels/#{Communication.get_guild_id()}/#{channel}/#{first_report.discord_message_id}"
-            IO.inspect(first_report_link)
             msg = msg ++ ["**First report:** #{first_report_link}"]
           else
             msg

--- a/lib/teiserver/communication.ex
+++ b/lib/teiserver/communication.ex
@@ -244,6 +244,9 @@ defmodule Teiserver.Communication do
   @spec send_discord_dm(T.userid(), String.t()) :: map | nil | {:error, String.t()}
   defdelegate send_discord_dm(userid, message), to: DiscordChannelLib
 
+  @spec create_discord_reaction(integer(), integer(), String.t()) :: :ok | {:error, any()}
+  defdelegate create_discord_reaction(channel_id, message_id, emoji), to: DiscordChannelLib
+
   @doc """
   Returns true if we are using discord in this environment and false if we are not.
   """

--- a/lib/teiserver/communication/libs/discord_channel_lib.ex
+++ b/lib/teiserver/communication/libs/discord_channel_lib.ex
@@ -250,6 +250,13 @@ defmodule Teiserver.Communication.DiscordChannelLib do
     end
   end
 
+  @spec create_discord_reaction(integer(), integer(), String.t()) :: any()
+  def create_discord_reaction(channel_id, message_id, icon) do
+    if use_discord?() do
+      Nostrum.Api.Message.react(channel_id, message_id, icon)
+    end
+  end
+
   @spec get_channel_id_from_any(any) :: non_neg_integer() | nil
   defp get_channel_id_from_any(identifier) when is_integer(identifier) do
     if identifier < 999_999 do

--- a/lib/teiserver/communication/libs/discord_channel_lib.ex
+++ b/lib/teiserver/communication/libs/discord_channel_lib.ex
@@ -251,9 +251,11 @@ defmodule Teiserver.Communication.DiscordChannelLib do
   end
 
   @spec create_discord_reaction(integer(), integer(), String.t()) :: any()
-  def create_discord_reaction(channel_id, message_id, icon) do
+  def create_discord_reaction(maybe_channel_id, message_id, icon) do
     if use_discord?() do
-      Nostrum.Api.Message.react(channel_id, message_id, icon)
+      case get_channel_id_from_any(maybe_channel_id) do
+        nil -> {:error, "No channel found"}
+        channel_id -> Nostrum.Api.Message.react(channel_id, message_id, icon)
     end
   end
 

--- a/lib/teiserver/communication/libs/discord_channel_lib.ex
+++ b/lib/teiserver/communication/libs/discord_channel_lib.ex
@@ -250,12 +250,15 @@ defmodule Teiserver.Communication.DiscordChannelLib do
     end
   end
 
-  @spec create_discord_reaction(integer(), integer(), String.t()) :: any()
+  @spec create_discord_reaction(non_neg_integer | String.t(), non_neg_integer, String.t()) :: map | nil | {:error, String.t()}
   def create_discord_reaction(maybe_channel_id, message_id, icon) do
     if use_discord?() do
       case get_channel_id_from_any(maybe_channel_id) do
         nil -> {:error, "No channel found"}
         channel_id -> Nostrum.Api.Message.react(channel_id, message_id, icon)
+      end
+    else
+      {:error, :discord_disabled}
     end
   end
 

--- a/lib/teiserver/moderation/schemas/report.ex
+++ b/lib/teiserver/moderation/schemas/report.ex
@@ -10,6 +10,7 @@ defmodule Teiserver.Moderation.Report do
     field :sub_type, :string
     field :extra_text, :string
     field :closed, :boolean, default: false
+    field :discord_message_id, :integer
 
     belongs_to :match, Teiserver.Battle.Match
     field :relationship, :string
@@ -30,7 +31,7 @@ defmodule Teiserver.Moderation.Report do
     struct
     |> cast(
       params,
-      ~w(reporter_id target_id type sub_type extra_text match_id relationship result_id closed report_group_id)a
+      ~w(reporter_id target_id type sub_type extra_text match_id discord_message_id relationship result_id closed report_group_id)a
     )
     |> validate_required(~w(reporter_id target_id type sub_type closed)a)
   end

--- a/priv/repo/migrations/20250827153539_add_message_id.exs
+++ b/priv/repo/migrations/20250827153539_add_message_id.exs
@@ -1,0 +1,9 @@
+defmodule Teiserver.Repo.Migrations.AddMessageId do
+  use Ecto.Migration
+
+  def change do
+    alter table(:moderation_reports) do
+      add :discord_message_id, :bigint
+    end
+  end
+end

--- a/priv/repo/migrations/20250827153539_add_report_discord_message_id.exs
+++ b/priv/repo/migrations/20250827153539_add_report_discord_message_id.exs
@@ -1,4 +1,4 @@
-defmodule Teiserver.Repo.Migrations.AddMessageId do
+defmodule Teiserver.Repo.Migrations.AddReportDiscordMessageId do
   use Ecto.Migration
 
   def change do


### PR DESCRIPTION
If someone gets reported and there already is a report of the same type for someone for the same match, it reacts with an arrow pointing towards the report and adding a link to the original report.
Arrows are currently added manually by Overwatch members

Added another entry in the "moderation_reports" table for the id of the discord message of the teiserver bot 

<img width="441" height="195" alt="image" src="https://github.com/user-attachments/assets/d88394e5-17c9-4fc7-901f-cc7ca170b4fc" />
