### PR TITLE
Add skylobby to partial optimisation level

### DIFF
--- a/lib/teiserver/protocols/spring/spring_in.ex
+++ b/lib/teiserver/protocols/spring/spring_in.ex
@@ -26,6 +26,7 @@ defmodule Teiserver.Protocols.SpringIn do
 
   @optimisation_level %{
     "LuaLobby Chobby" => :partial,
+    "skylobby" => :partial,
     "SLTS Client d" => :none
   }
 


### PR DESCRIPTION
It seems that a recent login queue rework has unintentionally fixed a bug with optimisation levels.

I am still trying to identify the initial cause, the conclusion so far is that instead of defaulting to `:full` optimisation skylobby optimisation level used to be set to its name `skylobby`. This had the effect of following the default processing (same behaviour as with `:partial` optimisation) of player left and joined events and results in sending `JOINEDBATTLE ` and `LEFTBATTLE` messages for every battle/lobby as opposed to `:full` optimisation where these messages are only sent for the client's current lobby.

Once this bug was fixed and skylobby was correctly using `:full` optimisation it stopped receiving join/leave messages outside it's lobby which broke some functionality.

(This is a small change that should have no effect on the server considering the number of skylobby users)