### PR TITLE
Batch lobby list updates

### DIFF
--- a/lib/teiserver/player/session.ex
+++ b/lib/teiserver/player/session.ex
@@ -1538,8 +1538,8 @@ defmodule Teiserver.Player.Session do
       :add_lobby ->
         send_to_player!({:lobby_list, {:add_lobby, ev.lobby_id, ev.overview}}, state)
 
-      :update_lobby ->
-        send_to_player!({:lobby_list, {:update_lobby, ev.lobby_id, ev.changes}}, state)
+      :update_lobbies ->
+        send_to_player!({:lobby_list, {:update_lobbies, ev.changes}}, state)
 
       :remove_lobby ->
         send_to_player!({:lobby_list, {:remove_lobby, ev.lobby_id}}, state)

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -195,6 +195,14 @@ defmodule Teiserver.Player.TachyonHandler do
     {:event, "lobby/listUpdated", data, state}
   end
 
+  def handle_info({:lobby_list, {:update_lobbies, lobbies}}, state) do
+    data =
+      Enum.map(lobbies, fn {id, overview} -> {id, lobby_overview_to_tachyon(id, overview)} end)
+      |> Map.new()
+
+    {:event, "lobby/listUpdated", %{lobbies: data}, state}
+  end
+
   def handle_info({:lobby_list, {:remove_lobby, lobby_id}}, state) do
     data = %{lobbies: %{lobby_id => nil}}
     {:event, "lobby/listUpdated", data, state}


### PR DESCRIPTION
With some very active lobbies (60+) the session process would be overwhelmed with hundreds of update messages in the mailbox and calls to do useful stuff like creating a lobby would timeout.