### PR TITLE
Add public maps page

### DIFF
--- a/lib/teiserver/asset/libs/map_lib.ex
+++ b/lib/teiserver/asset/libs/map_lib.ex
@@ -3,6 +3,9 @@ defmodule Teiserver.Asset.MapLib do
   alias Ecto.Multi
   alias Teiserver.Repo
 
+  @spec icon :: String.t()
+  def icon, do: "fa-solid fa-map"
+
   @spec create_maps([map()]) ::
           {:ok, [Asset.Map.t()]} | {:error, String.t(), Ecto.Changeset.t(), map()}
   def create_maps(map_attrs) do

--- a/lib/teiserver_web/live/general/home/index.html.heex
+++ b/lib/teiserver_web/live/general/home/index.html.heex
@@ -59,6 +59,10 @@
     Matches
   </.menu_card>
 
+  <.menu_card icon={Teiserver.Asset.MapLib.icon()} icon_class="fa-solid" url={~p"/maps"}>
+    Maps
+  </.menu_card>
+
   <.menu_card icon={Teiserver.Microblog.icon()} icon_class="fa-solid" url={~p"/microblog"}>
     Microblog
   </.menu_card>

--- a/lib/teiserver_web/live/maps/index.ex
+++ b/lib/teiserver_web/live/maps/index.ex
@@ -1,0 +1,77 @@
+defmodule TeiserverWeb.MapsLive.Index do
+  use TeiserverWeb, :live_view
+  alias Teiserver.Asset
+
+  @impl true
+  def mount(_params, _session, socket) do
+    socket =
+      socket
+      |> assign(:site_menu_active, "maps")
+      |> assign(:view_colour, :default)
+      |> assign(:maps, [])
+      |> assign(:filtered_maps, [])
+      |> assign(:selected_queue, "all")
+      |> assign(:available_queues, [])
+      |> assign(:current_user, socket.assigns[:current_user])
+      |> add_breadcrumb(name: "Maps", url: "/maps")
+      |> load_maps()
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
+    queue = params["queue"] || "all"
+
+    socket =
+      socket
+      |> assign(:selected_queue, queue)
+      |> apply_filter(queue)
+
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_event("filter-by-queue", %{"queue" => queue}, socket) do
+    {:noreply, push_patch(socket, to: ~p"/maps?queue=#{queue}")}
+  end
+
+  defp load_maps(socket) do
+    maps = Asset.get_all_maps()
+    available_queues = extract_unique_queues(maps)
+
+    socket
+    |> assign(:maps, maps)
+    |> assign(:available_queues, available_queues)
+    |> apply_filter(socket.assigns.selected_queue)
+  end
+
+  defp apply_filter(socket, queue) do
+    filtered_maps = filter_maps_by_queue(socket.assigns.maps, queue)
+    assign(socket, :filtered_maps, filtered_maps)
+  end
+
+  defp filter_maps_by_queue(maps, "all") do
+    maps
+  end
+
+  defp filter_maps_by_queue(maps, queue) do
+    Enum.filter(maps, fn map ->
+      queue in (map.matchmaking_queues || [])
+    end)
+  end
+
+  defp extract_unique_queues(maps) do
+    maps
+    |> Enum.flat_map(fn map -> map.matchmaking_queues || [] end)
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  # Converts map display name to URL slug for beyondallreason.info/maps/:map pages
+  defp map_display_name_to_url(display_name) do
+    display_name
+    |> String.downcase()
+    |> String.replace(" ", "-")
+  end
+end

--- a/lib/teiserver_web/live/maps/index.html.heex
+++ b/lib/teiserver_web/live/maps/index.html.heex
@@ -1,0 +1,89 @@
+<div class="row section-menu">
+  <div class="col-md-12">
+    <div class="alert alert-info mb-3">
+      <i class="fa-solid fa-info-circle"></i>
+      <strong>Under Development:</strong>
+      This page shows the map pools used for matchmaking and is currently under development.
+    </div>
+
+    <div class="mb-3">
+      <a
+        href="https://www.beyondallreason.info/maps"
+        target="_blank"
+        class="btn btn-outline-primary btn-sm"
+      >
+        <i class="fa-solid fa-external-link-alt"></i> View on beyondallreason.info
+      </a>
+    </div>
+
+    <div class="row mb-3">
+      <div class="col-md-3">
+        <label for="queue-filter" class="control-label">Filter by Queue:</label>
+        <form phx-change="filter-by-queue">
+          <select id="queue-filter" class="form-select" name="queue">
+            <option value="all" selected={@selected_queue == "all"}>All Maps</option>
+            <%= for queue <- @available_queues do %>
+              <option value={queue} selected={@selected_queue == queue}>{queue}</option>
+            <% end %>
+          </select>
+        </form>
+      </div>
+    </div>
+
+    <%= if Enum.empty?(@filtered_maps) do %>
+      <div class="alert alert-info">
+        <i class="fa-solid fa-info-circle"></i> No maps found for the selected queue.
+      </div>
+    <% else %>
+      <div class="row">
+        <%= for map <- @filtered_maps do %>
+          <div class="col-sm-6 col-md-4 col-lg-3 mb-4">
+            <a
+              href={"https://www.beyondallreason.info/map/#{map_display_name_to_url(map.display_name)}"}
+              target="_blank"
+              class="card h-100 text-decoration-none"
+              style="display: block;"
+            >
+              <%= if map.thumbnail_url do %>
+                <img
+                  src={map.thumbnail_url}
+                  class="card-img-top"
+                  alt={map.display_name}
+                  style="height: 150px; object-fit: cover;"
+                />
+              <% else %>
+                <div
+                  class="card-img-top bg-light d-flex align-items-center justify-content-center"
+                  style="height: 150px;"
+                >
+                  <i class="fa-solid fa-map fa-3x text-muted"></i>
+                </div>
+              <% end %>
+
+              <div class="card-body d-flex flex-column">
+                <h6 class="card-title">{map.display_name}</h6>
+                <p class="card-text text-muted small mb-2">
+                  <code>{map.spring_name}</code>
+                </p>
+
+                <%= if map.matchmaking_queues && length(map.matchmaking_queues) > 0 do %>
+                  <div class="mt-auto">
+                    <div class="d-flex flex-wrap gap-1">
+                      <%= for queue <- map.matchmaking_queues do %>
+                        <span class="badge bg-primary">{queue}</span>
+                      <% end %>
+                    </div>
+                  </div>
+                <% else %>
+                  <div class="mt-auto">
+                    <span class="badge bg-secondary">No queues</span>
+                  </div>
+                <% end %>
+              </div>
+            </a>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/lib/teiserver_web/router.ex
+++ b/lib/teiserver_web/router.ex
@@ -268,6 +268,12 @@ defmodule TeiserverWeb.Router do
     end
   end
 
+  scope "/maps", TeiserverWeb.MapsLive, as: :maps do
+    pipe_through([:live_browser, :app_layout])
+
+    live "/", Index, :index
+  end
+
   scope "/teiserver/account", TeiserverWeb.Account, as: :ts_account do
     pipe_through([:browser, :app_layout, :protected])
 


### PR DESCRIPTION
Closes #589

<img width="1439" height="654" alt="image" src="https://github.com/user-attachments/assets/a656a427-25be-46ce-8522-1bec448f95ee" />

Adds a `/maps` page that links to the beyondallreason.info maps page at that top, and as an onclick for each card.

Couple big caveats:

This does NOT have pagination yet.  Waiting on #730 - I'll add it once that is merged.

Each map card will actually show up like this:

<img width="392" height="222" alt="image" src="https://github.com/user-attachments/assets/a1ec52ea-fe7e-4dce-9914-36c835aa7689" />


 This is from the CSS `overflow: scroll` on the `card` component which is fixed in #754 