### PR TITLE
Resetup connection monitor

### DIFF
--- a/lib/teiserver/player/session.ex
+++ b/lib/teiserver/player/session.ex
@@ -467,7 +467,10 @@ defmodule Teiserver.Player.Session do
 
   @impl true
   def handle_call({:replace, new_conn_pid}, _from, state) do
-    monitors = MC.demonitor_by_val(state.monitors, :connection, [:flush])
+    monitors =
+      MC.demonitor_by_val(state.monitors, :connection, [:flush])
+      |> MC.monitor(new_conn_pid, :connection)
+
     Logger.info("session reused")
 
     {current_party, invited_to} = get_party_states(state.party)
@@ -1266,7 +1269,7 @@ defmodule Teiserver.Player.Session do
         # we don't care about cancelling the timer if the player reconnects since reconnection
         # should be fairly low (and rate limited) so too many messages isn't an issue
         {:ok, _} = :timer.send_after(2_000, :player_timeout)
-        Logger.info("Player disconnected abruptly")
+        Logger.info("Player disconnected abruptly because #{inspect(reason)}")
 
         state =
           state


### PR DESCRIPTION
This fixes a bug where, if the player disconnects abruptly, and then
reconnects, the session wouldn't monitor the new connection process.
So when that new connection disappear abruptly as well, the session
would linger.

Also added a few logs related to lobbies.