### PR TITLE
Customizable access token TTL in OAuth module added

### DIFF
--- a/lib/teiserver/o_auth.ex
+++ b/lib/teiserver/o_auth.ex
@@ -185,8 +185,12 @@ defmodule Teiserver.OAuth do
             :scopes => Application.scopes(),
             optional(:original_scopes) => Application.scopes()
           },
-          create_refresh: boolean() | options(),
-          scopes: Application.scopes()
+          [
+            {:create_refresh, boolean()}
+            | {:scopes, Application.scopes()}
+            | {:now, DateTime.t()}
+            | {:access_token_ttl, Timex.Duration.t()}
+          ]
         ) ::
           {:ok, Token.t()} | {:error, :invalid_scope | Ecto.Changeset.t()}
   def create_token(user_id, application, opts \\ [])
@@ -206,8 +210,7 @@ defmodule Teiserver.OAuth do
   defp do_create_token(owner_attr, application, opts) do
     now = Keyword.get(opts, :now, DateTime.utc_now())
     scopes = opts[:scopes]
-    # Allow custom access token TTL in minutes, default to 30 minutes
-    access_token_ttl = Keyword.get(opts, :access_token_ttl, 30)
+    access_token_ttl = Keyword.get(opts, :access_token_ttl, Timex.Duration.from_minutes(30))
 
     if Enum.empty?(scopes) ||
          not MapSet.subset?(MapSet.new(scopes), MapSet.new(application.scopes)) do
@@ -219,7 +222,7 @@ defmodule Teiserver.OAuth do
           application_id: application.id,
           scopes: scopes,
           original_scopes: Map.get(application, :original_scopes, application.scopes),
-          expires_at: Timex.add(now, Timex.Duration.from_minutes(access_token_ttl)),
+          expires_at: Timex.add(now, access_token_ttl),
           type: :access
         }
         |> Map.merge(owner_attr)


### PR DESCRIPTION
Ref https://github.com/beyond-all-reason/teiserver/issues/818
- Added support for a configurable access token TTL in minutes, defauts to 30 minutes.
- Updated `create_user_token` function to accept token options, including the new TTL parameter.
- Enhanced user creation and token refresh endpoints to handle `access_token_ttl` from request parameters.
- Added tests using **Claude Code** to verify behavior for custom, default, and invalid TTL values.

New optional parameter to API: `access_token_ttl`(int, seconds) 
Defaults to 30 minutes or 1800 seconds. (Open for suggestions on defaults)
Currently accepts any positive integer input

From a security perspective I can understand the need for this but I would definitely prefer to see some absolute cap on TTL of 30 days or even 2 weeks. Should be simple to add but open to feedback here.

Example request:
```json
{
  "name": "loadtest_user",
  "email": "loadtest@example.com",
  "password": "password123",
  "access_token_ttl": 86400
}
```

**Claude Code used to write and debug tests**