### PR TITLE
Fix unused imports for good

### DIFF
--- a/lib/teiserver_web/controllers/telemetry/infolog_controller.ex
+++ b/lib/teiserver_web/controllers/telemetry/infolog_controller.ex
@@ -1,7 +1,6 @@
 defmodule TeiserverWeb.Telemetry.InfologController do
   use TeiserverWeb, :controller
   alias Teiserver.Telemetry
-  import Teiserver.Helper.NumberHelper, only: [int_parse: 1]
 
   plug(AssignPlug,
     site_menu_active: "telemetry",

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,7 @@ defmodule Teiserver.MixProject do
       package: package(),
       dialyzer: dialyzer(),
       elixirc_paths: elixirc_paths(Mix.env()),
+      elixirc_options: [warnings_as_errors: true],
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps(),


### PR DESCRIPTION
from the doc:
  • --warnings-as-errors - exit with non-zero status if compilation has one
    or more warnings. Only concerns compilation warnings from the project, not
    its dependencies.