### PR TITLE
Change Spring protocol output handler to properly match sent pattern

### DIFF
--- a/lib/teiserver/protocols/spring/spring_user_in.ex
+++ b/lib/teiserver/protocols/spring/spring_user_in.ex
@@ -317,7 +317,13 @@ defmodule Teiserver.Protocols.Spring.UserIn do
           )
 
         {:error, reason} ->
-          reply(:user, :relationship_change, {"ignore_by_id", userid_str, {:error, reason}}, msg_id, state)
+          reply(
+            :user,
+            :relationship_change,
+            {"ignore_by_id", userid_str, {:error, reason}},
+            msg_id,
+            state
+          )
       end
     else
       reply(:user, :relationship_change, {"ignore_by_id", userid_str, :error}, msg_id, state)
@@ -350,7 +356,13 @@ defmodule Teiserver.Protocols.Spring.UserIn do
           reply(:user, :relationship_change, {"block_by_id", userid_str, :success}, msg_id, state)
 
         {:error, reason} ->
-          reply(:user, :relationship_change, {"block_by_id", userid_str, {:error, reason}}, msg_id, state)
+          reply(
+            :user,
+            :relationship_change,
+            {"block_by_id", userid_str, {:error, reason}},
+            msg_id,
+            state
+          )
       end
     else
       reply(:user, :relationship_change, {"block_by_id", userid_str, :error}, msg_id, state)
@@ -383,7 +395,13 @@ defmodule Teiserver.Protocols.Spring.UserIn do
           reply(:user, :relationship_change, {"avoid_by_id", userid_str, :success}, msg_id, state)
 
         {:error, reason} ->
-          reply(:user, :relationship_change, {"avoid_by_id", userid_str, {:error, reason}}, msg_id, state)
+          reply(
+            :user,
+            :relationship_change,
+            {"avoid_by_id", userid_str, {:error, reason}},
+            msg_id,
+            state
+          )
       end
     else
       reply(:user, :relationship_change, {"avoid_by_id", userid_str, :error}, msg_id, state)


### PR DESCRIPTION
The Spring protocol handlers for `ignore_by_id`, `block_by_id`, and `avoid_by_id` are sending error reasons in the wrong format. Changed  the Spring protocol output handler to properly match the `{:error, reason}` tuple pattern that is sent.

Fixes #960  so when users reach the relationship limit,  we get error messages like ```s.user.avoid_by_id 12345	error	Maximum 300 avoids reached```