### PR TITLE
Refine flood protection logic to exempt heartbeat for authenticated connections

### DIFF
--- a/lib/teiserver/tcp/spring/spring_tcp_server.ex
+++ b/lib/teiserver/tcp/spring/spring_tcp_server.ex
@@ -1176,19 +1176,18 @@ defmodule Teiserver.SpringTcpServer do
   @spec flood_protect?(String.t(), map()) :: {boolean, map()}
   defp flood_protect?(_data, %{exempt_from_cmd_throttle: true} = state), do: {false, state}
 
-  defp flood_protect?("c.auth.login_queue_heartbeat" <> _rest, state), do: {false, state}
+  # Only exempt heartbeat for authenticated connections
+  defp flood_protect?("c.auth.login_queue_heartbeat" <> _rest, %{userid: userid} = state)
+       when not is_nil(userid),
+       do: {false, state}
 
-  defp flood_protect?(data, state) do
+  defp flood_protect?(_data, state) do
+    now = System.system_time(:second)
+    limiter = now - state.flood_rate_window_size
+
     cmd_timestamps =
-      if String.contains?(data, "\n") do
-        now = System.system_time(:second)
-        limiter = now - state.flood_rate_window_size
-
-        [now | state.cmd_timestamps]
-        |> Enum.filter(fn cmd_ts -> cmd_ts > limiter end)
-      else
-        state.cmd_timestamps
-      end
+      [now | state.cmd_timestamps]
+      |> Enum.filter(fn cmd_ts -> cmd_ts > limiter end)
 
     if Enum.count(cmd_timestamps) > state.flood_rate_limit_count do
       {true, %{state | cmd_timestamps: cmd_timestamps}}


### PR DESCRIPTION
The flood protection in spring_tcp_server.ex only counts commands that contain a newline character. Partial TCP data bypasses the counter entirely. c.auth.login_queue_heartbeat is also explicitly exempt, even for unauthenticated connections.

This means an unauthenticated client can send data to the server without ever triggering flood protection.

Relevant code: flood_protect?/2 at spring_tcp_server.ex:1167-1183

Fix: count all incoming data toward the flood limit regardless of newline presence, and remove the heartbeat exemption for unauthenticated connections