### PR TITLE
Fix error when creating a match with AI

### DIFF
--- a/lib/teiserver/battle.ex
+++ b/lib/teiserver/battle.ex
@@ -435,7 +435,7 @@ defmodule Teiserver.Battle do
         Repo.transaction(fn ->
           for {ally_team, index} <- Enum.with_index(ally_teams),
               team <- ally_team.teams,
-              player <- team.players do
+              player <- Map.get(team, :players, []) do
             %{
               match_id: match.id,
               team_id: index,

--- a/test/teiserver/battle/start_script_test.exs
+++ b/test/teiserver/battle/start_script_test.exs
@@ -1,0 +1,89 @@
+defmodule Teiserver.Battle.StartScriptTest do
+  use Teiserver.DataCase, async: false
+
+  alias Teiserver.Battle
+
+  test "test start script duel" do
+    user1 = Central.Helpers.GeneralTestLib.make_user(%{"data" => %{"roles" => ["Verified"]}})
+    user2 = Central.Helpers.GeneralTestLib.make_user(%{"data" => %{"roles" => ["Verified"]}})
+
+    start_script = %{
+      game_name: "Beyond All Reason test-28379-33ba377",
+      ally_teams: [
+        %{
+          teams: [
+            %{
+              players: [
+                %{
+                  name: user1.name,
+                  user_id: user1.id,
+                  password: "AAAAAAA"
+                }
+              ]
+            }
+          ],
+          startBox: %{left: 0, right: 0.25, top: 0, bottom: 1}
+        },
+        %{
+          teams: [
+            %{
+              players: [
+                %{
+                  name: user2.name,
+                  user_id: user2.id,
+                  password: "BBBBBBB"
+                }
+              ]
+            }
+          ],
+          startBox: %{left: 0.75, right: 1, top: 0, bottom: 1}
+        }
+      ],
+      map_name: "BarR 1.1",
+      engine_version: "2025.04.04",
+      spectators: [],
+      start_pos_type: :ingame
+    }
+
+    {:ok, match} = Battle.create_match_from_start_script(start_script, false)
+    assert Battle.get_match_membership(user1.id, match.id) != nil
+    assert Battle.get_match_membership(user2.id, match.id) != nil
+  end
+
+  test "test start script 1 vs bot" do
+    user1 = Central.Helpers.GeneralTestLib.make_user(%{"data" => %{"roles" => ["Verified"]}})
+
+    start_script = %{
+      game_name: "Beyond All Reason test-28379-33ba377",
+      ally_teams: [
+        %{
+          teams: [
+            %{
+              players: [
+                %{
+                  name: user1.name,
+                  user_id: user1.id,
+                  password: "AAAAAAA"
+                }
+              ]
+            }
+          ],
+          startBox: %{left: 0, right: 0.25, top: 0, bottom: 1}
+        },
+        %{
+          teams: [
+            %{bots: [%{name: "BARbarIAn", host_user_id: user1.id, ai_short_name: "BARb"}]}
+          ],
+          startBox: %{left: 0.75, right: 1, top: 0, bottom: 1}
+        }
+      ],
+      map_name: "BarR 1.1",
+      engine_version: "2025.04.04",
+      spectators: [],
+      start_pos_type: :ingame
+    }
+
+    {:ok, match} = Battle.create_match_from_start_script(start_script, false)
+    assert Battle.get_match_membership(user1.id, match.id) != nil
+  end
+end


### PR DESCRIPTION
When one team only has bots, we would get the following error:

```
(teiserver 0.1.0) lib/teiserver/battle.ex:438: anonymous fn/4 in Teiserver.Battle.create_match_from_start_script/2
(elixir 1.19.4) lib/enum.ex:2520: Enum."-reduce/3-lists^foldl/2-0-"/3
(teiserver 0.1.0) lib/teiserver/battle.ex:436: anonymous fn/2 in Teiserver.Battle.create_match_from_start_script/2
(ecto_sql 3.12.1) lib/ecto/adapters/sql.ex:1400: anonymous fn/3 in Ecto.Adapters.SQL.checkout_or_transaction/4
(db_connection 2.7.0) lib/db_connection.ex:1756: DBConnection.run_transaction/4
(teiserver 0.1.0) lib/teiserver/battle.ex:435: Teiserver.Battle.create_match_from_start_script/2
test/teiserver/battle/start_script_test.exs:86: (test)
```

So fixed that and added a few simple tests around that.