### PR TITLE
Fix Dialyzer warnings `unknown type` for `TeiserverWeb.AdminDashLive` modules

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -163,8 +163,6 @@
   {"lib/teiserver_web/live/account/relationship/index.html.heex", :call},
   {"lib/teiserver_web/live/admin/chat/index.html.heex", :no_return},
   {"lib/teiserver_web/live/admin/chat/index.html.heex", :call},
-  {"lib/teiserver_web/live/admin_dashboard/index.ex", :unknown_type},
-  {"lib/teiserver_web/live/admin_dashboard/policy.ex", :unknown_type},
   {"lib/teiserver_web/live/battles/match/chat.ex", :no_return},
   {"lib/teiserver_web/live/battles/match/chat.ex", :call},
   {"lib/teiserver_web/live/battles/match/chat.html.heex", :no_return},

--- a/lib/teiserver_web/live/admin_dashboard/index.ex
+++ b/lib/teiserver_web/live/admin_dashboard/index.ex
@@ -1,5 +1,6 @@
 defmodule TeiserverWeb.AdminDashLive.Index do
   use TeiserverWeb, :live_view
+  alias Phoenix.LiveView.Socket
   alias Phoenix.PubSub
 
   alias Teiserver
@@ -108,7 +109,7 @@ defmodule TeiserverWeb.AdminDashLive.Index do
     {:noreply, socket}
   end
 
-  @spec update_policies(Plug.Socket.t()) :: Plug.Socket.t()
+  @spec update_policies(Socket.t()) :: Socket.t()
   defp update_policies(socket) do
     policies =
       Game.list_lobby_policies()
@@ -122,7 +123,7 @@ defmodule TeiserverWeb.AdminDashLive.Index do
     |> assign(:policies, policies)
   end
 
-  @spec update_lobbies(Plug.Socket.t()) :: Plug.Socket.t()
+  @spec update_lobbies(Socket.t()) :: Socket.t()
   defp update_lobbies(socket) do
     lobbies =
       Battle.list_lobby_ids()
@@ -147,7 +148,7 @@ defmodule TeiserverWeb.AdminDashLive.Index do
     |> assign(:lobbies, lobbies)
   end
 
-  @spec update_server_pids(Plug.Socket.t()) :: Plug.Socket.t()
+  @spec update_server_pids(Socket.t()) :: Socket.t()
   defp update_server_pids(socket) do
     lobby_id_server_pid =
       case Horde.Registry.lookup(Teiserver.ServerRegistry, "LobbyIdServer") do

--- a/lib/teiserver_web/live/admin_dashboard/policy.ex
+++ b/lib/teiserver_web/live/admin_dashboard/policy.ex
@@ -1,5 +1,6 @@
 defmodule TeiserverWeb.AdminDashLive.Policy do
   use TeiserverWeb, :live_view
+  alias Phoenix.LiveView.Socket
   alias Phoenix.PubSub
   import Teiserver.Helper.NumberHelper, only: [int_parse: 1]
 
@@ -73,7 +74,7 @@ defmodule TeiserverWeb.AdminDashLive.Policy do
     {:noreply, socket}
   end
 
-  @spec get_policy_bots(Plug.Socket.t()) :: Plug.Socket.t()
+  @spec get_policy_bots(Socket.t()) :: Socket.t()
   defp get_policy_bots(socket) do
     bots = Game.call_lobby_organiser(socket.assigns.id, :get_agent_status)
 


### PR DESCRIPTION
The Socket module is `Phoenix.LiveView.Socket`, not `Plug.Socket`.