### PR TITLE
Delete unneeded `config/dialyzer_ignore.exs`

### DIFF
--- a/config/dialyzer_ignore.exs
+++ b/config/dialyzer_ignore.exs
@@ -1,4 +1,0 @@
-[
-  ~r/The function call [a-z_]+ will not succeed/,
-  ~r/has no local return/
-]


### PR DESCRIPTION
Keeping this file around has no effect, so it's better to delete it.