### PR TITLE
Fix #788

### DIFF
--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -400,9 +400,16 @@ defmodule Teiserver.Player.TachyonHandler do
 
   def handle_command("friend/sendRequest", "request", _message_id, msg, state) do
     with {:ok, target} <- get_user(msg["data"]["to"]),
-         {:ok, %Account.FriendRequest{}} <-
-           Account.create_friend_request(state.user.id, target.id) do
-      Player.Session.friend_request_received(target.id, state.user.id)
+         {:ok, data} <- Account.create_friend_request(state.user.id, target.id) do
+      case data do
+        %Account.FriendRequest{} ->
+          Player.Session.friend_request_received(target.id, state.user.id)
+
+        :auto_accepted ->
+          Player.Session.friend_request_accepted(target.id, state.user.id)
+          Player.Session.friend_request_accepted(state.user.id, target.id)
+      end
+
       {:response, state}
     else
       {:error, :invalid_user} ->

--- a/test/teiserver_web/tachyon/friend_test.exs
+++ b/test/teiserver_web/tachyon/friend_test.exs
@@ -97,6 +97,22 @@ defmodule TeiserverWeb.Tachyon.FriendTest do
                Tachyon.recv_message!(ctx[:client2])
     end
 
+    test "mutual requests", ctx do
+      assert %{"status" => "success"} =
+               Tachyon.send_friend_request!(ctx[:client], ctx[:user2].id)
+
+      %{"commandId" => "friend/requestReceived"} = Tachyon.recv_message!(ctx[:client2])
+
+      assert %{"status" => "success"} =
+               Tachyon.send_friend_request!(ctx[:client2], ctx[:user].id)
+
+      %{"commandId" => "friend/requestAccepted"} = Tachyon.recv_message!(ctx[:client])
+      %{"commandId" => "friend/requestAccepted"} = Tachyon.recv_message!(ctx[:client2])
+
+      [f1] = Teiserver.Account.list_friends_for_user(%{id: ctx[:user].id})
+      assert f1.user1_id == ctx[:user].id || f1.user2_id == ctx[:user2].id
+    end
+
     test "accept from invalid user", ctx do
       assert %{"status" => "failed", "reason" => "invalid_user"} =
                Tachyon.accept_friend_request!(ctx[:client], "wtfid")


### PR DESCRIPTION
The tachyon side didn't correctly handle the case where the friend request logic returned :auto_created.