### PR TITLE
User OAuth application management

### DIFF
--- a/lib/teiserver_web/controllers/account/security_controller.ex
+++ b/lib/teiserver_web/controllers/account/security_controller.ex
@@ -1,7 +1,9 @@
 defmodule TeiserverWeb.Account.SecurityController do
   use TeiserverWeb, :controller
+  require Logger
 
   alias Teiserver.Account
+  alias Teiserver.OAuth
 
   plug(:add_breadcrumb, name: "Account", url: "/teiserver/account")
   plug(:add_breadcrumb, name: "Security", url: "/teiserver/account/security")
@@ -21,8 +23,13 @@ defmodule TeiserverWeb.Account.SecurityController do
         order_by: "Most recently used"
       )
 
+    oauth_applications = OAuth.list_authorized_applications(conn.assigns.current_user.id)
+    oauth_token_counts = OAuth.get_application_token_counts(conn.assigns.current_user.id)
+
     conn
     |> assign(:user_tokens, user_tokens)
+    |> assign(:oauth_applications, oauth_applications)
+    |> assign(:oauth_token_counts, oauth_token_counts)
     |> render("index.html")
   end
 
@@ -46,7 +53,7 @@ defmodule TeiserverWeb.Account.SecurityController do
       {:ok, _user} ->
         conn
         |> put_flash(:info, "Account password updated successfully.")
-        |> redirect(to: Routes.ts_account_security_path(conn, :index))
+        |> redirect(to: ~p"/teiserver/account/security")
 
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "edit_password.html", user: user, changeset: changeset)
@@ -67,5 +74,24 @@ defmodule TeiserverWeb.Account.SecurityController do
     conn
     |> put_flash(:info, "Token deleted successfully.")
     |> redirect(to: Routes.ts_account_security_path(conn, :index))
+  end
+
+  @spec revoke_oauth_application(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def revoke_oauth_application(conn, %{"id" => application_id}) do
+    case OAuth.revoke_application_access(conn.assigns.current_user.id, application_id) do
+      :ok ->
+        Logger.info(
+          "user_id=#{conn.assigns.current_user.id} revoked_oauth_application_id=#{application_id}"
+        )
+
+        conn
+        |> put_flash(:info, "OAuth application access revoked successfully.")
+        |> redirect(to: ~p"/teiserver/account/security")
+
+      {:error, _reason} ->
+        conn
+        |> put_flash(:error, "Failed to revoke OAuth application access.")
+        |> redirect(to: ~p"/teiserver/account/security")
+    end
   end
 end

--- a/lib/teiserver_web/router.ex
+++ b/lib/teiserver_web/router.ex
@@ -284,6 +284,7 @@ defmodule TeiserverWeb.Router do
     get("/security/edit_password", SecurityController, :edit_password)
     put("/security/update_password", SecurityController, :update_password)
     delete("/security/delete_token/:id", SecurityController, :delete_token)
+    delete("/security/revoke_oauth/:id", SecurityController, :revoke_oauth_application)
   end
 
   scope "/battle", TeiserverWeb.Battle.LobbyLive, as: :ts_battle do

--- a/lib/teiserver_web/templates/account/security/index.html.heex
+++ b/lib/teiserver_web/templates/account/security/index.html.heex
@@ -2,7 +2,7 @@
 
 <div class="row">
   <div class="col-md-12">
-    <div class="card card-primary">
+    <div class="card card-primary mb-4">
       <div class="card-body">
         <a
           href={Routes.ts_account_security_path(@conn, :edit_password)}
@@ -52,5 +52,79 @@
         <% end %>
       </div>
     </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <h4>OAuth Applications</h4>
+    <%= if Enum.empty?(@oauth_applications) do %>
+      <div class="text-muted">
+        <i class="fa-fw fa-solid fa-info-circle"></i> You have no authorized OAuth applications.
+      </div>
+    <% else %>
+      <div class="row g-3">
+        <%= for app <- @oauth_applications do %>
+          <div class="col-lg-6 col-md-12">
+            <div class={"card h-100 border-start border-4 #{if Enum.any?(app.scopes, &String.starts_with?(&1, "admin.")), do: "border-success", else: "border-primary"}"}>
+              <div class="card-body d-flex flex-column">
+                <div class="d-flex justify-content-between align-items-start mb-3">
+                  <h5 class="card-title mb-0">{app.name}</h5>
+                  <span class="badge bg-secondary">
+                    {Map.get(@oauth_token_counts, app.id, 0)} {if Map.get(
+                                                                    @oauth_token_counts,
+                                                                    app.id,
+                                                                    0
+                                                                  ) == 1,
+                                                                  do: "token",
+                                                                  else: "tokens"}
+                  </span>
+                </div>
+
+                <div class="mb-3">
+                  <div class="row g-2">
+                    <div class="col-sm-4">
+                      <small class="text-muted">Client ID</small>
+                      <div class="fw-bold text-truncate" title={app.uid}>{app.uid}</div>
+                    </div>
+                    <div class="col-sm-8">
+                      <small class="text-muted">Scopes</small>
+                      <div class="fw-bold">{Enum.join(app.scopes, ", ")}</div>
+                    </div>
+                  </div>
+
+                  <%= if app.description do %>
+                    <div class="mt-2">
+                      <small class="text-muted">Description</small>
+                      <div class="text-muted">{app.description}</div>
+                    </div>
+                  <% end %>
+
+                  <div class="mt-2">
+                    <small class="text-muted">Authorized</small>
+                    <div class="text-muted">
+                      <i class="fa-fw fa-solid fa-calendar-alt me-1"></i>
+                      {date_to_str(app.inserted_at, format: :ymd_hms)}
+                    </div>
+                  </div>
+                </div>
+
+                <div class="mt-auto">
+                  {link(raw("<i class=\"fa-fw fa-solid fa-times\"></i> Revoke Access"),
+                    to: Routes.ts_account_security_path(@conn, :revoke_oauth_application, app),
+                    method: :delete,
+                    data: [
+                      confirm:
+                        "Are you sure you want to revoke access to #{app.name}? This will invalidate all tokens for this application."
+                    ],
+                    class: "btn btn-outline-danger btn-sm w-100"
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/test/teiserver/o_auth/application_query_test.exs
+++ b/test/teiserver/o_auth/application_query_test.exs
@@ -108,4 +108,80 @@ defmodule Teiserver.OAuth.ApplicationQueryTest do
                ApplicationQueries.get_stats([app.id, other_app.id])
     end
   end
+
+  describe "user application management" do
+    setup [:setup_app]
+
+    test "list_authorized_applications returns correct apps", %{user: user, app: app} do
+      OAuthFixtures.token_attrs(user.id, app) |> OAuthFixtures.create_token()
+
+      apps = ApplicationQueries.list_authorized_applications(user.id)
+
+      [returned_app] = apps
+      assert returned_app.id == app.id
+    end
+
+    test "list_authorized_applications shows apps with expired tokens", %{user: user, app: app} do
+      yesterday = DateTime.utc_now() |> Timex.subtract(Timex.Duration.from_days(1))
+
+      OAuthFixtures.token_attrs(user.id, app)
+      |> Map.put(:expires_at, yesterday)
+      |> OAuthFixtures.create_token()
+
+      apps = ApplicationQueries.list_authorized_applications(user.id)
+
+      [returned_app] = apps
+      assert returned_app.id == app.id
+    end
+
+    test "get_application_token_counts returns correct token counts", %{user: user, app: app} do
+      # Create multiple tokens
+      Enum.each(1..2, fn _ ->
+        OAuthFixtures.token_attrs(user.id, app) |> OAuthFixtures.create_token()
+      end)
+
+      counts = ApplicationQueries.get_application_token_counts(user.id)
+      assert counts[app.id] == 2
+    end
+
+    test "revoke_application_access deletes correct tokens and codes", %{user: user, app: app} do
+      # Create tokens for this user and app
+      user_token = OAuthFixtures.token_attrs(user.id, app) |> OAuthFixtures.create_token()
+      user_code = OAuthFixtures.code_attrs(user.id, app) |> OAuthFixtures.create_code()
+
+      # Create tokens for different user, same app
+      other_user = Teiserver.TeiserverTestLib.new_user()
+
+      other_user_token =
+        OAuthFixtures.token_attrs(other_user.id, app) |> OAuthFixtures.create_token()
+
+      # Create tokens for same user, different app
+      other_app =
+        OAuthFixtures.app_attrs(user.id)
+        |> Map.merge(%{name: "other app", uid: "other_app"})
+        |> OAuthFixtures.create_app()
+
+      other_app_token =
+        OAuthFixtures.token_attrs(user.id, other_app) |> OAuthFixtures.create_token()
+
+      # Revoke access for user and app
+      assert :ok = Teiserver.OAuth.revoke_application_access(user.id, app.id)
+
+      # Verify only user's tokens/codes for this app are deleted
+      refute Teiserver.OAuth.TokenQueries.get_token(user_token.value)
+      refute Teiserver.OAuth.CodeQueries.get_code(user_code.value)
+
+      # Verify other tokens remain
+      assert Teiserver.OAuth.TokenQueries.get_token(other_user_token.value)
+      assert Teiserver.OAuth.TokenQueries.get_token(other_app_token.value)
+    end
+
+    test "revoke_application_access returns :ok even when no tokens or codes exist", %{
+      user: user,
+      app: app
+    } do
+      # No tokens or codes created
+      assert :ok = Teiserver.OAuth.revoke_application_access(user.id, app.id)
+    end
+  end
 end

--- a/test/teiserver_web/controllers/account/security_controller_test.exs
+++ b/test/teiserver_web/controllers/account/security_controller_test.exs
@@ -2,15 +2,72 @@ defmodule TeiserverWeb.Account.SecurityControllerTest do
   use TeiserverWeb.ConnCase
 
   alias Central.Helpers.GeneralTestLib
+  alias Teiserver.OAuth
+  alias Teiserver.OAuthFixtures
 
   test "redirected to edit password once logged in" do
     {:ok, kw} = GeneralTestLib.conn_setup([], [:no_login])
-    {:ok, conn} = Keyword.fetch(kw, :conn)
-    {:ok, user} = Keyword.fetch(kw, :user)
+    conn = kw[:conn]
+    user = kw[:user]
 
     conn = get(conn, ~p"/teiserver/account/security/edit_password")
     assert redirected_to(conn) == ~p"/login"
     conn = GeneralTestLib.login(conn, user.email)
     assert redirected_to(conn) == ~p"/teiserver/account/security/edit_password"
+  end
+
+  describe "OAuth application revocation" do
+    setup do
+      {:ok, kw} =
+        GeneralTestLib.conn_setup(Teiserver.TeiserverTestLib.player_permissions())
+        |> Teiserver.TeiserverTestLib.conn_setup()
+
+      conn = kw[:conn]
+      user = kw[:user]
+
+      {:ok, app} =
+        OAuth.create_application(%{
+          name: "Test App",
+          uid: "test_app",
+          owner_id: user.id,
+          scopes: ["tachyon.lobby"],
+          redirect_uris: ["http://localhost/callback"]
+        })
+
+      token = OAuthFixtures.token_attrs(user.id, app) |> OAuthFixtures.create_token()
+      code = OAuthFixtures.code_attrs(user.id, app) |> OAuthFixtures.create_code()
+
+      {:ok, conn: conn, user: user, app: app, token: token, code: code}
+    end
+
+    test "successfully revokes OAuth application access", %{
+      conn: conn,
+      app: app,
+      token: token,
+      code: code
+    } do
+      conn = delete(conn, ~p"/teiserver/account/security/revoke_oauth/#{app.id}")
+      assert redirected_to(conn) == ~p"/teiserver/account/security"
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :info)
+
+      refute Teiserver.OAuth.TokenQueries.get_token(token.value)
+      refute Teiserver.OAuth.CodeQueries.get_code(code.value)
+    end
+
+    test "handles revocation when no tokens or codes exist", %{conn: conn, user: user} do
+      {:ok, app} =
+        OAuth.create_application(%{
+          name: "Empty App",
+          uid: "empty_app",
+          owner_id: user.id,
+          scopes: ["tachyon.lobby"],
+          redirect_uris: ["http://localhost/callback"]
+        })
+
+      conn = delete(conn, ~p"/teiserver/account/security/revoke_oauth/#{app.id}")
+      assert redirected_to(conn) == ~p"/teiserver/account/security"
+      assert Phoenix.Flash.get(conn.assigns.flash, :info)
+    end
   end
 end


### PR DESCRIPTION
Adds a section under account/security to allow users to revoke all tokens associated with an OAuth application.

<img width="1364" height="481" alt="image" src="https://github.com/user-attachments/assets/d66a671c-8d32-481c-a5b3-10df916b1a12" />

While I'm looking at this security page I noticed the whole User tokens section seems not to be doing anything anymore?  Should we remove it?

Closes #590
Closes #526