### PR TITLE
Removed all Credo disable comments

### DIFF
--- a/lib/teiserver/account.ex
+++ b/lib/teiserver/account.ex
@@ -1953,54 +1953,55 @@ defmodule Teiserver.Account do
 
         existing_request ->
           # Auto-accept the existing request
-          # credo:disable-for-next-line Credo.Check.Readability.WithSingleClause
-          with :ok <- FriendRequestLib.accept_friend_request(existing_request) do
-            # Send pubsub broadcasts for both users to update UI
-            PubSub.broadcast(
-              Teiserver.PubSub,
-              "account_user_relationships:#{existing_request.from_user_id}",
-              %{
-                channel: "account_user_relationships:#{existing_request.from_user_id}",
-                event: :friend_request_accepted,
-                userid: existing_request.from_user_id,
-                accepter_id: existing_request.to_user_id
-              }
-            )
 
-            PubSub.broadcast(
-              Teiserver.PubSub,
-              "account_user_relationships:#{existing_request.to_user_id}",
-              %{
-                channel: "account_user_relationships:#{existing_request.to_user_id}",
-                event: :friend_request_accepted,
-                userid: existing_request.to_user_id,
-                accepter_id: existing_request.from_user_id
-              }
-            )
+          case FriendRequestLib.accept_friend_request(existing_request) do
+            :ok ->
+              # Send pubsub broadcasts for both users to update UI
+              PubSub.broadcast(
+                Teiserver.PubSub,
+                "account_user_relationships:#{existing_request.from_user_id}",
+                %{
+                  channel: "account_user_relationships:#{existing_request.from_user_id}",
+                  event: :friend_request_accepted,
+                  userid: existing_request.from_user_id,
+                  accepter_id: existing_request.to_user_id
+                }
+              )
 
-            # Clear caches for both users
-            Teiserver.cache_delete(
-              :account_incoming_friend_request_cache,
-              existing_request.from_user_id
-            )
+              PubSub.broadcast(
+                Teiserver.PubSub,
+                "account_user_relationships:#{existing_request.to_user_id}",
+                %{
+                  channel: "account_user_relationships:#{existing_request.to_user_id}",
+                  event: :friend_request_accepted,
+                  userid: existing_request.to_user_id,
+                  accepter_id: existing_request.from_user_id
+                }
+              )
 
-            Teiserver.cache_delete(
-              :account_outgoing_friend_request_cache,
-              existing_request.from_user_id
-            )
+              # Clear caches for both users
+              Teiserver.cache_delete(
+                :account_incoming_friend_request_cache,
+                existing_request.from_user_id
+              )
 
-            Teiserver.cache_delete(
-              :account_incoming_friend_request_cache,
-              existing_request.to_user_id
-            )
+              Teiserver.cache_delete(
+                :account_outgoing_friend_request_cache,
+                existing_request.from_user_id
+              )
 
-            Teiserver.cache_delete(
-              :account_outgoing_friend_request_cache,
-              existing_request.to_user_id
-            )
+              Teiserver.cache_delete(
+                :account_incoming_friend_request_cache,
+                existing_request.to_user_id
+              )
 
-            {:ok, :auto_accepted}
-          else
+              Teiserver.cache_delete(
+                :account_outgoing_friend_request_cache,
+                existing_request.to_user_id
+              )
+
+              {:ok, :auto_accepted}
+
             {:error, reason} ->
               {:error, reason}
           end
@@ -2221,7 +2222,6 @@ defmodule Teiserver.Account do
   @spec update_client(T.userid(), map()) :: nil | :ok
   defdelegate update_client(userid, partial_client), to: ClientLib
 
-  # credo:disable-for-next-line Credo.Check.Design.TagTODO
   # TODO: Remove these in favour of update_client
   @spec merge_update_client(map()) :: nil | :ok
   defdelegate merge_update_client(client), to: ClientLib

--- a/lib/teiserver/autohost/session.ex
+++ b/lib/teiserver/autohost/session.ex
@@ -56,7 +56,7 @@ defmodule Teiserver.Autohost.Session do
   def callback_mode, do: :handle_event_function
 
   @type start_response :: %{ips: [String.t()], port: integer()}
-  # credo:disable-for-next-line Credo.Check.Design.TagTODO
+
   # TODO: there should be some kind of retry here
   @spec start_battle(Bot.id(), TachyonBattle.id(), pid(), Autohost.start_script()) ::
           {:ok, start_response()} | {:error, term()}
@@ -329,7 +329,6 @@ defmodule Teiserver.Autohost.Session do
     {:keep_state, data}
   end
 
-  # credo:disable-for-next-line Credo.Check.Design.TagTODO
   # TODO: will need to "resurrect" a battle if we ever get into this situation.
   # Because the autohost is the ultimate source of truth when it comes to running
   # battle, so if it tells teiserver that something is running, we need to

--- a/lib/teiserver/battle.ex
+++ b/lib/teiserver/battle.ex
@@ -472,7 +472,6 @@ defmodule Teiserver.Battle do
     already_finished? = match.finished != nil
     winning_ally_team = List.first(winning_ally_teams)
 
-    # credo:disable-for-next-line Credo.Check.Design.TagTODO
     # TODO Currently trusting the first received event,
     # should be reworked to accept what the majority agrees on
     if winning_ally_team != nil && match.winning_team != nil &&
@@ -625,7 +624,6 @@ defmodule Teiserver.Battle do
             # because the bot itself is in a new lobby since the last one finished
             script_tags = data["battleContext"]["scriptTags"]
 
-            # credo:disable-for-next-line Credo.Check.Design.TagTODO
             # TODO the server/match/id is legacy and should be removed
             # After updating Teiserver, there may be some ongoing matches with the legacy tags
             id = script_tags["game/server_match_id"] || script_tags["server/match/id"]

--- a/lib/teiserver/battle/balance/respect_avoids.ex
+++ b/lib/teiserver/battle/balance/respect_avoids.ex
@@ -284,8 +284,7 @@ defmodule Teiserver.Battle.Balance.RespectAvoids do
 
     logs = [
       "Perform brute force with the following players to get the best score.",
-      # credo:disable-for-next-line Credo.Check.Refactor.MapJoin
-      "Players: #{Enum.join(Enum.map(state.top_experienced, fn x -> x.name end), ", ")}",
+      "Players: #{Enum.map_join(state.top_experienced, ", ", fn x -> x.name end)}",
       @splitter,
       "Brute force result:",
       "Team rating diff penalty: #{format(combo_result.rating_diff_penalty)}",
@@ -295,8 +294,7 @@ defmodule Teiserver.Battle.Balance.RespectAvoids do
       "Score: #{format(combo_result.score)} (lower is better)",
       @splitter,
       "Draft remaining players (ordered from best to worst).",
-      # credo:disable-for-next-line Credo.Check.Refactor.MapJoin
-      "Remaining: #{Enum.join(Enum.map(remaining, fn x -> x.name end), ", ")}"
+      "Remaining: #{Enum.map_join(remaining, ", ", fn x -> x.name end)}"
     ]
 
     default_acc = combo_result

--- a/lib/teiserver/battle/balance/split_noobs.ex
+++ b/lib/teiserver/battle/balance/split_noobs.ex
@@ -240,8 +240,7 @@ defmodule Teiserver.Battle.Balance.SplitNoobs do
 
     logs = [
       "Perform brute force with the following players to get the best score.",
-      # credo:disable-for-next-line Credo.Check.Refactor.MapJoin
-      "Players: #{Enum.join(Enum.map(state.top_experienced, fn x -> log_player(x) end), ", ")}",
+      "Players: #{Enum.map_join(state.top_experienced, ", ", fn x -> log_player(x) end)}",
       @splitter,
       "Brute force result:",
       "Team rating diff penalty: #{format(combo_result.rating_diff_penalty)}",
@@ -251,8 +250,7 @@ defmodule Teiserver.Battle.Balance.SplitNoobs do
       "Score: #{format(combo_result.score)} (lower is better)",
       @splitter,
       "Draft remaining players (ordered from best to worst).",
-      # credo:disable-for-next-line Credo.Check.Refactor.MapJoin
-      "Remaining: #{Enum.join(Enum.map(remaining, fn x -> log_player(x) end), ", ")}"
+      "Remaining: #{Enum.map_join(remaining, ", ", fn x -> log_player(x) end)}"
     ]
 
     default_acc = combo_result

--- a/lib/teiserver/battle/libs/match_lib.ex
+++ b/lib/teiserver/battle/libs/match_lib.ex
@@ -177,7 +177,7 @@ defmodule Teiserver.Battle.MatchLib do
       type_icon: icon(),
       item_id: match.id,
       item_type: "teiserver_battle_match",
-      # credo:disable-for-next-line Credo.Check.Design.TagTODO
+
       # TODO: Make this colour/icon based on type of match
       item_colour: StylingHelper.colours(colours()) |> elem(0),
       item_icon: icon(),

--- a/lib/teiserver/battle/tasks/breakdown_match_data_task.ex
+++ b/lib/teiserver/battle/tasks/breakdown_match_data_task.ex
@@ -97,7 +97,6 @@ defmodule Teiserver.Battle.Tasks.BreakdownMatchDataTask do
       |> Enum.frequencies()
       |> Map.new()
 
-    # credo:disable-for-next-line Credo.Check.Design.TagTODO
     # TODO: change this to be based on data["player_count"]
     # we were not tracking player count as a separate number so can't be done yet
     weighted_count =

--- a/lib/teiserver/config_helpers.ex
+++ b/lib/teiserver/config_helpers.ex
@@ -18,10 +18,8 @@ defmodule Teiserver.ConfigHelpers do
   end
 
   def get_env(var, default, type) do
-    # credo:disable-for-next-line Credo.Check.Readability.WithSingleClause
-    with {:ok, val} <- System.fetch_env(var) do
-      get_with_type(val, type)
-    else
+    case System.fetch_env(var) do
+      {:ok, val} -> get_with_type(val, type)
       :error -> default
     end
   end

--- a/lib/teiserver/coordinator/consul_server.ex
+++ b/lib/teiserver/coordinator/consul_server.ex
@@ -853,7 +853,6 @@ defmodule Teiserver.Coordinator.ConsulServer do
         end
 
       :clan ->
-        # credo:disable-for-next-line Credo.Check.Design.TagTODO
         # TODO: Implement
         :player
     end

--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -258,7 +258,6 @@ defmodule Teiserver.CacheUser do
         {:error, "Too many repeated symbols in name"}
 
       true ->
-        # credo:disable-for-next-line Credo.Check.Design.TagTODO
         # TODO: create a unique index on lower(name) so that this check is fast
         # (and also redundant)
         users = Account.query_users(search: [name_lower: name], select: [:name])
@@ -917,14 +916,12 @@ defmodule Teiserver.CacheUser do
         {:error, "Account is not verified"}
 
       true ->
-        # credo:disable-for-next-line Credo.Check.Design.TagTODO
         # TODO: copy/paste the capacity restriction and queuing from try_md5_login later
         :telemetry.execute([:tachyon, :login, :ok], %{count: 1})
         do_login(user, ip, lobby_client, lobby_hash)
     end
   end
 
-  # credo:disable-for-next-line Credo.Check.Design.TagTODO
   # TODO: once we got rid of spring, do_login should not accept the IP as a string
   # but as a :inet.ip_address which is what we get from the conn object
   # And then we need to stringify it as usual when storing in DB
@@ -1204,7 +1201,6 @@ defmodule Teiserver.CacheUser do
       not String.contains?(email, ".") ->
         {:error, "invalid email"}
 
-      # credo:disable-for-next-line Credo.Check.Design.TagTODO
       # TODO: create a unique index on lower(email) so that this check is fast
       # (and also redundant)
       Account.query_users(search: [email_lower: email], select: [:email]) != [] ->

--- a/lib/teiserver/data/types.ex
+++ b/lib/teiserver/data/types.ex
@@ -19,7 +19,7 @@ defmodule Teiserver.Data.Types do
 
   @type lobby() :: map()
   @type client() :: map()
-  # credo:disable-for-next-line Credo.Check.Design.TagTODO
+
   # TODO: We should drop the next line and replace all calls with `Teiserver.Account.User.t()`.
   @type user() :: map()
 

--- a/lib/teiserver/game/libs/match_rating_lib.ex
+++ b/lib/teiserver/game/libs/match_rating_lib.ex
@@ -27,7 +27,6 @@ defmodule Teiserver.Game.MatchRatingLib do
     "Partied Team"
   ]
 
-  # credo:disable-for-next-line Credo.Check.Design.TagTODO
   # TODO Remove "Team" from here once the split is done
 
   @spec rating_type_list() :: [String.t()]

--- a/lib/teiserver/lobby.ex
+++ b/lib/teiserver/lobby.ex
@@ -195,7 +195,6 @@ defmodule Teiserver.Lobby do
       }
     )
 
-    # credo:disable-for-next-line Credo.Check.Design.TagTODO
     # TODO: Depreciate this
     if client != nil and client.protocol == :spring do
       send(client.tcp_pid, {:force_join_battle, lobby_id, script_password})
@@ -534,7 +533,6 @@ defmodule Teiserver.Lobby do
               {:failure, "Battle closed"}
 
             host_client ->
-              # credo:disable-for-next-line Credo.Check.Design.TagTODO
               # TODO: Depreciate
               send(host_client.tcp_pid, {:request_user_join_lobby, userid})
 
@@ -625,7 +623,6 @@ defmodule Teiserver.Lobby do
     client = Client.get_client_by_id(userid)
 
     if client != nil and client.protocol == :spring do
-      # credo:disable-for-next-line Credo.Check.Design.TagTODO
       # TODO: SpringLegacy depreciation
       send(client.tcp_pid, {:join_battle_request_response, lobby_id, :accept, nil})
     end
@@ -665,7 +662,6 @@ defmodule Teiserver.Lobby do
     client = Client.get_client_by_id(userid)
 
     if client do
-      # credo:disable-for-next-line Credo.Check.Design.TagTODO
       # TODO: Depreciate
       send(client.tcp_pid, {:join_battle_request_response, lobby_id, :deny, reason})
     end

--- a/lib/teiserver/logging/tasks/persist_server_day_task.ex
+++ b/lib/teiserver/logging/tasks/persist_server_day_task.ex
@@ -402,7 +402,6 @@ defmodule Teiserver.Logging.Tasks.PersistServerDayTask do
       )
       |> Enum.count()
 
-    # credo:disable-for-next-line Credo.Check.Design.TagTODO
     # TODO: Calculate number of battles that took place
     battles = 0
 

--- a/lib/teiserver/matchmaking/algo/bruteforce_filter.ex
+++ b/lib/teiserver/matchmaking/algo/bruteforce_filter.ex
@@ -52,7 +52,6 @@ defmodule Teiserver.Matchmaking.Algo.BruteforceFilter do
   # we could also stretch it if the member's skill is at one extreme of
   # the distribution
   defp acceptable_win_proba(%Member{} = _member) do
-    # credo:disable-for-next-line Credo.Check.Design.TagTODO
     # TODO: actually do something based on the member
     {0.3, 0.7}
   end

--- a/lib/teiserver/matchmaking/member.ex
+++ b/lib/teiserver/matchmaking/member.ex
@@ -47,7 +47,7 @@ defmodule Teiserver.Matchmaking.Member do
       id: UUID.uuid4(),
       player_ids: player_ids,
       rating: get_member_rating(player_ids, game_type),
-      # credo:disable-for-next-line Credo.Check.Design.TagTODO
+
       # TODO tachyon_mvp: fetch the list of player id avoided by this player
       avoid: [],
       joined_at: DateTime.utc_now()

--- a/lib/teiserver/matchmaking/pairing_room.ex
+++ b/lib/teiserver/matchmaking/pairing_room.ex
@@ -56,7 +56,6 @@ defmodule Teiserver.Matchmaking.PairingRoom do
   """
   def timeout(room_pid), do: send(room_pid, :timeout)
 
-  # credo:disable-for-next-line Credo.Check.Design.TagTODO
   # TODO tachyon_mvp: transform this state into a simple state machine when
   # adding the step to setup the match (finding host and sending start script
   # to every player)
@@ -283,7 +282,6 @@ defmodule Teiserver.Matchmaking.PairingRoom do
     end
   end
 
-  # credo:disable-for-next-line Credo.Check.Design.TagTODO
   # TODO implement some smarter engine/game selection logic here in the future, get first for now
   @spec select_engine([%{version: String.t()}]) :: %{version: String.t()}
   def select_engine(engines) do

--- a/lib/teiserver/matchmaking/queue_server.ex
+++ b/lib/teiserver/matchmaking/queue_server.ex
@@ -130,7 +130,6 @@ defmodule Teiserver.Matchmaking.QueueServer do
         :bruteforce_filter -> Algo.BruteforceFilter
       end
 
-    # credo:disable-for-next-line Credo.Check.Refactor.Apply
     alg_state = apply(alg_module, :init, [attrs.team_size, attrs.team_count])
 
     %{
@@ -649,7 +648,7 @@ defmodule Teiserver.Matchmaking.QueueServer do
   @spec match_members(state()) :: :no_match | {:match, [[[Member.t()]]]}
   def match_members(state) do
     {alg_module, alg_state} = state.queue.algo
-    # credo:disable-for-next-line Credo.Check.Refactor.Apply
+
     apply(alg_module, :get_matches, [state.members, alg_state])
   end
 

--- a/lib/teiserver/mix_tasks/seasonal_uncertainty_reset_task.ex
+++ b/lib/teiserver/mix_tasks/seasonal_uncertainty_reset_task.ex
@@ -91,14 +91,14 @@ defmodule Mix.Tasks.Teiserver.SeasonalUncertaintyResetTask do
       end)
       |> Repo.transaction()
 
-    # credo:disable-for-next-line Credo.Check.Readability.WithSingleClause
-    with {:ok, result} <- sql_transaction_result do
-      time_taken = System.system_time(:millisecond) - start_time
+    case sql_transaction_result do
+      {:ok, result} ->
+        time_taken = System.system_time(:millisecond) - start_time
 
-      Logger.info(
-        "SeasonalUncertaintyResetTask complete, took #{time_taken}ms. Updated #{result.update_ratings.num_rows} ratings."
-      )
-    else
+        Logger.info(
+          "SeasonalUncertaintyResetTask complete, took #{time_taken}ms. Updated #{result.update_ratings.num_rows} ratings."
+        )
+
       _error ->
         Logger.error("SeasonalUncertaintyResetTask failed.")
     end

--- a/lib/teiserver/moderation/queries/report_group_queries.ex
+++ b/lib/teiserver/moderation/queries/report_group_queries.ex
@@ -137,7 +137,6 @@ defmodule Teiserver.Moderation.ReportGroupQueries do
       left_join: reports in assoc(report_groups, :reports),
       preload: [reports: reports]
 
-    # credo:disable-for-next-line Credo.Check.Design.TagTODO
     # TODO add reporters here
   end
 

--- a/lib/teiserver/o_auth/queries/application_query.ex
+++ b/lib/teiserver/o_auth/queries/application_query.ex
@@ -25,12 +25,9 @@ defmodule Teiserver.OAuth.ApplicationQueries do
   def get_application_by_id(nil), do: nil
 
   def get_application_by_id(id) do
-    # credo:disable-for-next-line Credo.Check.Readability.PreferImplicitTry
-    try do
-      base_query() |> preload(:owner) |> where_id(id) |> Repo.one()
-    rescue
-      Ecto.Query.CastError -> nil
-    end
+    base_query() |> preload(:owner) |> where_id(id) |> Repo.one()
+  rescue
+    Ecto.Query.CastError -> nil
   end
 
   @doc """

--- a/lib/teiserver/player/session.ex
+++ b/lib/teiserver/player/session.ex
@@ -87,7 +87,6 @@ defmodule Teiserver.Player.Session do
           lobby_list_subscription: nil | %{counter: non_neg_integer()}
         }
 
-  # credo:disable-for-next-line Credo.Check.Design.TagTODO
   # TODO: would be better to have that as a db setting, perhaps passed as an
   # argument to init()
   @messaging_buffer_size 200
@@ -1387,7 +1386,6 @@ defmodule Teiserver.Player.Session do
           MC.demonitor_by_val(state.monitors, :mm_room, [:flush])
           |> MC.monitor(battle_pid, {:battle, battle_id})
 
-        # credo:disable-for-next-line Credo.Check.Design.TagTODO
         # TODO: this should ideally come from an engine event, but in first approximation it'll do
         broadcast_user_update!(state.user, :playing)
 
@@ -1431,7 +1429,6 @@ defmodule Teiserver.Player.Session do
         state = send_to_player(state, {:battle_start, data})
         monitors = MC.monitor(state.monitors, battle_pid, {:battle, battle_id})
 
-        # credo:disable-for-next-line Credo.Check.Design.TagTODO
         # TODO: this should ideally come from an engine event, but in first approximation it'll do
         broadcast_user_update!(state.user, :playing)
 
@@ -1829,7 +1826,6 @@ defmodule Teiserver.Player.Session do
   end
 
   defp leave_all_queues(queues_to_leave, state) do
-    # credo:disable-for-next-line Credo.Check.Design.TagTODO
     # TODO tachyon_mvp: leaving queue ignore failure there.
     # It is a bit unclear what kind of failure can happen, and also
     # what should be done in that case
@@ -1846,7 +1842,6 @@ defmodule Teiserver.Player.Session do
   end
 
   defp send_to_player(state, message) do
-    # credo:disable-for-next-line Credo.Check.Design.TagTODO
     # TODO tachyon_mvp: what should server do if the connection is down at that time?
     # The best is likely to store it and send the notification upon reconnection
     if state.conn_pid != nil do
@@ -1884,7 +1879,6 @@ defmodule Teiserver.Player.Session do
       nil ->
         broadcast_user_update!(user, :offline)
 
-      # credo:disable-for-next-line Credo.Check.Design.TagTODO
       # TODO: needs to store a monitor in the state to handle the case where the
       # session dies before it can process this message.
       pid ->

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -245,7 +245,6 @@ defmodule Teiserver.Player.TachyonHandler do
   end
 
   def handle_info(:force_disconnect, state) do
-    # credo:disable-for-next-line Credo.Check.Design.TagTODO
     # TODO: send a proper tachyon message to inform the client it is getting disconnected
     {:stop, :normal, state}
   end
@@ -354,29 +353,29 @@ defmodule Teiserver.Player.TachyonHandler do
   end
 
   def handle_command("messaging/send", "request", _message_id, msg, state) do
-    # credo:disable-for-next-line Credo.Check.Readability.WithSingleClause
-    with {:ok, target} <- message_target_from_tachyon(msg["data"]["target"]) do
-      case target do
-        {:player, _user_id} ->
-          msg =
-            Messaging.new(
-              msg["data"]["message"],
-              {:player, state.user.id},
-              :erlang.monotonic_time(:micro_seconds)
-            )
+    case message_target_from_tachyon(msg["data"]["target"]) do
+      {:ok, target} ->
+        case target do
+          {:player, _user_id} ->
+            msg =
+              Messaging.new(
+                msg["data"]["message"],
+                {:player, state.user.id},
+                :erlang.monotonic_time(:micro_seconds)
+              )
 
-          case Messaging.send(msg, target) do
-            :ok -> {:response, state}
-            {:error, :invalid_recipient} -> {:error_response, :invalid_target, state}
-          end
+            case Messaging.send(msg, target) do
+              :ok -> {:response, state}
+              {:error, :invalid_recipient} -> {:error_response, :invalid_target, state}
+            end
 
-        :party ->
-          case Session.send_party_message(state.user.id, msg["data"]["message"]) do
-            :ok -> {:response, state}
-            {:error, reason} -> {:error_response, :invalid_request, inspect(reason), state}
-          end
-      end
-    else
+          :party ->
+            case Session.send_party_message(state.user.id, msg["data"]["message"]) do
+              :ok -> {:response, state}
+              {:error, reason} -> {:error_response, :invalid_request, inspect(reason), state}
+            end
+        end
+
       {:error, :invalid_recipient} ->
         {:error_response, :invalid_target, state}
     end
@@ -659,7 +658,6 @@ defmodule Teiserver.Player.TachyonHandler do
   end
 
   def handle_command("lobby/create", "request", _msg_id, msg, state) do
-    # credo:disable-for-next-line Credo.Check.Design.TagTODO
     # TODO: the `lobby/update` has very similar logic. There should be a way
     # to combine the parsing
     create_data = %{

--- a/lib/teiserver/protocols/spring/spring.ex
+++ b/lib/teiserver/protocols/spring/spring.ex
@@ -229,14 +229,11 @@ defmodule Teiserver.Protocols.Spring do
   end
 
   def unzip(data) do
-    # credo:disable-for-next-line Credo.Check.Readability.PreferImplicitTry
-    try do
-      result = :zlib.uncompress(data)
-      {:ok, result}
-    rescue
-      _error ->
-        {:error, :unzip_decompress}
-    end
+    result = :zlib.uncompress(data)
+    {:ok, result}
+  rescue
+    _error ->
+      {:error, :unzip_decompress}
   end
 
   @spec decode_value(String.t()) :: {:ok, any} | {:error, String.t()}

--- a/lib/teiserver/protocols/spring/spring_party_in.ex
+++ b/lib/teiserver/protocols/spring/spring_party_in.ex
@@ -90,13 +90,13 @@ defmodule Teiserver.Protocols.Spring.PartyIn do
   def do_handle("decline_invite_to_party", data, msg_id, state) do
     cmd_id = "c.party.decline_invite_to_party"
 
-    # credo:disable-for-next-line Credo.Check.Readability.WithSingleClause
-    with [party_id] <- String.split(data) |> Enum.map(&String.trim/1) do
-      # no need to unsubscribe here because it'll be done when handling the
-      # :invite_cancelled event
-      Account.cancel_party_invite(party_id, state.user.id)
-      SpringOut.reply(:okay, cmd_id, msg_id, state)
-    else
+    case String.split(data) |> Enum.map(&String.trim/1) do
+      [party_id] ->
+        # no need to unsubscribe here because it'll be done when handling the
+        # :invite_cancelled event
+        Account.cancel_party_invite(party_id, state.user.id)
+        SpringOut.reply(:okay, cmd_id, msg_id, state)
+
       _other ->
         SpringOut.reply(
           :no,

--- a/lib/teiserver/protocols/spring/spring_telemetry_in.ex
+++ b/lib/teiserver/protocols/spring/spring_telemetry_in.ex
@@ -12,7 +12,6 @@ defmodule Teiserver.Protocols.Spring.TelemetryIn do
   import SpringIn, only: [_no_match: 4]
   # import Teiserver.Helper.NumberHelper, only: [int_parse: 1]
 
-  # credo:disable-for-next-line Credo.Check.Design.TagTODO
   # TODO: Less nested hackyness
   @spec do_handle(String.t(), String.t(), String.t() | nil, map()) :: map()
   def do_handle("upload_infolog", data, msg_id, state) do
@@ -181,7 +180,6 @@ defmodule Teiserver.Protocols.Spring.TelemetryIn do
           case Spring.decode_value(value64) do
             {:ok, _value} ->
               if state.userid do
-                # credo:disable-for-next-line Credo.Check.Design.TagTODO
                 # TODO: Do stuff with live client events
                 # Telemetry.log_live_client_event(state.userid, event_name, value)
                 # for now, they're prefixed with underscores to silence warnings

--- a/lib/teiserver/tachyon/transport.ex
+++ b/lib/teiserver/tachyon/transport.ex
@@ -124,7 +124,6 @@ defmodule Teiserver.Tachyon.Transport do
   end
 
   def handle_info(:force_disconnect, state) do
-    # credo:disable-for-next-line Credo.Check.Design.TagTODO
     # TODO: send a proper tachyon message to inform the client it is getting disconnected
     {:stop, :normal, state}
   end

--- a/lib/teiserver/tachyon_battle.ex
+++ b/lib/teiserver/tachyon_battle.ex
@@ -40,7 +40,7 @@ defmodule Teiserver.TachyonBattle do
           {:ok, T.id(), pid()} | {:error, term()}
   def start_battle_process(autohost_id, match_id, start_script) do
     battle_id = gen_id()
-    # credo:disable-for-next-line Credo.Check.Design.TagTODO
+
     # TODO: handle potential errors, like "already registered"
     case TachyonBattle.Supervisor.start_battle(battle_id, match_id, autohost_id, start_script) do
       {:ok, pid} ->

--- a/lib/teiserver/tachyon_battle/battle.ex
+++ b/lib/teiserver/tachyon_battle/battle.ex
@@ -34,7 +34,6 @@ defmodule Teiserver.TachyonBattle.Battle do
     GenServer.start_link(__MODULE__, arg, name: via_tuple(battle_id))
   end
 
-  # credo:disable-for-next-line Credo.Check.Design.TagTODO
   # TODO! handle the case where the battle isn't there somehow. This
   # will become important when we start tracking event history for autohosts
   # and doing state recovery

--- a/lib/teiserver/tcp/spring/spring_tcp_server.ex
+++ b/lib/teiserver/tcp/spring/spring_tcp_server.ex
@@ -1434,15 +1434,11 @@ defmodule Teiserver.SpringTcpServer do
       # > Received `Packet`s are delivered as lists of bytes,
       mode: :list,
 
-      # credo:disable-for-next-line Credo.Check.Design.TagFIXME
-      # FIXME: This looks sketchy!
       # Why don't we verify the certificate when we do a TLS upgrade?
+      # Reason: Because when we did stuff broke, I can't recall what it broke
+      # if we were going to stick with Spring then I would suggest addressing
+      # this
       verify: :verify_none
-
-      # NOTE: Deprecated since OTP-17, has no effect.
-      # For newest version mentioning this option see:
-      # https://www.erlang.org/docs/22/apps/ssl/ssl.pdf
-      # ssl_imp: :new
     ]
   end
 end

--- a/lib/teiserver/telemetry/libs/telemetry_lib.ex
+++ b/lib/teiserver/telemetry/libs/telemetry_lib.ex
@@ -12,16 +12,13 @@ defmodule Teiserver.Telemetry.TelemetryLib do
 
   @spec get_totals_and_reset :: map()
   def get_totals_and_reset do
-    # credo:disable-for-next-line Credo.Check.Readability.PreferImplicitTry
-    try do
-      GenServer.call(TelemetryServer, :get_totals_and_reset)
-      # In certain situations (e.g. just after startup) it can be
-      # the process hasn't started up so we need to handle that
-      # without dying
-    catch
-      :exit, _reason ->
-        nil
-    end
+    GenServer.call(TelemetryServer, :get_totals_and_reset)
+  catch
+    # In certain situations (e.g. just after startup) it can be
+    # the process hasn't started up so we need to handle that
+    # without dying
+    :exit, _reason ->
+      nil
   end
 
   @spec increment(any) :: :ok

--- a/lib/teiserver_web/controllers/api/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/api/admin/user_controller.ex
@@ -70,20 +70,16 @@ defmodule TeiserverWeb.API.Admin.UserController do
   end
 
   defp get_generic_lobby_app do
-    # credo:disable-for-next-line Credo.Check.Readability.WithSingleClause
-    with app when not is_nil(app) <- OAuth.get_application_by_uid("generic_lobby") do
-      {:ok, app}
-    else
+    case OAuth.get_application_by_uid("generic_lobby") do
       nil -> {:error, :app_not_found}
+      app -> {:ok, app}
     end
   end
 
   defp get_user_by_email(email) do
-    # credo:disable-for-next-line Credo.Check.Readability.WithSingleClause
-    with user when not is_nil(user) <- Account.get_user_by_email(email) do
-      {:ok, user}
-    else
+    case Account.get_user_by_email(email) do
       nil -> {:error, :user_not_found}
+      user -> {:ok, user}
     end
   end
 

--- a/lib/teiserver_web/controllers/report/exports_controller.ex
+++ b/lib/teiserver_web/controllers/report/exports_controller.ex
@@ -28,7 +28,6 @@ defmodule TeiserverWeb.Report.ExportsController do
   def show(conn, %{"id" => id}) do
     module = get_module(id)
 
-    # credo:disable-for-next-line Credo.Check.Refactor.Apply
     if allow?(conn.assigns.current_user, apply(module, :permissions, [])) do
       assigns = module.show_form(conn)
 
@@ -51,7 +50,6 @@ defmodule TeiserverWeb.Report.ExportsController do
   def download(conn, %{"id" => id, "report" => report_params}) do
     module = get_module(id)
 
-    # credo:disable-for-next-line Credo.Check.Refactor.Apply
     if allow?(conn.assigns.current_user, apply(module, :permissions, [])) do
       {:file, file_path, file_name, content_type} = module.show_form(conn, report_params)
 

--- a/lib/teiserver_web/controllers/report/rating_controller.ex
+++ b/lib/teiserver_web/controllers/report/rating_controller.ex
@@ -55,7 +55,7 @@ defmodule TeiserverWeb.Report.RatingController do
     rating_type =
       if Enum.count(player_ids) == 2 do
         "Duel"
-        # credo:disable-for-next-line Credo.Check.Design.TagTODO
+
         # TODO Should probably get rating based on team size instead
       else
         "Large Team"

--- a/lib/teiserver_web/controllers/report/report_controller.ex
+++ b/lib/teiserver_web/controllers/report/report_controller.ex
@@ -91,7 +91,6 @@ defmodule TeiserverWeb.Report.ReportController do
           raise "No handler for name of '#{name}'"
       end
 
-    # credo:disable-for-next-line Credo.Check.Refactor.Apply
     if allow?(conn.assigns.current_user, apply(module, :permissions, [])) do
       assigns =
         case module.run(conn, params) do

--- a/lib/teiserver_web/live/battles/lobbies/chat.ex
+++ b/lib/teiserver_web/live/battles/lobbies/chat.ex
@@ -218,7 +218,7 @@ defmodule TeiserverWeb.Battle.LobbyLive.Chat do
       |> assign(:lobby, lobby)
 
     # Players
-    # credo:disable-for-next-line Credo.Check.Design.TagTODO
+
     # TODO: This can likely be optimised somewhat
     socket =
       case player_changes do

--- a/lib/teiserver_web/live/battles/lobbies/show.ex
+++ b/lib/teiserver_web/live/battles/lobbies/show.ex
@@ -211,7 +211,7 @@ defmodule TeiserverWeb.Battle.LobbyLive.Show do
       |> assign(:consul, consul_state)
 
     # Players
-    # credo:disable-for-next-line Credo.Check.Design.TagTODO
+
     # TODO: This can likely be optimised somewhat
     socket =
       case player_changes do

--- a/lib/teiserver_web/live/moderation/overwatch/report_group_detail.ex
+++ b/lib/teiserver_web/live/moderation/overwatch/report_group_detail.ex
@@ -17,7 +17,6 @@ defmodule TeiserverWeb.Moderation.OverwatchLive.ReportGroupDetail do
     |> ReportGroupLib.make_favourite()
     |> insert_recently(socket)
 
-    # credo:disable-for-next-line Credo.Check.Design.TagTODO
     # TODO also assign reporter info here, it's needed for report authors and chat link
 
     socket =

--- a/lib/teiserver_web/live/tournament/show.ex
+++ b/lib/teiserver_web/live/tournament/show.ex
@@ -199,7 +199,7 @@ defmodule TeiserverWeb.TournamentLive.Show do
       |> get_consul_state()
 
     # Players
-    # credo:disable-for-next-line Credo.Check.Design.TagTODO
+
     # TODO: This can likely be optimised somewhat
     socket =
       case player_changes do

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -194,7 +194,6 @@ defmodule Teiserver.Support.Tachyon do
     "ws://#{conf[:url][:host]}:#{conf[:http][:port]}/tachyon"
   end
 
-  # credo:disable-for-next-line Credo.Check.Design.TagTODO
   # TODO tachyon_mvp: add a json validation here to make sure the request
   # sent there is conforming
   def request(command_id, data \\ nil) do
@@ -259,7 +258,6 @@ defmodule Teiserver.Support.Tachyon do
     WSC.send_message(client, {:text, event(command_id, data) |> Jason.encode!()})
   end
 
-  # credo:disable-for-next-line Credo.Check.Design.TagTODO
   # TODO tachyon_mvp: create a version of this function that also check the
   # the response against the expected json schema
   def recv_message(client, opts \\ []) do
@@ -274,14 +272,12 @@ defmodule Teiserver.Support.Tachyon do
           {:ok, decoded}
         else
           {:error, %JsonXema.ValidationError{} = err} ->
-            # credo:disable-for-next-line Credo.Check.Warning.IoInspect
             resp |> Jason.decode!() |> IO.inspect(label: "schema validation failed on")
             {:error, err}
 
           err ->
-            # credo:disable-for-next-line Credo.Check.Warning.IoInspect
             resp |> Jason.decode!() |> IO.inspect(label: "schema validation failed on")
-            # credo:disable-for-next-line Credo.Check.Warning.IoInspect
+
             IO.inspect(err, label: "unknown error")
             err
         end

--- a/test/teiserver/protocols/spring/spring_auth_test.exs
+++ b/test/teiserver/protocols/spring/spring_auth_test.exs
@@ -137,7 +137,6 @@ IGNORELISTEND\n"
     assert reply == "SAIDPRIVATE #{user2.name} What about now?\n"
   end
 
-  # credo:disable-for-next-line Credo.Check.Design.TagTODO
   # TODO: Make this work
   # test "SAYPRIVATE with special characters", %{socket: socket1, user: user} = context do
   #   user2 = new_user()

--- a/test/teiserver/servers/spring_tcp_server_test.exs
+++ b/test/teiserver/servers/spring_tcp_server_test.exs
@@ -307,7 +307,7 @@ defmodule Teiserver.SpringTcpServerTest do
            }
 
     assert r == "CLIENTSTATUS #{u1.name} 0\nJOINEDBATTLE #{lobby_id + 1} #{u1.name}\n"
-    # credo:disable-for-next-line Credo.Check.Design.TagTODO
+
     # TODO: Find out why the below doesn't happen
     # assert r == "LEFTBATTLE #{lobby_id} #{u1.name}\nJOINEDBATTLE #{lobby_id + 1} #{u1.name}\n"
 
@@ -340,7 +340,6 @@ defmodule Teiserver.SpringTcpServerTest do
     :timer.sleep(500)
     r = _recv_raw(socket)
 
-    # credo:disable-for-next-line Credo.Check.Design.TagTODO
     # TODO: Sometimes this fails for no apparent reason, unable to reproduce since the above
     # 500 sleep call but I seem to recall that previously not helping
     expected =

--- a/test/teiserver_web/live/battle_live_test.exs
+++ b/test/teiserver_web/live/battle_live_test.exs
@@ -134,7 +134,7 @@ defmodule TeiserverWeb.Live.BattleTest do
 
       # Currently we don't show spectators, we just want to ensure it doesn't crash
       _html = render(view)
-      # credo:disable-for-next-line Credo.Check.Design.TagTODO
+
       # TODO: handle showing of spectators
 
       # # Team 0

--- a/test/teiserver_web/live/client_live_test.exs
+++ b/test/teiserver_web/live/client_live_test.exs
@@ -64,6 +64,7 @@ defmodule TeiserverWeb.Live.ClientTest do
     end
 
     @tag :needs_attention
+    # this part is failing because the liveview subscribes to old pubsubs
     test "show - valid client", %{conn: conn} do
       {:ok, server_context} = TeiserverTestLib.start_spring_server()
       %{socket: socket, user: user} = TeiserverTestLib.auth_setup(server_context)
@@ -78,8 +79,7 @@ defmodule TeiserverWeb.Live.ClientTest do
       assert html =~ "Battle:"
 
       # Log out the user
-      # credo:disable-for-next-line Credo.Check.Design.TagFIXME
-      # FIXME: this part is failing because the liveview subscribes to old pubsubs
+      # this part is failing because the liveview subscribes to old pubsubs
       _send_raw(socket, "EXIT\n")
       assert_redirect(view, "/teiserver/admin/client", 250)
     end

--- a/test/teiserver_web/tachyon/lobby_test.exs
+++ b/test/teiserver_web/tachyon/lobby_test.exs
@@ -604,7 +604,6 @@ defmodule TeiserverWeb.Tachyon.LobbyTest do
         start_req = Tachyon.recv_message!(ctx[:autohost_client])
 
       start_req_response = %{
-        # credo:disable-for-next-line Credo.Check.Readability.LargeNumbers
         port: 32781,
         ips: ["127.0.0.1"]
       }

--- a/test/teiserver_web/tachyon/matchmaking_test.exs
+++ b/test/teiserver_web/tachyon/matchmaking_test.exs
@@ -753,7 +753,6 @@ defmodule Teiserver.Tachyon.MatchmakingTest do
 
       host_data = %{
         ips: ["127.0.0.1"],
-        # credo:disable-for-next-line Credo.Check.Readability.LargeNumbers
         port: 48912
       }
 


### PR DESCRIPTION
Removes all the credo disables using the regex `# credo:disable-for-next-line.+$` and then addressing the credo warnings that come up.