### PR TITLE
Tests for metric's buckets

### DIFF
--- a/lib/teiserver/monitoring/buckets.ex
+++ b/lib/teiserver/monitoring/buckets.ex
@@ -84,7 +84,6 @@ defmodule Teiserver.Monitoring.Buckets do
     end
   end
 
-  # hack since :gb_trees.larger/2 is only available from otp 27
   defp larger(key, tree) do
     case :gb_trees.iterator_from(key, tree) |> :gb_trees.next() do
       :none -> :none

--- a/test/teiserver/monitoring/buckets_test.exs
+++ b/test/teiserver/monitoring/buckets_test.exs
@@ -1,0 +1,36 @@
+defmodule Teiserver.Monitoring.BucketsTest do
+  use Teiserver.DataCase, async: true
+
+  alias Teiserver.Monitoring.Buckets
+  alias Telemetry.Metrics.Distribution
+
+  test "return correct bucket for ints" do
+    config = Buckets.config(%Distribution{reporter_options: [buckets: [1, 2, 3]]})
+    assert 0 == Buckets.bucket_for(0, config)
+    assert 3 == Buckets.bucket_for(100, config)
+  end
+
+  test "return correct bucket for floats" do
+    config = Buckets.config(%Distribution{reporter_options: [buckets: [1, 2, 3]]})
+    assert 0 == Buckets.bucket_for(0.8, config)
+    assert 1 == Buckets.bucket_for(1.1, config)
+    assert 3 == Buckets.bucket_for(100, config)
+  end
+
+  test "upper bound is inclusive" do
+    config = Buckets.config(%Distribution{reporter_options: [buckets: [1, 2, 3]]})
+    assert 0 == Buckets.bucket_for(1, config)
+  end
+
+  test "return upper bound as float" do
+    config = Buckets.config(%Distribution{reporter_options: [buckets: [1, 2, 3]]})
+    assert Buckets.upper_bound(0, config) == "1.0"
+    assert Buckets.upper_bound(1, config) == "2.0"
+    assert Buckets.upper_bound(2, config) == "3.0"
+  end
+
+  test "+Inf upper bound for excess bucket index" do
+    config = Buckets.config(%Distribution{reporter_options: [buckets: [1, 2, 3]]})
+    assert Buckets.upper_bound(3, config) == "+Inf"
+  end
+end


### PR DESCRIPTION
The implementation I got from https://github.com/tuist/tuist/pull/8022
uses `:gb_trees.larger` to find the correct bucket for a value. However,
this function perform a strict comparison.
So given buckets [1, 2, 3], the value `1` would be assigned to the
second bucket.

According to https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile

> Each float sample must have a label le where the label value denotes the inclusive upper bound of the bucket

Which means a value of 1 should instead be in the first bucket.

Because otp 26 doesn't have `:gb_trees.larger/2`, I implemented a
similar function using `iterator_from`, which uses a ≥ operation, so we
get the correct result.