### PR TITLE
Fix port information in development.md for HTTPS

### DIFF
--- a/documents/guides/development.md
+++ b/documents/guides/development.md
@@ -42,7 +42,7 @@ When successful, the following services should be available:
 The website should be available via the URLs below:
 
 - HTTP: [http://localhost:4000/]
-- HTTPS: [https://localhost:8080/]
+- HTTPS: [https://localhost:8888/]
 
 ### Spring Lobby Server
 


### PR DESCRIPTION
HTTPS works with http://localhost:8888/ not 8080.