### PR TITLE
Changed 2FA QR code from SVG to PNG

### DIFF
--- a/lib/teiserver_web/controllers/account/security_controller.ex
+++ b/lib/teiserver_web/controllers/account/security_controller.ex
@@ -52,17 +52,19 @@ defmodule TeiserverWeb.Account.SecurityController do
     changeset = TOTP.changeset(%TOTP{user_id: user.id, secret: encoded_secret})
     otpauth_uri = Account.generate_otpauth_uri(user.name, secret)
 
-    qr_svg =
-      otpauth_uri
-      |> EQRCode.encode()
-      |> EQRCode.svg(width: 250)
+    qr_img_src =
+      "data:image/png;base64," <>
+        (otpauth_uri
+         |> EQRCode.encode()
+         |> EQRCode.png(width: 250)
+         |> Base.encode64())
 
     conn
     |> add_breadcrumb(name: "edit_totp", url: conn.request_path)
     |> assign(:changeset, changeset)
     |> assign(:user, user)
     |> assign(:otpauth_uri, otpauth_uri)
-    |> assign(:qr_svg, qr_svg)
+    |> assign(:qr_img_src, qr_img_src)
     |> render("edit_totp.html")
   end
 

--- a/lib/teiserver_web/templates/account/security/edit_totp.html.heex
+++ b/lib/teiserver_web/templates/account/security/edit_totp.html.heex
@@ -17,7 +17,10 @@
         <%= form_for @changeset, ~p"/teiserver/account/security/totp/update", fn f -> %>
           <div class="bg-gray-800 p-6 mb-4 d-flex align-items-center" style="gap: 20px;">
             <div>
-              {raw(@qr_svg)}
+              <img
+                src={@qr_img_src}
+                alt="QR code you can scan to register this with the multi factor authentication application of your choice"
+              />
             </div>
 
             <div class="text-white" style="max-width: 400px;">


### PR DESCRIPTION
The 2FA QR code is a PNG now, instead of an SVG, which should fix resolve #835 

(sorry for lots of commits, done it in the original totp branch)