### PR TITLE
Handle another localhost ipv6 representation

### DIFF
--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -915,6 +915,9 @@ defmodule Teiserver.CacheUser do
     end
   end
 
+  # TODO: once we got rid of spring, do_login should not accept the IP as a string
+  # but as a :inet.ip_address which is what we get from the conn object
+  # And then we need to stringify it as usual when storing in DB
   @spec do_login(T.user(), String.t(), String.t(), String.t()) :: {:ok, T.user()}
   def do_login(user, ip, lobby_client, lobby_hash) do
     stats = Account.get_user_stat_data(user.id)

--- a/lib/teiserver/libs/geoip.ex
+++ b/lib/teiserver/libs/geoip.ex
@@ -9,6 +9,7 @@ defmodule Teiserver.Geoip do
   @spec get_flag(String.t(), String.t() | nil) :: String.t()
   def get_flag("127." <> _, _), do: "??"
   def get_flag("::ffff:127.0.0.1", _), do: "??"
+  def get_flag("::1", _), do: "??"
 
   def get_flag(ip, default) do
     if Config.get_site_config_cache("system.Use geoip") do


### PR DESCRIPTION
I had a go at dealing directly with :inet.ip_address, but it's getting quite complicated to also keep the existing string based IPs, so only left a comment.