### PR TITLE
Fix deprecation warning when executing `mise run setup:db`

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -21,7 +21,7 @@ PGPASSWORD = "123456789"
 [tasks."setup:db"]
 depends = ["pg:start"]
 description = "Sets up the application database"
-run = "mix do ecto.drop, ecto.setup"
+run = "mix do ecto.drop + ecto.setup"
 
 [tasks."setup:deps"]
 run = "mix deps.get"


### PR DESCRIPTION
See the warning from the output below:

```
$ mise run setup:db
[pg:start] $ (pg_ctl -D tmp/postgres/data -l tmp/postgres.log status >/dev/null 2>&1) || pg_ctl -D tmp/postgres/data -l tmp/postgres.log start
[setup:db] $ mix do ecto.drop, ecto.setup
warning: using commas as separators in "mix do" is deprecated, use + between commands instead
```