### PR TITLE
Link to overwatch profiles, not admin profiles

### DIFF
--- a/lib/teiserver/bridge/discord_bridge_bot.ex
+++ b/lib/teiserver/bridge/discord_bridge_bot.ex
@@ -322,8 +322,8 @@ defmodule Teiserver.Bridge.DiscordBridgeBot do
       msg =
         [
           "# [Moderation report #{report.type}/#{report.sub_type}](#{url})#{match_icon}",
-          "**Target:** [#{report.target.name}](https://#{host}/moderation/overwatch/target/#{report.target.id})",
-          "**Reporter:** [#{report.reporter.name}](https://#{host}/moderation/overwatch/target/#{report.reporter.id})",
+          "**Target:** [#{report.target.name}](https://#{host}/moderation/report/user/#{report.target.id})",
+          "**Reporter:** [#{report.reporter.name}](https://#{host}/moderation/report/user/#{report.reporter.id})",
           "**Reason:** #{format_link(report.extra_text)}",
           "**Status:** Open"
         ]

--- a/lib/teiserver/bridge/discord_bridge_bot.ex
+++ b/lib/teiserver/bridge/discord_bridge_bot.ex
@@ -322,8 +322,8 @@ defmodule Teiserver.Bridge.DiscordBridgeBot do
       msg =
         [
           "# [Moderation report #{report.type}/#{report.sub_type}](#{url})#{match_icon}",
-          "**Target:** [#{report.target.name}](https://#{host}/teiserver/admin/user/#{report.target.id})",
-          "**Reporter:** [#{report.reporter.name}](https://#{host}/teiserver/admin/user/#{report.reporter.id})",
+          "**Target:** [#{report.target.name}](https://#{host}/moderation/overwatch/target/#{report.target.id})",
+          "**Reporter:** [#{report.reporter.name}](https://#{host}/moderation/overwatch/target/#{report.reporter.id})",
           "**Reason:** #{format_link(report.extra_text)}",
           "**Status:** Open"
         ]


### PR DESCRIPTION
This changes the link on reports to no longer link to the admin pages, but instead to the pages accessible to overwatch members