### PR TITLE
Add matches history to profile using privacy settings

### DIFF
--- a/lib/teiserver_web/live/account/profile/matches.ex
+++ b/lib/teiserver_web/live/account/profile/matches.ex
@@ -1,7 +1,8 @@
 defmodule TeiserverWeb.Account.ProfileLive.Matches do
   @moduledoc false
   use TeiserverWeb, :live_view
-  alias Teiserver.Account
+  alias Teiserver.{Account, Battle, Config, Game}
+  import TeiserverWeb.PaginationComponents, only: [pagination: 1]
 
   @impl true
   def mount(%{"userid" => userid_str}, _session, socket) do
@@ -17,11 +18,13 @@ defmodule TeiserverWeb.Account.ProfileLive.Matches do
 
         true ->
           socket
+          |> Teiserver.Plugs.CachePlug.live_call()
           |> assign(:tab, nil)
           |> assign(:site_menu_active, "teiserver_account")
           |> assign(:view_colour, Teiserver.Account.UserLib.colours())
           |> assign(:user, user)
           |> TeiserverWeb.Account.ProfileLive.Overview.get_relationships_and_permissions()
+          |> assign_pagination_defaults()
       end
 
     {:ok, socket}
@@ -29,15 +32,133 @@ defmodule TeiserverWeb.Account.ProfileLive.Matches do
 
   @impl true
   def handle_params(params, _url, socket) do
-    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
-  end
+    parsed = TeiserverWeb.Parsers.PaginationParams.parse_params(params)
 
-  defp apply_action(socket, _live_action, _params) do
-    socket
+    socket =
+      socket
+      |> assign(:page, parsed.page - 1)
+      |> assign(:limit, parsed.limit)
+      |> check_privacy_and_load_matches()
+
+    {:noreply, socket}
   end
 
   @impl true
   def handle_event(_string, _event, socket) do
     {:noreply, socket}
+  end
+
+  defp assign_pagination_defaults(socket) do
+    socket
+    |> assign(:page, 0)
+    |> assign(:limit, 50)
+    |> assign(:total_count, 0)
+    |> assign(:total_pages, 1)
+    |> assign(:current_count, 0)
+    |> assign(:matches, [])
+    |> assign(:can_view_matches, false)
+  end
+
+  defp check_privacy_and_load_matches(socket) do
+    can_view_matches =
+      can_view_match_history?(socket.assigns.user, socket.assigns.profile_permissions)
+
+    can_view_ratings = can_view_ratings?(socket.assigns.user, socket.assigns.profile_permissions)
+
+    socket =
+      socket
+      |> assign(:can_view_matches, can_view_matches)
+      |> assign(:can_view_ratings, can_view_ratings)
+
+    if can_view_matches do
+      load_user_matches(socket)
+    else
+      socket
+    end
+  end
+
+  def can_view_match_history?(profile_user, profile_permissions) do
+    match_visibility =
+      Config.get_user_config_cache(profile_user, "privacy.Match history visibility")
+
+    case match_visibility do
+      "Only myself" -> :self in profile_permissions
+      "Friends" -> :self in profile_permissions or :friend in profile_permissions
+      "Any player" -> not Enum.any?(profile_permissions, &(&1 in [:block, :avoid, :ignore]))
+      "Completely public" -> true
+      _ -> false
+    end
+  end
+
+  def can_view_ratings?(profile_user, profile_permissions) do
+    ratings_visibility = Config.get_user_config_cache(profile_user, "privacy.Ratings visibility")
+
+    case ratings_visibility do
+      "Only myself" -> :self in profile_permissions
+      "Friends" -> :self in profile_permissions or :friend in profile_permissions
+      "Any player" -> not Enum.any?(profile_permissions, &(&1 in [:block, :avoid, :ignore]))
+      "Completely public" -> true
+      _ -> false
+    end
+  end
+
+  defp load_rating_data_for_matches(matches, user_id) do
+    match_ids = Enum.map(matches, & &1.id)
+
+    rating_data =
+      if match_ids != [] do
+        Game.list_rating_logs(search: [match_id_in: match_ids, user_id: user_id])
+        |> Map.new(&{&1.match_id, &1})
+      else
+        %{}
+      end
+
+    Enum.map(matches, fn match ->
+      rating_log = Map.get(rating_data, match.id)
+
+      match
+      |> Map.put(:rating_log, rating_log)
+      |> Map.put(:rating_change, rating_log && rating_log.value["rating_value_change"])
+      |> Map.put(:skill, rating_log && rating_log.value["skill"])
+    end)
+  end
+
+  defp load_user_matches(%{assigns: %{user: user, page: page, limit: limit}} = socket) do
+    if connected?(socket) do
+      search_criteria = [has_started: true, user_id: user.id]
+
+      total_count = Battle.count_matches(search: search_criteria)
+
+      matches =
+        Battle.list_matches(
+          search: search_criteria,
+          preload: [:queue],
+          order_by: "Newest first",
+          limit: limit,
+          offset: page * limit
+        )
+
+      matches_with_ratings = load_rating_data_for_matches(matches, user.id)
+
+      socket
+      |> assign(:matches, matches_with_ratings)
+      |> assign(:total_count, total_count)
+      |> assign(:total_pages, max(1, div(total_count - 1, limit) + 1))
+      |> assign(:current_count, length(matches))
+    else
+      socket
+      |> assign(:matches, [])
+      |> assign(:total_count, 0)
+      |> assign(:total_pages, 1)
+      |> assign(:current_count, 0)
+    end
+  end
+
+  defp rating_change_display_class_and_icon(rating_change) do
+    cond do
+      rating_change > 0 -> {"text-success", "arrow-up"}
+      rating_change < 0 -> {"text-danger", "arrow-down"}
+      true -> {"text-warning", "pause"}
+    end
   end
 end

--- a/lib/teiserver_web/live/account/profile/matches.html.heex
+++ b/lib/teiserver_web/live/account/profile/matches.html.heex
@@ -8,6 +8,83 @@
 
 <div class="row mt-2 mb-3">
   <div class="col">
-    List of recent matches goes here
+    <%= if @can_view_matches do %>
+      <div class="row mt-2">
+        <div class="col">
+          <.table
+            id="matches"
+            rows={@matches}
+            table_class="table-sm table-hover"
+            row_click={fn match -> JS.navigate(~p"/battle/#{match.id}") end}
+          >
+            <:col :let={match} label="Map">{match.map}</:col>
+            <:col :let={match} label="Players">{match.team_count * match.team_size}</:col>
+            <:col :let={match} label="Type">{match.game_type}</:col>
+            <:col :let={match} label="Outcome">
+              <%= if hd(match.members).win do %>
+                <Fontawesome.icon icon="trophy" style="solid" class="text-success" /> &nbsp;
+                Win
+              <% else %>
+                Loss
+              <% end %>
+            </:col>
+            <:col :let={match} label="Skill">
+              <%= if @can_view_ratings && match.skill do %>
+                {round(match.skill, 1)}
+              <% end %>
+            </:col>
+            <:col :let={match} label="Rating Change">
+              <%= if @can_view_ratings && match.rating_change do %>
+                <% {text_class, icon} = rating_change_display_class_and_icon(match.rating_change) %>
+                <span class={text_class}>
+                  <Fontawesome.icon icon={icon} style="solid" class="me-1" />
+                  {if match.rating_change > 0, do: "+", else: ""}{round(match.rating_change, 1)}
+                </span>
+              <% end %>
+            </:col>
+            <:col :let={match} label="Duration">
+              {if match.finished && match.started,
+                do: duration_to_str_short(Timex.diff(match.finished, match.started, :second)),
+                else: "N/A"}
+            </:col>
+            <:col :let={match} label="Date">
+              {date_to_str(match.finished, format: :hms_or_ymd, tz: @tz)}
+            </:col>
+
+            <:col :let={match} label="">
+              <div class="visually-hidden">
+                <.link navigate={~p"/battle/#{match.id}"}>
+                  Show
+                </.link>
+              </div>
+            </:col>
+          </.table>
+
+          <%= if assigns[:total_pages] do %>
+            <.pagination
+              page={@page}
+              total_pages={@total_pages}
+              base_url={~p"/profile/#{@user.id}/matches"}
+              limit={@limit}
+              total_count={@total_count}
+              current_count={@current_count}
+              show_go_to={@total_pages > 5}
+              class="mt-3"
+              include_params={["limit"]}
+              current_params={
+                %{
+                  "limit" => @limit
+                }
+              }
+            />
+          <% end %>
+        </div>
+      </div>
+    <% else %>
+      <div class="alert alert-info" role="alert">
+        <h4 class="alert-heading">Match History Private</h4>
+        <p>This user has chosen to keep their match history private.</p>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/test/teiserver_web/live/account/profile/matches_test.exs
+++ b/test/teiserver_web/live/account/profile/matches_test.exs
@@ -1,0 +1,148 @@
+defmodule TeiserverWeb.Live.Account.Profile.MatchesTest do
+  use TeiserverWeb.ConnCase, async: false
+
+  alias Central.Helpers.GeneralTestLib
+  alias Teiserver.{Account, Config, TeiserverTestLib}
+  alias TeiserverWeb.Account.ProfileLive.Matches
+
+  setup do
+    {:ok, data} =
+      TeiserverTestLib.player_permissions()
+      |> GeneralTestLib.conn_setup()
+      |> TeiserverTestLib.conn_setup()
+
+    profile_user = GeneralTestLib.make_user()
+
+    %{conn: data[:conn], viewer: data[:user], profile_user: profile_user}
+  end
+
+  describe "privacy controls with actual relationships" do
+    test "self can always view their own matches and ratings", %{
+      viewer: viewer,
+      profile_user: _profile_user
+    } do
+      profile_user = viewer
+
+      for privacy_setting <- ["Only myself", "Friends", "Any player", "Completely public"] do
+        Config.set_user_config(
+          profile_user.id,
+          "privacy.Match history visibility",
+          privacy_setting
+        )
+
+        Config.set_user_config(profile_user.id, "privacy.Ratings visibility", privacy_setting)
+
+        assert Matches.can_view_match_history?(profile_user, [:self]) == true
+        assert Matches.can_view_ratings?(profile_user, [:self]) == true
+      end
+    end
+
+    test "friend can view when privacy allows friends", %{
+      viewer: viewer,
+      profile_user: profile_user
+    } do
+      {:ok, _friend} = Account.create_friend(viewer.id, profile_user.id)
+
+      Config.set_user_config(profile_user.id, "privacy.Match history visibility", "Friends")
+      Config.set_user_config(profile_user.id, "privacy.Ratings visibility", "Friends")
+
+      assert Matches.can_view_match_history?(profile_user, [:friend]) == true
+      assert Matches.can_view_ratings?(profile_user, [:friend]) == true
+
+      Config.set_user_config(profile_user.id, "privacy.Match history visibility", "Only myself")
+      Config.set_user_config(profile_user.id, "privacy.Ratings visibility", "Only myself")
+
+      assert Matches.can_view_match_history?(profile_user, [:friend]) == false
+      assert Matches.can_view_ratings?(profile_user, [:friend]) == false
+    end
+
+    test "stranger can view when privacy allows any player", %{
+      viewer: _viewer,
+      profile_user: profile_user
+    } do
+      Config.set_user_config(profile_user.id, "privacy.Match history visibility", "Any player")
+      Config.set_user_config(profile_user.id, "privacy.Ratings visibility", "Any player")
+
+      assert Matches.can_view_match_history?(profile_user, []) == true
+      assert Matches.can_view_ratings?(profile_user, []) == true
+
+      Config.set_user_config(profile_user.id, "privacy.Match history visibility", "Friends")
+      Config.set_user_config(profile_user.id, "privacy.Ratings visibility", "Friends")
+
+      assert Matches.can_view_match_history?(profile_user, []) == false
+      assert Matches.can_view_ratings?(profile_user, []) == false
+    end
+
+    test "blocked user can view with completely public settings", %{
+      viewer: viewer,
+      profile_user: profile_user
+    } do
+      {:ok, _block} = Account.block_user(profile_user.id, viewer.id)
+
+      Config.set_user_config(
+        profile_user.id,
+        "privacy.Match history visibility",
+        "Completely public"
+      )
+
+      Config.set_user_config(profile_user.id, "privacy.Ratings visibility", "Completely public")
+
+      assert Matches.can_view_match_history?(profile_user, [:block, :avoid, :ignore]) == true
+      assert Matches.can_view_ratings?(profile_user, [:block, :avoid, :ignore]) == true
+
+      Config.set_user_config(profile_user.id, "privacy.Match history visibility", "Any player")
+      Config.set_user_config(profile_user.id, "privacy.Ratings visibility", "Any player")
+
+      assert Matches.can_view_match_history?(profile_user, [:block, :avoid, :ignore]) == false
+      assert Matches.can_view_ratings?(profile_user, [:block, :avoid, :ignore]) == false
+    end
+
+    test "avoided user can view with completely public settings", %{
+      viewer: viewer,
+      profile_user: profile_user
+    } do
+      {:ok, _avoid} = Account.avoid_user(profile_user.id, viewer.id)
+
+      Config.set_user_config(
+        profile_user.id,
+        "privacy.Match history visibility",
+        "Completely public"
+      )
+
+      Config.set_user_config(profile_user.id, "privacy.Ratings visibility", "Completely public")
+
+      assert Matches.can_view_match_history?(profile_user, [:avoid, :ignore]) == true
+      assert Matches.can_view_ratings?(profile_user, [:avoid, :ignore]) == true
+
+      Config.set_user_config(profile_user.id, "privacy.Match history visibility", "Any player")
+      Config.set_user_config(profile_user.id, "privacy.Ratings visibility", "Any player")
+
+      assert Matches.can_view_match_history?(profile_user, [:avoid, :ignore]) == false
+      assert Matches.can_view_ratings?(profile_user, [:avoid, :ignore]) == false
+    end
+
+    test "ignored user can view with completely public settings", %{
+      viewer: viewer,
+      profile_user: profile_user
+    } do
+      {:ok, _ignore} = Account.ignore_user(profile_user.id, viewer.id)
+
+      Config.set_user_config(
+        profile_user.id,
+        "privacy.Match history visibility",
+        "Completely public"
+      )
+
+      Config.set_user_config(profile_user.id, "privacy.Ratings visibility", "Completely public")
+
+      assert Matches.can_view_match_history?(profile_user, [:ignore]) == true
+      assert Matches.can_view_ratings?(profile_user, [:ignore]) == true
+
+      Config.set_user_config(profile_user.id, "privacy.Match history visibility", "Any player")
+      Config.set_user_config(profile_user.id, "privacy.Ratings visibility", "Any player")
+
+      assert Matches.can_view_match_history?(profile_user, [:ignore]) == false
+      assert Matches.can_view_ratings?(profile_user, [:ignore]) == false
+    end
+  end
+end


### PR DESCRIPTION
Populating the /profile/:id/matches page

<img width="1193" height="212" alt="image" src="https://github.com/user-attachments/assets/6416cae6-df05-4a82-99a7-632b888702cc" />

The whole table itself will load based on the privacy settings for match history, and the ratings will load or not based on their existence (ranked game) and whether the privacy controls will allow visibility.

<img width="596" height="232" alt="image" src="https://github.com/user-attachments/assets/861ba660-1044-4462-a449-8146081c73d4" />
