### PR TITLE
Catch user stat queries with no search arguments

### DIFF
--- a/lib/teiserver/account.ex
+++ b/lib/teiserver/account.ex
@@ -129,6 +129,10 @@ defmodule Teiserver.Account do
   end
 
   def user_stat_query(id, args) do
+    if id == nil and args[:search] == nil do
+      raise ArgumentError, "user_stat_query called without either user id or search parameters"
+    end
+
     UserStatLib.query_user_stats()
     |> UserStatLib.search(%{user_id: id})
     |> UserStatLib.search(args[:search])


### PR DESCRIPTION
An attempt to track down issues caused by the missing WHERE clause in the following query `SELECT t0."user_id", t0."data" FROM "teiserver_account_user_stats" AS t0`.