### PR TITLE
Fixed permission check for the admin button

### DIFF
--- a/lib/teiserver_web/components/nav_components.ex
+++ b/lib/teiserver_web/components/nav_components.ex
@@ -121,7 +121,7 @@ defmodule TeiserverWeb.NavComponents do
             />
 
             <.top_nav_item
-              :if={allow_any?(@current_user, ~w(Contributor Overwatch))}
+              :if={allow_any?(@current_user, ~w(Admin Server Moderator))}
               text="Admin"
               route={~p"/teiserver/admin"}
               active={@active == "admin"}


### PR DESCRIPTION
The admin button in the nav components now only shows for Server, Admin and Moderator roles