### PR TITLE
Receive end game data over POST request

### DIFF
--- a/lib/teiserver/plugs/baisc_auth_bot_plug.ex
+++ b/lib/teiserver/plugs/baisc_auth_bot_plug.ex
@@ -1,0 +1,31 @@
+defmodule Teiserver.Plugs.BasicAuthBotPlug do
+  @moduledoc false
+  import Plug.Conn
+  alias Teiserver.Account
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    case get_req_header(conn, "authorization") do
+      ["Basic " <> encoded] ->
+        [username, password] = Base.decode64!(encoded) |> String.split(":")
+
+        with user <- Account.get_user_by_name(username),
+             true <- Teiserver.CacheUser.is_bot?(user),
+             true <- Account.verify_plain_password(password, user.password) do
+          conn
+        else
+          _ -> unauthorized(conn)
+        end
+
+      _ ->
+        unauthorized(conn)
+    end
+  end
+
+  defp unauthorized(conn) do
+    conn
+    |> send_resp(401, "Unauthorized")
+    |> halt()
+  end
+end

--- a/lib/teiserver_web/router.ex
+++ b/lib/teiserver_web/router.ex
@@ -51,6 +51,11 @@ defmodule TeiserverWeb.Router do
     plug(:accepts, ["json"])
   end
 
+  pipeline :spads_api do
+    plug(:accepts, ["json"])
+    plug(Teiserver.Plugs.BasicAuthBotPlug)
+  end
+
   pipeline :token_api do
     plug(:accepts, ["json"])
     plug(:put_secure_browser_headers)
@@ -410,12 +415,13 @@ defmodule TeiserverWeb.Router do
   end
 
   scope "/teiserver/api/spads", TeiserverWeb.API, as: :ts do
-    pipe_through([:api])
+    pipe_through([:spads_api])
     get "/get_rating/:target_id/:type", SpadsController, :get_rating
     get "/get_rating/:caller_id/:target_id/:type", SpadsController, :get_rating
 
     get "/balance_battle", SpadsController, :balance_battle
     post "/balance_battle", SpadsController, :balance_battle
+    post "/end_game_data", SpadsController, :end_game_data
   end
 
   scope "/teiserver/api/public", TeiserverWeb.API, as: :ts do


### PR DESCRIPTION
Receive end game data over POST request, an attempt to fix not receiving end game data for matches and failing to rate them.
Added basic authorization for SPADS API.