### PR TITLE
Silence the `Could not check origin for Phoenix.Socket transport`

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -68,7 +68,7 @@ config :teiserver, Teiserver.Repo,
 
 check_origin =
   if Teiserver.ConfigHelpers.get_env("TEI_SHOULD_CHECK_ORIGIN", false, :bool) do
-    ["//#{domain_name}", "//*.#{domain_name}"]
+    :conn
   else
     false
   end


### PR DESCRIPTION
I've tested this when connecting with a random name and the IP of the server and these error log are no more. According to the doc this setting is still secure, since phoenix is still going to check that the origin match what's in the `conn` object.