### PR TITLE
Fix showing lists on complex match events

### DIFF
--- a/lib/teiserver_web/templates/telemetry/complex_match_event/detail.html.heex
+++ b/lib/teiserver_web/templates/telemetry/complex_match_event/detail.html.heex
@@ -90,7 +90,21 @@
                           <Fontawesome.icon icon={:show} style="solid" /> Show
                         </.link>
                       <% else %>
-                        {value}
+                        <%= if is_list(value) and Enum.all?(value, &is_map/1) do %>
+                          <ul>
+                            <%= for map <- value do %>
+                              <li>
+                                <ul>
+                                  <%= for {k, v} <- map do %>
+                                    <li>{k}: {v}</li>
+                                  <% end %>
+                                </ul>
+                              </li>
+                            <% end %>
+                          </ul>
+                        <% else %>
+                          {value}
+                        <% end %>
                       <% end %>
                     </td>
                   <% end %>


### PR DESCRIPTION
A quick fix to support showing lists of maps  in complex match events for the new widget report event.

<img width="1606" height="433" alt="image" src="https://github.com/user-attachments/assets/f50cb7e1-69ba-426d-8d0d-1c772e0e1422" />