### PR TITLE
Enable back warnings_as_errors option

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -10,8 +10,7 @@ defmodule Teiserver.MixProject do
       package: package(),
       dialyzer: dialyzer(),
       elixirc_paths: elixirc_paths(Mix.env()),
-      # TODO fix warnings and re-enable
-      elixirc_options: [warnings_as_errors: false],
+      elixirc_options: [warnings_as_errors: true],
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps(),


### PR DESCRIPTION
This was part of the upgrade to Elixir 1.19 in #886.