### PR TITLE
Disable a dialyzer warning

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -95,6 +95,7 @@
   {"lib/teiserver/microblog.ex", :invalid_contract},
   {"lib/teiserver/microblog/libs/post_tag_lib.ex", :invalid_contract},
   {"lib/teiserver/mix_tasks/fake_data.ex", :no_return},
+  {"lib/teiserver/mix_tasks/fake_data.ex", :unused_fun},
   {"lib/teiserver/moderation.ex", :unknown_type},
   {"lib/teiserver/moderation.ex", :invalid_contract},
   {"lib/teiserver/moderation/libs/report_group_lib.ex", :call},


### PR DESCRIPTION
For some reason we're getting a bunch of lint failure on CI but not locally about some functions being unused.

https://github.com/beyond-all-reason/teiserver/actions/runs/21570521710/job/62148850079?pr=989

So disable that shit