### PR TITLE
Handle nil script tags

### DIFF
--- a/lib/teiserver/protocols/spring/spring_out.ex
+++ b/lib/teiserver/protocols/spring/spring_out.ex
@@ -286,6 +286,10 @@ defmodule Teiserver.Protocols.SpringOut do
     "REMOVESTARTRECT #{team}\n"
   end
 
+  defp do_reply(:add_script_tags, nil) do
+    "SETSCRIPTTAGS\n"
+  end
+
   defp do_reply(:add_script_tags, tags) do
     tags =
       tags


### PR DESCRIPTION
We do get the following errors sometimes:

```
** (Protocol.UndefinedError) protocol Enumerable not implemented for Atom. This protocol is implemented for: DBConnection.PrepareStream, DBConnection.Stream, Date.Range, Ecto.Adapters.SQL.Stream, File.Stream, Function, GenEvent.Stream, HashDict, HashSet, IO.Stream, IP.Range, IP.Subnet, Jason.OrderedObject, List, MDEx.Alert, MDEx.BlockQuote, MDEx.Code, MDEx.CodeBlock, MDEx.DescriptionDetails, MDEx.DescriptionItem, MDEx.DescriptionList, MDEx.DescriptionTerm, MDEx.Document, MDEx.Emph, MDEx.Escaped, MDEx.EscapedTag, MDEx.FootnoteDefinition, MDEx.FootnoteReference, MDEx.FrontMatter, MDEx.Heading, MDEx.HtmlBlock, MDEx.HtmlInline, MDEx.Image, MDEx.LineBreak, MDEx.Link, MDEx.List, MDEx.ListItem, MDEx.Math, MDEx.MultilineBlockQuote, MDEx.Paragraph, MDEx.Raw, MDEx.ShortCode, MDEx.SoftBreak, MDEx.SpoileredText, MDEx.Strikethrough, MDEx.Strong, MDEx.Subscript, MDEx.Superscript, MDEx.Table, MDEx.TableCell, MDEx.TableRow, MDEx.TaskItem, MDEx.Text, MDEx.ThematicBreak, MDEx.Underline, MDEx.WikiLink, Map, MapSet, MerkleMap, Phoenix.LiveView.LiveStream, Postgrex.Stream, Range, Stream, Timex.Interval

Got value:

    nil

    (elixir 1.19.4) lib/enum.ex:5: Enumerable.impl_for!/1
    (elixir 1.19.4) lib/enum.ex:170: Enumerable.reduce/3
    (elixir 1.19.4) lib/enum.ex:4570: Enum.map_intersperse/3
    (elixir 1.19.4) lib/enum.ex:1789: Enum.map_join/3
    (teiserver 0.1.0) lib/teiserver/protocols/spring/spring_out.ex:292: Teiserver.Protocols.SpringOut.do_reply/2
    (teiserver 0.1.0) lib/teiserver/protocols/spring/spring_out.ex:40: Teiserver.Protocols.SpringOut.reply/5
    (teiserver 0.1.0) lib/teiserver/protocols/spring/spring_out.ex:649: Teiserver.Protocols.SpringOut.do_join_battle/3
    (teiserver 0.1.0) lib/teiserver/tcp/spring/spring_tcp_server.ex:482: Teiserver.SpringTcpServer.handle_info/2
Last message: {:join_battle_request_response, 250, :accept, nil}
```

I do not know what causes it but this should at least not terminate the connection process.