### PR TITLE
Disallow reports with empty extra_text field

### DIFF
--- a/lib/teiserver_web/live/moderation/report_user/index.html.heex
+++ b/lib/teiserver_web/live/moderation/report_user/index.html.heex
@@ -88,17 +88,18 @@
 
       <div :if={@stage == :extra_text} class="card-body">
         <h5>Extra info:</h5>
-        Please provide some information about what you are reporting:
+        Please respect volunteer time and help make our lives easier by providing some information!
         <ul>
           <li>A description of what was done or specific words said</li>
           <li>
-            Links to the replay itself from
+            A link to the replay itself from
             <a href="https://bar-rts.com/replays" target="_blank">BAR Replays</a>
+            if you did not select the game from the list before
           </li>
           <li>Timestamps (even if approximate) of in-game events</li>
         </ul>
         <br /><br />
-        We may ignore reports with descriptions stating simply "spec cheating", if you want to accuse someone of that, please provide a link to the replay and concrete examples of what you think is suspicious, with timestamps. If you'd like, open a ticket on the Discord to accompany the report.
+        We may ignore reports with descriptions stating simply "spec cheating", if you want to accuse someone of that, please provide a link to the replay and concrete examples of what you think is suspicious, with timestamps. If you'd like to provide more information, open a ticket on the Discord to accompany the report.
         <input
           type="text"
           name="extra_text"


### PR DESCRIPTION
Disables the `SUBMIT REPORT` button when for reports, when the `extra_text` field is empty.
Rewording of the first sentence on the page.

Still a draft until approval of Moderation team of the changes