### PR TITLE
Prefer Mise over asdf to set up development environment

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-erlang 26.2.5.1
-elixir 1.19.4-otp-26

--- a/documents/guides/local_setup.md
+++ b/documents/guides/local_setup.md
@@ -28,9 +28,6 @@ You will need to install:
 
 Make sure that you have the correct version of Elixir (currently using 1.19.4) and Erlang OTP (currently 26.2.5.1). You can find the dependency requirement [here](https://github.com/beyond-all-reason/teiserver/blob/master/mix.exs#L8).
 
-> [!TIP]
-> You can use [asdf](https://github.com/asdf-vm/asdf) to install the correct version, it will be picked up from the file `.tool-versions`.
-
 ### Install build tools (gcc, g++, make) and cryptographic libraries
 
 #### Ubuntu/Debian


### PR DESCRIPTION
See this [comparison between Mise and asdf](https://mise.jdx.dev/dev-tools/comparison-to-asdf.html). Yes, it's on Mise's website, but it's honest.

It's clear to contributors what they should use now that we only recommend Mise.

In summary, Mise has tasks and environments, better supply chain security, Windows support, and improved UX.