### PR TITLE
Exclude mix tasks from compilation in prod env

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,14 @@ defmodule Teiserver.MixProject do
   # Specifies which paths to compile per environment.
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(:dev), do: ["lib", "test/support"]
-  defp elixirc_paths(_), do: ["lib"]
+
+  # mix tasks aren't available in production (no mix installed)
+  # this also avoid compilation warnings/error because some dependencies
+  # aren't available in prod for these tasks (like httpoison)
+  defp elixirc_paths(_) do
+    Path.wildcard("lib/**/*.ex")
+    |> Enum.reject(&String.starts_with?(&1, "lib/teiserver/mix_tasks/"))
+  end
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do


### PR DESCRIPTION
Now that we have fatal compiler warnings, this causes the production
build to fail when some dependencies are not available in the prod env.
For example, HTTPoison used in one task.
Since mix isn't available on the prod servers, we can disable the
compilation of theses tasks.
