### PR TITLE
FIX ordering by name in reports and bans

### DIFF
--- a/lib/teiserver/moderation/libs/ban_lib.ex
+++ b/lib/teiserver/moderation/libs/ban_lib.ex
@@ -90,12 +90,14 @@ defmodule Teiserver.Moderation.BanLib do
 
   def order_by(query, "Name (A-Z)") do
     from bans in query,
-      order_by: [asc: bans.name]
+      left_join: sources in assoc(bans, :source),
+      order_by: [asc: sources.name]
   end
 
   def order_by(query, "Name (Z-A)") do
     from bans in query,
-      order_by: [desc: bans.name]
+      left_join: sources in assoc(bans, :source),
+      order_by: [desc: sources.name]
   end
 
   def order_by(query, "Newest first") do

--- a/lib/teiserver/moderation/libs/report_lib.ex
+++ b/lib/teiserver/moderation/libs/report_lib.ex
@@ -225,6 +225,18 @@ defmodule Teiserver.Moderation.ReportLib do
       order_by: [asc: reports.inserted_at]
   end
 
+  def order_by(query, "Name (A-Z)") do
+    from reports in query,
+      left_join: targets in assoc(reports, :target),
+      order_by: [asc: targets.name]
+  end
+
+  def order_by(query, "Name (Z-A)") do
+    from reports in query,
+      left_join: targets in assoc(reports, :target),
+      order_by: [desc: targets.name]
+  end
+
   @spec preload(Ecto.Query.t(), List.t() | nil) :: Ecto.Query.t()
   def preload(query, nil), do: query
 


### PR DESCRIPTION
Trying to order reports or bans by name (Order by Name A-Z etc.) caused a 500 internal server error.