### PR TITLE
Add displayname to user updates

### DIFF
--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -159,6 +159,7 @@ defmodule Teiserver.Player.TachyonHandler do
         %{
           userId: to_string(user_state.user_id),
           username: user_state.username,
+          displayName: user_state.username,
           clanId: user_state.clan_id,
           country: user_state.country,
           status: user_state.status,

--- a/test/teiserver_web/tachyon/user_test.exs
+++ b/test/teiserver_web/tachyon/user_test.exs
@@ -56,6 +56,7 @@ defmodule TeiserverWeb.Tachyon.UserTest do
 
       assert userdata["userId"] == to_string(user.id)
       assert userdata["username"] == user.name
+      assert userdata["displayName"] == user.name
       assert userdata["clanId"] == user.clan_id
       assert userdata["status"] == "menu"
     end
@@ -106,6 +107,7 @@ defmodule TeiserverWeb.Tachyon.UserTest do
 
       assert user_data["userId"] == to_string(other_user.id)
       assert user_data["username"] == other_user.name
+      assert user_data["displayName"] == other_user.name
       assert user_data["clanId"] == other_user.clan_id
       assert user_data["status"] == "offline"
     end


### PR DESCRIPTION
Until we have more logic to split username from display name, use the username for both.