### PR TITLE
Changed permission on chat link button

### DIFF
--- a/lib/teiserver_web/live/battles/match/match_components.ex
+++ b/lib/teiserver_web/live/battles/match/match_components.ex
@@ -52,7 +52,7 @@ defmodule TeiserverWeb.Battle.MatchComponents do
       </.section_menu_button>
 
       <.section_menu_button
-        :if={allow?(@current_user, "Reviewer")}
+        :if={allow?(@current_user, "Overwatch")}
         bsname={@view_colour}
         icon={StylingHelper.icon(:chat)}
         active={@active == "chat"}


### PR DESCRIPTION
Changed permission on chat link button so all Overwatch members can use it

It's been a long time since all Overwatch members can use the chat logs by editing the URL, so giving permission to use the button is just a QoL improvement.