### PR TITLE
Fix nil lobby when checking for restrictions

### DIFF
--- a/lib/teiserver/coordinator/consul_server.ex
+++ b/lib/teiserver/coordinator/consul_server.ex
@@ -925,7 +925,7 @@ defmodule Teiserver.Coordinator.ConsulServer do
 
   def is_on_friendlist?(userid, state, :all) do
     member_ids =
-      Battle.get_lobby(state.lobby_id)
+      (Battle.get_lobby(state.lobby_id) || %{})
       |> Map.get(:players, [])
 
     # If battle has no players it'll succeed regardless

--- a/lib/teiserver/lobby/libs/lobby_restrictions.ex
+++ b/lib/teiserver/lobby/libs/lobby_restrictions.ex
@@ -284,8 +284,7 @@ defmodule Teiserver.Lobby.LobbyRestrictions do
   @spec allowed_to_set_restrictions(map()) :: :ok | {:error, String.t()}
   def allowed_to_set_restrictions(state) do
     name =
-      state.lobby_id
-      |> Battle.get_lobby()
+      (Battle.get_lobby(state.lobby_id) || %{})
       |> Map.get(:name)
 
     cond do
@@ -299,6 +298,8 @@ defmodule Teiserver.Lobby.LobbyRestrictions do
         :ok
     end
   end
+
+  defp allwelcome_name?(nil), do: false
 
   defp allwelcome_name?(name) do
     name =


### PR DESCRIPTION
```
** (BadMapError) expected a map, got:

    nil

    (elixir 1.19.4) lib/map.ex:541: Map.get(nil, :name, nil)
    (teiserver 0.1.0) lib/teiserver/lobby/libs/lobby_restrictions.ex:289: Teiserver.Lobby.LobbyRestrictions.allowed_to_set_restrictions/1
    (teiserver 0.1.0) lib/teiserver/coordinator/consul_commands.ex:758: Teiserver.Coordinator.ConsulCommands.handle_command/2
    (teiserver 0.1.0) lib/teiserver/coordinator/consul_server.ex:362: Teiserver.Coordinator.ConsulServer.handle_info/2
    (stdlib 5.2.3) gen_server.erl:1095: :gen_server.try_handle_info/3
    (stdlib 5.2.3) gen_server.erl:1183: :gen_server.handle_msg/6
    (stdlib 5.2.3) proc_lib.erl:241: :proc_lib.init_p_do_apply/3
```