### PR TITLE
Fixx RSS feed parsing issue

### DIFF
--- a/lib/teiserver_web/templates/microblog/rss/index.xml.eex
+++ b/lib/teiserver_web/templates/microblog/rss/index.xml.eex
@@ -16,16 +16,16 @@
         contents = post.contents
       %>
       <item>
-        <title><%= post.title %></title>
-        <author><%= post.poster.name %></author>
-        <posted_to><%= if post.discord_channel, do: post.discord_channel.name, else: "none" %></posted_to>
+        <title><%= post.title |> html_escape |> safe_to_string %></title>
+        <author><%= post.poster.name |> html_escape |> safe_to_string %></author>
+        <posted_to><%= (if post.discord_channel, do: post.discord_channel.name, else: "none") |> html_escape |> safe_to_string %></posted_to>
         <link><%= ~p"/microblog/show/#{post.id}" %></link>
         <id><%= post.id %></id>
         <guid><%= "#{post.id}/#{post.updated_at |> guid_date()}" %></guid>
         <last_updated><%= post.updated_at |> format_date %></last_updated>
         <description><%= "<![CDATA[#{post.summary |> html_escape |> safe_to_string}]]>" %></description>
         <contents><%= "<![CDATA[#{contents}]]>"  %></contents>
-        <tags><%= post.tags |> Enum.map(fn t -> t.name end) |> Enum.join(", ") %></tags>
+        <tags><%= post.tags |> Enum.map(fn t -> t.name end) |> Enum.join(", ") |> html_escape |> safe_to_string %></tags>
         <pubDate><%= post.inserted_at |> format_date %></pubDate>
       </item>
     <% end %>

--- a/lib/teiserver_web/templates/microblog/rss/index_html.xml.eex
+++ b/lib/teiserver_web/templates/microblog/rss/index_html.xml.eex
@@ -16,16 +16,16 @@
         {:safe, contents} = post.contents |> MDEx.to_html! |> raw
       %>
       <item>
-        <title><%= post.title %></title>
-        <author><%= post.poster.name %></author>
-        <posted_to><%= if post.discord_channel, do: post.discord_channel.name, else: "none" %></posted_to>
+        <title><%= post.title |> html_escape |> safe_to_string %></title>
+        <author><%= post.poster.name |> html_escape |> safe_to_string %></author>
+        <posted_to><%= (if post.discord_channel, do: post.discord_channel.name, else: "none") |> html_escape |> safe_to_string %></posted_to>
         <link><%= ~p"/microblog/show/#{post.id}" %></link>
         <id><%= post.id %></id>
         <guid><%= "#{post.id}/#{post.updated_at |> guid_date()}" %></guid>
         <last_updated><%= post.updated_at |> format_date %></last_updated>
         <description><%= "<![CDATA[#{post.summary |> html_escape |> safe_to_string}]]>" %></description>
         <contents><%= "<![CDATA[#{contents}]]>" %></contents>
-        <tags><%= post.tags |> Enum.map(fn t -> t.name end) |> Enum.join(", ") %></tags>
+        <tags><%= post.tags |> Enum.map(fn t -> t.name end) |> Enum.join(", ") |> html_escape |> safe_to_string %></tags>
         <pubDate><%= post.inserted_at |> format_date %></pubDate>
       </item>
     <% end %>

--- a/test/teiserver_web/controllers/microblog/rss_controller_test.exs
+++ b/test/teiserver_web/controllers/microblog/rss_controller_test.exs
@@ -39,6 +39,31 @@ defmodule TeiserverWeb.Microblog.RssControllerTest do
     end
   end
 
+  describe "XML escaping" do
+    setup do
+      tag = tag_fixture(name: "Test&Tag")
+
+      post =
+        post_fixture(
+          title: "Q&A Session <test>",
+          contents: "Some content with & and < symbols"
+        )
+
+      _post_tag = post_tag_fixture(post_id: post.id, tag_id: tag.id)
+      %{special_post: post, tag: tag}
+    end
+
+    test "special chars escaped", %{conn: conn} do
+      conn = get(conn, ~p"/microblog/rss")
+      resp = response(conn, 200)
+      assert resp =~ "Q&amp;A Session"
+      assert resp =~ "&lt;test&gt;"
+      # Verify the tags are escaped too
+      assert resp =~ "Test&amp;Tag"
+      refute resp =~ "<title>Q&A"
+    end
+  end
+
   describe "Auth" do
     setup [:filler_posts, :auth_setup]
 


### PR DESCRIPTION
Fixes https://github.com/beyond-all-reason/teiserver/issues/950 locally

Added inline parsing and string casting, seemed to be breaking from ampersand signs found in discord mentions for @ l egion. Added a test that creates a post with the characters and checks for proper sanitization. 
On the left is local, right is current site
<img width="2456" height="1376" alt="image" src="https://github.com/user-attachments/assets/9758b902-0099-4bec-956c-ba644d7a73c7" />

**Note: Claude Code was used to help write the test**