### PR TITLE
Restore lobby list at startup

### DIFF
--- a/lib/teiserver/player/session.ex
+++ b/lib/teiserver/player/session.ex
@@ -1399,11 +1399,13 @@ defmodule Teiserver.Player.Session do
   def handle_info(
         %{
           topic: "teiserver_tachyonlobby_list",
-          counter: c
+          counter: c,
+          event: event
         },
         state
       )
-      when state.lobby_list_subscription == nil or state.lobby_list_subscription.counter >= c do
+      when event != :reset_list and
+             (state.lobby_list_subscription == nil or state.lobby_list_subscription.counter >= c) do
     {:noreply, state}
   end
 
@@ -1426,8 +1428,11 @@ defmodule Teiserver.Player.Session do
       :remove_lobby ->
         send_to_player!({:lobby_list, {:remove_lobby, ev.lobby_id}}, state)
 
+      :reset_list ->
+        send_to_player!({:lobby_list, {:reset_list, ev.lobbies}}, state)
+
       _ ->
-        raise "Unknow lobby_list event: #{inspect(ev)}"
+        raise "Unknow lobby_list event: #{inspect(ev.event)} -- #{inspect(ev)}"
     end
 
     {:noreply, state}

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -194,6 +194,16 @@ defmodule Teiserver.Player.TachyonHandler do
     {:event, "lobby/listUpdated", data, state}
   end
 
+  def handle_info({:lobby_list, {:reset_list, lobbies}}, state) do
+    lobbies =
+      Enum.map(lobbies, fn {lobby_id, overview} ->
+        {lobby_id, lobby_overview_to_tachyon(lobby_id, overview)}
+      end)
+      |> Enum.into(%{})
+
+    {:event, "lobby/listReset", %{lobbies: lobbies}, state}
+  end
+
   def handle_info({:timeout, message_id}, state)
       when is_map_key(state.pending_responses, message_id) do
     Logger.debug("User did not reply in time to request with id #{message_id}")

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -4,7 +4,10 @@ defmodule Teiserver.TachyonLobby.Lobby do
   """
 
   require Logger
-  use GenServer, restart: :transient
+
+  # lobby process holds transient state about a specific lobby. If this process
+  # goes down, there is no point restarting since the state will be lost
+  use GenServer, restart: :temporary
 
   alias Teiserver.Asset
   alias Teiserver.Autohost
@@ -125,6 +128,18 @@ defmodule Teiserver.TachyonLobby.Lobby do
   @spec gen_id() :: id()
   def gen_id(), do: UUID.uuid4()
 
+  # note: this uses a pid and not a lobby id because it's (currently) only
+  # used by the lobby list process to bootstrap its state, and at that time
+  # it has the pid (from the registry).
+  # but if the needs arise, this could be overloaded to use a lobby id
+  # and the usual via_tuple mechanism
+  @spec get_overview(pid()) :: TachyonLobby.List.overview() | nil
+  def get_overview(lobby_pid) do
+    GenServer.call(lobby_pid, :get_overview)
+  catch
+    :exit, {:noproc, _} -> nil
+  end
+
   @spec get_details(id()) :: {:ok, details()} | {:error, reason :: term()}
   def get_details(id) do
     GenServer.call(via_tuple(id), :get_details)
@@ -194,6 +209,10 @@ defmodule Teiserver.TachyonLobby.Lobby do
   @impl true
   def handle_call(:get_details, _from, state) do
     {:reply, {:ok, get_details_from_state(state)}, state}
+  end
+
+  def handle_call(:get_overview, _from, state) do
+    {:reply, get_overview_from_state(state), state}
   end
 
   def handle_call({:join, join_data, _pid}, _from, state)

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -187,21 +187,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
       current_battle: nil
     }
 
-    TachyonLobby.List.register_lobby(self(), id, %{
-      name: state.name,
-      player_count: map_size(state.players),
-      max_player_count:
-        Enum.sum(
-          for at <- state.ally_team_config, team <- at.teams do
-            team.max_players
-          end
-        ),
-      map_name: state.map_name,
-      engine_version: state.engine_version,
-      game_version: state.game_version,
-      current_battle: nil
-    })
-
+    TachyonLobby.List.register_lobby(self(), id, get_overview_from_state(state))
     {:ok, state}
   end
 
@@ -316,6 +302,24 @@ defmodule Teiserver.TachyonLobby.Lobby do
   @spec via_tuple(id()) :: GenServer.name()
   defp via_tuple(lobby_id) do
     TachyonLobby.Registry.via_tuple(lobby_id)
+  end
+
+  @spec get_overview_from_state(state :: state()) :: TachyonLobby.List.overview()
+  defp get_overview_from_state(state) do
+    %{
+      name: state.name,
+      player_count: map_size(state.players),
+      max_player_count:
+        Enum.sum(
+          for at <- state.ally_team_config, team <- at.teams do
+            team.max_players
+          end
+        ),
+      map_name: state.map_name,
+      engine_version: state.engine_version,
+      game_version: state.game_version,
+      current_battle: nil
+    }
   end
 
   defp get_details_from_state(state) do

--- a/lib/teiserver/tachyon_lobby/registry.ex
+++ b/lib/teiserver/tachyon_lobby/registry.ex
@@ -25,6 +25,11 @@ defmodule Teiserver.TachyonLobby.Registry do
     end
   end
 
+  @spec list_lobbies() :: [{Lobby.id(), pid()}]
+  def list_lobbies() do
+    Horde.Registry.select(__MODULE__, [{{:"$1", :"$2", :_}, [], [{{:"$1", :"$2"}}]}])
+  end
+
   @impl true
   def init(init_args) do
     Horde.Registry.init(init_args)


### PR DESCRIPTION
Because there is a single process responsible for the listing of lobbies, if this process crash and restart, the listing may become desync with what the clients have.
This address this issue by bootstrapping the state of the listing at startup.