### PR TITLE
Event when lobby crash

### DIFF
--- a/lib/teiserver/player/session.ex
+++ b/lib/teiserver/player/session.ex
@@ -1244,7 +1244,7 @@ defmodule Teiserver.Player.Session do
   end
 
   @impl true
-  def handle_info({:DOWN, ref, :process, _, _reason}, state) do
+  def handle_info({:DOWN, ref, :process, _, reason}, state) do
     val = MC.get_val(state.monitors, ref)
     state = Map.update!(state, :monitors, &MC.demonitor_by_val(&1, val))
 
@@ -1338,8 +1338,13 @@ defmodule Teiserver.Player.Session do
             {:noreply, state}
         end
 
+      {:lobby, lobby_id} ->
+        Logger.info("Lobby #{lobby_id} went down because #{inspect(reason)}")
+        send_to_player!({:lobby, lobby_id, {:left, "lobby crashed"}}, state)
+        {:noreply, %{state | lobby: nil}}
+
       {:battle, battle_id} ->
-        Logger.info("battle #{battle_id} went down")
+        Logger.info("battle #{battle_id} went down because #{inspect(reason)}")
         broadcast_user_update!(state.user, :menu)
         {:noreply, %{state | battle: nil}}
     end

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -175,6 +175,10 @@ defmodule Teiserver.Player.TachyonHandler do
     {:event, events, state}
   end
 
+  def handle_info({:lobby, lobby_id, {:left, reason}}, state) do
+    {:event, "lobby/left", %{id: lobby_id, reason: reason}, state}
+  end
+
   def handle_info({:lobby_list, {:add_lobby, lobby_id, overview}}, state) do
     data = %{
       updates: [

--- a/priv/tachyon/schema/lobby/left/event.json
+++ b/priv/tachyon/schema/lobby/left/event.json
@@ -1,0 +1,26 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/left/event.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "LobbyLeftEvent",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "event" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "lobby/left" },
+        "data": {
+            "title": "LobbyLeftEventData",
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "reason": { "type": "string" }
+            },
+            "required": ["id", "reason"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/test/teiserver_web/tachyon/lobby_test.exs
+++ b/test/teiserver_web/tachyon/lobby_test.exs
@@ -252,6 +252,18 @@ defmodule TeiserverWeb.Tachyon.LobbyTest do
     end
   end
 
+  test "get lobby/left event when lobby dies", ctx do
+    {:ok, lobby_id: lobby_id} = setup_lobby(ctx)
+    lobby_pid = Teiserver.TachyonLobby.lookup(lobby_id)
+    assert is_pid(lobby_pid)
+    Process.exit(lobby_pid, :kill)
+
+    %{"commandId" => "lobby/left"} = Tachyon.recv_message!(ctx[:client])
+
+    # can create another lobby afterwards (session state is cleaned)
+    {:ok, _} = setup_lobby(ctx)
+  end
+
   defp setup_lobby(%{client: client}, overrides \\ %{}) do
     lobby_data =
       %{


### PR DESCRIPTION
When lobby dies unexpectedly, members should receive a `lobby/left` event.