### PR TITLE
962 fix

### DIFF
--- a/lib/teiserver_web/live/battles/lobbies/chat.ex
+++ b/lib/teiserver_web/live/battles/lobbies/chat.ex
@@ -144,8 +144,8 @@ defmodule TeiserverWeb.Battle.LobbyLive.Chat do
         if Account.client_exists?(current_user.id) do
           Lobby.say(current_user.id, "web: #{content}", id)
         else
-          coordinator_id = Coordinator.get_coordinator_userid()
-          Lobby.say(coordinator_id, "#{current_user.name} (web): #{content}", id)
+          Coordinator.get_coordinator_userid()
+          |> Lobby.say("#{current_user.name} (web): #{content}", id)
         end
     end
 


### PR DESCRIPTION
**Needs Testing** Fix proposal for  #962  - Web live chat messages from moderators crash the lobby when the user is not connected via a game client.

When a moderator sends a message from the web chat interface (/battle/lobbies/:id/chat) without being connected through a game client, `Lobby.say/3` fails because there's no registered client for that user ID. This causes SPADS and the lobby to crash.

Solution
Check if the user has a connected game client before calling `Lobby.say/3`:
If connected: Send the message normally as the user
If not connected: Send via Coordinator with user attribution ( "username (web): message")

I was unable to test this locally with a working SPADS instance. I would like some help verifying if this will fix the issue. 
