### PR TITLE
feat(lobby): limit lobby name length

### DIFF
--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -657,11 +657,22 @@ defmodule Teiserver.Player.TachyonHandler do
     end
   end
 
+  @max_lobby_name_length 100
+
   def handle_command("lobby/create", "request", _msg_id, msg, state) do
     # TODO: the `lobby/update` has very similar logic. There should be a way
     # to combine the parsing
+    name = msg["data"]["name"]
+
+    if String.length(name) > @max_lobby_name_length do
+      return(
+        {:error_response, :invalid_request,
+         "lobby name must not exceed #{@max_lobby_name_length} characters", state}
+      )
+    end
+
     create_data = %{
-      name: msg["data"]["name"],
+      name: name,
       map_name: msg["data"]["mapName"],
       ally_team_config:
         for at <- msg["data"]["allyTeamConfig"] do

--- a/lib/teiserver/protocols/spring/spring_in.ex
+++ b/lib/teiserver/protocols/spring/spring_in.ex
@@ -823,12 +823,17 @@ defmodule Teiserver.Protocols.SpringIn do
 
           client = Client.get_client_by_id(state.userid)
 
+          max_lobby_name_length = 100
+
           cond do
             client == nil ->
               {:failure, "No client"}
 
             not Auth.is_bot?(state.userid) ->
               {:failure, "Not a bot"}
+
+            String.length(name) > max_lobby_name_length ->
+              {:failure, "Lobby name must not exceed #{max_lobby_name_length} characters"}
 
             true ->
               password = if Enum.member?(["empty", "*"], password), do: nil, else: password

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -18,6 +18,9 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   @behaviour :gen_statem
 
+  # Maximum length for lobby names to prevent UI overflow and abuse
+  @max_lobby_name_length 100
+
   @type id :: String.t()
 
   @type ally_team_config :: [
@@ -1706,12 +1709,16 @@ defmodule Teiserver.TachyonLobby.Lobby do
   @spec update_property(atom(), term(), state(), T.userid()) ::
           {:ok, [event()]} | {:error, String.t()}
   defp update_property(:name, new_name, _state, _user_id) do
-    # we can expand lobby name validation later
-    if new_name == "" do
-      {:error, "name must not be empty"}
-    end
+    cond do
+      new_name == "" ->
+        {:error, "name must not be empty"}
 
-    {:ok, [{:update_lobby_name, new_name}]}
+      String.length(new_name) > @max_lobby_name_length ->
+        {:error, "name must not exceed #{@max_lobby_name_length} characters"}
+
+      true ->
+        {:ok, [{:update_lobby_name, new_name}]}
+    end
   end
 
   defp update_property(:map_name, new_name, state, user_id) do


### PR DESCRIPTION
## Summary

Implements lobby name length limit (100 characters) as requested in #1001.

## Changes

- Added @max_lobby_name_length constant (100 chars)
- Updated Lobby.update_property(:name) to validate length
- Added validation in Tachyon lobby/create handler
- Added validation in Spring OPENBATTLE handler

## Why 100 characters?

- Long enough for descriptive names
- Short enough to prevent UI overflow on mobile clients
- Prevents abuse/excessive names
- Reasonable for database storage

## Mobile Impact

This directly benefits mobile clients by preventing lobby names from overflowing on small screens.

## Testing

Validation added at multiple layers:
1. Tachyon protocol (lobby/create)
2. Spring protocol (OPENBATTLE)
3. Lobby state updates (update_property)

Closes #1001