### PR TITLE
Handle case where member_count is nil

### DIFF
--- a/lib/teiserver/lobby/libs/lobby_lib.ex
+++ b/lib/teiserver/lobby/libs/lobby_lib.ex
@@ -348,17 +348,17 @@ defmodule Teiserver.Lobby.LobbyLib do
 
   @spec get_lobby_member_count(T.lobby_id()) :: integer()
   def get_lobby_member_count(lobby_id) do
-    call_lobby(lobby_id, :get_member_count)
+    call_lobby(lobby_id, :get_member_count) || 0
   end
 
   @spec get_lobby_spectator_count(T.lobby_id()) :: integer()
   def get_lobby_spectator_count(lobby_id) do
-    call_lobby(lobby_id, :get_spectator_count)
+    call_lobby(lobby_id, :get_spectator_count) || 0
   end
 
   @spec get_lobby_player_count(T.lobby_id()) :: integer()
   def get_lobby_player_count(lobby_id) do
-    call_lobby(lobby_id, :get_player_count)
+    call_lobby(lobby_id, :get_player_count) || 0
   end
 
   @spec list_lobby_players(T.lobby_id()) :: [T.client()] | nil


### PR DESCRIPTION
Error from logs:

```
[error] request_id=01KE7ZFMMMRK6S6G4EHPCNNRTJ user_id=247928 pid=<0.18684724.0>  GenServer #PID<0.18684724.0> terminating
** (ArithmeticError) bad argument in arithmetic expression
    :erlang.-(nil)
    (teiserver 0.1.0) lib/teiserver_web/live/battles/lobbies/index.ex:181: anonymous fn/1 in TeiserverWeb.Battle.LobbyLive.Index.sort_lobbies/1
    (elixir 1.19.4) lib/enum.ex:3347: anonymous fn/2 in Enum.sort_by/3
    (elixir 1.19.4) lib/enum.ex:1688: Enum."-map/2-lists^map/1-1-"/2
    (elixir 1.19.4) lib/enum.ex:1688: Enum."-map/2-lists^map/1-1-"/2
    (elixir 1.19.4) lib/enum.ex:3347: Enum.sort_by/3
    (teiserver 0.1.0) lib/teiserver_web/live/battles/lobbies/index.ex:228: TeiserverWeb.Battle.LobbyLive.Index.populate_initial_assigns/1
    (teiserver 0.1.0) lib/teiserver_web/live/battles/lobbies/index.ex:26: TeiserverWeb.Battle.LobbyLive.Index.mount/3
```