### PR TITLE
add red ui hints on required microblog fields

### DIFF
--- a/lib/teiserver_web/live/microblog/admin/post/post_form_component.ex
+++ b/lib/teiserver_web/live/microblog/admin/post/post_form_component.ex
@@ -108,7 +108,9 @@ defmodule TeiserverWeb.Microblog.PostFormComponent do
       <.form for={@form} phx-target={@myself} phx-change="validate" phx-submit="save" id="post-form">
         <div class="row mb-4">
           <div class="col-md-12 col-lg-8 col-xl-6">
-            <label for="post_title" class="control-label">Title:</label>
+            <label for="post_title" class="control-label">
+              Title <span class="text-danger">*</span>:
+            </label>
             <.input field={@form[:title]} type="text" autofocus="autofocus" phx-debounce="100" />
             <br />
             <label for="poster_alias" class="control-label">Contributor Alias:</label>
@@ -140,7 +142,9 @@ defmodule TeiserverWeb.Microblog.PostFormComponent do
             ><%= @form[:summary].value %></textarea>
             <br />
 
-            <label for="post_contents" class="control-label">Contents:</label>
+            <label for="post_contents" class="control-label">
+              Contents <span class="text-danger">*</span>:
+            </label>
             <span class="float-end monospace">
               <span style="font-size: 1.2em; font-weight: bold;"># Heading</span>
               &nbsp;&nbsp; <em>__italic__</em>
@@ -159,7 +163,10 @@ defmodule TeiserverWeb.Microblog.PostFormComponent do
             ><%= @form[:contents].value %></textarea>
           </div>
           <div class="col">
-            <h4>Tags ({Enum.count(@selected_tags)})</h4>
+            <h4>
+              Tags ({Enum.count(@selected_tags)})
+              <span class="text-danger" style="font-size: 0.8em;">(Required)</span>
+            </h4>
             <%= for tag <- @tags do %>
               <%= if Enum.member?(@selected_tags, tag.id) do %>
                 <span


### PR DESCRIPTION
LLM Disclosure: 
- this code was generated by Google Antigravity Gemini Pro (High)
- this code was reviewed by NortySpock and tested before raising this PR

Before:

<img width="918" height="892" alt="image" src="https://github.com/user-attachments/assets/5a5b69f2-f1fb-4da4-9631-3069bdc6ea03" />


After:

<img width="1045" height="970" alt="image" src="https://github.com/user-attachments/assets/30756c4e-1cbe-4aae-b219-f319cc06e75b" />

_(because I found it confusing while testing xml issues)_