### PR TITLE
Store login limit in the GenServer process

### DIFF
--- a/lib/teiserver/account.ex
+++ b/lib/teiserver/account.ex
@@ -2342,5 +2342,6 @@ defmodule Teiserver.Account do
       not Teiserver.Config.get_site_config_cache("teiserver.Require Chobby registration")
   end
 
+  defdelegate set_login_limit(limit), to: LoginThrottleServer
   defdelegate reset_login_rate_limiter(rate), to: LoginThrottleServer, as: :reset_rate_limiter
 end

--- a/lib/teiserver/account/servers/login_throttle_server.ex
+++ b/lib/teiserver/account/servers/login_throttle_server.ex
@@ -13,6 +13,7 @@ defmodule Teiserver.Account.LoginThrottleServer do
   @typep member :: %{pid: pid(), mon_ref: reference(), user_id: T.userid()}
   @typep state :: %{
            tick_timer_ref: :timer.tref() | nil,
+           total_limit: non_neg_integer(),
            queue: :queue.queue(member()),
            monitors: MapSet.t(pid()),
            rate_limiter: BurstyRateLimiter.t()
@@ -34,6 +35,7 @@ defmodule Teiserver.Account.LoginThrottleServer do
 
     state = %{
       tick_timer_ref: timer_ref,
+      total_limit: Config.get_site_config_cache("system.User limit"),
       queue: :queue.new(),
       monitors: MapSet.new(),
       rate_limiter: rate_limiter
@@ -55,6 +57,10 @@ defmodule Teiserver.Account.LoginThrottleServer do
   @spec attempt_login(pid(), T.userid()) :: boolean()
   def attempt_login(pid, userid) do
     GenServer.call(__MODULE__, {:attempt_login, pid, userid})
+  end
+
+  def set_login_limit(limit) do
+    GenServer.call(__MODULE__, {:set_login_limit, limit})
   end
 
   @doc """
@@ -107,7 +113,7 @@ defmodule Teiserver.Account.LoginThrottleServer do
 
   def handle_call({:attempt_login, pid, userid}, _from, state) do
     category = categorise_user(userid)
-    capacity = get_capacity()
+    capacity = get_capacity(state.total_limit)
 
     can_login? = category == :instant or (capacity > 0 && :queue.is_empty(state.queue))
 
@@ -128,9 +134,13 @@ defmodule Teiserver.Account.LoginThrottleServer do
     {:reply, :ok, %{state | rate_limiter: rl}}
   end
 
+  def handle_call({:set_login_limit, limit}, _from, state) do
+    {:reply, :ok, %{state | total_limit: limit}}
+  end
+
   @impl true
   def handle_info(:tick, state) do
-    capacity = get_capacity()
+    capacity = get_capacity(state.total_limit)
 
     if capacity <= 0 do
       {:noreply, state}
@@ -221,8 +231,7 @@ defmodule Teiserver.Account.LoginThrottleServer do
     end
   end
 
-  defp get_capacity() do
-    total_limit = Config.get_site_config_cache("system.User limit")
+  defp get_capacity(total_limit) do
     count = Account.count_non_bot_clients()
     total_limit - count
   end

--- a/lib/teiserver/libs/teiserver_configs.ex
+++ b/lib/teiserver/libs/teiserver_configs.ex
@@ -296,7 +296,8 @@ defmodule Teiserver.TeiserverConfigs do
       permissions: ["Admin"],
       description: "The cap for number of concurrent users",
       default: 1000,
-      value_label: ""
+      value_label: "",
+      update_callback: fn rate -> Teiserver.Account.set_login_limit(rate) end
     })
 
     add_site_config_type(%{

--- a/test/teiserver/account/login_throttle_server_test.exs
+++ b/test/teiserver/account/login_throttle_server_test.exs
@@ -2,7 +2,6 @@ defmodule Teiserver.Account.LoginThrottleServerTest do
   @moduledoc false
 
   use Teiserver.DataCase, async: false
-  alias Teiserver.Config
   alias Teiserver.Account
   alias Teiserver.Account.LoginThrottleServer
 
@@ -133,7 +132,7 @@ defmodule Teiserver.Account.LoginThrottleServerTest do
     # this is a hack because there seems to be some flakyness with `count_client`
     # from other tests
     current_count = Teiserver.Account.count_non_bot_clients()
-    Config.update_site_config("system.User limit", current_count + n)
+    LoginThrottleServer.set_login_limit(current_count + n)
   end
 
   defp oneshot_pid() do


### PR DESCRIPTION
This means we don't need to check the cached limit every tick. The impact is negligible, it's more about having a self-contained state.

Having to check the cache for every tick also creates some noise in tests when the sandbox is tearing down and a tick happens right there (it happens more often than not).