### PR TITLE
Responsive Navbar & BAR logo

### DIFF
--- a/assets/scss/mdb/_navbar.scss
+++ b/assets/scss/mdb/_navbar.scss
@@ -30,6 +30,26 @@
   position: absolute;
 }
 
+// Only apply absolute positioning when navbar is expanded (not collapsed)
+@media (min-width: 992px) {
+  .navbar-nav .dropdown-menu {
+    position: absolute;
+  }
+}
+
+// When navbar is collapsed, let dropdowns flow naturally
+@media (max-width: 991px) {
+  .navbar-nav .dropdown-menu {
+    position: static;
+    float: none;
+    width: auto;
+    margin-top: 0;
+    background-color: transparent;
+    border: 0;
+    box-shadow: none;
+  }
+}
+
 .navbar-light {
   .navbar-toggler-icon {
     background-image: none;

--- a/lib/teiserver_web/components/nav_components.ex
+++ b/lib/teiserver_web/components/nav_components.ex
@@ -5,6 +5,7 @@ defmodule TeiserverWeb.NavComponents do
   # import TeiserverWeb.Gettext
 
   import Teiserver.Account.AuthLib, only: [allow?: 2, allow_any?: 2]
+  import Phoenix.HTML, only: [raw: 1]
 
   use Phoenix.VerifiedRoutes,
     endpoint: TeiserverWeb.Endpoint,
@@ -44,25 +45,30 @@ defmodule TeiserverWeb.NavComponents do
     <nav class="navbar navbar-expand-lg m-0 p-0" id="top-nav">
       <!-- Container wrapper -->
       <div class="container-fluid">
-        <!-- Collapsible wrapper -->
+        <!-- Navbar brand -->
+        <a class="navbar-brand" href="/">
+          <img src={~p"/images/logo/logo.svg"} alt="BAR Logo" style="height: 24px; width: auto;" />
+        </a>
+
+        <button
+          class="navbar-toggler"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#navbarSupportedContent"
+          aria-controls="navbarSupportedContent"
+          aria-expanded="false"
+          aria-label="Toggle navigation"
+        >
+          <span class="navbar-toggler-icon"></span>
+        </button>
+
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
-          <!-- Navbar brand -->
-          <a class="navbar-brand mt-2 mt-lg-0" href="/">
-            <i
-              class={"fa-fw #{Application.get_env(:teiserver, Teiserver)[:site_icon]}"}
-              style="margin: -4px 20px 0 0px;"
-            >
-            </i>
-            <span id="page-title">
-              {Application.get_env(:teiserver, Teiserver)[:site_title]}
-            </span>
-          </a>
-          <!-- Left links -->
-          <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+          <!-- Left navigation -->
+          <ul class="navbar-nav me-auto">
             <.top_nav_item text="Home" active={@active == "central_home"} route={~p"/"} />
 
             <.top_nav_item
-              text="My account"
+              text={raw("My&nbsp;Account")}
               active={@active == "teiserver_account"}
               route={~p"/profile"}
             />
@@ -127,24 +133,24 @@ defmodule TeiserverWeb.NavComponents do
               active={@active == "admin"}
             />
           </ul>
-          <!-- Left links -->
+          <!-- Left navigation -->
+
+          <!-- Right elements -->
+          <ul class="navbar-nav">
+            <%= if @current_user do %>
+              <TeiserverWeb.UserComponents.recents_dropdown current_user={@current_user} />
+              <TeiserverWeb.UserComponents.account_dropdown current_user={@current_user} />
+            <% else %>
+              <li class="nav-item">
+                <a class="nav-link" href={~p"/login"}>
+                  Sign in
+                </a>
+              </li>
+            <% end %>
+          </ul>
+          <!-- Right elements -->
         </div>
         <!-- Collapsible wrapper -->
-
-        <!-- Right elements -->
-        <div class="d-flex align-items-center">
-          <%= if @current_user do %>
-            <TeiserverWeb.UserComponents.recents_dropdown current_user={@current_user} />
-            <TeiserverWeb.UserComponents.account_dropdown current_user={@current_user} />
-
-            <div style="width: 300px; display: inline-block;"></div>
-          <% else %>
-            <a class="nav-link" href={~p"/login"}>
-              Sign in
-            </a>
-          <% end %>
-        </div>
-        <!-- Right elements -->
       </div>
     </nav>
     """

--- a/lib/teiserver_web/components/user_components.ex
+++ b/lib/teiserver_web/components/user_components.ex
@@ -74,42 +74,45 @@ defmodule TeiserverWeb.UserComponents do
       |> assign(recents: recents)
 
     ~H"""
-    <div :if={not Enum.empty?(@recents)} class="nav-item dropdown mx-2">
+    <li :if={not Enum.empty?(@recents)} class="nav-item dropdown">
       <a
-        class="dropdown-toggle dropdown-toggle-icon-only"
+        class="nav-link dropdown-toggle"
         href="#"
         data-bs-toggle="dropdown"
         aria-haspopup="true"
         aria-expanded="false"
         id="user-recents-link"
       >
-        <i class="fa-solid fa-clock fa-fw fa-lg"></i>
+        <i class="fa-solid fa-clock fa-fw"></i>
       </a>
-      <div
+      <ul
         class="dropdown-menu dropdown-menu-end"
         aria-labelledby="user-recents-link"
         style="min-width: 300px; max-width: 500px;"
       >
-        <span class="dropdown-header" style="font-weight: bold;">
-          Recent items
-        </span>
-
-        <a :for={r <- @recents} class="dropdown-item" href={r.url}>
-          <Fontawesome.icon icon={r.type_icon} style="regular" css_style={"color: #{r.type_colour}"} />
-
-          <%= if r.item_icon do %>
+        <li><span class="dropdown-header" style="font-weight: bold;">Recent items</span></li>
+        <li :for={r <- @recents}>
+          <a class="dropdown-item" href={r.url}>
             <Fontawesome.icon
-              icon={r.item_icon}
+              icon={r.type_icon}
               style="regular"
-              css_style={"color: #{r.item_colour}"}
+              css_style={"color: #{r.type_colour}"}
             />
-          <% else %>
-            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-          <% end %>
-          &nbsp; {r.item_label}
-        </a>
-      </div>
-    </div>
+
+            <%= if r.item_icon do %>
+              <Fontawesome.icon
+                icon={r.item_icon}
+                style="regular"
+                css_style={"color: #{r.item_colour}"}
+              />
+            <% else %>
+              &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            <% end %>
+            &nbsp; {r.item_label}
+          </a>
+        </li>
+      </ul>
+    </li>
     """
   end
 
@@ -120,46 +123,47 @@ defmodule TeiserverWeb.UserComponents do
 
   def account_dropdown(assigns) do
     ~H"""
-    <div class="nav-item dropdown mx-2">
+    <li class="nav-item dropdown">
       <a
-        class="dropdown-toggle dropdown-toggle-icon-only"
+        class="nav-link dropdown-toggle"
         href="#"
         data-bs-toggle="dropdown"
         aria-haspopup="true"
         aria-expanded="false"
         id="user-dropdown-link"
       >
-        <i class="fa-solid fa-user fa-fw fa-lg"></i>
+        <i class="fa-solid fa-user fa-fw"></i>
       </a>
-      <div
+      <ul
         class="dropdown-menu dropdown-menu-end"
         aria-labelledby="user-dropdown-link"
         style="min-width: 300px; max-width: 500px;"
       >
-        <a class="dropdown-item" href={~p"/profile"}>
-          <i class={"fa-fw #{Teiserver.Account.icon()}"}></i> &nbsp;
-          Account
-        </a>
-
-        <hr style="margin: 0;" />
-
-        <form action={~p"/logout"} method="post" class="link" id="signout-form" style="margin: 0;">
-          <input type="hidden" name="_csrf_token" value={Phoenix.Controller.get_csrf_token()} />
-
-          <a
-            class="dropdown-item"
-            data-submit="parent"
-            href="#"
-            rel="nofollow"
-            onclick="$('#signout-form').submit();"
-            id="signout-link"
-          >
-            <i class="fa-solid fa-sign-out fa-fw"></i> &nbsp;
-            Sign out {@current_user.name}
+        <li>
+          <a class="dropdown-item" href={~p"/profile"}>
+            <i class={"fa-fw #{Teiserver.Account.icon()}"}></i> &nbsp;
+            Profile
           </a>
-        </form>
-      </div>
-    </div>
+        </li>
+        <li>
+          <form action={~p"/logout"} method="post" class="link" id="signout-form" style="margin: 0;">
+            <input type="hidden" name="_csrf_token" value={Phoenix.Controller.get_csrf_token()} />
+
+            <a
+              class="dropdown-item"
+              data-submit="parent"
+              href="#"
+              rel="nofollow"
+              onclick="$('#signout-form').submit();"
+              id="signout-link"
+            >
+              <i class="fa-solid fa-sign-out fa-fw"></i> &nbsp;
+              Sign out {@current_user.name}
+            </a>
+          </form>
+        </li>
+      </ul>
+    </li>
     """
   end
 end

--- a/lib/teiserver_web/templates/general/general/unauth_index.html.heex
+++ b/lib/teiserver_web/templates/general/general/unauth_index.html.heex
@@ -5,11 +5,11 @@
     <nav class="navbar navbar-expand-lg navbar-light pt-4 px-0">
       <a class="navbar-brand" href={~p"/"}>
         <img
-          src={Routes.static_path(@conn, "/images/logo/square_logo.svg")}
-          width="30"
+          src={Routes.static_path(@conn, "/images/logo/logo.svg")}
+          alt="BAR Logo"
+          style="height: 24px; width: auto;"
           class="mr-2"
         />
-        {Application.get_env(:teiserver, Teiserver)[:site_title]}
       </a>
       <button
         class="navbar-toggler"

--- a/priv/static/images/logo/logo.svg
+++ b/priv/static/images/logo/logo.svg
@@ -1,0 +1,697 @@
+<svg width="3149" height="1438" viewBox="0 0 3149 1438" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_di)">
+<path d="M895.159 681.046C969.757 697.89 1028.71 735.19 1072.03 792.943C1116.55 849.493 1138.81 914.466 1138.81 987.861C1138.81 1096.15 1013.59 1334.38 1013.59 1334.38C1013.59 1334.38 847.633 1334.38 712.874 1334.38H83V62H693.022C822.967 62 924.637 90.8768 998.032 148.63C1072.63 206.384 1109.93 287.6 1109.93 392.278C1109.93 466.876 1090.08 529.443 1050.37 579.977C1011.87 629.308 960.132 662.998 895.159 681.046ZM436.74 567.343H615.415C704.452 567.343 748.97 530.646 748.97 457.251C748.97 381.449 704.452 343.548 615.415 343.548H436.74V567.343ZM642.487 1049.22C731.524 1049.22 776.042 1011.93 776.042 937.327C776.042 898.825 764.01 869.346 739.946 848.892C717.086 828.437 683.998 818.21 640.682 818.21H436.74V1049.22H642.487Z" fill="url(#paint0_linear)"/>
+<path d="M895.159 681.046C969.757 697.89 1028.71 735.19 1072.03 792.943C1116.55 849.493 1138.81 914.466 1138.81 987.861C1138.81 1096.15 1013.59 1334.38 1013.59 1334.38C1013.59 1334.38 847.633 1334.38 712.874 1334.38H83V62H693.022C822.967 62 924.637 90.8768 998.032 148.63C1072.63 206.384 1109.93 287.6 1109.93 392.278C1109.93 466.876 1090.08 529.443 1050.37 579.977C1011.87 629.308 960.132 662.998 895.159 681.046ZM436.74 567.343H615.415C704.452 567.343 748.97 530.646 748.97 457.251C748.97 381.449 704.452 343.548 615.415 343.548H436.74V567.343ZM642.487 1049.22C731.524 1049.22 776.042 1011.93 776.042 937.327C776.042 898.825 764.01 869.346 739.946 848.892C717.086 828.437 683.998 818.21 640.682 818.21H436.74V1049.22H642.487Z" fill="url(#paint1_radial)"/>
+<path d="M1774.52 1126.83H1323.32L1254.74 1334.38H882.951L1346.78 62H1754.67L2216.7 1334.38H1843.1L1774.52 1126.83ZM1686.09 856.111L1548.92 444.617L1413.56 856.111H1686.09Z" fill="url(#paint2_linear)"/>
+<path d="M1774.52 1126.83H1323.32L1254.74 1334.38H882.951L1346.78 62H1754.67L2216.7 1334.38H1843.1L1774.52 1126.83ZM1686.09 856.111L1548.92 444.617L1413.56 856.111H1686.09Z" fill="url(#paint3_radial)"/>
+<path d="M2671.5 1334.38L2418.82 865.135H2380.92V1334.38H2323.2L1876.59 62H2584.87C2687.14 62 2773.77 80.048 2844.76 116.144C2915.74 151.037 2969.29 199.766 3005.38 262.333C3041.48 323.696 3059.53 392.88 3059.53 469.884C3059.53 556.515 3035.46 632.918 2987.33 699.094C2940.41 764.066 2871.23 810.389 2779.78 838.063L3066.75 1334.38H2671.5ZM2380.92 623.292H2555.99C2604.12 623.292 2640.21 611.862 2664.28 589.001C2688.34 566.14 2700.37 533.052 2700.37 489.737C2700.37 448.828 2687.74 416.944 2662.47 394.083C2638.41 370.019 2602.91 357.987 2555.99 357.987H2380.92V623.292Z" fill="url(#paint4_linear)"/>
+<path d="M2671.5 1334.38L2418.82 865.135H2380.92V1334.38H2323.2L1876.59 62H2584.87C2687.14 62 2773.77 80.048 2844.76 116.144C2915.74 151.037 2969.29 199.766 3005.38 262.333C3041.48 323.696 3059.53 392.88 3059.53 469.884C3059.53 556.515 3035.46 632.918 2987.33 699.094C2940.41 764.066 2871.23 810.389 2779.78 838.063L3066.75 1334.38H2671.5ZM2380.92 623.292H2555.99C2604.12 623.292 2640.21 611.862 2664.28 589.001C2688.34 566.14 2700.37 533.052 2700.37 489.737C2700.37 448.828 2687.74 416.944 2662.47 394.083C2638.41 370.019 2602.91 357.987 2555.99 357.987H2380.92V623.292Z" fill="url(#paint5_radial)"/>
+</g>
+<g opacity="0.6" filter="url(#filter1_i)">
+<path d="M2099.07 418.182C2084.13 443.598 2046.75 462.777 2022 477.277C2022 487.321 2040.77 531 2040.77 531C2040.77 531 2056.28 517.491 2061.5 512.794C2065.65 509.051 2086.52 501.014 2087.59 497.274C2089.44 490.789 2102.31 481.723 2107.86 477.277C2115.84 470.888 2124.24 463.424 2131.27 456.385C2146.36 441.282 2156.6 427.362 2168.25 409.527C2175.34 398.674 2179.06 382.642 2187.63 373.115C2194.55 365.414 2202.03 360.994 2209.84 354.909C2218.72 348 2227.55 340.48 2235.34 332.226C2239.47 327.848 2252.52 317.01 2253.97 311.931C2259.14 293.838 2297.16 293.691 2299.74 270.445C2300.33 265.13 2312.93 250.776 2317.19 247.464C2326.02 240.586 2332.01 232.807 2342.68 226.87C2361.19 216.578 2368.28 195.09 2386.81 184.489C2395.16 179.713 2401.41 171.962 2409.77 167.775C2418.57 163.372 2417.98 163 2408.43 163C2404.69 163 2402.5 167.191 2397.85 168.521C2387.46 171.491 2384.34 180.679 2376.23 187.175C2370 192.163 2362.69 202.432 2356.1 208.664C2347.45 216.846 2333.02 230.871 2322.55 235.526C2310.09 241.072 2301.98 254.427 2291.1 262.387C2277.32 272.463 2271.02 286.895 2255.31 295.217C2242.44 302.04 2227.97 312.737 2217.89 322.825C2208.06 332.664 2194.17 338.358 2183.75 347.746C2173.04 357.394 2162.53 367.063 2150.95 376.547C2132.34 391.788 2111.32 397.333 2099.07 418.182Z" fill="url(#paint6_linear)"/>
+</g>
+<g opacity="0.6" filter="url(#filter2_i)">
+<path d="M1901.93 742.7C1916.87 717.284 1954.25 698.105 1979 683.605C1979 673.561 1960.23 629.882 1960.23 629.882C1960.23 629.882 1944.72 643.392 1939.5 648.088C1935.35 651.831 1914.48 659.868 1913.41 663.608C1911.56 670.093 1898.69 679.16 1893.14 683.605C1885.16 689.995 1876.76 697.459 1869.73 704.497C1854.64 719.6 1844.4 733.52 1832.75 751.355C1825.66 762.209 1821.94 778.24 1813.37 787.767C1806.45 795.468 1798.97 799.888 1791.16 805.973C1782.28 812.882 1773.45 820.402 1765.66 828.656C1761.53 833.034 1748.48 843.873 1747.03 848.951C1741.86 867.045 1703.84 867.191 1701.26 890.437C1700.67 895.753 1688.07 910.106 1683.81 913.418C1674.98 920.296 1668.99 928.076 1658.32 934.012C1639.81 944.305 1632.72 965.793 1614.19 976.393C1605.84 981.169 1599.59 988.921 1591.23 993.107C1582.43 997.51 1583.02 997.882 1592.57 997.882C1596.31 997.882 1598.5 993.691 1603.15 992.361C1613.54 989.391 1616.66 980.203 1624.77 973.707C1631 968.72 1638.31 958.45 1644.9 952.218C1653.55 944.037 1667.98 930.011 1678.45 925.357C1690.91 919.81 1699.02 906.455 1709.9 898.495C1723.68 888.42 1729.98 873.987 1745.69 865.665C1758.56 858.842 1773.03 848.145 1783.11 838.057C1792.94 828.218 1806.83 822.524 1817.25 813.136C1827.96 803.489 1838.47 793.819 1850.05 784.335C1868.66 769.094 1889.68 763.549 1901.93 742.7Z" fill="url(#paint7_linear)"/>
+</g>
+<g opacity="0.6" filter="url(#filter3_i)">
+<path d="M2107.84 556.736C2090.9 564.606 2065.88 601.736 2065.88 601.736L2052 563.5C2052 563.5 2054.72 562.002 2058 559C2060.61 556.608 2061.08 552.445 2063.5 552C2067.7 551.228 2067.97 550.818 2071.11 547.588C2075.62 542.945 2080.84 538.106 2085.71 534.1C2096.15 525.505 2105.56 519.899 2117.51 513.638C2124.79 509.828 2135.13 508.455 2141.65 503.634C2146.93 499.736 2150.18 495.293 2154.49 490.734C2159.39 485.559 2164.67 480.447 2170.35 476.039C2173.36 473.701 2180.99 466.128 2184.28 465.523C2196.01 463.368 2198.41 439.398 2213.23 439.187C2216.62 439.138 2226.44 432.068 2228.79 429.587C2233.66 424.434 2238.93 421.134 2243.33 414.764C2250.94 403.719 2264.93 400.558 2272.74 389.516C2276.26 384.542 2281.53 381.076 2284.68 376.056C2287.99 370.775 2288.19 371.173 2287.61 377.193C2287.38 379.553 2284.6 380.679 2283.48 383.532C2280.98 389.899 2274.99 391.308 2270.4 396.028C2266.88 399.652 2259.96 403.634 2255.62 407.411C2249.94 412.371 2240.21 420.615 2236.64 426.929C2232.38 434.454 2223.47 438.753 2217.79 445.131C2210.59 453.204 2201.11 456.299 2194.9 465.695C2189.82 473.399 2182.19 481.871 2175.21 487.612C2168.41 493.212 2163.97 501.624 2157.42 507.624C2150.68 513.79 2143.94 519.828 2137.26 526.554C2126.51 537.361 2121.73 550.279 2107.84 556.736Z" fill="url(#paint8_linear)"/>
+</g>
+<g opacity="0.6" filter="url(#filter4_i)">
+<path d="M1893.16 604.147C1910.1 596.276 1935.12 559.147 1935.12 559.147L1949 597.382C1949 597.382 1946.28 598.881 1943 601.882C1940.39 604.274 1939.92 608.437 1937.5 608.882C1933.3 609.655 1933.03 610.064 1929.89 613.294C1925.38 617.937 1920.16 622.777 1915.29 626.782C1904.85 635.378 1895.44 640.984 1883.49 647.244C1876.21 651.054 1865.87 652.427 1859.35 657.248C1854.07 661.146 1850.82 665.589 1846.51 670.148C1841.61 675.324 1836.33 680.435 1830.65 684.843C1827.64 687.182 1820.01 694.754 1816.72 695.359C1804.99 697.514 1802.59 721.485 1787.77 721.696C1784.38 721.744 1774.56 728.815 1772.21 731.296C1767.34 736.448 1762.07 739.748 1757.67 746.118C1750.06 757.164 1736.07 760.324 1728.26 771.366C1724.74 776.34 1719.47 779.807 1716.32 784.827C1713.01 790.107 1712.81 789.709 1713.39 783.69C1713.62 781.329 1716.4 780.204 1717.52 777.351C1720.02 770.983 1726.01 769.575 1730.6 764.854C1734.12 761.23 1741.04 757.249 1745.38 753.471C1751.06 748.512 1760.79 740.267 1764.36 733.953C1768.62 726.429 1777.53 722.129 1783.21 715.752C1790.41 707.679 1799.89 704.584 1806.1 695.187C1811.18 687.484 1818.81 679.011 1825.79 673.27C1832.59 667.671 1837.03 659.258 1843.58 653.258C1850.32 647.093 1857.06 641.054 1863.74 634.329C1874.49 623.521 1879.27 610.603 1893.16 604.147Z" fill="url(#paint9_linear)"/>
+</g>
+<g opacity="0.5" filter="url(#filter5_i)">
+<path d="M1344.45 67.728C1347.81 84.991 1350.49 101.318 1350.49 119.071C1350.49 126.067 1343.75 126.854 1341.43 132.662C1340.25 135.599 1338.56 139.688 1336.56 135.682C1334.76 132.084 1334.03 136.039 1333.88 138.702C1333.51 144.859 1330.85 149.636 1330.85 156.068C1330.85 164.352 1330.63 170.464 1326.66 177.964C1323.75 183.464 1320.28 185.932 1320.28 192.31C1320.28 195.241 1324.07 200.884 1320.96 203.552C1318.01 206.077 1314.99 208.776 1311.98 211.186C1305.98 215.986 1317.01 227.694 1317.26 232.327C1317.78 241.671 1318.66 252.461 1320.37 261.858C1322.25 272.21 1321.39 282.478 1321.79 293.066C1322.12 301.625 1325.52 309.589 1321.04 317.647C1319.81 319.86 1319.24 324.905 1315.75 321.422C1312.96 318.623 1310.6 312.643 1308.54 309.341C1306.75 306.484 1303.02 321.065 1302.25 323.771C1301.41 326.692 1299.14 329.057 1299.14 331.993C1299.14 334.891 1300.12 339.944 1298.81 342.563C1294.11 351.957 1281.02 356.628 1281.02 368.235C1281.02 376.283 1284.04 382.081 1284.04 390.047C1284.04 402.22 1282.53 415.382 1282.53 427.967C1282.53 430.908 1284.44 436.285 1283.96 438.454C1283.15 442.071 1281.59 445.547 1280.94 449.108C1279.24 458.471 1268.37 465.122 1268.94 475.451C1269.34 482.537 1276.49 487.631 1276.49 495.837C1276.49 505.614 1273.47 513.745 1273.47 523.773V556.24C1273.47 566.147 1267.43 574.832 1267.43 584.932C1267.43 597.402 1262.17 573.148 1261.39 587.197C1261.07 592.914 1263.44 602.536 1260.64 607.583C1258.99 610.539 1258.57 614.081 1258.37 617.398C1258.05 622.866 1250.25 614.929 1249.65 612.868C1247.13 604.303 1246.29 595.16 1242.1 587.197C1240.32 583.827 1237.23 581.611 1237.23 577.297C1237.23 572.581 1238.17 566.884 1237.15 562.28C1234.45 550.152 1231.19 571.526 1231.19 575.116C1231.19 585.467 1230.13 596.542 1231.27 606.828C1232.47 617.595 1235.93 623.863 1237.15 631.744C1238.8 642.509 1239.24 659.682 1236.89 670.251C1235.49 676.553 1233.58 683.404 1232.78 689.799C1232.31 693.573 1231.99 699.383 1230.43 702.802C1230.14 703.446 1229.61 708.108 1228.84 707.668C1226.18 706.145 1225.47 700.136 1224.81 697.433C1223.07 690.248 1220.89 681.787 1220.62 674.446C1220.43 669.316 1216.98 653.832 1214.66 666.56C1213.24 674.378 1216 681.299 1208.54 685.688C1205.29 687.599 1203.52 700.518 1201.83 704.144C1200.45 707.088 1198.77 711.557 1198.05 714.799C1197.16 718.802 1198.57 721.356 1194.61 717.399C1189.48 712.266 1186.15 721.909 1184.38 725.453C1180.1 734.007 1181.36 743.953 1181.36 753.306C1181.36 761.672 1181.72 767.754 1177.58 775.202C1173.56 782.434 1176.41 789.264 1176.83 797.098C1177.17 803.692 1176.91 810.019 1175.23 815.891C1172.71 824.721 1161.37 816.855 1159.04 812.199C1157.96 810.032 1158.17 804.525 1156.44 803.139C1153.48 800.772 1151.17 799.377 1148.81 796.343C1143.37 789.358 1137.56 797.78 1137.56 803.139C1137.56 810.123 1133.03 814.642 1133.03 822.015C1133.03 827.765 1126.99 832.76 1126.99 838.626C1126.99 844.533 1124.07 835.662 1123.64 835.186C1119.68 830.794 1119.44 840.329 1119.44 842.401V865.136C1119.44 888.088 1117.93 910.911 1117.93 933.677C1117.93 938.14 1110.88 984.911 1108.03 984.097C1101.52 982.237 1098.63 961.483 1098.3 955.657C1097.97 949.632 1096.51 939.92 1094.11 934.516C1090.93 927.375 1089.24 920.625 1089.24 912.62C1089.24 910.491 1090.25 904.825 1088.91 903.14C1087.07 900.846 1086.22 903.055 1086.22 898.274C1086.22 892.351 1083.2 886.726 1083.2 880.908C1083.2 873.825 1082.08 882.257 1080.94 883.173C1079.27 884.508 1080.18 878.293 1080.18 876.378C1080.18 872.621 1078.67 869.269 1078.67 865.807C1078.67 855.779 1089.24 857.639 1089.24 848.441C1089.24 842.169 1086.37 838.015 1084.8 832.501C1082.94 826.024 1081.26 821.098 1081.69 813.709C1081.85 811.053 1081.98 800.263 1078.67 798.608L1344.45 67.728Z" fill="url(#paint10_linear)"/>
+</g>
+<g filter="url(#filter6_di)">
+<circle cx="157" cy="119" r="21" fill="#B4B4B4"/>
+<circle cx="157" cy="119" r="21" fill="url(#paint11_radial)"/>
+</g>
+<g filter="url(#filter7_di)">
+<circle cx="2059" cy="119" r="21" fill="#B4B4B4"/>
+<circle cx="2059" cy="119" r="21" fill="url(#paint12_radial)"/>
+</g>
+<g filter="url(#filter8_di)">
+<circle cx="2236" cy="119" r="21" fill="#B4B4B4"/>
+<circle cx="2236" cy="119" r="21" fill="url(#paint13_radial)"/>
+</g>
+<g filter="url(#filter9_di)">
+<circle cx="1704.2" cy="123.341" r="21" fill="#B4B4B4"/>
+<circle cx="1704.2" cy="123.341" r="21" fill="url(#paint14_radial)"/>
+</g>
+<g filter="url(#filter10_di)">
+<circle cx="1763.21" cy="284.902" r="21" fill="#B4B4B4"/>
+<circle cx="1763.21" cy="284.902" r="21" fill="url(#paint15_radial)"/>
+</g>
+<g filter="url(#filter11_di)">
+<circle cx="1822.38" cy="446.403" r="21" fill="#B4B4B4"/>
+<circle cx="1822.38" cy="446.403" r="21" fill="url(#paint16_radial)"/>
+</g>
+<g filter="url(#filter12_di)">
+<circle cx="1881.56" cy="607.904" r="21" fill="#B4B4B4"/>
+<circle cx="1881.56" cy="607.904" r="21" fill="url(#paint17_radial)"/>
+</g>
+<g filter="url(#filter13_di)">
+<circle cx="1940.73" cy="769.405" r="21" fill="#B4B4B4"/>
+<circle cx="1940.73" cy="769.405" r="21" fill="url(#paint18_radial)"/>
+</g>
+<g filter="url(#filter14_di)">
+<circle cx="1999.9" cy="930.906" r="21" fill="#B4B4B4"/>
+<circle cx="1999.9" cy="930.906" r="21" fill="url(#paint19_radial)"/>
+</g>
+<g filter="url(#filter15_di)">
+<circle cx="2059.08" cy="1092.41" r="21" fill="#B4B4B4"/>
+<circle cx="2059.08" cy="1092.41" r="21" fill="url(#paint20_radial)"/>
+</g>
+<g filter="url(#filter16_di)">
+<circle cx="2118.25" cy="1253.91" r="21" fill="#B4B4B4"/>
+<circle cx="2118.25" cy="1253.91" r="21" fill="url(#paint21_radial)"/>
+</g>
+<g filter="url(#filter17_di)">
+<circle cx="334" cy="119" r="21" fill="#B4B4B4"/>
+<circle cx="334" cy="119" r="21" fill="url(#paint22_radial)"/>
+</g>
+<g filter="url(#filter18_di)">
+<circle cx="511" cy="119" r="21" fill="#B4B4B4"/>
+<circle cx="511" cy="119" r="21" fill="url(#paint23_radial)"/>
+</g>
+<g filter="url(#filter19_di)">
+<circle cx="2413" cy="119" r="21" fill="#B4B4B4"/>
+<circle cx="2413" cy="119" r="21" fill="url(#paint24_radial)"/>
+</g>
+<g filter="url(#filter20_di)">
+<circle cx="688" cy="119" r="21" fill="#B4B4B4"/>
+<circle cx="688" cy="119" r="21" fill="url(#paint25_radial)"/>
+</g>
+<g filter="url(#filter21_di)">
+<circle cx="2590" cy="119" r="21" fill="#B4B4B4"/>
+<circle cx="2590" cy="119" r="21" fill="url(#paint26_radial)"/>
+</g>
+<g filter="url(#filter22_di)">
+<circle cx="865" cy="147" r="21" fill="#B4B4B4"/>
+<circle cx="865" cy="147" r="21" fill="url(#paint27_radial)"/>
+</g>
+<g filter="url(#filter23_di)">
+<circle cx="2767" cy="147" r="21" fill="#B4B4B4"/>
+<circle cx="2767" cy="147" r="21" fill="url(#paint28_radial)"/>
+</g>
+<g filter="url(#filter24_di)">
+<circle cx="1007" cy="253" r="21" fill="#B4B4B4"/>
+<circle cx="1007" cy="253" r="21" fill="url(#paint29_radial)"/>
+</g>
+<g filter="url(#filter25_di)">
+<circle cx="2909" cy="253" r="21" fill="#B4B4B4"/>
+<circle cx="2909" cy="253" r="21" fill="url(#paint30_radial)"/>
+</g>
+<g filter="url(#filter26_di)">
+<circle cx="1049" cy="398" r="21" fill="#B4B4B4"/>
+<circle cx="1049" cy="398" r="21" fill="url(#paint31_radial)"/>
+</g>
+<g filter="url(#filter27_di)">
+<circle cx="2981" cy="398" r="21" fill="#B4B4B4"/>
+<circle cx="2981" cy="398" r="21" fill="url(#paint32_radial)"/>
+</g>
+<defs>
+<filter id="filter0_di" x="0.828949" y="0.371712" width="3148.09" height="1436.72" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dy="20.5428"/>
+<feGaussianBlur stdDeviation="41.0855"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.55 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="8.2171"/>
+<feGaussianBlur stdDeviation="114.012"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow"/>
+</filter>
+<filter id="filter1_i" x="2020" y="163" width="396" height="369" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow"/>
+</filter>
+<filter id="filter2_i" x="1583" y="629.882" width="396" height="369" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow"/>
+</filter>
+<filter id="filter3_i" x="2050" y="372.367" width="237.864" height="230.368" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow"/>
+</filter>
+<filter id="filter4_i" x="1711.14" y="559.147" width="237.864" height="230.368" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow"/>
+</filter>
+<filter id="filter5_i" x="1076.67" y="67.728" width="273.815" height="917.38" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow"/>
+</filter>
+<filter id="filter6_di" x="130" y="93" width="50" height="50" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dx="-2" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="-2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow"/>
+</filter>
+<filter id="filter7_di" x="2032" y="93" width="50" height="50" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dx="-2" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="-2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow"/>
+</filter>
+<filter id="filter8_di" x="2209" y="93" width="50" height="50" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dx="-2" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="-2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow"/>
+</filter>
+<filter id="filter9_di" x="1677.2" y="97.3406" width="50" height="50" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dx="-2" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="-2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow"/>
+</filter>
+<filter id="filter10_di" x="1736.21" y="258.902" width="50" height="50" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dx="-2" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="-2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow"/>
+</filter>
+<filter id="filter11_di" x="1795.38" y="420.403" width="50" height="50" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dx="-2" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="-2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow"/>
+</filter>
+<filter id="filter12_di" x="1854.56" y="581.904" width="50" height="50" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dx="-2" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="-2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow"/>
+</filter>
+<filter id="filter13_di" x="1913.73" y="743.405" width="50" height="50" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dx="-2" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="-2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow"/>
+</filter>
+<filter id="filter14_di" x="1972.9" y="904.906" width="50" height="50" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dx="-2" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="-2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow"/>
+</filter>
+<filter id="filter15_di" x="2032.08" y="1066.41" width="50" height="50" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dx="-2" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="-2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow"/>
+</filter>
+<filter id="filter16_di" x="2091.25" y="1227.91" width="50" height="50" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dx="-2" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="-2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow"/>
+</filter>
+<filter id="filter17_di" x="307" y="93" width="50" height="50" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dx="-2" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="-2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow"/>
+</filter>
+<filter id="filter18_di" x="484" y="93" width="50" height="50" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dx="-2" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="-2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow"/>
+</filter>
+<filter id="filter19_di" x="2386" y="93" width="50" height="50" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dx="-2" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="-2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow"/>
+</filter>
+<filter id="filter20_di" x="661" y="93" width="50" height="50" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dx="-2" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="-2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow"/>
+</filter>
+<filter id="filter21_di" x="2563" y="93" width="50" height="50" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dx="-2" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="-2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow"/>
+</filter>
+<filter id="filter22_di" x="838" y="121" width="50" height="50" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dx="-2" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="-2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow"/>
+</filter>
+<filter id="filter23_di" x="2740" y="121" width="50" height="50" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dx="-2" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="-2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow"/>
+</filter>
+<filter id="filter24_di" x="980" y="227" width="50" height="50" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dx="-2" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="-2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow"/>
+</filter>
+<filter id="filter25_di" x="2882" y="227" width="50" height="50" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dx="-2" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="-2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow"/>
+</filter>
+<filter id="filter26_di" x="1022" y="372" width="50" height="50" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dx="-2" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="-2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow"/>
+</filter>
+<filter id="filter27_di" x="2954" y="372" width="50" height="50" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dx="-2" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-2" dy="-2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.11 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow"/>
+</filter>
+<linearGradient id="paint0_linear" x1="1513.83" y1="23.7542" x2="1514.74" y2="1334.38" gradientUnits="userSpaceOnUse">
+<stop offset="0.254144" stop-color="#D8D8D8"/>
+<stop offset="1" stop-color="#B1B1B1"/>
+</linearGradient>
+<radialGradient id="paint1_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(83.0002 295.5) rotate(76.9938) scale(2408.28 9107.03)">
+<stop stop-color="#F3F3F3"/>
+<stop offset="0.140625" stop-color="#CECECE"/>
+<stop offset="0.234797" stop-color="#FAFAFA" stop-opacity="0.83"/>
+<stop offset="0.30493" stop-color="#CFCFCF" stop-opacity="0.640625"/>
+<stop offset="0.40625" stop-color="white" stop-opacity="0.53125"/>
+<stop offset="0.48826" stop-color="#C7C7C7" stop-opacity="0.86"/>
+<stop offset="0.499213" stop-color="#E8E8E8" stop-opacity="0.62"/>
+<stop offset="0.588783" stop-color="#CACACA" stop-opacity="0.689794"/>
+<stop offset="0.59592" stop-color="#E2E2E2" stop-opacity="0.742505"/>
+<stop offset="0.619792" stop-color="#BFBFBF" stop-opacity="0.8"/>
+<stop offset="0.721795" stop-color="#D0D0D0" stop-opacity="0.69"/>
+<stop offset="0.777429" stop-color="#C5C5C5" stop-opacity="0.190756"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="paint2_linear" x1="1513.83" y1="23.7542" x2="1514.74" y2="1334.38" gradientUnits="userSpaceOnUse">
+<stop offset="0.254144" stop-color="#D8D8D8"/>
+<stop offset="1" stop-color="#B1B1B1"/>
+</linearGradient>
+<radialGradient id="paint3_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(83.0002 295.5) rotate(76.9938) scale(2408.28 9107.03)">
+<stop stop-color="#F3F3F3"/>
+<stop offset="0.140625" stop-color="#CECECE"/>
+<stop offset="0.234797" stop-color="#FAFAFA" stop-opacity="0.83"/>
+<stop offset="0.30493" stop-color="#CFCFCF" stop-opacity="0.640625"/>
+<stop offset="0.40625" stop-color="white" stop-opacity="0.53125"/>
+<stop offset="0.48826" stop-color="#C7C7C7" stop-opacity="0.86"/>
+<stop offset="0.499213" stop-color="#E8E8E8" stop-opacity="0.62"/>
+<stop offset="0.588783" stop-color="#CACACA" stop-opacity="0.689794"/>
+<stop offset="0.59592" stop-color="#E2E2E2" stop-opacity="0.742505"/>
+<stop offset="0.619792" stop-color="#BFBFBF" stop-opacity="0.8"/>
+<stop offset="0.721795" stop-color="#D0D0D0" stop-opacity="0.69"/>
+<stop offset="0.777429" stop-color="#C5C5C5" stop-opacity="0.190756"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="paint4_linear" x1="1513.83" y1="23.7542" x2="1514.74" y2="1334.38" gradientUnits="userSpaceOnUse">
+<stop offset="0.254144" stop-color="#D8D8D8"/>
+<stop offset="1" stop-color="#B1B1B1"/>
+</linearGradient>
+<radialGradient id="paint5_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(83.0002 295.5) rotate(76.9938) scale(2408.28 9107.03)">
+<stop stop-color="#F3F3F3"/>
+<stop offset="0.140625" stop-color="#CECECE"/>
+<stop offset="0.234797" stop-color="#FAFAFA" stop-opacity="0.83"/>
+<stop offset="0.30493" stop-color="#CFCFCF" stop-opacity="0.640625"/>
+<stop offset="0.40625" stop-color="white" stop-opacity="0.53125"/>
+<stop offset="0.48826" stop-color="#C7C7C7" stop-opacity="0.86"/>
+<stop offset="0.499213" stop-color="#E8E8E8" stop-opacity="0.62"/>
+<stop offset="0.588783" stop-color="#CACACA" stop-opacity="0.689794"/>
+<stop offset="0.59592" stop-color="#E2E2E2" stop-opacity="0.742505"/>
+<stop offset="0.619792" stop-color="#BFBFBF" stop-opacity="0.8"/>
+<stop offset="0.721795" stop-color="#D0D0D0" stop-opacity="0.69"/>
+<stop offset="0.777429" stop-color="#C5C5C5" stop-opacity="0.190756"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="paint6_linear" x1="2215.93" y1="185.78" x2="2215.93" y2="531.002" gradientUnits="userSpaceOnUse">
+<stop stop-color="#C4C4C4" stop-opacity="0.38"/>
+<stop offset="1" stop-color="#C4C4C4"/>
+</linearGradient>
+<linearGradient id="paint7_linear" x1="1785.07" y1="975.102" x2="1785.07" y2="629.88" gradientUnits="userSpaceOnUse">
+<stop stop-color="#C4C4C4" stop-opacity="0.38"/>
+<stop offset="1" stop-color="#C4C4C4"/>
+</linearGradient>
+<linearGradient id="paint8_linear" x1="2261.52" y1="497.201" x2="2043.81" y2="476.169" gradientUnits="userSpaceOnUse">
+<stop stop-color="#C4C4C4" stop-opacity="0.38"/>
+<stop offset="1" stop-color="#C4C4C4"/>
+</linearGradient>
+<linearGradient id="paint9_linear" x1="1739.48" y1="663.681" x2="1957.19" y2="684.713" gradientUnits="userSpaceOnUse">
+<stop stop-color="#C4C4C4" stop-opacity="0.38"/>
+<stop offset="1" stop-color="#C4C4C4"/>
+</linearGradient>
+<linearGradient id="paint10_linear" x1="1212.46" y1="124.454" x2="1212.46" y2="984.113" gradientUnits="userSpaceOnUse">
+<stop stop-color="#C4C4C4" stop-opacity="0.38"/>
+<stop offset="1" stop-color="#C4C4C4"/>
+</linearGradient>
+<radialGradient id="paint11_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(153 113.5) rotate(64.9831) scale(33.1059 44.1851)">
+<stop offset="0.125" stop-color="#FFFDFD"/>
+<stop offset="0.473958" stop-color="#EFEFEF" stop-opacity="0.76"/>
+<stop offset="1" stop-color="#BFBFBF" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint12_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(2055 113.5) rotate(64.9831) scale(33.1059 44.1851)">
+<stop offset="0.125" stop-color="#FFFDFD"/>
+<stop offset="0.473958" stop-color="#EFEFEF" stop-opacity="0.76"/>
+<stop offset="1" stop-color="#BFBFBF" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint13_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(2232 113.5) rotate(64.9831) scale(33.1059 44.1851)">
+<stop offset="0.125" stop-color="#FFFDFD"/>
+<stop offset="0.473958" stop-color="#EFEFEF" stop-opacity="0.76"/>
+<stop offset="1" stop-color="#BFBFBF" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint14_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1700.2 117.841) rotate(64.9831) scale(33.1059 44.1851)">
+<stop offset="0.125" stop-color="#FFFDFD"/>
+<stop offset="0.473958" stop-color="#EFEFEF" stop-opacity="0.76"/>
+<stop offset="1" stop-color="#BFBFBF" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint15_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1759.21 279.402) rotate(64.9831) scale(33.1059 44.1851)">
+<stop offset="0.125" stop-color="#FFFDFD"/>
+<stop offset="0.473958" stop-color="#EFEFEF" stop-opacity="0.76"/>
+<stop offset="1" stop-color="#BFBFBF" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint16_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1818.38 440.903) rotate(64.9831) scale(33.1059 44.1851)">
+<stop offset="0.125" stop-color="#FFFDFD"/>
+<stop offset="0.473958" stop-color="#EFEFEF" stop-opacity="0.76"/>
+<stop offset="1" stop-color="#BFBFBF" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint17_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1877.56 602.404) rotate(64.9831) scale(33.1059 44.1851)">
+<stop offset="0.125" stop-color="#FFFDFD"/>
+<stop offset="0.473958" stop-color="#EFEFEF" stop-opacity="0.76"/>
+<stop offset="1" stop-color="#BFBFBF" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint18_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1936.73 763.905) rotate(64.9831) scale(33.1059 44.1851)">
+<stop offset="0.125" stop-color="#FFFDFD"/>
+<stop offset="0.473958" stop-color="#EFEFEF" stop-opacity="0.76"/>
+<stop offset="1" stop-color="#BFBFBF" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint19_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1995.9 925.406) rotate(64.9831) scale(33.1059 44.1851)">
+<stop offset="0.125" stop-color="#FFFDFD"/>
+<stop offset="0.473958" stop-color="#EFEFEF" stop-opacity="0.76"/>
+<stop offset="1" stop-color="#BFBFBF" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint20_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(2055.08 1086.91) rotate(64.9831) scale(33.1059 44.1851)">
+<stop offset="0.125" stop-color="#FFFDFD"/>
+<stop offset="0.473958" stop-color="#EFEFEF" stop-opacity="0.76"/>
+<stop offset="1" stop-color="#BFBFBF" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint21_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(2114.25 1248.41) rotate(64.9831) scale(33.1059 44.1851)">
+<stop offset="0.125" stop-color="#FFFDFD"/>
+<stop offset="0.473958" stop-color="#EFEFEF" stop-opacity="0.76"/>
+<stop offset="1" stop-color="#BFBFBF" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint22_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(330 113.5) rotate(64.9831) scale(33.1059 44.1851)">
+<stop offset="0.125" stop-color="#FFFDFD"/>
+<stop offset="0.473958" stop-color="#EFEFEF" stop-opacity="0.76"/>
+<stop offset="1" stop-color="#BFBFBF" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint23_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(507 113.5) rotate(64.9831) scale(33.1059 44.1851)">
+<stop offset="0.125" stop-color="#FFFDFD"/>
+<stop offset="0.473958" stop-color="#EFEFEF" stop-opacity="0.76"/>
+<stop offset="1" stop-color="#BFBFBF" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint24_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(2409 113.5) rotate(64.9831) scale(33.1059 44.1851)">
+<stop offset="0.125" stop-color="#FFFDFD"/>
+<stop offset="0.473958" stop-color="#EFEFEF" stop-opacity="0.76"/>
+<stop offset="1" stop-color="#BFBFBF" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint25_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(684 113.5) rotate(64.9831) scale(33.1059 44.1851)">
+<stop offset="0.125" stop-color="#FFFDFD"/>
+<stop offset="0.473958" stop-color="#EFEFEF" stop-opacity="0.76"/>
+<stop offset="1" stop-color="#BFBFBF" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint26_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(2586 113.5) rotate(64.9831) scale(33.1059 44.1851)">
+<stop offset="0.125" stop-color="#FFFDFD"/>
+<stop offset="0.473958" stop-color="#EFEFEF" stop-opacity="0.76"/>
+<stop offset="1" stop-color="#BFBFBF" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint27_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(861 141.5) rotate(64.9831) scale(33.1059 44.1851)">
+<stop offset="0.125" stop-color="#FFFDFD"/>
+<stop offset="0.473958" stop-color="#EFEFEF" stop-opacity="0.76"/>
+<stop offset="1" stop-color="#BFBFBF" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint28_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(2763 141.5) rotate(64.9831) scale(33.1059 44.1851)">
+<stop offset="0.125" stop-color="#FFFDFD"/>
+<stop offset="0.473958" stop-color="#EFEFEF" stop-opacity="0.76"/>
+<stop offset="1" stop-color="#BFBFBF" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint29_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1003 247.5) rotate(64.9831) scale(33.1059 44.1851)">
+<stop offset="0.125" stop-color="#FFFDFD"/>
+<stop offset="0.473958" stop-color="#EFEFEF" stop-opacity="0.76"/>
+<stop offset="1" stop-color="#BFBFBF" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint30_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(2905 247.5) rotate(64.9831) scale(33.1059 44.1851)">
+<stop offset="0.125" stop-color="#FFFDFD"/>
+<stop offset="0.473958" stop-color="#EFEFEF" stop-opacity="0.76"/>
+<stop offset="1" stop-color="#BFBFBF" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint31_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1045 392.5) rotate(64.9831) scale(33.1059 44.1851)">
+<stop offset="0.125" stop-color="#FFFDFD"/>
+<stop offset="0.473958" stop-color="#EFEFEF" stop-opacity="0.76"/>
+<stop offset="1" stop-color="#BFBFBF" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint32_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(2977 392.5) rotate(64.9831) scale(33.1059 44.1851)">
+<stop offset="0.125" stop-color="#FFFDFD"/>
+<stop offset="0.473958" stop-color="#EFEFEF" stop-opacity="0.76"/>
+<stop offset="1" stop-color="#BFBFBF" stop-opacity="0"/>
+</radialGradient>
+</defs>
+</svg>


### PR DESCRIPTION
FIxing the navbar to be properly responsive for small display sizes

- Added responsiveness to navbar, when collapsed the menu is accessible through the hamburger icon
- Added the BAR logo.svg (stolen from bar-lobby) to replace the robot and the BAR text
- Renamed `My account` and `Account` to `Profile` to reflect the actual url route and avoid 'my account' collapsing weirdly to two lines

Uncollapsed:
<img width="847" height="394" alt="image" src="https://github.com/user-attachments/assets/2ea0c0fb-f6db-48e6-8c02-2b63955dee4a" />


Collapsed:

<img width="524" height="665" alt="image" src="https://github.com/user-attachments/assets/403dc0f6-12c6-43f6-b6b0-f623870f0279" />


Note:  I made a css change so a `mix assets.deploy` will need to be run to recompile this so the dropdown menus properly expand in the collapsed nav.
