### PR TITLE
Update matchmaking list after fetching maps and engines

### DIFF
--- a/lib/teiserver/matchmaking/queue_registry.ex
+++ b/lib/teiserver/matchmaking/queue_registry.ex
@@ -43,4 +43,8 @@ defmodule Teiserver.Matchmaking.QueueRegistry do
   def list() do
     Horde.Registry.select(__MODULE__, [{{:"$1", :_, :"$2"}, [], [{{:"$1", :"$2"}}]}])
   end
+
+  def update_value(id, callback) do
+    Horde.Registry.update_value(__MODULE__, id, callback)
+  end
 end

--- a/lib/teiserver/matchmaking/queue_server.ex
+++ b/lib/teiserver/matchmaking/queue_server.ex
@@ -248,6 +248,8 @@ defmodule Teiserver.Matchmaking.QueueServer do
 
     queue = %{state.queue | engines: engines, games: games, maps: maps}
 
+    QueueRegistry.update_value(state.id, fn _ -> queue end)
+
     {:noreply, %{state | queue: queue}}
   end
 


### PR DESCRIPTION
Otherwise the registry value is never updated and calling `matchmaking/list` never holds the maps and engine versions.