### PR TITLE
Do not query players from within mm queue

### DIFF
--- a/lib/teiserver/party/server.ex
+++ b/lib/teiserver/party/server.ex
@@ -318,7 +318,7 @@ defmodule Teiserver.Party.Server do
       do: {:reply, {:error, :already_queued}, state}
 
   def handle_call({:join_matchmaking_queues, queues}, _from, state) do
-    members_id = Enum.map(state.members, fn m -> %{id: m.id} end)
+    members_id = Enum.map(state.members, fn m -> m.id end)
 
     result =
       Enum.reduce_while(queues, state.monitors, fn {q_id, version}, monitors ->

--- a/test/teiserver/matchmaking/queue_test.exs
+++ b/test/teiserver/matchmaking/queue_test.exs
@@ -149,7 +149,7 @@ defmodule Teiserver.Matchmaking.QueueTest do
       party_id = UUID.uuid4()
 
       # Create a party with 1 player (valid for team_size: 1 queue)
-      {:ok, _pid} = Matchmaking.party_join_queue(queue_id, version, party_id, [user1])
+      {:ok, _pid} = Matchmaking.party_join_queue(queue_id, version, party_id, [user1.id])
       {:ok, stats} = Matchmaking.get_stats(queue_id)
       # No stats updated yet, party is pending
       assert stats == %{


### PR DESCRIPTION
Move the logic to create members to outside the queue. Also store the pid of sessions.
Storing the pid and avoiding querying the player registry is important since this system is setup after the matchmaking one, and so may not be available. This is especially likely to break when the system is shutting down.
Moving the member creation is to help with some sql sandbox test stupidity, overall it doesn't really matter where the call is made.