### PR TITLE
Lobby spectators

### DIFF
--- a/lib/teiserver/autohost.ex
+++ b/lib/teiserver/autohost.ex
@@ -9,12 +9,13 @@ defmodule Teiserver.Autohost do
   @type reg_value :: Registry.reg_value()
 
   @type start_script :: %{
-          battleId: Teiserver.TachyonBattle.id(),
-          engineVersion: String.t(),
-          gameName: String.t(),
-          mapName: String.t(),
-          startPosType: :fixed | :random | :ingame | :beforegame,
-          allyTeams: [ally_team(), ...]
+          required(:battleId) => Teiserver.TachyonBattle.id(),
+          required(:engineVersion) => String.t(),
+          required(:gameName) => String.t(),
+          required(:mapName) => String.t(),
+          required(:startPosType) => :fixed | :random | :ingame | :beforegame,
+          required(:allyTeams) => [ally_team(), ...],
+          optional(:spectators) => [player()]
         }
 
   @type ally_team :: %{

--- a/lib/teiserver/helpers/tachyon_parser.ex
+++ b/lib/teiserver/helpers/tachyon_parser.ex
@@ -5,6 +5,14 @@ defmodule Teiserver.Helpers.TachyonParser do
   """
   alias Teiserver.Data.Types, as: T
 
+  @spec parse_int(String.t()) :: {:ok, integer()} | :error
+  def parse_int(raw) do
+    case Integer.parse(raw) do
+      {n, ""} -> {:ok, n}
+      _ -> :error
+    end
+  end
+
   @spec parse_user_ids([String.t()]) :: {valid_ids :: [T.userid()], invalid_ids :: [String.t()]}
   def parse_user_ids(raw_ids) do
     Enum.reduce(raw_ids, {[], []}, fn raw_id, {ok, invalid} ->

--- a/lib/teiserver/player/session.ex
+++ b/lib/teiserver/player/session.ex
@@ -450,6 +450,11 @@ defmodule Teiserver.Player.Session do
     GenServer.call(via_tuple(user_id), {:lobby, {:join_ally_team, ally_team}})
   end
 
+  @spec lobby_spectate(T.userid()) :: :ok | {:error, reason :: term()}
+  def lobby_spectate(user_id) do
+    GenServer.call(via_tuple(user_id), {:lobby, :spectate})
+  end
+
   @spec start_lobby_battle(T.userid()) :: :ok | {:error, reason :: term}
   def start_lobby_battle(user_id) do
     GenServer.call(via_tuple(user_id), {:lobby, :start_battle})
@@ -907,6 +912,13 @@ defmodule Teiserver.Player.Session do
       end
 
     {:reply, resp, state}
+  end
+
+  def handle_call({:lobby, :spectate}, _from, state) when is_nil(state.lobby),
+    do: {:reply, {:error, :not_in_lobby}, state}
+
+  def handle_call({:lobby, :spectate}, _from, state) do
+    {:reply, TachyonLobby.spectate(state.lobby.id, state.user.id), state}
   end
 
   def handle_call({:lobby, :leave}, _from, state) when is_nil(state.lobby),

--- a/lib/teiserver/player/session.ex
+++ b/lib/teiserver/player/session.ex
@@ -444,6 +444,12 @@ defmodule Teiserver.Player.Session do
     GenServer.call(via_tuple(user_id), {:lobby, :leave})
   end
 
+  @spec join_ally_team(T.userid(), ally_team_idx :: non_neg_integer()) ::
+          :ok | {:error, reason :: term()}
+  def join_ally_team(user_id, ally_team) do
+    GenServer.call(via_tuple(user_id), {:lobby, {:join_ally_team, ally_team}})
+  end
+
   @spec start_lobby_battle(T.userid()) :: :ok | {:error, reason :: term}
   def start_lobby_battle(user_id) do
     GenServer.call(via_tuple(user_id), {:lobby, :start_battle})
@@ -888,6 +894,19 @@ defmodule Teiserver.Player.Session do
       {:error, reason} ->
         {:reply, {:error, reason}, state}
     end
+  end
+
+  def handle_call({:lobby, {:join_ally_team, _}}, _from, state) when is_nil(state.lobby),
+    do: {:reply, {:error, :not_in_lobby}, state}
+
+  def handle_call({:lobby, {:join_ally_team, ally_team}}, _from, state) do
+    resp =
+      case TachyonLobby.join_ally_team(state.lobby.id, state.user.id, ally_team) do
+        {:ok, _details} -> :ok
+        x -> x
+      end
+
+    {:reply, resp, state}
   end
 
   def handle_call({:lobby, :leave}, _from, state) when is_nil(state.lobby),

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -950,9 +950,26 @@ defmodule Teiserver.Player.TachyonHandler do
     {"lobby/updated", data}
   end
 
-  defp lobby_update_to_tachyon(lobby_id, %{event: :remove_player} = ev) do
-    data = %{id: lobby_id, members: %{to_string(ev.id) => nil}}
+  defp lobby_update_to_tachyon(lobby_id, %{event: :updated} = ev) do
+    members =
+      Enum.map(ev.updates, fn {p_id, updates} ->
+        {to_string(p_id), player_update_to_tachyon(p_id, updates)}
+      end)
+      |> Enum.into(%{})
+
+    data = %{id: lobby_id, members: members}
     {"lobby/updated", data}
+  end
+
+  defp player_update_to_tachyon(_p_id, nil), do: nil
+
+  defp player_update_to_tachyon(p_id, updates) do
+    case Map.get(updates, :team) do
+      nil -> %{}
+      t -> lobby_team_to_tachyon(t)
+    end
+    |> Map.put(:id, to_string(p_id))
+    |> Map.put(:type, :player)
   end
 
   # handle partial overview object

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -670,6 +670,22 @@ defmodule Teiserver.Player.TachyonHandler do
     end
   end
 
+  def handle_command("lobby/joinAllyTeam", "request", _msg_id, msg, state) do
+    with {:ok, ally_team} <- TachyonParser.parse_int(msg["data"]["allyTeam"]),
+         :ok <- Player.Session.join_ally_team(state.user.id, ally_team) do
+      {:response, state}
+    else
+      {:error, :invalid_int} ->
+        {:error_response, :invalid_request, "Invalid ally team", state}
+
+      {:error, reason} when reason in [:not_in_lobby, :ally_team_full] ->
+        {:error_response, reason, state}
+
+      {:error, reason} ->
+        {:error_response, :invalid_request, to_string(reason), state}
+    end
+  end
+
   def handle_command("lobby/startBattle", "request", _msg_id, _msg, state) do
     case Player.Session.start_lobby_battle(state.user.id) do
       :ok ->

--- a/lib/teiserver/tachyon_battle/types.ex
+++ b/lib/teiserver/tachyon_battle/types.ex
@@ -10,11 +10,12 @@ defmodule Teiserver.TachyonBattle.Types do
   # redeclaration of Autohost.start_script(), but without the battle id
   # https://elixirforum.com/t/typespec-combining-maps/31416
   @type start_script :: %{
-          engineVersion: String.t(),
-          gameName: String.t(),
-          mapName: String.t(),
-          startPosType: :fixed | :random | :ingame | :beforegame,
-          allyTeams: [ally_team(), ...]
+          required(:engineVersion) => String.t(),
+          required(:gameName) => String.t(),
+          required(:mapName) => String.t(),
+          required(:startPosType) => :fixed | :random | :ingame | :beforegame,
+          required(:allyTeams) => [ally_team(), ...],
+          optional(:spectators) => [player()]
         }
 
   @type ally_team :: %{

--- a/lib/teiserver/tachyon_lobby.ex
+++ b/lib/teiserver/tachyon_lobby.ex
@@ -59,6 +59,9 @@ defmodule Teiserver.TachyonLobby do
           {:ok, lobby_pid :: pid(), details()} | {:error, reason :: term()}
   defdelegate join(lobby_id, join_data, pid \\ self()), to: Lobby
 
+  @spec spectate(id(), T.userid()) :: :ok | {:error, :invalid_lobby | :not_in_lobby}
+  defdelegate spectate(lobby_id, user_id), to: Lobby
+
   @spec leave(id(), T.userid()) :: :ok | {:error, reason :: term()}
   defdelegate leave(lobby_id, user_id), to: Lobby
 

--- a/lib/teiserver/tachyon_lobby.ex
+++ b/lib/teiserver/tachyon_lobby.ex
@@ -57,10 +57,16 @@ defmodule Teiserver.TachyonLobby do
   @type player_join_data :: Lobby.player_join_data()
   @spec join(id(), player_join_data(), pid()) ::
           {:ok, lobby_pid :: pid(), details()} | {:error, reason :: term()}
-  defdelegate join(lobby_id, join_data, pid), to: Lobby
+  defdelegate join(lobby_id, join_data, pid \\ self()), to: Lobby
 
   @spec leave(id(), T.userid()) :: :ok | {:error, reason :: term()}
   defdelegate leave(lobby_id, user_id), to: Lobby
+
+  @spec join_ally_team(id(), T.userid(), allyTeam :: non_neg_integer()) ::
+          {:ok, details()}
+          | {:error,
+             reason :: :invalid_lobby | :not_in_lobby | :invalid_ally_team | :ally_team_full}
+  defdelegate join_ally_team(lobby_id, user_id, ally_team), to: Lobby
 
   @spec start_battle(id(), T.userid()) :: :ok | {:error, reason :: term()}
   defdelegate start_battle(lobby_id, user_id), to: Lobby

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -78,10 +78,12 @@ defmodule Teiserver.TachyonLobby.Lobby do
           engine_version: String.t(),
           ally_team_config: ally_team_config(),
           members: %{
-            T.userid() => %{
-              type: :player,
-              team: team()
-            }
+            T.userid() =>
+              %{
+                type: :player,
+                team: team()
+              }
+              | %{type: :spec, join_queue_position: number() | nil}
           },
           current_battle:
             nil
@@ -101,6 +103,16 @@ defmodule Teiserver.TachyonLobby.Lobby do
            team: team()
          }
 
+  @typep spectator :: %{
+           id: T.userid(),
+           name: String.t(),
+           # used to generate the start script, and then will be sent to the
+           # player so they can join the battle
+           password: String.t(),
+           pid: pid(),
+           join_queue_position: number() | nil
+         }
+
   @typep state :: %{
            id: id(),
            monitors: MC.t(),
@@ -111,6 +123,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
            ally_team_config: ally_team_config(),
            # used to track the players in the lobby.
            players: %{T.userid() => player()},
+           spectators: %{T.userid() => spectator()},
            current_battle:
              nil
              | %{
@@ -193,6 +206,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
           team: {0, 0, 0}
         }
       },
+      spectators: %{},
       current_battle: nil
     }
 
@@ -211,48 +225,54 @@ defmodule Teiserver.TachyonLobby.Lobby do
   end
 
   def handle_call({:join, join_data, _pid}, _from, state)
-      when is_map_key(join_data.id, state.players) do
+      when is_map_key(join_data.id, state.players) or is_map_key(join_data.id, state.spectators) do
     {:reply, {:ok, self(), get_details_from_state(state)}, state}
   end
 
   def handle_call({:join, join_data, pid}, _from, state) do
-    # find the least full team
-    team = find_team(state.ally_team_config, Map.values(state.players))
     user_id = join_data.id
 
-    case team do
-      nil ->
-        {:reply, {:error, :lobby_full}, state}
+    state =
+      put_in(state, [:spectators, user_id], %{
+        id: user_id,
+        name: join_data.name,
+        password: gen_password(),
+        pid: pid,
+        join_queue_position: nil
+      })
+      |> Map.update!(:monitors, &MC.monitor(&1, pid, {:user, user_id}))
 
-      team ->
-        state =
-          put_in(state, [:players, user_id], %{
-            id: user_id,
-            name: join_data.name,
-            password: gen_password(),
-            pid: pid,
-            team: team
-          })
-          |> Map.update!(:monitors, &MC.monitor(&1, pid, {:user, user_id}))
+    update = %{type: :spec}
+    broadcast_update({:update, user_id, %{user_id => update}}, state)
 
-        TachyonLobby.List.update_lobby(state.id, %{player_count: map_size(state.players)})
-        broadcast_update({:update, user_id, %{user_id => %{team: team}}}, state)
-
-        {:reply, {:ok, self(), get_details_from_state(state)}, state}
-    end
+    {:reply, {:ok, self(), get_details_from_state(state)}, state}
   end
 
-  def handle_call({:leave, user_id}, _from, state) do
+  def handle_call({:leave, user_id}, _from, state) when is_map_key(state.players, user_id) do
     case remove_player(user_id, state) do
-      {:ok, state} when map_size(state.players) > 0 -> {:reply, :ok, state}
-      {:ok, state} -> {:reply, :ok, state, {:continue, :empty}}
-      {:error, _} = err -> {:reply, err, state}
+      state when map_size(state.players) > 0 or map_size(state.spectators) > 0 ->
+        {:reply, :ok, state}
+
+      state ->
+        {:reply, :ok, state, {:continue, :empty}}
     end
   end
+
+  def handle_call({:leave, user_id}, _from, state) when is_map_key(state.spectators, user_id) do
+    state = remove_spectator(user_id, state)
+
+    if map_size(state.players) > 0 or map_size(state.spectators) > 0 do
+      {:reply, :ok, state}
+    else
+      {:reply, :ok, state, {:continue, :empty}}
+    end
+  end
+
+  def handle_call({:leave, _user_id}, _from, state), do: {:reply, {:error, :not_in_lobby}, state}
 
   def handle_call({:start_battle, user_id}, _from, state)
-      when not is_map_key(state.players, user_id),
-      do: {:reply, {:error, :not_a_player_in_lobby}, state}
+      when not is_map_key(state.players, user_id) and not is_map_key(state.spectators, user_id),
+      do: {:reply, {:error, :not_in_lobby}, state}
 
   def handle_call({:start_battle, _user_id}, _from, state) do
     with autohost_id when autohost_id != nil <- Autohost.find_autohost(),
@@ -298,13 +318,19 @@ defmodule Teiserver.TachyonLobby.Lobby do
         {:user, user_id} ->
           Logger.debug("user #{user_id} disappeared from the lobby because #{inspect(reason)}")
 
-          case remove_player(user_id, state) do
-            {:ok, state} -> state
-            _ -> state
+          cond do
+            is_map_key(state.players, user_id) ->
+              remove_player(user_id, state)
+
+            is_map_key(state.spectators, user_id) ->
+              remove_spectator(user_id, state)
           end
+
+        nil ->
+          state
       end
 
-    if Enum.empty?(state.players) do
+    if Enum.empty?(state.players) and Enum.empty?(state.spectators) do
       {:noreply, state, {:continue, :empty}}
     else
       {:noreply, state}
@@ -340,7 +366,20 @@ defmodule Teiserver.TachyonLobby.Lobby do
     }
   end
 
+  @spec get_details_from_state(state()) :: details()
   defp get_details_from_state(state) do
+    players =
+      Enum.map(state.players, fn {p_id, p} ->
+        {p_id, %{type: :player, team: p.team}}
+      end)
+      |> Enum.into(%{})
+
+    spectators =
+      Enum.map(state.spectators, fn {s_id, s} ->
+        {s_id, %{type: :spec, join_queue_position: s.join_queue_position}}
+      end)
+      |> Enum.into(%{})
+
     Map.take(state, [
       :id,
       :name,
@@ -349,79 +388,87 @@ defmodule Teiserver.TachyonLobby.Lobby do
       :engine_version,
       :ally_team_config
     ])
-    |> Map.put(
-      :members,
-      Enum.map(state.players, fn {p_id, p} ->
-        {p_id, %{type: :player, team: p.team}}
-      end)
-      |> Enum.into(%{})
-    )
+    |> Map.put(:members, Map.merge(players, spectators))
   end
+
+  # temporarily commented out until I get to implement lobby/joinQueue
+  # # this function isn't too efficient, but it's never going to be run on
+  # # massive inputs since the engine cannot support more than 254 players anyway
+  # @spec find_team(ally_team_config(), [player()]) :: team() | nil
+  # defp find_team(ally_team_config, players) do
+  #   # find the least full ally team
+  #   ally_team =
+  #     for {at, at_idx} <- Enum.with_index(ally_team_config) do
+  #       total_capacity = Enum.sum_by(at.teams, fn t -> t.max_players end)
+  #
+  #       players_in_ally_team =
+  #         Enum.filter(players, fn %{team: {x, _, _}} -> x == at_idx end)
+  #         |> Enum.count()
+  #
+  #       capacity = total_capacity - players_in_ally_team
+  #       {capacity, at_idx, at.teams}
+  #     end
+  #     |> Enum.filter(fn {c, _, _} -> c > 0 end)
+  #     # select the biggest capacity with the lowest index
+  #     |> Enum.min(
+  #       fn {c1, idx1, _}, {c2, idx2, _} ->
+  #         c1 >= c2 && idx1 <= idx2
+  #       end,
+  #       fn -> nil end
+  #     )
+  #
+  #   case ally_team do
+  #     nil ->
+  #       nil
+  #
+  #     {_, at_idx, teams} ->
+  #       {_, t_idx, p_idx} =
+  #         for {t, t_idx} <- Enum.with_index(teams) do
+  #           player_count =
+  #             Enum.filter(players, fn %{team: {x, y, _}} ->
+  #               x == at_idx && y == t_idx
+  #             end)
+  #             |> Enum.count()
+  #
+  #           capacity = t.max_players - player_count
+  #           {capacity, t_idx, player_count}
+  #         end
+  #         |> Enum.filter(fn {c, _, _} -> c > 0 end)
+  #         # guarantee not to raise an exception
+  #         |> Enum.min()
+  #
+  #       {at_idx, t_idx, p_idx}
+  #   end
+  # end
 
   defp broadcast_update({:update, user_id, updates}, state) do
-    for {p_id, p} <- state.players, p_id != user_id do
-      send(
-        p.pid,
-        {:lobby, state.id, {:updated, [%{event: :updated, updates: updates}]}}
-      )
-    end
-
-    :ok
+    events = [%{event: :updated, updates: updates}]
+    broadcast_to_members(state, user_id, {:lobby, state.id, {:updated, events}})
   end
 
-  # this function isn't too efficient, but it's never going to be run on
-  # massive inputs since the engine cannot support more than 254 players anyway
-  @spec find_team(ally_team_config(), [player()]) :: team() | nil
-  defp find_team(ally_team_config, players) do
-    # find the least full ally team
-    ally_team =
-      for {at, at_idx} <- Enum.with_index(ally_team_config) do
-        total_capacity = Enum.sum_by(at.teams, fn t -> t.max_players end)
-
-        players_in_ally_team =
-          Enum.filter(players, fn %{team: {x, _, _}} -> x == at_idx end)
-          |> Enum.count()
-
-        capacity = total_capacity - players_in_ally_team
-        {capacity, at_idx, at.teams}
-      end
-      |> Enum.filter(fn {c, _, _} -> c > 0 end)
-      # select the biggest capacity with the lowest index
-      |> Enum.min(
-        fn {c1, idx1, _}, {c2, idx2, _} ->
-          c1 >= c2 && idx1 <= idx2
-        end,
-        fn -> nil end
-      )
-
-    case ally_team do
-      nil ->
-        nil
-
-      {_, at_idx, teams} ->
-        {_, t_idx, p_idx} =
-          for {t, t_idx} <- Enum.with_index(teams) do
-            player_count =
-              Enum.filter(players, fn %{team: {x, y, _}} ->
-                x == at_idx && y == t_idx
-              end)
-              |> Enum.count()
-
-            capacity = t.max_players - player_count
-            {capacity, t_idx, player_count}
-          end
-          |> Enum.filter(fn {c, _, _} -> c > 0 end)
-          # guarantee not to raise an exception
-          |> Enum.min()
-
-        {at_idx, t_idx, p_idx}
+  defp broadcast_to_members(state, sender_id, message) do
+    for {p_id, p} <- state.players, p_id != sender_id do
+      send(p.pid, message)
     end
+
+    for {s_id, s} <- state.spectators, s_id != sender_id do
+      send(s.pid, message)
+    end
+
+    state
   end
 
-  @spec remove_player(T.userid(), state()) :: {:ok, state()} | {:error, :not_in_lobby}
-  defp remove_player(user_id, state) when not is_map_key(state.players, user_id),
-    do: {:error, :not_in_lobby}
+  # temporarily commented out until I implement lobby/joinQueue
+  # defp find_spec_queue_pos(spectators) do
+  #   if Enum.empty?(spectators) do
+  #     1
+  #   else
+  #     {_, s} = Enum.max_by(spectators, fn {_, s} -> s.join_queue_position end)
+  #     s.join_queue_position
+  #   end
+  # end
 
+  @spec remove_player(T.userid(), state()) :: state()
   defp remove_player(user_id, state) do
     {%{team: {at_idx, t_idx, p_idx}} = removed, players} =
       Map.pop!(state.players, user_id)
@@ -461,13 +508,27 @@ defmodule Teiserver.TachyonLobby.Lobby do
       Map.update!(state, :monitors, &MC.demonitor_by_val(&1, removed.id))
       |> Map.put(:players, updated_players)
 
-    if map_size(state.players) > 0 do
+    # avoid sending a useless lobby list update when the last member of the lobby
+    # just left. The caller of this function will detect the lobby is empty and
+    # terminate the process, which will trigger the final lobby list update for
+    # this lobby
+    if map_size(state.players) > 0 || map_size(state.spectators) > 0 do
       TachyonLobby.List.update_lobby(state.id, %{player_count: map_size(state.players)})
       updates = Map.new(changes) |> Map.put(user_id, nil)
       broadcast_update({:update, user_id, updates}, state)
     end
 
-    {:ok, state}
+    state
+  end
+
+  @spec remove_player(T.userid(), state()) :: state()
+  defp remove_spectator(user_id, state) do
+    state =
+      Map.update!(state, :spectators, &Map.delete(&1, user_id))
+      |> Map.update!(:monitors, &MC.demonitor_by_val(&1, user_id))
+
+    broadcast_update({:update, user_id, %{user_id => nil}}, state)
+    state
   end
 
   defp gen_password(), do: :crypto.strong_rand_bytes(16) |> Base.encode16()

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -63,7 +63,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
   For example, a player in the first ally team, in the second spot
   would have: {0, 1, 0}
   """
-  @type team :: {non_neg_integer(), non_neg_integer(), non_neg_integer()}
+  @type team ::
+          {allyTeam :: non_neg_integer(), team :: non_neg_integer(), player :: non_neg_integer()}
 
   @typedoc """
   The public state of the lobby. Anything that clients need to know about
@@ -79,7 +80,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
           members: %{
             T.userid() => %{
               type: :player,
-              id: T.userid(),
               team: team()
             }
           },
@@ -92,12 +92,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
         }
 
   @typep player :: %{
-           # These represent the indices respectively into
-           # {ally team index, team index, player index}
-           # since we don't really support "archon mode" though, the player index
-           # is likely always going to be 0.
-           # For example, a player in the first ally team, in the second spot
-           # would have: {0, 1, 0}
            id: T.userid(),
            name: String.t(),
            # used to generate the start script, and then will be sent to the
@@ -357,7 +351,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
     |> Map.put(
       :members,
       Enum.map(state.players, fn {p_id, p} ->
-        {p_id, %{id: p.id, type: :player, team: p.team}}
+        {p_id, %{type: :player, team: p.team}}
       end)
       |> Enum.into(%{})
     )

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -375,7 +375,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
         map: %{springName: state.map_name}
       }
 
-      for {p_id, p} <- state.players,
+      for {p_id, p} <- Enum.concat(state.players, state.spectators),
           do: Player.lobby_battle_start(p_id, battle_data, start_data, p.password)
 
       now = DateTime.utc_now()
@@ -671,7 +671,11 @@ defmodule Teiserver.TachyonLobby.Lobby do
       gameName: state.game_version,
       mapName: state.map_name,
       startPosType: :ingame,
-      allyTeams: ally_teams
+      allyTeams: ally_teams,
+      spectators:
+        Enum.map(state.spectators, fn {_s_id, s} ->
+          %{userId: to_string(s.id), name: s.name, password: s.name}
+        end)
     }
   end
 end

--- a/priv/tachyon/schema/definitions/lobbyDetails.json
+++ b/priv/tachyon/schema/definitions/lobbyDetails.json
@@ -5,6 +5,7 @@
     "type": "object",
     "properties": {
         "id": { "type": "string" },
+        "name": { "type": "string" },
         "mapName": { "type": "string" },
         "engineVersion": { "type": "string" },
         "gameVersion": { "type": "string" },
@@ -41,15 +42,34 @@
             "type": "object",
             "patternProperties": {
                 "^(.*)$": {
-                    "type": "object",
-                    "properties": {
-                        "type": { "const": "player" },
-                        "id": { "$ref": "../definitions/userId.json" },
-                        "allyTeam": { "type": "string" },
-                        "team": { "type": "string" },
-                        "player": { "type": "string" }
-                    },
-                    "required": ["type", "id", "allyTeam", "team", "player"]
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "type": { "const": "player" },
+                                "id": { "$ref": "../definitions/userId.json" },
+                                "allyTeam": { "type": "string" },
+                                "team": { "type": "string" },
+                                "player": { "type": "string" }
+                            },
+                            "required": [
+                                "type",
+                                "id",
+                                "allyTeam",
+                                "team",
+                                "player"
+                            ]
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "type": { "const": "spec" },
+                                "id": { "$ref": "../definitions/userId.json" },
+                                "joinQueuePosition": { "type": "number" }
+                            },
+                            "required": ["type", "id"]
+                        }
+                    ]
                 }
             }
         },
@@ -64,6 +84,7 @@
     },
     "required": [
         "id",
+        "name",
         "mapName",
         "engineVersion",
         "gameVersion",

--- a/priv/tachyon/schema/lobby/joinAllyTeam/request.json
+++ b/priv/tachyon/schema/lobby/joinAllyTeam/request.json
@@ -1,0 +1,23 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/joinAllyTeam/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "LobbyJoinAllyTeamRequest",
+    "tachyon": {
+        "source": "user",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "lobby/joinAllyTeam" },
+        "data": {
+            "title": "LobbyJoinAllyTeamRequestData",
+            "type": "object",
+            "properties": { "allyTeam": { "type": "string" } },
+            "required": ["allyTeam"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/lobby/joinAllyTeam/response.json
+++ b/priv/tachyon/schema/lobby/joinAllyTeam/response.json
@@ -1,0 +1,45 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/joinAllyTeam/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "LobbyJoinAllyTeamResponse",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "LobbyJoinAllyTeamOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "lobby/joinAllyTeam" },
+                "status": { "const": "success" }
+            },
+            "required": ["type", "messageId", "commandId", "status"]
+        },
+        {
+            "title": "LobbyJoinAllyTeamFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "lobby/joinAllyTeam" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "not_in_lobby",
+                        "ally_team_full",
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}

--- a/priv/tachyon/schema/lobby/spectate/request.json
+++ b/priv/tachyon/schema/lobby/spectate/request.json
@@ -1,0 +1,17 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/spectate/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "LobbySpectateRequest",
+    "tachyon": {
+        "source": "user",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "lobby/spectate" }
+    },
+    "required": ["type", "messageId", "commandId"]
+}

--- a/priv/tachyon/schema/lobby/spectate/response.json
+++ b/priv/tachyon/schema/lobby/spectate/response.json
@@ -1,0 +1,44 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/spectate/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "LobbySpectateResponse",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "LobbySpectateOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "lobby/spectate" },
+                "status": { "const": "success" }
+            },
+            "required": ["type", "messageId", "commandId", "status"]
+        },
+        {
+            "title": "LobbySpectateFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "lobby/spectate" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "not_in_lobby",
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}

--- a/priv/tachyon/schema/lobby/updated/event.json
+++ b/priv/tachyon/schema/lobby/updated/event.json
@@ -17,6 +17,7 @@
             "type": "object",
             "properties": {
                 "id": { "type": "string" },
+                "name": { "type": "string" },
                 "mapName": { "type": "string" },
                 "engineVersion": { "type": "string" },
                 "gameVersion": { "type": "string" },
@@ -69,22 +70,38 @@
                         "^(.*)$": {
                             "anyOf": [
                                 {
-                                    "type": "object",
-                                    "properties": {
-                                        "type": { "const": "player" },
-                                        "id": {
-                                            "$ref": "../../definitions/userId.json"
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": { "const": "player" },
+                                                "id": {
+                                                    "$ref": "../../definitions/userId.json"
+                                                },
+                                                "allyTeam": {
+                                                    "type": "string"
+                                                },
+                                                "team": { "type": "string" },
+                                                "player": { "type": "string" }
+                                            },
+                                            "required": ["type", "id"]
                                         },
-                                        "allyTeam": { "type": "string" },
-                                        "team": { "type": "string" },
-                                        "player": { "type": "string" }
-                                    },
-                                    "required": [
-                                        "type",
-                                        "id",
-                                        "allyTeam",
-                                        "team",
-                                        "player"
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": { "const": "spec" },
+                                                "id": {
+                                                    "$ref": "../../definitions/userId.json"
+                                                },
+                                                "joinQueuePosition": {
+                                                    "anyOf": [
+                                                        { "type": "number" },
+                                                        { "type": "null" }
+                                                    ]
+                                                }
+                                            },
+                                            "required": ["type", "id"]
+                                        }
                                     ]
                                 },
                                 { "type": "null" }

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -531,6 +531,12 @@ defmodule Teiserver.Support.Tachyon do
     resp
   end
 
+  def spectate!(client) do
+    :ok = send_request(client, "lobby/spectate")
+    {:ok, resp} = recv_message(client)
+    resp
+  end
+
   def start_lobby_battle!(client) do
     :ok = send_request(client, "lobby/startBattle")
     {:ok, resp} = recv_message(client)

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -525,6 +525,12 @@ defmodule Teiserver.Support.Tachyon do
     resp
   end
 
+  def join_ally_team!(client, ally_team) do
+    :ok = send_request(client, "lobby/joinAllyTeam", %{allyTeam: ally_team})
+    {:ok, resp} = recv_message(client)
+    resp
+  end
+
   def start_lobby_battle!(client) do
     :ok = send_request(client, "lobby/startBattle")
     {:ok, resp} = recv_message(client)

--- a/test/teiserver/tachyon_lobby/list_test.exs
+++ b/test/teiserver/tachyon_lobby/list_test.exs
@@ -57,6 +57,7 @@ defmodule Teiserver.TachyonLobby.ListTest do
     assert ev2.counter > ev.counter
   end
 
+  @tag :skip
   test "get updates when player joins or leaves lobby" do
     {:ok, sink_pid} = Task.start_link(:timer, :sleep, [:infinity])
 

--- a/test/teiserver/tachyon_lobby/lobby_test.exs
+++ b/test/teiserver/tachyon_lobby/lobby_test.exs
@@ -6,6 +6,8 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
 
   @moduletag :tachyon
 
+  @default_user_id "1234"
+
   test "create a lobby" do
     {:ok, pid, details} = Lobby.create(mk_start_params([1, 1]))
     p = poll_until_some(fn -> Lobby.lookup(details.id) end)
@@ -75,7 +77,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
       assert {:error, :invalid_lobby} == Lobby.join("nope", mk_player("user-id"), self())
     end
 
-    test "can join lobby as spectator" do
+    test "as a spectator" do
       {:ok, _pid, %{id: id}} = Lobby.create(mk_start_params([1, 1]))
 
       {:ok, sink_pid} = Task.start_link(:timer, :sleep, [:infinity])
@@ -100,22 +102,6 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
       assert details == details2
     end
 
-    @tag :skip
-    test "join the most empty team" do
-      # create a lobby 2 vs 15. Players should be put in the largest team
-      {:ok, _pid, %{id: id}} = Lobby.create(mk_start_params([2, 15]))
-      {:ok, _, details} = Lobby.join(id, mk_player("user2"), self())
-      assert details.members["user2"].team == {1, 0, 0}
-      {:ok, _, details} = Lobby.join(id, mk_player("user3"), self())
-      assert details.members["user3"].team == {1, 1, 0}
-    end
-
-    @tag :skip
-    test "lobby full" do
-      {:ok, _pid, %{id: id}} = Lobby.create(mk_start_params([1]))
-      {:error, :lobby_full} = Lobby.join(id, mk_player("user2"), self())
-    end
-
     test "participants get updated events on join" do
       {:ok, sink_pid} = Task.start_link(:timer, :sleep, [:infinity])
       {:ok, _pid, %{id: id}} = Lobby.create(mk_start_params([2, 2]))
@@ -129,6 +115,101 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
                            updates: %{"user2" => %{type: :spec}}
                          }
                        ]}}
+
+      {:ok, sink_pid} = Task.start_link(:timer, :sleep, [:infinity])
+      {:ok, _pid, %{id: id}} = Lobby.create(mk_start_params([2, 2]))
+      {:ok, _, _details} = Lobby.join(id, mk_player("user2"), sink_pid)
+
+      expected_updates = %{"user2" => %{type: :spec}}
+
+      assert_receive {:lobby, ^id, {:updated, [%{event: :updated, updates: ^expected_updates}]}}
+    end
+  end
+
+  describe "joining an ally team" do
+    test "must be valid lobby" do
+      {:error, :invalid_lobby} = Lobby.join_ally_team("nope", "user", 0)
+    end
+
+    test "must be in lobby" do
+      {:ok, _pid, %{id: id}} = Lobby.create(mk_start_params([1, 1]))
+      {:error, :not_in_lobby} = Lobby.leave(id, "not here")
+    end
+
+    test "must target valid ally team" do
+      {:ok, _pid, %{id: id}} = Lobby.create(mk_start_params([1, 1]))
+      {:ok, _pid, _details} = Lobby.join(id, mk_player("user2"))
+      {:error, :invalid_ally_team} = Lobby.join_ally_team(id, "user2", 2)
+    end
+
+    test "ally team must have empty space" do
+      {:ok, _pid, %{id: id}} = Lobby.create(mk_start_params([1, 1]))
+      {:ok, _pid, _details} = Lobby.join(id, mk_player("user2"))
+      {:error, :ally_team_full} = Lobby.join_ally_team(id, "user2", 0)
+    end
+
+    test "works" do
+      {:ok, sink_pid} = Task.start_link(:timer, :sleep, [:infinity])
+      {:ok, _pid, %{id: id}} = Lobby.create(mk_start_params([1, 1]))
+      {:ok, _, _details} = Lobby.join(id, mk_player("user2"), sink_pid)
+      {:ok, details} = Lobby.join_ally_team(id, "user2", 1)
+      assert %{team: {1, _, _}, type: :player} = details.members["user2"]
+
+      # is idempotent
+      {:ok, details2} = Lobby.join_ally_team(id, "user2", 1)
+      assert details == details2
+    end
+
+    test "player moving also get updates" do
+      {:ok, sink_pid} = Task.start_link(:timer, :sleep, [:infinity])
+
+      {:ok, _pid, %{id: id}} =
+        mk_start_params([1, 1]) |> Map.put(:creator_pid, sink_pid) |> Lobby.create()
+
+      {:ok, _, _details} = Lobby.join(id, mk_player("user2"))
+      {:ok, _details} = Lobby.join_ally_team(id, "user2", 1)
+
+      expected = %{
+        event: :updated,
+        updates: %{"user2" => %{team: {1, 0, 0}, type: :player, join_queue_position: nil}}
+      }
+      assert_receive {:lobby, ^id, {:updated, [^expected]}}
+    end
+
+    test "can change ally team" do
+      {:ok, sink_pid} = Task.start_link(:timer, :sleep, [:infinity])
+      {:ok, _pid, %{id: id}} = Lobby.create(mk_start_params([2, 2]))
+      {:ok, _, _details} = Lobby.join(id, mk_player("user2"), sink_pid)
+      {:ok, details} = Lobby.join_ally_team(id, "user2", 1)
+      assert %{team: {1, _, _}, type: :player} = details.members["user2"]
+
+      {:ok, details} = Lobby.join_ally_team(id, "user2", 0)
+      assert %{team: {0, _, _}, type: :player} = details.members["user2"]
+    end
+
+    test "other players are reshuffled" do
+      {:ok, sink_pid} = Task.start_link(:timer, :sleep, [:infinity])
+      {:ok, _pid, %{id: id}} = Lobby.create(mk_start_params([2, 2]))
+      {:ok, _, _details} = Lobby.join(id, mk_player("user2"), sink_pid)
+      assert_receive _
+
+      {:ok, details} = Lobby.join_ally_team(id, "user2", 0)
+
+      expected_update = %{
+        "user2" => %{
+          type: :player,
+          team: {0, 1, 0},
+          join_queue_position: nil
+        }
+      }
+
+      assert_receive {:lobby, ^id, {:updated, [%{event: :updated, updates: ^expected_update}]}}
+
+      assert %{team: {0, _, _}, type: :player} = details.members["user2"]
+
+      # moving from ally team 0 to 1 should reorder "user2" in the first ally team
+      {:ok, details} = Lobby.join_ally_team(id, @default_user_id, 1)
+      %{@default_user_id => %{team: {1, 0, 0}}, "user2" => %{team: {0, 0, 0}}} = details.members
     end
   end
 
@@ -145,6 +226,32 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
       {:error, :not_in_lobby} = Lobby.leave(id, "user2")
     end
 
+    @tag :skip
+    test "can leave lobby" do
+      {:ok, _pid, %{id: id}} = Lobby.create(mk_start_params([2, 2]))
+      {:ok, _pid, _details} = Lobby.join(id, mk_player("user2"), self())
+      {:ok, _pid, _details} = Lobby.join(id, mk_player("user3"), self())
+      {:ok, _pid, details} = Lobby.join(id, mk_player("user4"), self())
+
+      # user 2 and 4 should be on the same team
+      assert details.members["user2"].team == {1, 0, 0}
+      assert details.members["user4"].team == {1, 1, 0}
+      :ok = Lobby.leave(id, "user2")
+
+      # join again to get the details
+      {:ok, _pid, details} = Lobby.join(id, mk_player("user2"), self())
+      assert details.members["user4"].team == {1, 0, 0}
+      assert details.members["user2"].team == {1, 1, 0}
+    end
+
+    test "can leave lobby and rejoin" do
+      {:ok, _pid, %{id: id}} = Lobby.create(mk_start_params([2, 2]))
+      player = mk_player("user2")
+      {:ok, _pid, _details} = Lobby.join(id, player, self())
+      :ok = Lobby.leave(id, "user2")
+      {:ok, _pid, _details} = Lobby.join(id, player, self())
+    end
+
     test "leaving lobby send updates to remaining members" do
       {:ok, sink_pid} = Task.start_link(:timer, :sleep, [:infinity])
       {:ok, _pid, %{id: id}} = Lobby.create(mk_start_params([2, 2]))
@@ -155,7 +262,6 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
       assert_received {:lobby, ^id, {:updated, [%{event: :updated, updates: %{"user2" => nil}}]}}
     end
 
-    @tag :skip
     test "reshuffling player on leave sends updates" do
       {:ok, sink_pid} = Task.start_link(:timer, :sleep, [:infinity])
       {:ok, _pid, %{id: id}} = Lobby.create(mk_start_params([2, 2]))
@@ -167,12 +273,20 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
       assert_received {:lobby, ^id, {:updated, [%{event: :updated}]}}
       assert_received {:lobby, ^id, {:updated, [%{event: :updated}]}}
 
+      {:ok, _details} = Lobby.join_ally_team(id, "user2", 1)
+      {:ok, _details} = Lobby.join_ally_team(id, "user3", 1)
+
+      assert_received {:lobby, ^id, {:updated, [%{event: :updated}]}}
+      assert_received {:lobby, ^id, {:updated, [%{event: :updated}]}}
+
       :ok = Lobby.leave(id, "user2")
-      assert_received {:lobby, ^id, {:updated, [%{updates: updates}]}}
 
-      expected = %{"user2" => nil, "user4" => %{team: {1, 0, 0}}}
+      expected_event = %{
+        event: :updated,
+        updates: %{"user2" => nil, "user3" => %{team: {1, 0, 0}}}
+      }
 
-      assert updates == expected
+      assert_received {:lobby, ^id, {:updated, [^expected_event]}}
     end
 
     test "player pid dying means player is removed from lobby" do
@@ -215,7 +329,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
 
   defp mk_start_params(teams) do
     %{
-      creator_data: %{id: "1234", name: "name-1234"},
+      creator_data: %{id: @default_user_id, name: "name-#{@default_user_id}"},
       creator_pid: self(),
       name: "test create lobby",
       map_name: "irrelevant map name",

--- a/test/teiserver_web/tachyon/lobby_test.exs
+++ b/test/teiserver_web/tachyon/lobby_test.exs
@@ -76,14 +76,12 @@ defmodule TeiserverWeb.Tachyon.LobbyTest do
         Tachyon.join_lobby!(ctx2[:client], lobby_id)
     end
 
-    @tag :skip
-    test "lobby full", %{lobby_id: lobby_id} do
+    test "ally team full", %{lobby_id: lobby_id} do
       {:ok, ctx2} = Tachyon.setup_client()
-      {:ok, ctx3} = Tachyon.setup_client()
       %{"status" => "success"} = Tachyon.join_lobby!(ctx2[:client], lobby_id)
 
-      %{"status" => "failed", "reason" => "lobby_full"} =
-        Tachyon.join_lobby!(ctx3[:client], lobby_id)
+      %{"status" => "failed", "reason" => "ally_team_full"} =
+        Tachyon.join_ally_team!(ctx2[:client], "000")
     end
 
     test "members get updated events on join", %{client: client, lobby_id: lobby_id} do
@@ -162,8 +160,6 @@ defmodule TeiserverWeb.Tachyon.LobbyTest do
       {Tachyon, :setup_autohost}
     ]
 
-    # lobby/joinAllyTeam not implemented yet, so no listUpdate
-    @tag :skip
     test "subscribe list updates", %{client: client} do
       %{"status" => "success"} = Tachyon.subscribe_lobby_list!(client)
 
@@ -189,7 +185,10 @@ defmodule TeiserverWeb.Tachyon.LobbyTest do
       assert lobbies[lobby_id]["maxPlayerCount"] == 4
 
       {:ok, ctx3} = Tachyon.setup_client()
-      %{"status" => "success"} = Tachyon.join_lobby!(ctx3[:client], lobby_id)
+      %{"status" => "success", "data" => data} = Tachyon.join_lobby!(ctx3[:client], lobby_id)
+      assert is_map_key(data["allyTeamConfig"], "000")
+      %{"status" => "success"} = Tachyon.join_ally_team!(ctx3[:client], "000")
+      %{"commandId" => "lobby/updated"} = Tachyon.recv_message!(ctx3[:client])
 
       %{"commandId" => "lobby/listUpdated", "data" => %{"lobbies" => lobbies}} =
         Tachyon.recv_message!(client)

--- a/test/teiserver_web/tachyon/lobby_test.exs
+++ b/test/teiserver_web/tachyon/lobby_test.exs
@@ -116,6 +116,24 @@ defmodule TeiserverWeb.Tachyon.LobbyTest do
     end
   end
 
+  describe "spectate" do
+    setup [:setup_lobby]
+
+    test "works", %{client: client, user: user} do
+      %{"status" => "success"} = Tachyon.spectate!(client)
+
+      %{"commandId" => "lobby/updated", "data" => data} = Tachyon.recv_message!(client)
+
+      user_id = to_string(user.id)
+
+      %{
+        "members" => %{
+          ^user_id => %{"type" => "spec", "allyTeam" => nil, "team" => nil, "player" => nil}
+        }
+      } = data
+    end
+  end
+
   describe "start battle" do
     setup [
       {Tachyon, :setup_app},

--- a/test/teiserver_web/tachyon/lobby_test.exs
+++ b/test/teiserver_web/tachyon/lobby_test.exs
@@ -131,10 +131,17 @@ defmodule TeiserverWeb.Tachyon.LobbyTest do
     end
 
     test "can start battle", ctx do
+      {:ok, ctx2} = Tachyon.setup_client()
+      %{"status" => "success"} = Tachyon.join_lobby!(ctx2[:client], ctx[:lobby_id])
+      %{"commandId" => "lobby/updated"} = Tachyon.recv_message!(ctx[:client])
+
       Tachyon.send_request(ctx[:client], "lobby/startBattle", %{id: ctx[:lobby_id]})
 
       %{"commandId" => "autohost/start"} =
         start_req = Tachyon.recv_message!(ctx[:autohost_client])
+
+      uid2 = to_string(ctx2[:user].id)
+      [%{"userId" => ^uid2}] = start_req["data"]["spectators"]
 
       start_req_response = %{
         port: 32781,

--- a/test/teiserver_web/tachyon/lobby_test.exs
+++ b/test/teiserver_web/tachyon/lobby_test.exs
@@ -48,6 +48,7 @@ defmodule TeiserverWeb.Tachyon.LobbyTest do
       {:ok, ctx2} = Tachyon.setup_client()
       %{"status" => "success", "data" => data} = Tachyon.join_lobby!(ctx2[:client], lobby_id)
       assert is_map_key(data["members"], to_string(user.id))
+      assert data["members"][to_string(ctx2[:user].id)]["type"] == "spec"
     end
 
     test "is idempotent", %{client: client, lobby_id: lobby_id} do
@@ -75,6 +76,7 @@ defmodule TeiserverWeb.Tachyon.LobbyTest do
         Tachyon.join_lobby!(ctx2[:client], lobby_id)
     end
 
+    @tag :skip
     test "lobby full", %{lobby_id: lobby_id} do
       {:ok, ctx2} = Tachyon.setup_client()
       {:ok, ctx3} = Tachyon.setup_client()
@@ -86,11 +88,9 @@ defmodule TeiserverWeb.Tachyon.LobbyTest do
 
     test "members get updated events on join", %{client: client, lobby_id: lobby_id} do
       {:ok, ctx2} = Tachyon.setup_client()
-      %{"status" => "success", "data" => details} = Tachyon.join_lobby!(ctx2[:client], lobby_id)
+      %{"status" => "success", "data" => _details} = Tachyon.join_lobby!(ctx2[:client], lobby_id)
       %{"commandId" => "lobby/updated", "data" => data} = Tachyon.recv_message!(client)
-      player_data = data["members"][to_string(ctx2[:user].id)]
-      assert is_map_key(player_data, "team")
-      assert is_map_key(details["allyTeamConfig"], player_data["allyTeam"])
+      assert %{"type" => "spec"} = data["members"][to_string(ctx2[:user].id)]
     end
   end
 
@@ -162,6 +162,8 @@ defmodule TeiserverWeb.Tachyon.LobbyTest do
       {Tachyon, :setup_autohost}
     ]
 
+    # lobby/joinAllyTeam not implemented yet, so no listUpdate
+    @tag :skip
     test "subscribe list updates", %{client: client} do
       %{"status" => "success"} = Tachyon.subscribe_lobby_list!(client)
 


### PR DESCRIPTION
Implement part of https://github.com/beyond-all-reason/tachyon/pull/71
Specifically, this introduce the concept of spectators in lobbies. When joining a lobby, people are spectators by default (except the creator who is always the first player). Specs can then move to a selected ally team with `lobby/joinAllyTeam`, and go back to spectator with `lobby/spectate`.

The tachyon PR also introduced `lobby/joinQueue` to join any available ally team or a join queue when they are all full, but this is not included in this PR. 