### PR TITLE
Use more granular latency buckets for spring commands

### DIFF
--- a/lib/teiserver/telemetry/libs/telemetry_lib.ex
+++ b/lib/teiserver/telemetry/libs/telemetry_lib.ex
@@ -77,7 +77,7 @@ defmodule Teiserver.Telemetry.TelemetryLib do
         event_name: [:spring, :in],
         measurement: :duration,
         reporter_options: [
-          buckets: [1, 10, 50, 100, 150, 250, 500, 1_000]
+          buckets: [1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987, 1597, 2584, 4181]
         ],
         tags: [:command]
       ),
@@ -86,7 +86,7 @@ defmodule Teiserver.Telemetry.TelemetryLib do
         event_name: [:spring, :out],
         measurement: :duration,
         reporter_options: [
-          buckets: [1, 10, 50, 100, 150, 250, 500, 1_000]
+          buckets: [1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987, 1597, 2584, 4181]
         ],
         tags: [:command]
       ),


### PR DESCRIPTION
Bucket sizes are most often subsequent powers of some base number, depending on required granularity in 1.2-4 range. Current buckets have some large gaps at the low end, then switch to someting like 2x and then I think 1000 is too little.

In this change I'm using fibonacci numbers which is roughly ~1.6 base and have an overall nice progression.

For the latency range we are interested in it's still only 18 buckets, so it's totally fine from cardinality perspective, we can even push it further if needed.