### PR TITLE
Make unranked lobby restrictions configurable

### DIFF
--- a/lib/teiserver/libs/teiserver_configs.ex
+++ b/lib/teiserver/libs/teiserver_configs.ex
@@ -453,6 +453,15 @@ defmodule Teiserver.TeiserverConfigs do
       default: false,
       update_callback: &Teiserver.Lobby.disable_live_lobby_feature(&1)
     })
+
+    add_site_config_type(%{
+      key: "lobby.Unranked lobby restrictions",
+      section: "Lobbies",
+      type: "boolean",
+      permissions: ["Admin"],
+      description: "If enabled unranked lobbies can have rating and rank restrictions set.",
+      default: true
+    })
   end
 
   defp discord_configs() do


### PR DESCRIPTION
Makes unranked lobby restrictions introduced with  https://github.com/beyond-all-reason/teiserver/pull/873 configurable.