### PR TITLE
Address issues for Credo.Check.Readability.LargeNumbers

### DIFF
--- a/lib/teiserver/battle/balance/brute_force_avoid.ex
+++ b/lib/teiserver/battle/balance/brute_force_avoid.ex
@@ -19,8 +19,7 @@ defmodule Teiserver.Battle.Balance.BruteForceAvoid do
   # Parties will be split if team diff is too large. It either uses absolute value or percentage
   # See get_max_team_diff function below for full details
   @max_team_diff_abs 10
-  # credo:disable-for-next-line Credo.Check.Readability.LargeNumbers
-  @max_team_diff_importance 10000
+  @max_team_diff_importance 10_000
   @party_importance 1000
   @avoid_importance 10
   @captain_diff_importance 1

--- a/lib/teiserver/coordinator/consul_commands.ex
+++ b/lib/teiserver/coordinator/consul_commands.ex
@@ -446,15 +446,12 @@ defmodule Teiserver.Coordinator.ConsulCommands do
               balance.time_taken < 1000 ->
                 "Time taken: #{balance.time_taken}us"
 
-              # credo:disable-for-next-line Credo.Check.Readability.LargeNumbers
-              balance.time_taken < 1000_000 ->
+              balance.time_taken < 1_000_000 ->
                 t = round(balance.time_taken / 1000)
                 "Time taken: #{t}ms"
 
-              # credo:disable-for-next-line Credo.Check.Readability.LargeNumbers
-              balance.time_taken < 1000_000_000 ->
-                # credo:disable-for-next-line Credo.Check.Readability.LargeNumbers
-                t = round(balance.time_taken / 1000_000)
+              balance.time_taken < 1_000_000_000 ->
+                t = round(balance.time_taken / 1_000_000)
                 "Time taken: #{t}s"
             end
 

--- a/lib/teiserver_web/controllers/admin/lobby_controller.ex
+++ b/lib/teiserver_web/controllers/admin/lobby_controller.ex
@@ -108,8 +108,7 @@ defmodule TeiserverWeb.Admin.LobbyController do
 
     {page, page_size} =
       if params["page"] == "all" do
-        # credo:disable-for-next-line Credo.Check.Readability.LargeNumbers
-        {0, 10000}
+        {0, 10_000}
       else
         {Map.get(params, "page", 0)
          |> int_parse()

--- a/test/support/teiserver_test_lib.ex
+++ b/test/support/teiserver_test_lib.ex
@@ -120,8 +120,7 @@ defmodule Teiserver.TeiserverTestLib do
   end
 
   def _recv_lines(), do: _recv_lines(1)
-  # credo:disable-for-next-line Credo.Check.Readability.LargeNumbers
-  def _recv_lines(:until_timeout), do: _recv_lines(99999)
+  def _recv_lines(:until_timeout), do: _recv_lines(99_999)
 
   def _recv_lines(lines) do
     receive do

--- a/test/teiserver/battle/match_monitor_test.exs
+++ b/test/teiserver/battle/match_monitor_test.exs
@@ -73,8 +73,7 @@ defmodule Teiserver.Battle.MatchMonitorTest do
     assert monitor_pid != nil
 
     # Send a launch message for a non-existent lobby
-    # credo:disable-for-next-line Credo.Check.Readability.LargeNumbers
-    send(monitor_pid, {:new_message, 99999, "autohosts", "* Launching game..."})
+    send(monitor_pid, {:new_message, 99_999, "autohosts", "* Launching game..."})
 
     # Verify the server is still running (hasn't crashed)
     Teiserver.Support.Polling.poll_until(

--- a/test/teiserver/matchmaking/pairing_test.exs
+++ b/test/teiserver/matchmaking/pairing_test.exs
@@ -29,9 +29,8 @@ defmodule Teiserver.Matchmaking.PairingTest do
       teams = [[m1], [m2]]
       {:ok, pid} = PairingRoom.start("queue_id", queue_attrs(), teams, 20_000)
 
-      # credo:disable-for-lines:2 Credo.Check.Readability.LargeNumbers
       assert {:error, :no_match} =
-               PairingRoom.ready(pid, %{user_id: -81234, name: "irrelevant", password: "pass"})
+               PairingRoom.ready(pid, %{user_id: -81_234, name: "irrelevant", password: "pass"})
     end
 
     test "can join" do


### PR DESCRIPTION
There are now only 3 lines where we still disable this check. Those are all for port numbers, which makes sense to keep together as this is how ports are typed in.