### PR TITLE
Vote history

### DIFF
--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -1152,7 +1152,8 @@ defmodule Teiserver.Player.TachyonHandler do
       ally_team_config: {:allyTeamConfig, &ally_team_config_to_tachyon/1},
       engine_version: :engineVersion,
       game_version: :gameVersion,
-      current_vote: {:currentVote, &vote_to_tachyon/1}
+      current_vote: {:currentVote, &vote_to_tachyon/1},
+      vote_history: {:voteHistory, &vote_history_to_tachyon/1}
     }
 
     Collections.transform_map(details, mappings)
@@ -1170,7 +1171,8 @@ defmodule Teiserver.Player.TachyonHandler do
       name: :name,
       map_name: :mapName,
       ally_team_config: {:allyTeamConfig, &ally_team_config_to_tachyon/1},
-      current_vote: {:currentVote, &vote_to_tachyon/1}
+      current_vote: {:currentVote, &vote_to_tachyon/1},
+      vote_history: {:voteHistory, &vote_history_to_tachyon/1}
     }
 
     Map.merge(%{id: lobby_id}, Collections.transform_map(update_map, mappings))
@@ -1278,6 +1280,18 @@ defmodule Teiserver.Player.TachyonHandler do
       end
     end)
     |> Collections.transform_map(mapping)
+  end
+
+  defp vote_history_to_tachyon(history) do
+    mapping = %{
+      outcome: :outcome,
+      finished_at: {:finishedAt, &DateTime.to_unix(&1, :microsecond)},
+      vote: {:vote, &vote_action_to_tachyon/1}
+    }
+
+    for {id, record} <- history, into: %{} do
+      {id, Collections.transform_map(record, mapping)}
+    end
   end
 
   defp vote_action_to_tachyon(action) do

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -3,6 +3,26 @@ defmodule Teiserver.TachyonLobby.Lobby do
   Represent a single lobby
   """
 
+  # This module has essentially 3 parts:
+  # 1: the external API as usual. A set of exported function that delegate to
+  # gen_statem.cast/call and so on
+  # 2: the internal handlers: the callbacks for gen_statem
+  # 3: an event sourcing system for the handlers.
+  #
+  # The handlers are responsible to check if the operation is valid, and then
+  # translate the operation into an event. See `@typep event` for the list.
+  # These events are then reduced/folded into an aggregate. This aggregate
+  # is used to
+  # 1: compute the end state after applying the original operation/event See process_events/2
+  # 2: the update events to send to lobby members. See broadcast_updates/1
+  # 3: update the lobby list process when relevant. Also handled in broadcast_updates/1
+  #
+  # The event sourcing approach is used so we can have some "atomic" operations, and more
+  # complex operations can be represented through them. It is mostly useful when dealing
+  # with player movements, to/from spectators or within ally teams.
+  # It also handles update events without having to dispatch them manually on a case by
+  # case basis.
+
   alias Teiserver.Asset
   alias Teiserver.Autohost
   alias Teiserver.Data.Types, as: T

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -203,6 +203,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
                  started_at: DateTime.t()
                },
            ids_to_rejoin: MapSet.t(T.userid()),
+           vote_idx: integer(),
            current_vote: nil | vote_state()
          }
 
@@ -440,6 +441,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
       bot_idx_counter: 0,
       current_battle: nil,
       ids_to_rejoin: MapSet.new(),
+      vote_idx: 1,
       current_vote: nil
     }
 
@@ -1321,6 +1323,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
   defp process_event({:start_vote, vote_state} = ev, aggregate) do
     aggregate
     |> put_in([:data, :current_vote], vote_state)
+    |> update_in([:data, :vote_idx], &(&1 + 1))
     |> Map.update!(:updates, &[ev | &1])
   end
 
@@ -1815,7 +1818,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
         quorum = (map_size(voters) * 0.501) |> :math.ceil() |> trunc()
 
         vote = %{
-          id: UUID.uuid4(),
+          id: "vote-#{state.vote_idx}",
           action: {:change_map, new_name},
           initiator: user_id,
           voters: voters,

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -100,6 +100,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
           quorum: non_neg_integer(),
           majority: non_neg_integer()
         }
+  @type vote_outcome :: :passed | :failed | :cancelled | :timeout
 
   @typedoc """
   The public state of the lobby. Anything that clients need to know about
@@ -134,7 +135,14 @@ defmodule Teiserver.TachyonLobby.Lobby do
                 id: TachyonBattle.id(),
                 started_at: DateTime.t()
               },
-          current_vote: nil | vote_state()
+          current_vote: nil | vote_state(),
+          vote_history: %{
+            String.t() => %{
+              vote: vote_state(),
+              finished_at: DateTime.t(),
+              outcome: vote_outcome()
+            }
+          }
         }
 
   @typedoc """
@@ -204,7 +212,14 @@ defmodule Teiserver.TachyonLobby.Lobby do
                },
            ids_to_rejoin: MapSet.t(T.userid()),
            vote_idx: integer(),
-           current_vote: nil | vote_state()
+           current_vote: nil | vote_state(),
+           vote_history: %{
+             String.t() => %{
+               vote: vote_state(),
+               finished_at: DateTime.t(),
+               outcome: vote_outcome()
+             }
+           }
          }
 
   # the list of internal events used to manipulate the lobby data, but also
@@ -226,8 +241,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
               new_config :: ally_team_config()}
            | {:start_vote, vote_state()}
            | {:cast_vote, T.userid(), vote_ballot()}
-           | :vote_timeout
-           | :vote_ended
+           | {:vote_ended, DateTime.t(), vote_outcome()}
 
   @spec gen_id() :: id()
   def gen_id, do: UUID.uuid4()
@@ -442,7 +456,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
       current_battle: nil,
       ids_to_rejoin: MapSet.new(),
       vote_idx: 1,
-      current_vote: nil
+      current_vote: nil,
+      vote_history: %{}
     }
 
     TachyonLobby.List.register_lobby(self(), id, get_overview_from_state(state))
@@ -1003,7 +1018,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   def handle_event(:info, {:vote_timeout, vote_id}, _state, data)
       when data.current_vote.id == vote_id do
-    event = :vote_timeout
+    event = {:vote_ended, DateTime.utc_now(), :timeout}
     aggregate = process_events([event], data) |> broadcast_updates()
     process_event_actions(aggregate)
     {:keep_state, aggregate.data}
@@ -1091,6 +1106,13 @@ defmodule Teiserver.TachyonLobby.Lobby do
       end)
       |> Enum.into(%{})
 
+    vote_history =
+      Enum.map(state.vote_history, fn {id, record} ->
+        {id,
+         %{finished_at: record.finished_at, vote: record.vote.action, outcome: record.outcome}}
+      end)
+      |> Enum.into(%{})
+
     Map.take(state, [
       :id,
       :name,
@@ -1104,6 +1126,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
     |> Map.put(:players, players)
     |> Map.put(:spectators, spectators)
     |> Map.put(:bots, Map.new(bots))
+    |> Map.put(:vote_history, vote_history)
   end
 
   # Given a list of events to process (in the event sourcing way) and the initial
@@ -1341,35 +1364,32 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
       {:ended, result} ->
         vote = new_aggregate.data.current_vote
+        new_aggregate = process_event({:vote_ended, DateTime.utc_now(), result}, new_aggregate)
 
-        new_aggregate =
-          new_aggregate
-          |> put_in([:data, :current_vote], nil)
-          |> Map.update!(:actions, &[{:vote_ended, vote, result} | &1])
+        case {result, vote.action} do
+          {:failed, _action} ->
+            new_aggregate
 
-        new_aggregate =
-          case {result, vote.action} do
-            {:failed, _action} ->
-              new_aggregate
-
-            {:passed, {:change_map, new_map}} ->
-              process_event({:update_map_name, new_map}, new_aggregate)
-              # just let the thing crash if a new vote action shows up. It'll be easy
-              # to spot and fix/add support. :start isn't yet supported
-          end
-
-        Map.update!(new_aggregate, :updates, &[:vote_ended | &1])
+          {:passed, {:change_map, new_map}} ->
+            process_event({:update_map_name, new_map}, new_aggregate)
+            # just let the thing crash if a new vote action shows up. It'll be easy
+            # to spot and fix/add support. :start isn't yet supported
+        end
     end
   end
 
-  # don't bother cancelling the timer. The event handler checks the vote id
+  # don't bother cancelling the vote timeout timer. The event handler checks the vote id
   # and it allows us not to worry about storing the tref
-  defp process_event(:vote_timeout = ev, aggregate) do
-    vote_ev = {:vote_ended, aggregate.data.current_vote, :timeout}
+  defp process_event({:vote_ended, ts, outcome}, aggregate) do
+    vote_ev = {:vote_ended, aggregate.data.current_vote, outcome}
+    vote_record = %{vote: aggregate.data.current_vote, finished_at: ts, outcome: outcome}
+    # TODO: trim the history if size too big
+    history = Map.put(aggregate.data.vote_history, aggregate.data.current_vote.id, vote_record)
 
     aggregate
     |> put_in([:data, :current_vote], nil)
-    |> Map.update!(:updates, &[ev | &1])
+    |> put_in([:data, :vote_history], history)
+    |> Map.update!(:updates, &[{:vote_ended, vote_record} | &1])
     |> Map.update!(:actions, &[vote_ev | &1])
   end
 
@@ -1481,11 +1501,16 @@ defmodule Teiserver.TachyonLobby.Lobby do
     |> put_in([:current_vote, :voters, user_id], ballot)
   end
 
-  defp update_change_from_event(:vote_timeout, change_map),
-    do: Map.put(change_map, :current_vote, nil)
-
-  defp update_change_from_event(:vote_ended, change_map),
-    do: Map.put(change_map, :current_vote, nil)
+  defp update_change_from_event({:vote_ended, record}, change_map) do
+    change_map
+    |> Map.put(:current_vote, nil)
+    |> Map.put_new(:vote_history, %{})
+    |> put_in([:vote_history, record.vote.id], %{
+      vote: record.vote.action,
+      finished_at: record.finished_at,
+      outcome: record.outcome
+    })
+  end
 
   defp broadcast_list_updates(%{data: final_state})
        when map_size(final_state.players) == 0 and map_size(final_state.spectators) == 0,

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -247,6 +247,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
   def gen_id, do: UUID.uuid4()
 
   @default_call_timeout 5000
+  @max_vote_history_size 10
 
   # note: this uses a pid and not a lobby id because it's (currently) only
   # used by the lobby list process to bootstrap its state, and at that time
@@ -1383,8 +1384,21 @@ defmodule Teiserver.TachyonLobby.Lobby do
   defp process_event({:vote_ended, ts, outcome}, aggregate) do
     vote_ev = {:vote_ended, aggregate.data.current_vote, outcome}
     vote_record = %{vote: aggregate.data.current_vote, finished_at: ts, outcome: outcome}
-    # TODO: trim the history if size too big
     history = Map.put(aggregate.data.vote_history, aggregate.data.current_vote.id, vote_record)
+
+    history =
+      if map_size(history) > @max_vote_history_size do
+        dates =
+          Enum.map(history, fn {_id, record} -> record.finished_at end)
+          |> Enum.sort()
+
+        cutoff = Enum.at(dates, 4)
+
+        Enum.filter(history, fn {_id, record} -> record.finished_at >= cutoff end)
+        |> Enum.into(%{})
+      else
+        history
+      end
 
     aggregate
     |> put_in([:data, :current_vote], nil)

--- a/priv/tachyon/schema/definitions/voteOutcomes.json
+++ b/priv/tachyon/schema/definitions/voteOutcomes.json
@@ -1,0 +1,5 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/definitions/voteOutcomes.json",
+    "title": "VoteOutcomes",
+    "enum": ["passed", "failed", "cancelled", "timeout"]
+}

--- a/priv/tachyon/schema/lobby/updated/event.json
+++ b/priv/tachyon/schema/lobby/updated/event.json
@@ -246,6 +246,35 @@
                         },
                         { "type": "null" }
                     ]
+                },
+                "voteHistory": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^.*$": {
+                            "anyOf": [
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "vote": {
+                                            "$ref": "../../definitions/voteActions.json"
+                                        },
+                                        "outcome": {
+                                            "$ref": "../../definitions/voteOutcomes.json"
+                                        },
+                                        "finishedAt": {
+                                            "$ref": "../../definitions/unixTime.json"
+                                        }
+                                    },
+                                    "required": [
+                                        "vote",
+                                        "outcome",
+                                        "finishedAt"
+                                    ]
+                                },
+                                { "type": "null" }
+                            ]
+                        }
+                    }
                 }
             },
             "required": ["id"]

--- a/test/teiserver/tachyon_lobby/lobby_test.exs
+++ b/test/teiserver/tachyon_lobby/lobby_test.exs
@@ -1025,6 +1025,38 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
       assert result == :passed
     end
 
+    test "history to track votes" do
+      %{id: id} = setup_full_lobby([1, 1])
+      :ok = Lobby.join_queue(id, "2")
+
+      :ok = Lobby.update_properties(id, @default_user_id, %{map_name: "new map"})
+      assert_receive {:lobby, ^id, {:updated, %{current_vote: vote}}}
+      :ok = Lobby.vote_submit(id, "2", {vote.id, :yes})
+      vote_id = vote.id
+
+      assert_receive {:lobby, ^id, {:updated, %{vote_history: %{^vote_id => vote1}}}}
+
+      assert %{vote: {:change_map, "new map"}, outcome: :passed} = vote1
+
+      :ok = Lobby.update_properties(id, @default_user_id, %{map_name: "new map2"})
+      assert_receive {:lobby, ^id, {:updated, %{current_vote: vote}}}
+      :ok = Lobby.vote_submit(id, "2", {vote.id, :no})
+      vote_id2 = vote.id
+
+      assert_receive {:lobby, ^id, {:updated, %{vote_history: %{^vote_id2 => vote2}}}}
+
+      %{vote: {:change_map, "new map2"}, outcome: :failed} = vote2
+
+      # and lobby details hold the entire history
+      {:ok, details} = LobbyProcess.get_details(id)
+      assert map_size(details.vote_history) == 2
+      assert vote_id < vote_id2
+      assert details.vote_history[vote_id].outcome == :passed
+      assert details.vote_history[vote_id].vote == {:change_map, "new map"}
+      assert details.vote_history[vote_id2].outcome == :failed
+      assert details.vote_history[vote_id2].vote == {:change_map, "new map2"}
+    end
+
     test "map stays when vote fails" do
       %{id: id} = setup_full_lobby([1, 1])
       :ok = Lobby.join_queue(id, "2")

--- a/test/teiserver_web/tachyon/lobby_test.exs
+++ b/test/teiserver_web/tachyon/lobby_test.exs
@@ -490,6 +490,16 @@ defmodule TeiserverWeb.Tachyon.LobbyTest do
                "commandId" => "lobby/updated",
                "data" => %{"currentVote" => nil, "mapName" => "new map name"}
              } = updated
+
+      # a new client joining the lobby gets the vote history
+      {:ok, ctx3} = Tachyon.setup_client()
+
+      %{"status" => "success", "data" => data} =
+        Tachyon.join_lobby!(ctx3[:client], lobby_id)
+
+      last_vote = data["voteHistory"][vote["id"]]
+      assert last_vote["outcome"] == "passed"
+      assert last_vote["vote"] == %{"type" => "changeMap", "newMapName" => "new map name"}
     end
   end
 


### PR DESCRIPTION
Implements the [tachyon changes](https://github.com/beyond-all-reason/tachyon/pull/123) related to expose a voting history for a lobby.