### PR TITLE
Increase flush interval

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -258,6 +258,7 @@ config :teiserver, Teiserver.PromEx,
   manual_metrics_start_delay: :no_delay,
   drop_metrics_groups: [],
   grafana: :disabled,
+  ets_flush_interval: 20_000,
   metrics_server: :disabled
 
 # Import environment specific config. This must remain at the bottom


### PR DESCRIPTION
We are seeing `GenServer Teiserver.PromEx.ETSCronFlusher terminating` under some load. This has some very bad effect on the overall server: all lobbies die and connections are dropped left and right.

The vmagent is scheduled to run every 15 seconds, and this scrape cancel the cronflusher. So by increasing the interval to more than 15 s (from a default of 7.5s), we should remove the ETSCronFlusher process from the equation.

This may mask another issue though, I do not understand why the metric gathering task takes so long (more than 10s, the timeout for the task).