### PR TITLE
adds bounds to minchevlevel command in lobby

### DIFF
--- a/lib/teiserver/coordinator/consul_commands.ex
+++ b/lib/teiserver/coordinator/consul_commands.ex
@@ -771,13 +771,14 @@ defmodule Teiserver.Coordinator.ConsulCommands do
             state
 
           {chev_level, _} ->
-            if chev_level < LobbyRestrictions.rank_min_chev_level() or
-                 chev_level > LobbyRestrictions.rank_max_chev_level() do
+            max_chev_level = LobbyRestrictions.rank_upper_bound() + 1
+
+            if chev_level < 1 or chev_level > max_chev_level do
               Lobby.sayprivateex(
                 state.coordinator_id,
                 senderid,
                 [
-                  "Chev level must be between #{LobbyRestrictions.rank_min_chev_level()} and #{LobbyRestrictions.rank_max_chev_level()}."
+                  "Chev level must be between 1 and #{max_chev_level}."
                 ],
                 state.lobby_id
               )
@@ -838,13 +839,14 @@ defmodule Teiserver.Coordinator.ConsulCommands do
             state
 
           {chev_level, _} ->
-            if chev_level < LobbyRestrictions.rank_min_chev_level() or
-                 chev_level > LobbyRestrictions.rank_max_chev_level() do
+            max_chev_level = LobbyRestrictions.rank_upper_bound() + 1
+
+            if chev_level < 1 or chev_level > max_chev_level do
               Lobby.sayprivateex(
                 state.coordinator_id,
                 senderid,
                 [
-                  "Chev level must be between #{LobbyRestrictions.rank_min_chev_level()} and #{LobbyRestrictions.rank_max_chev_level()}."
+                  "Chev level must be between 1 and #{max_chev_level}."
                 ],
                 state.lobby_id
               )

--- a/lib/teiserver/lobby/libs/lobby_restrictions.ex
+++ b/lib/teiserver/lobby/libs/lobby_restrictions.ex
@@ -7,15 +7,11 @@ defmodule Teiserver.Lobby.LobbyRestrictions do
   alias Teiserver.Battle.{BalanceLib, MatchLib}
   alias Teiserver.Battle
 
-  @rank_upper_bound 1000
-  @rank_min_chev_level 1
-  @rank_max_chev_level 8
+  @rank_upper_bound 7
   @rating_upper_bound 1000
   @splitter "------------------------------------------------------"
   @spec rank_upper_bound() :: number
   def rank_upper_bound, do: @rank_upper_bound
-  def rank_min_chev_level, do: @rank_min_chev_level
-  def rank_max_chev_level, do: @rank_max_chev_level
   def rating_upper_bound, do: @rating_upper_bound
 
   def get_lobby_restrictions_welcome_text(state) do


### PR DESCRIPTION
Links to issue #954 

Only allows minchevlevel command to be within the bounds of 1 - 8. Other values are given the error message "Chev level must be between"