### PR TITLE
refactor: Supervise spring tcp servers

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -35,7 +35,54 @@ config :teiserver, TeiserverWeb.Endpoint,
   debug_errors: Config.config_env() == :dev,
   code_reloader: Config.config_env() == :dev,
   check_origin: Config.config_env() == :prod,
-  version: Mix.Project.config()[:version]
+  version: Mix.Project.config()[:version],
+  https: [
+    versions: [:"tlsv1.2"],
+    port: 8888,
+    otp_app: :teiserver,
+    ciphers: [
+      ~c"ECDHE-ECDSA-AES256-GCM-SHA384",
+      ~c"ECDHE-RSA-AES256-GCM-SHA384",
+      ~c"ECDHE-ECDSA-AES256-SHA384",
+      ~c"ECDHE-RSA-AES256-SHA384",
+      ~c"ECDHE-ECDSA-DES-CBC3-SHA",
+      ~c"ECDH-ECDSA-AES256-GCM-SHA384",
+      ~c"ECDH-RSA-AES256-GCM-SHA384",
+      ~c"ECDH-ECDSA-AES256-SHA384",
+      ~c"ECDH-RSA-AES256-SHA384",
+      ~c"DHE-DSS-AES256-GCM-SHA384",
+      ~c"DHE-DSS-AES256-SHA256",
+      ~c"AES256-GCM-SHA384",
+      ~c"AES256-SHA256",
+      ~c"ECDHE-ECDSA-AES128-GCM-SHA256",
+      ~c"ECDHE-RSA-AES128-GCM-SHA256",
+      ~c"ECDHE-ECDSA-AES128-SHA256",
+      ~c"ECDHE-RSA-AES128-SHA256",
+      ~c"ECDH-ECDSA-AES128-GCM-SHA256",
+      ~c"ECDH-RSA-AES128-GCM-SHA256",
+      ~c"ECDH-ECDSA-AES128-SHA256",
+      ~c"ECDH-RSA-AES128-SHA256",
+      ~c"DHE-DSS-AES128-GCM-SHA256",
+      ~c"DHE-DSS-AES128-SHA256",
+      ~c"AES128-GCM-SHA256",
+      ~c"AES128-SHA256",
+      ~c"ECDHE-ECDSA-AES256-SHA",
+      ~c"ECDHE-RSA-AES256-SHA",
+      ~c"DHE-DSS-AES256-SHA",
+      ~c"ECDH-ECDSA-AES256-SHA",
+      ~c"ECDH-RSA-AES256-SHA",
+      ~c"AES256-SHA",
+      ~c"ECDHE-ECDSA-AES128-SHA",
+      ~c"ECDHE-RSA-AES128-SHA",
+      ~c"DHE-DSS-AES128-SHA",
+      ~c"ECDH-ECDSA-AES128-SHA",
+      ~c"ECDH-RSA-AES128-SHA",
+      ~c"AES128-SHA"
+    ],
+    secure_renegotiate: true,
+    reuse_sessions: true,
+    honor_cipher_order: true
+  ]
 
 config :esbuild,
   version: "0.14.41",
@@ -46,28 +93,46 @@ config :esbuild,
     env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
   ]
 
+config :teiserver, Teiserver.SpringTcpServer,
+  # Heatbeat interval in ms
+  heartbeat_interval: 30_000,
+  # Heartbeat timeout in seconds
+  heartbeat_timeout: 120,
+  # For each listener config see `:ranch.opts()`
+  # https://ninenines.eu/docs/en/ranch/2.2/manual/ranch/#_transport_opts_socketopts
+  listeners: [
+    tcp: [
+      max_connections: :infinity,
+      socket_opts: [
+        # this is may be overriden with env variable TEI_SPRING_TCP_PORT on config/runtime.exs
+        port: 8200,
+        nodelay: false,
+        delay_send: true
+      ]
+    ],
+    tls: [
+      max_connections: :infinity,
+      socket_opts: [
+        # this is may be overriden with env variable TEI_SPRING_TLS_PORT on config/runtime.exs
+        port: 8201,
+        nodelay: false,
+        delay_send: true
+      ]
+    ]
+  ]
+
 config :teiserver, Teiserver,
-  ports: [
-    tcp: 8200,
-    tls: 8201
-  ],
   website: [
     url: "mywebsite.com"
   ],
   enable_benchmark: false,
   enable_hooks: true,
-
-  # Heatbeat interval is ms
-  heartbeat_interval: 30_000,
-  # Heartbeat timeout is seconds
-  heartbeat_timeout: 120,
   test_mode: false,
   server_admin_name: "Server Admin",
   game_name: "Full game name",
   game_name_short: "Game",
   main_website: "https://site.com/",
   discord: nil,
-  default_spring_protocol: Teiserver.Protocols.Spring,
   github_repo: "https://github.com/beyond-all-reason/teiserver",
   enable_discord_bridge: true,
   enable_coordinator_mode: true,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -12,6 +12,10 @@ config :teiserver, Teiserver.Repo,
   pool_size: 10,
   timeout: 180_000
 
+config :teiserver, Teiserver.SpringTcpServer,
+  heartbeat_interval: nil,
+  heartbeat_timeout: nil
+
 # For development, we disable any cache and enable
 # debugging and code reloading.
 #
@@ -55,12 +59,6 @@ config :teiserver, Teiserver,
     certfile: "priv/certs/localhost.crt",
     cacertfile: "priv/certs/localhost.crt"
   ],
-  ports: [
-    tcp: 8200,
-    tls: 8201
-  ],
-  heartbeat_interval: nil,
-  heartbeat_timeout: nil,
   enable_discord_bridge: false,
   accept_all_emails: true
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -15,15 +15,17 @@ config :teiserver, Teiserver.Repo,
   pool_size: 50,
   timeout: 300_000
 
+config :teiserver, Teiserver.SpringTcpServer,
+  listeners: [
+    tcp: [socket_opts: [port: 9200]],
+    tls: [socket_opts: [port: 9201]]
+  ]
+
 config :teiserver, Teiserver,
   certs: [
     keyfile: "priv/certs/localhost.key",
     certfile: "priv/certs/localhost.crt",
     cacertfile: "priv/certs/localhost.crt"
-  ],
-  ports: [
-    tcp: 9200,
-    tls: 9201
   ],
   test_mode: true,
   enable_hooks: false,
@@ -46,6 +48,8 @@ config :teiserver, DiscordBridgeBot,
 config :teiserver, TeiserverWeb.Endpoint,
   url: [host: "localhost"],
   http: [port: 4002],
+  # We don't spawn the https endpoint in test
+  https: nil,
   # Spawn a real server. This is required for websocket upgrade since it
   # doesn't work with the test Plug.Conn used for "regular" http requests
   server: true

--- a/lib/teiserver/protocols/spring/spring.ex
+++ b/lib/teiserver/protocols/spring/spring.ex
@@ -1,14 +1,6 @@
 defmodule Teiserver.Protocols.Spring do
   @moduledoc false
   alias Teiserver.BitParse
-  alias Teiserver.Protocols.SpringIn
-  alias Teiserver.Protocols.SpringOut
-
-  @spec protocol_in :: Teiserver.Protocols.SpringIn
-  def protocol_in(), do: SpringIn
-
-  @spec protocol_out :: Teiserver.Protocols.SpringOut
-  def protocol_out(), do: SpringOut
 
   @spec parse_client_status(String.t()) :: map()
   def parse_client_status(status_str) do

--- a/lib/teiserver/protocols/spring/spring_in.ex
+++ b/lib/teiserver/protocols/spring/spring_in.ex
@@ -1424,7 +1424,7 @@ defmodule Teiserver.Protocols.SpringIn do
 
   # @spec engage_flood_protection(map()) :: {:stop, String.t(), map()}
   # defp engage_flood_protection(state) do
-  #   state.protocol_out.reply(:disconnect, "Spring status flood protection", nil, state)
+  #   reply(:disconnect, "Spring status flood protection", nil, state)
   #   CacheUser.set_flood_level(state.userid, 10)
   #   Client.disconnect(state.userid, "SpringIn.status.flood_protection")
   #   Logger.error("Spring Status command overflow from #{state.username}/#{state.userid}")

--- a/lib/teiserver/protocols/spring/spring_out.ex
+++ b/lib/teiserver/protocols/spring/spring_out.ex
@@ -87,8 +87,8 @@ defmodule Teiserver.Protocols.SpringOut do
     "TASSERVER 0.38-33-ga5f3b28 * 8201 0\n"
   end
 
-  defp do_reply(:redirect, url) do
-    "REDIRECT #{url} #{Application.get_env(:teiserver, Teiserver)[:ports][:tcp]}\n"
+  defp do_reply(:redirect, {ip, port}) do
+    "REDIRECT #{ip} #{port}\n"
   end
 
   defp do_reply(:compflags, nil) do
@@ -807,7 +807,7 @@ defmodule Teiserver.Protocols.SpringOut do
           case Map.has_key?(state_acc.known_users, member_id) do
             false ->
               client = Client.get_client_by_id(member_id)
-              state_acc.protocol_out.reply(:user_logged_in, client, nil, state)
+              reply(:user_logged_in, client, nil, state)
 
               %{
                 state_acc

--- a/test/teiserver/protocols/spring/spring_auth_async_test.exs
+++ b/test/teiserver/protocols/spring/spring_auth_async_test.exs
@@ -1,18 +1,17 @@
 defmodule Teiserver.SpringAuthAsyncTest do
   use Teiserver.ServerCase, async: false
   alias Teiserver.Client
-  alias Teiserver.Protocols.Spring
+  alias Teiserver.Protocols.SpringIn
 
   import Teiserver.TeiserverTestLib,
     only: [
-      async_auth_setup: 1,
-      _send_lines: 2,
+      async_auth_setup: 0,
       _recv_lines: 0,
       _recv_lines: 1
     ]
 
   setup do
-    %{user: user, state: state} = async_auth_setup(Spring)
+    %{user: user, state: state} = async_auth_setup()
     {:ok, state: state, user: user}
   end
 
@@ -21,14 +20,14 @@ defmodule Teiserver.SpringAuthAsyncTest do
   end
 
   test "PING", %{state: state, user: user} do
-    _send_lines(state, "#4 PING\n")
+    SpringIn.data_in("#4 PING\n", state)
     reply = _recv_lines()
     teardown(user)
     assert reply == "#4 PONG\n"
   end
 
   test "GETUSERINFO", %{state: state, user: user} do
-    _send_lines(state, "GETUSERINFO\n")
+    SpringIn.data_in("GETUSERINFO\n", state)
     reply = _recv_lines(3)
     teardown(user)
     assert reply =~ "SERVERMSG Registration date: "

--- a/test/teiserver/protocols/spring/spring_battle_host_async_test.exs
+++ b/test/teiserver/protocols/spring/spring_battle_host_async_test.exs
@@ -1,21 +1,21 @@
 defmodule Teiserver.Protocols.Spring.SpringBattleHostAsyncTest do
   use Teiserver.ServerCase, async: true
-  alias Teiserver.Protocols.Spring
   alias Teiserver.Client
 
   # Seems flaky on CI, but can't reproduce locally
   # https://github.com/beyond-all-reason/teiserver/actions/runs/10629702218/job/29467089868
   @moduletag :needs_attention
 
+  alias Teiserver.Protocols.SpringIn
+
   import Teiserver.TeiserverTestLib,
     only: [
-      async_auth_setup: 1,
-      _send_lines: 2,
+      async_auth_setup: 0,
       _recv_lines: 0
     ]
 
   setup do
-    %{user: user, state: state} = async_auth_setup(Spring)
+    %{user: user, state: state} = async_auth_setup()
     {:ok, state: state, user: user}
   end
 
@@ -24,11 +24,11 @@ defmodule Teiserver.Protocols.Spring.SpringBattleHostAsyncTest do
   end
 
   test "battle commands when not in a battle", %{state: state, user: user} do
-    _send_lines(state, "LEAVEBATTLE\n")
+    SpringIn.data_in("LEAVEBATTLE\n", state)
     reply = _recv_lines()
     assert reply == ""
 
-    _send_lines(state, "MYBATTLESTATUS 123 123\n")
+    SpringIn.data_in("MYBATTLESTATUS 123 123\n", state)
     reply = _recv_lines()
     teardown(user)
     assert reply == ""

--- a/test/teiserver/protocols/spring/spring_handle_test.exs
+++ b/test/teiserver/protocols/spring/spring_handle_test.exs
@@ -6,10 +6,9 @@ defmodule Teiserver.SpringHandleTest do
   use Teiserver.DataCase, async: false
   alias Teiserver.TeiserverTestLib
   alias Teiserver.Protocols.SpringIn
-  alias Teiserver.Protocols.SpringOut
 
   test "LOGIN and EXIT" do
-    state = TeiserverTestLib.mock_state_raw(SpringIn, SpringOut)
+    state = TeiserverTestLib.mock_state_raw()
 
     SpringIn.handle(
       "LOGIN TestUser X03MO1qnZdYdgyfeuILPmQ== 0 * LuaLobby Chobby\t1993717506 0d04a635e200f308\tb sp\n",
@@ -21,13 +20,12 @@ defmodule Teiserver.SpringHandleTest do
   end
 
   test "EXIT" do
-    state = TeiserverTestLib.mock_state_auth(SpringIn, SpringOut)
+    state = TeiserverTestLib.mock_state_auth()
     SpringIn.handle("EXIT", state)
   end
 
   test "LEAVEBATTLE" do
-    state = TeiserverTestLib.mock_state_auth(SpringIn, SpringOut)
-    state = %{state | lobby_id: 1}
+    state = TeiserverTestLib.mock_state_auth(%{lobby_id: 1})
     SpringIn.handle("LEAVEBATTLE", state)
   end
 
@@ -38,8 +36,7 @@ defmodule Teiserver.SpringHandleTest do
       ""
     ]
 
-    state = TeiserverTestLib.mock_state_auth(SpringIn, SpringOut)
-    state = %{state | lobby_id: 1}
+    state = TeiserverTestLib.mock_state_auth(%{lobby_id: 1})
 
     for v <- values do
       resp = SpringIn.handle(v, state)


### PR DESCRIPTION
This accomplishes the following:

- Allows our application to supervise the spring tcp servers
- Lays the groundwork for manually starting spring servers in test mode for asynchronous tests

Ranch embedded mode: https://ninenines.eu/docs/en/ranch/1.8/guide/embedded/

Additionally, we:

- Decouple configuration of spring tcp servers per listener
- Increase configurability of each listener
- Simplify server initialization process
- Deprecate ranch protocol initialization process with socket argument
- Remove some test cruft