### PR TITLE
Fix tachyon handler state

### DIFF
--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -560,7 +560,7 @@ defmodule Teiserver.Player.TachyonHandler do
     else
       {:error, reason} when reason in [:invalid_player, :invalid_user] ->
         {:error_response, :invalid_request,
-         "User with id #{raw_user_id} isn't valid or connected"}
+         "User with id #{raw_user_id} isn't valid or connected", state}
 
       {:error, reason} ->
         {:error_response, :invalid_request, inspect(reason), state}

--- a/test/teiserver_web/tachyon/party_test.exs
+++ b/test/teiserver_web/tachyon/party_test.exs
@@ -44,7 +44,10 @@ defmodule TeiserverWeb.Tachyon.PartyTest do
       user2 = Tachyon.create_user()
 
       assert %{"status" => "failed", "reason" => "invalid_request"} =
+               resp =
                Tachyon.invite_to_party!(ctx.client, user2.id)
+
+      assert resp["details"] =~ "User with id"
     end
 
     test "must be in party", ctx do


### PR DESCRIPTION
Must always return the state, otherwise the error message is the actual state and any subsequent request will fail.