### PR TITLE
Change friend error responses to atoms & make tachyon return the correct error

### DIFF
--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -410,10 +410,14 @@ defmodule Teiserver.Player.TachyonHandler do
       {:error, :invalid_user} ->
         {:error_response, :invalid_user, state}
 
-      # this is a bit scuffed and could be refactored so that `create_friend_request`
-      # returns an atom instead of a raw string
-      {:error, err} when is_binary(err) ->
-        {:error_response, :invalid_user, state}
+      {:error, :already_in_friendlist} ->
+        {:error_response, :already_in_friendlist, state}
+
+      {:error, :outgoing_capacity_reached} ->
+        {:error_response, :outgoing_capacity_reached, state}
+
+      {:error, :incoming_capacity_reached} ->
+        {:error_response, :incoming_capacity_reached, state}
 
       err ->
         Logger.error("cannot create friend request #{inspect(err)}")

--- a/lib/teiserver/protocols/spring/spring_in.ex
+++ b/lib/teiserver/protocols/spring/spring_in.ex
@@ -7,6 +7,7 @@ defmodule Teiserver.Protocols.SpringIn do
   """
   require Logger
   alias Teiserver.{Account, Lobby, Coordinator, Battle, Room, CacheUser, Client, Config}
+  alias Teiserver.Account.FriendRequestLib
   alias Phoenix.PubSub
   import Teiserver.Helper.NumberHelper, only: [int_parse: 1]
   import Teiserver.Helper.TimexHelper, only: [date_to_str: 2]
@@ -540,8 +541,10 @@ defmodule Teiserver.Protocols.SpringIn do
               :ok
 
             {:error, reason} ->
+              user_friendly_reason = FriendRequestLib.error_atom_to_user_friendly_string(reason)
+
               Logger.warning(
-                "Failed to create friend request to #{username} for #{state.userid}: #{reason}"
+                "Failed to create friend request to #{username} for #{state.userid}: #{user_friendly_reason}"
               )
           end
         end

--- a/lib/teiserver/protocols/spring/spring_user_in.ex
+++ b/lib/teiserver/protocols/spring/spring_user_in.ex
@@ -1,6 +1,7 @@
 defmodule Teiserver.Protocols.Spring.UserIn do
   @moduledoc false
   alias Teiserver.Account
+  alias Teiserver.Account.FriendRequestLib
   alias Teiserver.Protocols.SpringIn
   import Teiserver.Protocols.SpringOut, only: [reply: 5]
   import Teiserver.Helper.NumberHelper, only: [int_parse: 1]
@@ -19,7 +20,7 @@ defmodule Teiserver.Protocols.Spring.UserIn do
           user ->
             case Account.create_friend_request(state.userid, user.id) do
               {:ok, _} -> {n, :success}
-              {:error, reason} -> {n, reason}
+              {:error, reason} -> {n, FriendRequestLib.error_atom_to_user_friendly_string(reason)}
             end
         end
       end)

--- a/lib/teiserver_web/live/account/profile/overview.ex
+++ b/lib/teiserver_web/live/account/profile/overview.ex
@@ -323,9 +323,12 @@ defmodule TeiserverWeb.Account.ProfileLive.Overview do
         {:noreply, socket}
 
       {:error, reason} ->
+        user_friendly_message =
+          Teiserver.Account.FriendRequestLib.error_atom_to_user_friendly_string(reason)
+
         socket =
           socket
-          |> put_flash(:warning, "Unable to create friend request: #{reason}")
+          |> put_flash(:warning, "Unable to create friend request: #{user_friendly_message}")
 
         {:noreply, socket}
     end


### PR DESCRIPTION
When implementing the friends list functionality in `bar-lobby` I noticed all the returned errors were `invalid_user`.

This makes tachyon return the correct error atoms

To maintain existing functionality I created an internal atom->string mapping for the web-UI and spring/chobby.