### PR TITLE
Prevent changing map when another vote is in progress

### DIFF
--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -1764,6 +1764,13 @@ defmodule Teiserver.TachyonLobby.Lobby do
       not is_map_key(state.players, user_id) ->
         {:error, "Only players can change the map"}
 
+      state.current_vote ->
+        case state.current_vote.action do
+          # make changing map idempotent, it's just a nicer API this way
+          {:change_map, ^new_name} -> {:ok, []}
+          _ -> {:error, :vote_in_progress}
+        end
+
       Enum.count(state.players, fn {_, p} -> not bot_id?(p.id) end) > 1 ->
         vote_duration_s = 60
 

--- a/test/teiserver/tachyon_lobby/lobby_test.exs
+++ b/test/teiserver/tachyon_lobby/lobby_test.exs
@@ -939,6 +939,17 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
       assert vote_update.id == vote.id
     end
 
+    test "changing a second time does nothing" do
+      %{id: id} = setup_full_lobby([1, 1])
+      :ok = Lobby.join_queue(id, "2")
+      :ok = Lobby.update_properties(id, @default_user_id, %{map_name: "new map"})
+
+      assert_receive {:lobby, ^id, {:updated, %{current_vote: vote}}}
+      assert vote != nil
+
+      :ok = Lobby.update_properties(id, @default_user_id, %{map_name: "new map"})
+    end
+
     test "vote timeout triggers event" do
       %{id: id} = setup_full_lobby([1, 1])
       :ok = Lobby.join_queue(id, "2")
@@ -1051,6 +1062,17 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
       assert_receive {:lobby, ^id, {:vote_ended, vote_id, result}}
       assert vote_id == vote.id
       assert result == :failed
+    end
+
+    test "cannot change map when vote already pending" do
+      %{id: id} = setup_full_lobby([1, 1])
+      :ok = Lobby.join_queue(id, "2")
+      :ok = Lobby.update_properties(id, @default_user_id, %{map_name: "new map"})
+      assert_receive {:lobby, ^id, {:updated, %{players: %{}}}}
+      assert_receive {:lobby, ^id, {:updated, %{current_vote: vote}}}
+      assert vote != nil
+
+      {:error, _} = Lobby.update_properties(id, @default_user_id, %{map_name: "different map"})
     end
   end
 


### PR DESCRIPTION
The error message is currently a string and we can't translate that. For now it'll do but we likely want to fix that for the release.