### PR TITLE
 Addressing issue #1001 lobby name limit

### DIFF
--- a/lib/teiserver/coordinator/consul_commands.ex
+++ b/lib/teiserver/coordinator/consul_commands.ex
@@ -1591,13 +1591,14 @@ defmodule Teiserver.Coordinator.ConsulCommands do
 
         state
 
-      # String.length(new_name) > 20 ->
-      #   Lobby.sayex(
-      #     state.coordinator_id,
-      #     "That name (#{new_name}) is too long",
-      #     state.lobby_id
-      #   )
-      #   state
+      String.length(new_name) > Teiserver.Lobby.LobbyLib.max_lobby_name_length() ->
+        Lobby.sayex(
+          state.coordinator_id,
+          "That name is too long",
+          state.lobby_id
+        )
+
+        state
 
       lobby.lobby_policy_id && starts_with_lobby_policy ->
         Lobby.sayex(

--- a/lib/teiserver/lobby/libs/lobby_lib.ex
+++ b/lib/teiserver/lobby/libs/lobby_lib.ex
@@ -9,6 +9,9 @@ defmodule Teiserver.Lobby.LobbyLib do
   alias Teiserver.Data.Types, as: T
   require Logger
 
+  @max_lobby_name_length 70
+  def max_lobby_name_length, do: @max_lobby_name_length
+
   @spec get_lobby(T.lobby_id()) :: T.lobby() | nil
   def get_lobby(id) do
     call_lobby(int_parse(id), :get_lobby_state)
@@ -175,6 +178,9 @@ defmodule Teiserver.Lobby.LobbyLib do
     cond do
       String.trim(data.name || "") == "" ->
         {:error, "No lobby name supplied"}
+
+      String.length(data.name) > @max_lobby_name_length ->
+        {:error, "Lobby name too long"}
 
       not Enum.member?(["normal", "replay"], data.type) ->
         {:error, "Invalid type '#{data.type}'"}

--- a/lib/teiserver/lobby/libs/lobby_lib.ex
+++ b/lib/teiserver/lobby/libs/lobby_lib.ex
@@ -9,7 +9,7 @@ defmodule Teiserver.Lobby.LobbyLib do
   alias Teiserver.Data.Types, as: T
   require Logger
 
-  @max_lobby_name_length 70
+  @max_lobby_name_length 100
   def max_lobby_name_length, do: @max_lobby_name_length
 
   @spec get_lobby(T.lobby_id()) :: T.lobby() | nil

--- a/lib/teiserver/protocols/spring/spring_battle_in.ex
+++ b/lib/teiserver/protocols/spring/spring_battle_in.ex
@@ -5,13 +5,20 @@ defmodule Teiserver.Protocols.Spring.BattleIn do
   import Teiserver.Helper.NumberHelper, only: [int_parse: 1]
   require Logger
 
+  @max_lobby_name_length Teiserver.Lobby.LobbyLib.max_lobby_name_length()
+
   @spec do_handle(String.t(), String.t(), String.t() | nil, map()) :: map()
   def do_handle("update_lobby_title", new_name, msg_id, state) do
-    if Lobby.allow?(state.userid, :update_lobby_title, state.lobby_id) do
-      Battle.rename_lobby(state.lobby_id, new_name, nil)
-      reply(:spring, :okay, "c.battle.update_lobby_title", msg_id, state)
-    else
-      state
+    cond do
+      not Lobby.allow?(state.userid, :update_lobby_title, state.lobby_id) ->
+        state
+
+      String.length(new_name) > @max_lobby_name_length ->
+        reply(:spring, :no, {"c.battle.update_lobby_title", "Lobby name too long"}, msg_id, state)
+
+      true ->
+        Battle.rename_lobby(state.lobby_id, new_name, nil)
+        reply(:spring, :okay, "c.battle.update_lobby_title", msg_id, state)
     end
   end
 

--- a/lib/teiserver/protocols/spring/spring_in.ex
+++ b/lib/teiserver/protocols/spring/spring_in.ex
@@ -820,6 +820,9 @@ defmodule Teiserver.Protocols.SpringIn do
             not CacheUser.is_bot?(state.userid) ->
               {:failure, "Not a bot"}
 
+            String.length(name) > Teiserver.Lobby.LobbyLib.max_lobby_name_length() ->
+              {:failure, "Lobby name too long"}
+
             true ->
               password = if Enum.member?(["empty", "*"], password), do: nil, else: password
 

--- a/lib/teiserver/tachyon_lobby.ex
+++ b/lib/teiserver/tachyon_lobby.ex
@@ -44,10 +44,22 @@ defmodule Teiserver.TachyonLobby do
     end
   end
 
+  @max_lobby_name_length Teiserver.Lobby.LobbyLib.max_lobby_name_length()
+
   def create(start_params) do
-    with {:ok, %{pid: pid, id: id}} <- TachyonLobby.Supervisor.start_lobby(start_params),
-         {:ok, details} <- Lobby.get_details(id) do
-      {:ok, pid, details}
+    cond do
+      not is_map_key(start_params, :name) or not is_binary(start_params.name) or
+          String.trim(start_params.name) == "" ->
+        {:error, :empty_lobby_name}
+
+      String.length(start_params.name) > @max_lobby_name_length ->
+        {:error, :lobby_name_too_long}
+
+      true ->
+        with {:ok, %{pid: pid, id: id}} <- TachyonLobby.Supervisor.start_lobby(start_params),
+             {:ok, details} <- Lobby.get_details(id) do
+          {:ok, pid, details}
+        end
     end
   end
 

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -1461,14 +1461,20 @@ defmodule Teiserver.TachyonLobby.Lobby do
     }
   end
 
+  @max_lobby_name_length Teiserver.Lobby.LobbyLib.max_lobby_name_length()
+
   @spec update_property(atom(), term(), state()) :: {:ok, [event()]} | {:error, String.t()}
   defp update_property(:name, new_name, _state) do
-    # we can expand lobby name validation later
-    if new_name == "" do
-      {:error, "name must not be empty"}
-    end
+    cond do
+      new_name == "" ->
+        {:error, "name must not be empty"}
 
-    {:ok, [{:update_lobby_name, new_name}]}
+      String.length(new_name) > @max_lobby_name_length ->
+        {:error, "Lobby name too long"}
+
+      true ->
+        {:ok, [{:update_lobby_name, new_name}]}
+    end
   end
 
   defp update_property(:map_name, new_name, _state),

--- a/test/teiserver/battle/lobby_server_test.exs
+++ b/test/teiserver/battle/lobby_server_test.exs
@@ -124,4 +124,32 @@ defmodule Teiserver.Battle.LobbyServerTest do
     LobbyLib.stop_lobby_server(lobby_id)
     assert LobbyLib.lobby_exists?(lobby_id) == false
   end
+
+  describe "validate_new_lobby name length" do
+    defp valid_lobby_data do
+      %{
+        name: "valid name",
+        type: "normal",
+        nattype: "none",
+        locked: false
+      }
+    end
+
+    test "accepts name within limit" do
+      max = Teiserver.Lobby.LobbyLib.max_lobby_name_length()
+      data = %{valid_lobby_data() | name: String.duplicate("a", max)}
+      assert true == LobbyLib.validate_new_lobby(data)
+    end
+
+    test "rejects name exceeding limit" do
+      max = Teiserver.Lobby.LobbyLib.max_lobby_name_length()
+      data = %{valid_lobby_data() | name: String.duplicate("a", max + 1)}
+      assert {:error, "Lobby name too long"} == LobbyLib.validate_new_lobby(data)
+    end
+
+    test "rejects empty name" do
+      data = %{valid_lobby_data() | name: ""}
+      assert {:error, "No lobby name supplied"} == LobbyLib.validate_new_lobby(data)
+    end
+  end
 end

--- a/test/teiserver/tachyon_lobby/lobby_test.exs
+++ b/test/teiserver/tachyon_lobby/lobby_test.exs
@@ -55,6 +55,24 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     assert details.engine_version == engine.name
   end
 
+  test "create lobby with name at max length" do
+    max = Teiserver.Lobby.LobbyLib.max_lobby_name_length()
+    params = mk_start_params([1, 1]) |> Map.put(:name, String.duplicate("a", max))
+    {:ok, _pid, details} = Lobby.create(params)
+    assert String.length(details.name) == max
+  end
+
+  test "create lobby with name exceeding max length" do
+    max = Teiserver.Lobby.LobbyLib.max_lobby_name_length()
+    params = mk_start_params([1, 1]) |> Map.put(:name, String.duplicate("a", max + 1))
+    assert {:error, :lobby_name_too_long} = Lobby.create(params)
+  end
+
+  test "create lobby with empty name" do
+    params = mk_start_params([1, 1]) |> Map.put(:name, "")
+    assert {:error, :empty_lobby_name} = Lobby.create(params)
+  end
+
   test "exit when no more players" do
     test_pid = self()
 
@@ -785,6 +803,22 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
       {:ok, details} = Teiserver.TachyonLobby.Lobby.get_details(id)
       assert details.name == "new name"
       assert_receive {:lobby, ^id, {:updated, %{name: "new name"}}}
+    end
+
+    test "name too long rejected" do
+      max = Teiserver.Lobby.LobbyLib.max_lobby_name_length()
+      {:ok, _pid, %{id: id}} = Lobby.create(mk_start_params([2, 2]))
+      long_name = String.duplicate("x", max + 1)
+      {:error, _} = Lobby.update_properties(id, @default_user_id, %{name: long_name})
+    end
+
+    test "name at max length accepted" do
+      max = Teiserver.Lobby.LobbyLib.max_lobby_name_length()
+      {:ok, _pid, %{id: id}} = Lobby.create(mk_start_params([2, 2]))
+      valid_name = String.duplicate("x", max)
+      :ok = Lobby.update_properties(id, @default_user_id, %{name: valid_name})
+      {:ok, details} = Teiserver.TachyonLobby.Lobby.get_details(id)
+      assert details.name == valid_name
     end
 
     test "map name" do


### PR DESCRIPTION
Let me know what you guys think for issue #1001. My attempt at fixing this for both spring and tach. Had a heck of a time with ai trying to teach me elixir for this lol:

made @max_lobby_name_length 100
That's enough to do:
NOOBS v BARBS +50 T4 Eco lemon zest lobby cuh| Unranked | 4v4 | Coop | Min chev: 4 | Max rating: 25
Made changes to the coordinator & protocol changes to utilize lobby length function
Added error checking & testing for it too