### PR TITLE
Restricted Contributor role from rendering the button

### DIFF
--- a/lib/teiserver_web/templates/admin/general/index.html.heex
+++ b/lib/teiserver_web/templates/admin/general/index.html.heex
@@ -131,7 +131,12 @@
     Bots
   </.menu_card>
 
-  <.menu_card icon={Teiserver.AssetLib.icon()} url={~p"/teiserver/admin/asset"} size={:small}>
+  <.menu_card
+    :if={allow_any?(@conn, ~w(Server Admin))}
+    icon={Teiserver.AssetLib.icon()}
+    url={~p"/teiserver/admin/asset"}
+    size={:small}
+  >
     Engine & game versions
   </.menu_card>
 </div>


### PR DESCRIPTION
Restrict the Contributor role from rendering the `Engine & game versions` button on the admin page, as they do not have permissions to access the page