### PR TITLE
Point upgrade of elixir

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 erlang 26.2.5.2
-elixir 1.18.2-otp-26
+elixir 1.18.4-otp-26


### PR DESCRIPTION
This shouldn't change anything, but this allow us to have a newer debian image from hexpm docker hub repo. There is no 1.18.2 version for trixie, only 1.18.4.

The [docker image](https://github.com/beyond-all-reason/ansible-teiserver/blob/main/roles/teiserver/templates/teiserver.Dockerfile.j2#L23-L24) has already been updated. 