### PR TITLE
Disable rating restrictions and rename unranked lobbies

### DIFF
--- a/lib/teiserver/lobby/libs/lobby_restrictions.ex
+++ b/lib/teiserver/lobby/libs/lobby_restrictions.ex
@@ -289,8 +289,11 @@ defmodule Teiserver.Lobby.LobbyRestrictions do
       |> Map.get(:name)
 
     cond do
+      state.ranked == false ->
+        {:error, "You cannot set a limit if the lobby is unranked"}
+
       allwelcome_name?(name) ->
-        {:error, "You cannot set a rating limit if all are welcome to the game"}
+        {:error, "You cannot set a limit if all are welcome to the game"}
 
       true ->
         :ok

--- a/lib/teiserver/lobby/servers/lobby_server.ex
+++ b/lib/teiserver/lobby/servers/lobby_server.ex
@@ -549,8 +549,8 @@ defmodule Teiserver.Battle.LobbyServer do
       [
         teaser,
         LobbyRestrictions.get_rank_bounds_for_title(consul_state),
-        # Rating stuff here
-        LobbyRestrictions.get_rating_bounds_for_title(consul_state)
+        LobbyRestrictions.get_rating_bounds_for_title(consul_state),
+        if(consul_state.ranked, do: nil, else: "Unranked")
       ]
       |> Enum.reject(&(&1 == nil))
       |> Enum.join(" | ")


### PR DESCRIPTION
The goal is to improve unranked experience for people who want more casual games without the pressure of ratings. These server changes will be paired with client changes that will hide the ratings in lobbies and in game in unranked lobbies. It should hopefully help with reducing conflicts and toxicity caused by people having different expectations from a game. It's not perfect but it's good enough until we have proper competitive casual split with the new client and matchmaking.