### PR TITLE
Handle exit signal in parties

### DIFF
--- a/lib/teiserver/party/server.ex
+++ b/lib/teiserver/party/server.ex
@@ -585,6 +585,10 @@ defmodule Teiserver.Party.Server do
     {:stop, :normal}
   end
 
+  def handle_event(:info, {:EXIT, _pid, reason}, _state, _data) do
+    {:stop, reason}
+  end
+
   @impl :gen_statem
   def terminate(:shutdown, :shutting_down, data) do
     # by that time, the party should have received all the :shutdown signals


### PR DESCRIPTION
trapping exit is required to get `terminate` to be invoked, but it also means that when the process receive an exit signal with a reason other than :shutdown or :normal, then it receives an EXIT message instead, and that wasn't handled.