### PR TITLE
chore: Streamline initial setup with mise

### DIFF
--- a/documents/guides/development.md
+++ b/documents/guides/development.md
@@ -1,23 +1,117 @@
 # Development
+
 After finishing the local setup you are ready to start developing Teiserver.
-This guide should hopefully help you with getting started by showing you some helpful commands and giving you a short introduction to different Teiserver components.
+
+This guide should hopefully help you with getting started by showing you some
+helpful commands and giving you a short introduction to different Teiserver
+components.
+
+The first things you want to do is check your setup is healthy by running the
+tests and checking the Teiserver services are up and running, see [[#Testing]]
+and [[#Running Teiserver]].
+
+## Testing
+
+Run `mix test --exclude needs_attention`.
+
+If you set up your environment appropriately this should never fail, if it does
+review your local environment or submit a bug.
+
+## Running Teiserver
+
+To run Teiserver locally you can use:
+
+```bash
+mix phx.server
+```
+
+Or run it in interactive mode (a REPL is available):
+
+```bash
+iex -S mix phx.server
+```
+
+> [!WARNING]
+> The encrypted services will only be available if you built your local
+> certificates and configured the `TEI_TLS_*` environment variables accordingly.
+
+When successful, the following services should be available:
+
+### Website
+
+The website should be available via the URLs below:
+
+- HTTP: [http://localhost:4000/]
+- HTTPS: [https://localhost:8080/]
+
+### Spring Lobby Server
+
+Available at:
+
+- Plaintext: `telnet localhost 8200`
+- TLS: `openssl s_client -connect localhost:8201`
+
+On successful connection you should receive an initial message from the server
+as below:
+
+```
+TASSERVER 0.38-33-ga5f3b28 * 8201 0
+```
+
+You can send plaintext messages according to the [spring protocol](https://github.com/spring/LobbyProtocol).
+For example: sending `PING` should receive `PONG`.
+
+### Tachyon
+
+You should first have a oauth token available, connecting for example with
+[websocat](https://github.com/vi/websocat):
+
+- Plaintext: `websocat -H="Sec-WebSocket-Protocol: v0.tachyon" -H="Authorization: Bearer <token>" ws://localhost:4000/tachyon`
+- SSL: `websocat -k -H="Sec-WebSocket-Protocol: v0.tachyon" -H="Authorization: Bearer <token>" wss://localhost:8888/tachyon`
+
+## Configuration
+
+Most of the configuration takes place in [config/config.exs](config/config.exs),
+being overridden according to the current environment: `config/{dev,test,prod}.exs`.
+
+After compilation and just before the application starts `config/runtime.exs`
+also executes.
+
+## Running a release build locally
+
+It's useful to run the release build locally to best reproduce a "production"
+environment where development facilities are not available and interfering with
+our application (e.g. performance testing).
+
+Configure `teiserver.env` appropriately and run:
+
+```bash
+MIX_ENV=prod mix release --overwrite
+set -o allexport; source teiserver.env; set +o allexport
+_build/prod/rel/teiserver/bin/teiserver start
+# or if you also want a shell
+_build/prod/rel/teiserver/bin/teiserver start_iex
+```
 
 ## Useful tools and commands
+
 ### Fake data
 
 You will probably want some testing data (users, matches etc.) to make development and testing easier.
 
 Running the following command will generate a large amount of fake data and setup a root account for you:
+
 ```bash
 mix teiserver.fakedata
 ```
+
 The database will be populated with false data as if generated over a period of time and the root account will have full access to everything.
 
 > [!NOTE]
 > Fake data is not perfect and might not be sufficient for your needs. You can modify and expand it by editing the [fakedata mix task](/lib/teiserver/mix_tasks/fake_data.ex) that generates it.
 
-
 ### Resetting your user password
+
 When running locally it's likely you won't want to connect the server to an email account, as such password resets need to be done a little differently.
 
 Run your server with `iex -S mix phx.server` and then once it has started up use the following code to update your password.
@@ -28,9 +122,11 @@ Teiserver.Account.update_user(user, %{"password" => "password"})
 ```
 
 ### Ignore large `mix format` passes in `git blame`
-In https://github.com/beyond-all-reason/teiserver/pull/304 we've started requiring compliance with `mix format` - this meant we had to use that on the entire codebase.
+
+In <https://github.com/beyond-all-reason/teiserver/pull/304> we've started requiring compliance with `mix format` - this meant we had to use that on the entire codebase.
 
 This obviously breaks `git blame`, but you can sidestep that by using
+
 ```bash
 git config blame.ignoreRevsFile .git-blame-ignore-revs
 ```
@@ -40,43 +136,54 @@ The attached `.git-blame-ignore-revs` file contains a list of commit hashes whic
 > [!NOTE]
 > See [this blog post by Stefan Judis](https://www.stefanjudis.com/today-i-learned/how-to-exclude-commits-from-git-blame/) for reference.
 
-
 ### Git hooks
+
 The `.githooks` directory contains a `pre-commit` Git hook that will run `mix format` on staged files before they get commited.
 To use this (and other Git hooks) you have to first make them executable with
+
 ```bash
 chmod +x .githooks/pre-commit
 ```
+
 then use the following command to change the location where Git looks for hook scripts (from the default `.git/hooks`) to the `.githooks` directory
+
 ```bash
 git config core.hooksPath .githooks
 ```
 
 ## Working on Teiserver
+
 Teiserver handles a lot: account creation and management, user ratings, balancing, moderation, Discord bot, microblogs, chat, telemetry and more with the introduction of Tachyon.
 
 This section is intended as a short overview of the main Teiserver components.
 
 ### Tachyon protocol
+
 [Tachyon](https://github.com/beyond-all-reason/tachyon) is the new protocol under development, designed to replace the old Spring Lobby Protocol.
 Check [this](https://beyond-all-reason.github.io/infrastructure/new_client/) for a wider overview. In short:
+
 - The new client is [BAR lobby](https://github.com/beyond-all-reason/bar-lobby), it'll replace the existing [Chobby](https://github.com/beyond-all-reason/BYAR-Chobby) client
 - The new autohost starting games is [Recoil autohost](https://github.com/beyond-all-reason/recoil-autohost) and will more or less replace SPADS, although a lot of what SPADS is currently doing will be done in Teiserver
 - Teiserver is still the same, although the Tachyon related code is isolated from the Spring one
 
 For developping Tachyon, you should also run
+
 ```bash
 mix teiserver.tachyon_setup
 ```
+
 This setup the OAuth applications required for Tachyon.
 
 There is also
+
 ```bash
 mix teiserver.gen_token --user CheerfulBeigeKarganeth --app generic_lobby
 ```
+
 which generates an access token valid for 24h. These help a lot when attempting to manually test the API.
 
 ### Spring protocol
+
 The [Spring Lobby protocol](https://springrts.com/dl/LobbyProtocol/ProtocolDescription.html) is the old protocol, in use until everything is ready to fully switch to Tachyon.
 
 Over time the protocol has been extended with additional commands, mainly for the needs of Beyond All Reason, most are also handled by the Chobby client.<br>
@@ -89,6 +196,7 @@ The relevant code for Spring protocol and it's extensions is mostly in the [this
 For testing Spring related features you will likely want to [set up SPADS](/documents/guides/spads_install.md).
 
 ### Discord bot
+
 Teiserver also hosts a Discord bot.<br>
 It was originally introduced as a bridge between Discord and game `#main` channels but has since been expanded with additional features, some of which are: posting moderation action messages and new report messages in the relevant Discord channels, support for custom commands (e.g. looking up units and text callbacks, checking your account stats), linking your Discord account to Teiserver (for receiving lobby/game notifications on Discord, e.g. exiting join queue, game starting), updating player/lobby counter channels on Discord.
 
@@ -102,16 +210,22 @@ Most of the relevant Discord bridge bot code is in [this](/lib/teiserver/bridge)
 If you want to develop the Discord bridge bot follow [this setup guide](https://github.com/beyond-all-reason/teiserver/blob/master/documents/guides/discord_bot.md).
 
 ### APIs
+
 Teiserver currently has 2 APIs: public API and SPADS API.
+
 #### Public API
+
 Available publicly without authentication, currently used for getting [leaderboards](https://www.beyondallreason.info/leaderboards).<br>
 Check [Public Controller](/lib/teiserver_web/controllers/api/public_controller.ex).
+
 #### SPADS API
+
 Protected and only used by SPADS autohosts to request player ratings, balance games and send end game data to Teiserver.<br>
 Check [SPADS Controller](/lib/teiserver_web/controllers/api/spads_controller.ex).
 
 ### Rating
-Teiserver is using the [Openskill](https://openskill.me/) rating system for rating players. 
+
+Teiserver is using the [Openskill](https://openskill.me/) rating system for rating players.
 
 > [!NOTE]
 > For more information about Openskill and the rating and balancing system in general check out [this BAR official guide](https://www.beyondallreason.info/guide/rating-and-lobby-balance).
@@ -119,6 +233,7 @@ Teiserver is using the [Openskill](https://openskill.me/) rating system for rati
 The Elixir Openskill library used by Teiserver and Beyond All Reason is [here](https://github.com/beyond-all-reason/openskill.ex).
 
 ### Balancing
+
 Teiserver is responsible for balancing games based on Openskill ratings.
 There are several balancing algorithms available, each with its own advantages and disadvantages.
 
@@ -129,7 +244,9 @@ Eventually we want to move the balance algorithms to some external solver which 
 The balance alrogirhtms are located in [this](/lib/teiserver/battle/balance) directory.
 
 ## Main 3rd party dependencies
+
 The main dependencies of the project are:
+
 - [Phoenix framework](https://www.phoenixframework.org/), a web framework with a role similar to Django or Rails.
 - [Ecto](https://github.com/elixir-ecto/ecto), database ORM
 - [Ranch](https://github.com/ninenines/ranch), a tcp server

--- a/documents/guides/local_setup.md
+++ b/documents/guides/local_setup.md
@@ -1,39 +1,53 @@
 # Local setup
+
 This guide should contain all the necessary steps for setting up Teiserver locally.
 
-## Install services
+## Using mise
+
+You can use [mise](https://mise.jdx.dev/dev-tools/) to automatically manage the
+dependencies and application tasks, this method streamlines the development
+setup.
+
+- Run `mise setup`
+- Run `mise run 'setup:certs:*'` (optional, creates ssl/tls certificates,
+requires openssl installed). Note this step might take a while to finish.
+
+## Manual setup
+
+### Install services
+
 You will need to install:
+
 - [Elixir + Erlang](https://elixir-lang.org/install.html).
 - [PostgreSQL](https://www.postgresql.org/download).
 
 Make sure that you have the correct version of Elixir (currently using 1.18) and Erlang OTP (currently 26.2.5.2). You can find the dependency requirement [here](https://github.com/beyond-all-reason/teiserver/blob/master/mix.exs#L8).
 
 > [!TIP]
-> You can use [asdf](https://github.com/asdf-vm/asdf) or [mise](https://mise.jdx.dev/dev-tools/) to install the correct version, it will be picked up from the file `.tool-version`.
+> You can use [asdf](https://github.com/asdf-vm/asdf) to install the correct version, it will be picked up from the file `.tool-versions`.
 
+### Install build tools (gcc, g++, make) and cryptographic libraries
 
-## Clone repo
-```bash
-git clone git@github.com:beyond-all-reason/teiserver.git
-cd teiserver
-```
+#### Ubuntu/Debian
 
-## Install build tools (gcc, g++, make) and cryptographic libraries
-### Ubuntu/Debian
 ```bash
 sudo apt update
 sudo apt install build-essential libssl-dev
 ```
 
-## Elixir setup
+### Elixir setup
+
 Download and compile the dependencies:
+
 ```bash
 mix deps.get
 mix deps.compile
 ```
 
-## Postgres setup
+### Postgres setup
+
 If you want to change the username or password then you will need to update the relevant files in [config](/config).
+
 ```bash
 sudo su postgres
 psql postgres postgres <<EOF
@@ -56,10 +70,10 @@ mix ecto.migrate
 ```
 
 ### Localhost certs
+
 To run the TLS server locally you will also need to create localhost certificates in `priv/certs` using the following commands
 
 ```bash
-mkdir -p priv/certs
 cd priv/certs
 openssl dhparam -out dh-params.pem 2048
 openssl req -x509 -out localhost.crt -keyout localhost.key \
@@ -69,45 +83,14 @@ openssl req -x509 -out localhost.crt -keyout localhost.key \
 cd ../..
 ```
 
-## SASS
+### SASS
+
 We use sass for our CSS generation and you'll need to run this to get it started.
+
 ```bash
 mix sass.install
 ```
 
-## Running Teiserver
-### Standard mode
-```bash
-mix phx.server
-```
-
-### Interactive REPL mode
-```
-iex -S mix phx.server
-```
-If all goes to plan you should be able to access your site locally at [http://localhost:4000/](http://localhost:4000/).
-
-### Release version
-```bash
-MIX_ENV=prod mix release --overwrite
-set -o allexport; source teiserver.env; set +o allexport
-_build/prod/rel/teiserver/bin/teiserver start
-# or if you also want a shell
-_build/prod/rel/teiserver/bin/teiserver start_iex
-```
-
-This should start the server in "production mode", which is useful when doing
-performance testing to avoid module loading issues with iex.
-
-
-## Configuration
-Most of the configuration takes place in [config/config.exs](config/config.exs) with the other config files overriding for specific environments. The first block of `config.exs` contains a bunch of keys and values, which you can update.
-
-### Connecting to the spring party of your server locally
-```bash
-telnet localhost 8200
-openssl s_client -connect localhost:8201
-```
-
 ## What's next?
+
 You should now be ready to start developing Teiserver!<br> Check out the [development guide](/documents/guides/development.md) to help you with getting started.

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,91 @@
+[tools]
+postgres = '15'
+erlang = '26.2.5.2'
+elixir = '1.18.4-otp-26'
+
+[vars]
+pg_data = 'tmp/postgres/data'
+pg_ctl = 'pg_ctl -D {{vars.pg_data}} -l tmp/postgres.log'
+pg_status = '({{vars.pg_ctl}} status >/dev/null 2>&1)'
+certs_path = 'priv/certs'
+
+[env]
+KERL_BUILD_DOCS = 'yes'
+ERL_AFLAGS = '-kernel shell_history enabled'
+TEI_TLS_PRIVATE_KEY_PATH = '{{vars.certs_path}}/localhost.key'
+TEI_TLS_CERT_PATH = '{{vars.certs_path}}/localhost.crt'
+TEI_TLS_CA_CERT_PATH = '{{vars.certs_path}}/localhost.crt'
+TEI_TLS_DH_FILE_PATH = '{{vars.certs_path}}/dh-params.pem'
+
+[tasks."setup:db"]
+depends = ["pg:start"]
+description = "Sets up the application database"
+run = "mix do ecto.drop, ecto.setup"
+
+[tasks."setup"]
+depends = ["pg:setup"]
+description = "Sets up the application dependencies from scratch"
+run = [
+  { task = "setup:sass" },
+  { task = "setup:db" }
+]
+
+[tasks."setup:sass"]
+run = "mix sass.install"
+
+[tasks."pg:start"]
+description = "Starts the local postgres instance"
+run = "{{vars.pg_status}} || {{vars.pg_ctl}} start"
+
+[tasks."pg:stop"]
+description = "Stops the local postgres instance"
+run = '''
+{{vars.pg_status}} && {{vars.pg_ctl}} stop || echo "Server already not running"
+'''
+
+[tasks."pg:setup"]
+description = "Sets up the local postgres instance"
+confirm = "This will reset your local postgres installation from scratch including data loss, are you sure?"
+depends = ["pg:stop"]
+run = [
+  "rm -rf tmp/postgres",
+  "mkdir -p tmp/",
+  "initdb --username=postgres {{vars.pg_data}}",
+  { task = "pg:start" },
+  """
+  psql -U postgres <<EOF
+    CREATE USER teiserver_dev WITH PASSWORD '123456789';
+    ALTER USER teiserver_dev WITH SUPERUSER;
+
+    CREATE USER teiserver_test WITH PASSWORD '123456789';
+    ALTER USER teiserver_test WITH SUPERUSER;
+EOF
+  """,
+]
+
+[tasks."setup:certs:dhparam"]
+sources = ['mise.toml']
+outputs = ['{{env.TEI_TLS_DH_FILE_PATH}}']
+run = 'openssl dhparam -out {{env.TEI_TLS_DH_FILE_PATH}} 2048'
+
+[tasks."setup:certs:cert"]
+sources = ['mise.toml']
+outputs = ['{{env.TEI_TLS_CERT_PATH}}', '{{env.TEI_TLS_PRIVATE_KEY_PATH}}']
+env.CERT_SSL_CONFIG = '''
+[dn]
+CN=localhost
+[req]
+distinguished_name = dn
+[EXT]
+subjectAltName=DNS:localhost
+keyUsage=digitalSignature
+extendedKeyUsage=serverAuth
+'''
+run = '''
+openssl req -x509 \
+  -out {{env.TEI_TLS_CERT_PATH}} \
+  -keyout {{env.TEI_TLS_PRIVATE_KEY_PATH}} \
+  -newkey rsa:2048 -nodes -sha256 \
+  -subj '/CN=localhost' -extensions EXT \
+  -config <(printf "${CERT_SSL_CONFIG}")
+'''


### PR DESCRIPTION
Streamline the documentation to more clearly denote how to start the application and ensure the local setup is working correctly.

Move certain sections from `local_setup.md` to `development.md`.

We still keep the manual method in case we want to have that available.