### PR TITLE
Add telemetry burst rate limiting for unauthenticated users

### DIFF
--- a/lib/teiserver/libs/teiserver_configs.ex
+++ b/lib/teiserver/libs/teiserver_configs.ex
@@ -217,6 +217,17 @@ defmodule Teiserver.TeiserverConfigs do
     })
 
     add_site_config_type(%{
+      key: "teiserver.Spring telemetry rate limit per minute",
+      section: "Legacy protocol",
+      type: "integer",
+      permissions: ["Admin"],
+      description:
+        "Maximum unauthenticated telemetry commands per minute per connection. " <>
+          "Authenticated users are not affected by this limit.",
+      default: 30
+    })
+
+    add_site_config_type(%{
       key: "teiserver.Ring flood rate limit count",
       section: "Legacy protocol",
       type: "integer",

--- a/lib/teiserver/protocols/spring/spring_in.ex
+++ b/lib/teiserver/protocols/spring/spring_in.ex
@@ -17,6 +17,7 @@ defmodule Teiserver.Protocols.SpringIn do
   alias Teiserver.Client
   alias Teiserver.Config
   alias Teiserver.Coordinator
+  alias Teiserver.Helpers.BurstyRateLimiter
   alias Teiserver.Lobby
   alias Teiserver.Protocols.Spring
   alias Teiserver.Protocols.Spring.AuthIn
@@ -27,7 +28,6 @@ defmodule Teiserver.Protocols.SpringIn do
   alias Teiserver.Protocols.Spring.TelemetryIn
   alias Teiserver.Protocols.Spring.UserIn
   alias Teiserver.Protocols.SpringOut
-  alias Teiserver.Helpers.BurstyRateLimiter
   alias Teiserver.Room
   alias Teiserver.SpringTcpServer
   require Logger

--- a/lib/teiserver/protocols/spring/spring_in.ex
+++ b/lib/teiserver/protocols/spring/spring_in.ex
@@ -27,6 +27,7 @@ defmodule Teiserver.Protocols.SpringIn do
   alias Teiserver.Protocols.Spring.TelemetryIn
   alias Teiserver.Protocols.Spring.UserIn
   alias Teiserver.Protocols.SpringOut
+  alias Teiserver.Helpers.BurstyRateLimiter
   alias Teiserver.Room
   alias Teiserver.SpringTcpServer
   require Logger
@@ -153,7 +154,21 @@ defmodule Teiserver.Protocols.SpringIn do
   end
 
   defp do_handle("c.telemetry." <> cmd, data, msg_id, state) do
-    TelemetryIn.do_handle(cmd, data, msg_id, state)
+    if state.userid != nil do
+      # Authenticated users are not rate limited on telemetry
+      TelemetryIn.do_handle(cmd, data, msg_id, state)
+    else
+      case BurstyRateLimiter.try_acquire(state.telemetry_rate_limiter) do
+        {:ok, updated_rl} ->
+          new_state = %{state | telemetry_rate_limiter: updated_rl}
+          TelemetryIn.do_handle(cmd, data, msg_id, new_state)
+
+        {:error, _wait_ms} ->
+          Logger.info("Telemetry rate limited for unauthenticated client #{state.ip}")
+          reply(:no, "Rate limited", msg_id, state)
+          state
+      end
+    end
   end
 
   defp do_handle("c.battle." <> cmd, data, msg_id, state) do

--- a/lib/teiserver/tcp/spring/spring_tcp_server.ex
+++ b/lib/teiserver/tcp/spring/spring_tcp_server.ex
@@ -11,6 +11,7 @@ defmodule Teiserver.SpringTcpServer do
   alias Teiserver.Config
   alias Teiserver.Coordinator
   alias Teiserver.Data.Types, as: T
+  alias Teiserver.Helpers.BurstyRateLimiter
   alias Teiserver.Protocols.Spring.PartyIn
   alias Teiserver.Protocols.SpringIn
   alias Teiserver.Protocols.SpringOut
@@ -1332,9 +1333,9 @@ defmodule Teiserver.SpringTcpServer do
 
             # Rate limiting for unauthenticated telemetry commands
             telemetry_rate_limiter:
-              Teiserver.Helpers.BurstyRateLimiter.per_minute(
-                Config.get_site_config_cache("teiserver.Spring telemetry rate limit per minute")
-              ),
+              "teiserver.Spring telemetry rate limit per minute"
+              |> Config.get_site_config_cache()
+              |> BurstyRateLimiter.per_minute(),
 
             # Caching app configs
             flood_rate_limit_count:

--- a/lib/teiserver/tcp/spring/spring_tcp_server.ex
+++ b/lib/teiserver/tcp/spring/spring_tcp_server.ex
@@ -1330,6 +1330,14 @@ defmodule Teiserver.SpringTcpServer do
             protocol_optimisation: :full,
             pending_messages: [],
 
+            # Rate limiting for unauthenticated telemetry commands
+            telemetry_rate_limiter:
+              Teiserver.Helpers.BurstyRateLimiter.per_minute(
+                Config.get_site_config_cache(
+                  "teiserver.Spring telemetry rate limit per minute"
+                )
+              ),
+
             # Caching app configs
             flood_rate_limit_count:
               Config.get_site_config_cache("teiserver.Spring flood rate limit count"),

--- a/lib/teiserver/tcp/spring/spring_tcp_server.ex
+++ b/lib/teiserver/tcp/spring/spring_tcp_server.ex
@@ -1333,9 +1333,7 @@ defmodule Teiserver.SpringTcpServer do
             # Rate limiting for unauthenticated telemetry commands
             telemetry_rate_limiter:
               Teiserver.Helpers.BurstyRateLimiter.per_minute(
-                Config.get_site_config_cache(
-                  "teiserver.Spring telemetry rate limit per minute"
-                )
+                Config.get_site_config_cache("teiserver.Spring telemetry rate limit per minute")
               ),
 
             # Caching app configs


### PR DESCRIPTION
Several c.telemetry.* commands are in the @unauthenticated_commands whitelist in spring_in.ex and write directly to the database without any auth check or rate limiting. This includes simple_client_event, complex_client_event, update_client_property, and upload_infolog.

The _test variants of these commands correctly deny unauthenticated users -- the non-test variants don't have the same check.

Confirmed locally via BAR-Devtools and verified the commands are accepted on prod.

Fix: either remove the telemetry commands from @unauthenticated_commands or add per-IP rate limiting for anonymous writes.