### PR TITLE
Tachyon game options

### DIFF
--- a/lib/teiserver/autohost.ex
+++ b/lib/teiserver/autohost.ex
@@ -17,6 +17,7 @@ defmodule Teiserver.Autohost do
           required(:map_name) => String.t(),
           required(:start_pos_type) => :fixed | :random | :ingame | :beforegame,
           required(:ally_teams) => [ally_team(), ...],
+          optional(:game_options) => %{String.t() => String.t()},
           optional(:spectators) => [player()],
           optional(:bots) => [bot()]
         }

--- a/lib/teiserver/autohost/tachyon_handler.ex
+++ b/lib/teiserver/autohost/tachyon_handler.ex
@@ -110,6 +110,7 @@ defmodule Teiserver.Autohost.TachyonHandler do
               %{players: {:players, &player_to_tachyon/1}, bots: {:bots, &bot_to_tachyon/1}}},
            start_box: {:startBox, %{top: :top, left: :left, bottom: :bottom, right: :right}}
          }},
+      game_options: :gameOptions,
       spectators: {:spectators, &player_to_tachyon/1}
     }
 

--- a/lib/teiserver/player/session.ex
+++ b/lib/teiserver/player/session.ex
@@ -473,7 +473,8 @@ defmodule Teiserver.Player.Session do
   @type lobby_start_params :: %{
           name: String.t(),
           map_name: String.t(),
-          ally_team_config: TachyonLobby.ally_team_config()
+          ally_team_config: TachyonLobby.ally_team_config(),
+          game_options: %{String.t() => String.t()}
         }
   @spec create_lobby(T.userid(), lobby_start_params()) ::
           {:ok, TachyonLobby.details()} | {:error, reason :: term()}

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -829,7 +829,11 @@ defmodule Teiserver.Player.TachyonHandler do
     keys = [
       {"name", :name},
       {"mapName", :map_name},
-      {"allyTeamConfig", :ally_team_config, &ally_team_config_from_tachyon/1}
+      {"allyTeamConfig", :ally_team_config, &ally_team_config_from_tachyon/1},
+      {"gameOptions", :game_options,
+       fn opts ->
+         Enum.map(opts, fn {k, v} -> {k, v["value"]} end) |> Enum.into(%{})
+       end}
     ]
 
     update_data = Enum.reduce(keys, %{}, &convert_key(&1, data, &2))
@@ -1177,7 +1181,8 @@ defmodule Teiserver.Player.TachyonHandler do
       map_name: :mapName,
       ally_team_config: {:allyTeamConfig, &ally_team_config_to_tachyon/1},
       current_vote: {:currentVote, &vote_to_tachyon/1},
-      vote_history: {:voteHistory, &vote_history_to_tachyon/1}
+      vote_history: {:voteHistory, &vote_history_to_tachyon/1},
+      game_options: {:gameOptions, &game_options_to_tachyon/1}
     }
 
     Map.merge(%{id: lobby_id}, Collections.transform_map(update_map, mappings))
@@ -1267,7 +1272,10 @@ defmodule Teiserver.Player.TachyonHandler do
   end
 
   defp game_options_to_tachyon(options) do
-    Enum.map(options, fn {k, v} -> {k, %{value: v}} end)
+    Enum.map(options, fn
+      {k, nil} -> {k, nil}
+      {k, v} -> {k, %{value: v}}
+    end)
     |> Enum.into(%{})
   end
 

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -678,7 +678,11 @@ defmodule Teiserver.Player.TachyonHandler do
             },
             teams: teams
           }
-        end
+        end,
+      game_options:
+        Map.get(msg["data"], "gameOptions", %{})
+        |> Enum.map(fn {k, v} -> {k, v["value"]} end)
+        |> Enum.into(%{})
     }
 
     case Session.create_lobby(state.user.id, create_data) do
@@ -1150,6 +1154,7 @@ defmodule Teiserver.Player.TachyonHandler do
       name: :name,
       map_name: :mapName,
       ally_team_config: {:allyTeamConfig, &ally_team_config_to_tachyon/1},
+      game_options: {:gameOptions, &game_options_to_tachyon/1},
       engine_version: :engineVersion,
       game_version: :gameVersion,
       current_vote: {:currentVote, &vote_to_tachyon/1},
@@ -1259,6 +1264,11 @@ defmodule Teiserver.Player.TachyonHandler do
 
       {to_string(i), val}
     end
+  end
+
+  defp game_options_to_tachyon(options) do
+    Enum.map(options, fn {k, v} -> {k, %{value: v}} end)
+    |> Enum.into(%{})
   end
 
   defp vote_to_tachyon(nil), do: nil

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -826,17 +826,26 @@ defmodule Teiserver.Player.TachyonHandler do
   end
 
   def handle_command("lobby/update", "request", _msg_id, %{"data" => data}, state) do
-    keys = [
-      {"name", :name},
-      {"mapName", :map_name},
-      {"allyTeamConfig", :ally_team_config, &ally_team_config_from_tachyon/1},
-      {"gameOptions", :game_options,
-       fn opts ->
-         Enum.map(opts, fn {k, v} -> {k, v["value"]} end) |> Enum.into(%{})
-       end}
-    ]
+    mappings = %{
+      "name" => :name,
+      "mapName" => :map_name,
+      "allyTeamConfig" =>
+        {:ally_team_config,
+         %{
+           "maxTeams" => :max_teams,
+           "startBox" =>
+             {:start_box,
+              %{"top" => :top, "bottom" => :bottom, "left" => :left, "right" => :right}},
+           "teams" => {:teams, %{"maxPlayers" => :max_players}}
+         }},
+      "gameOptions" =>
+        {:game_options,
+         fn opts ->
+           Enum.map(opts, fn {k, v} -> {k, v["value"]} end) |> Enum.into(%{})
+         end}
+    }
 
-    update_data = Enum.reduce(keys, %{}, &convert_key(&1, data, &2))
+    update_data = Collections.transform_map(data, mappings)
 
     case Session.lobby_update_properties(state.user.id, update_data) do
       :ok ->
@@ -1106,44 +1115,6 @@ defmodule Teiserver.Player.TachyonHandler do
       end
     end)
     |> Enum.reject(&is_nil/1)
-  end
-
-  defp ally_team_config_from_tachyon(data) do
-    keys = [
-      {"maxTeams", :max_teams},
-      {"startBox", :start_box, &start_box_from_tachyon/1},
-      {"teams", :teams, &teams_from_tachyon/1}
-    ]
-
-    Enum.map(data, fn d -> Enum.reduce(keys, %{}, &convert_key(&1, d, &2)) end)
-  end
-
-  defp start_box_from_tachyon(data) do
-    keys = [{"top", :top}, {"bottom", :bottom}, {"left", :left}, {"right", :right}]
-    Enum.reduce(keys, %{}, &convert_key(&1, data, &2))
-  end
-
-  # util function to convert keys in a map, with a possible transformation for the val
-  defp convert_key(key_spec, data, map) do
-    case key_spec do
-      {from_k, to_k} ->
-        if is_map_key(data, from_k) do
-          Map.put(map, to_k, Map.get(data, from_k))
-        else
-          map
-        end
-
-      {from_k, to_k, f} ->
-        if is_map_key(data, from_k) do
-          Map.put(map, to_k, f.(Map.get(data, from_k)))
-        else
-          map
-        end
-    end
-  end
-
-  defp teams_from_tachyon(data) do
-    Enum.map(data, fn d -> %{max_players: d["maxPlayers"]} end)
   end
 
   defp lobby_details_to_tachyon(details) do

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -73,7 +73,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
           required(:map_name) => String.t(),
           required(:ally_team_config) => ally_team_config(),
           optional(:game_version) => String.t(),
-          optional(:engine_version) => String.t()
+          optional(:engine_version) => String.t(),
+          optional(:game_options) => %{String.t() => String.t()}
         }
 
   @typedoc """
@@ -113,6 +114,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
           game_version: String.t(),
           engine_version: String.t(),
           ally_team_config: ally_team_config(),
+          game_options: %{String.t() => String.t()},
           players: %{
             T.userid() => %{team: team(), ready?: boolean(), asset_status: asset_status()}
           },
@@ -199,6 +201,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
            game_version: String.t(),
            engine_version: String.t(),
            ally_team_config: ally_team_config(),
+           game_options: %{String.t() => String.t()},
            # used to track the players in the lobby.
            players: %{player_id() => player() | bot()},
            spectators: %{T.userid() => spectator()},
@@ -376,7 +379,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
   @type lobby_update_data :: %{
           optional(:name) => String.t(),
           optional(:map_name) => String.t(),
-          optional(:ally_team_config) => ally_team_config()
+          optional(:ally_team_config) => ally_team_config(),
+          optional(:game_options) => %{String.t() => String.t() | nil}
         }
 
   @doc """
@@ -441,6 +445,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
       game_version: start_params.game_version,
       engine_version: start_params.engine_version,
       ally_team_config: start_params.ally_team_config,
+      game_options: Map.get(start_params, :game_options, %{}),
       players: %{
         start_params.creator_data.id => %{
           id: start_params.creator_data.id,
@@ -1122,7 +1127,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
       :engine_version,
       :ally_team_config,
       :current_battle,
-      :current_vote
+      :current_vote,
+      :game_options
     ])
     |> Map.put(:players, players)
     |> Map.put(:spectators, spectators)

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -242,6 +242,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
            | {:update_map_name, new_name :: String.t()}
            | {:update_ally_team_config, old_config :: ally_team_config(),
               new_config :: ally_team_config()}
+           | {:update_game_options, changes :: %{String.t() => String.t() | nil}}
            | {:start_vote, vote_state()}
            | {:cast_vote, T.userid(), vote_ballot()}
            | {:vote_ended, DateTime.t(), vote_outcome()}
@@ -1350,6 +1351,12 @@ defmodule Teiserver.TachyonLobby.Lobby do
     new_aggregate |> put_in([:updates], [ev | final_events] ++ aggregate.updates)
   end
 
+  defp process_event({:update_game_options, changes} = ev, aggregate) do
+    aggregate
+    |> update_in([:data, :game_options], &patch_merge(&1, changes))
+    |> Map.update!(:updates, &[ev | &1])
+  end
+
   defp process_event({:start_vote, vote_state} = ev, aggregate) do
     aggregate
     |> put_in([:data, :current_vote], vote_state)
@@ -1510,6 +1517,9 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
     Map.put(change_map, :ally_team_config, changes)
   end
+
+  defp update_change_from_event({:update_game_options, changes}, change_map),
+    do: Map.put(change_map, :game_options, changes)
 
   defp update_change_from_event({:start_vote, vote}, change_map),
     do: Map.put(change_map, :current_vote, vote)
@@ -1883,6 +1893,11 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   defp update_property(:ally_team_config, new_config, state, _user_id) do
     {:ok, [{:update_ally_team_config, state.ally_team_config, new_config}]}
+  end
+
+  defp update_property(:game_options, changes, _state, _user_id) do
+    # TODO: set a size limit on that thing to avoid a DOS
+    {:ok, [{:update_game_options, changes}]}
   end
 
   defp update_property(prop, _value, _state, _user_id),

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -1834,6 +1834,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
           %{user_id: s.id, name: s.name, password: s.password}
         end)
     }
+    |> Map.merge(Map.take(state, [:game_options]))
   end
 
   @spec update_property(atom(), term(), state(), T.userid()) ::

--- a/priv/tachyon/schema/lobby/create/request.json
+++ b/priv/tachyon/schema/lobby/create/request.json
@@ -20,9 +20,23 @@
                 "mapName": { "type": "string" },
                 "allyTeamConfig": {
                     "$ref": "../../definitions/allyTeamConfig.json"
+                },
+                "gameOptions": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^.*$": {
+                            "type": "object",
+                            "properties": { "value": { "type": "string" } },
+                            "required": ["value"]
+                        }
+                    }
                 }
             },
-            "required": ["name", "mapName", "allyTeamConfig"]
+            "required": [
+                "name",
+                "mapName",
+                "allyTeamConfig"
+            ]
         }
     },
     "required": ["type", "messageId", "commandId", "data"]

--- a/priv/tachyon/schema/lobby/update/request.json
+++ b/priv/tachyon/schema/lobby/update/request.json
@@ -23,6 +23,24 @@
                 "mapName": { "type": "string" },
                 "allyTeamConfig": {
                     "$ref": "../../definitions/allyTeamConfig.json"
+                },
+                "gameOptions": {
+                    "description": "Set to null to remove a game option",
+                    "type": "object",
+                    "patternProperties": {
+                        "^.*$": {
+                            "anyOf": [
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "value": { "type": "string" }
+                                    },
+                                    "required": ["value"]
+                                },
+                                { "type": "null" }
+                            ]
+                        }
+                    }
                 }
             }
         }

--- a/priv/tachyon/schema/lobby/updated/event.json
+++ b/priv/tachyon/schema/lobby/updated/event.json
@@ -21,6 +21,23 @@
                 "mapName": { "type": "string" },
                 "engineVersion": { "type": "string" },
                 "gameVersion": { "type": "string" },
+                "gameOptions": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^.*$": {
+                            "anyOf": [
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "value": { "type": "string" }
+                                    },
+                                    "required": ["value"]
+                                },
+                                { "type": "null" }
+                            ]
+                        }
+                    }
+                },
                 "allyTeamConfig": {
                     "type": "object",
                     "patternProperties": {

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -519,6 +519,16 @@ defmodule Teiserver.Support.Tachyon do
       allyTeamConfig: lobby_data.ally_team_config
     }
 
+    data =
+      if is_map_key(lobby_data, :game_options) do
+        opts =
+          Enum.map(lobby_data.game_options, fn {k, v} -> {k, %{value: v}} end) |> Enum.into(%{})
+
+        Map.put(data, :gameOptions, opts)
+      else
+        data
+      end
+
     :ok = send_request(client, "lobby/create", data)
     {:ok, resp} = recv_message(client)
     resp

--- a/test/teiserver/tachyon_lobby/lobby_test.exs
+++ b/test/teiserver/tachyon_lobby/lobby_test.exs
@@ -1440,6 +1440,63 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
   end
 
+  describe "update game options" do
+    test "can add an option" do
+      {:ok, _pid, %{id: id}} =
+        mk_start_params([2, 2]) |> Lobby.create()
+
+      :ok = Lobby.update_properties(id, @default_user_id, %{game_options: %{"foo" => "bar"}})
+      {:ok, details} = LobbyProcess.get_details(id)
+      assert details.game_options == %{"foo" => "bar"}
+      assert_receive {:lobby, ^id, {:updated, %{game_options: %{"foo" => "bar"}}}}
+    end
+
+    test "can update option" do
+      {:ok, _pid, %{id: id}} =
+        mk_start_params([2, 2])
+        |> Map.put(:game_options, %{"foo" => "bar"})
+        |> Lobby.create()
+
+      :ok =
+        Lobby.update_properties(id, @default_user_id, %{game_options: %{"foo" => "another bar"}})
+
+      {:ok, details} = LobbyProcess.get_details(id)
+      assert details.game_options == %{"foo" => "another bar"}
+      assert_receive {:lobby, ^id, {:updated, %{game_options: %{"foo" => "another bar"}}}}
+    end
+
+    test "can remove an option" do
+      {:ok, _pid, %{id: id}} =
+        mk_start_params([2, 2])
+        |> Map.put(:game_options, %{"foo" => "bar"})
+        |> Lobby.create()
+
+      :ok = Lobby.update_properties(id, @default_user_id, %{game_options: %{"foo" => nil}})
+      {:ok, details} = LobbyProcess.get_details(id)
+      assert details.game_options == %{}
+      assert_receive {:lobby, ^id, {:updated, %{game_options: %{"foo" => nil}}}}
+    end
+
+    test "can add remove and update in one request" do
+      {:ok, _pid, %{id: id}} =
+        mk_start_params([2, 2])
+        |> Map.put(:game_options, %{"foo" => "bar", "ranked" => "true"})
+        |> Lobby.create()
+
+      :ok =
+        Lobby.update_properties(id, @default_user_id, %{
+          game_options: %{"foo" => nil, "ranked" => "false", "blah" => "qux"}
+        })
+
+      {:ok, details} = LobbyProcess.get_details(id)
+      assert details.game_options == %{"ranked" => "false", "blah" => "qux"}
+
+      assert_receive {:lobby, ^id,
+                      {:updated,
+                       %{game_options: %{"foo" => nil, "ranked" => "false", "blah" => "qux"}}}}
+    end
+  end
+
   # note: [test lobby battle]
   # these tests are a bit anemic because they also require a connected autohost
   # and it's a lot of setup. There are some end to end tests in the

--- a/test/teiserver/tachyon_lobby/lobby_test.exs
+++ b/test/teiserver/tachyon_lobby/lobby_test.exs
@@ -60,6 +60,17 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     assert details.engine_version == engine.name
   end
 
+  test "create lobby with game options" do
+    {:ok, _pid, details} =
+      mk_start_params([1, 1])
+      |> Map.put(:game_options, %{"foo" => "bar"})
+      |> Lobby.create()
+
+    assert details.game_options == %{"foo" => "bar"}
+    {:ok, details2} = LobbyProcess.get_details(details.id)
+    assert details2.game_options == %{"foo" => "bar"}
+  end
+
   test "exit when no more players" do
     test_pid = self()
 

--- a/test/teiserver_web/tachyon/autohost_test.exs
+++ b/test/teiserver_web/tachyon/autohost_test.exs
@@ -134,7 +134,8 @@ defmodule TeiserverWeb.Tachyon.Autohost do
           teams: [%{bots: [%{host_user_id: 123, ai_short_name: "testAI", name: "test AI"}]}],
           start_box: %{left: 0.6, right: 1, top: 0.6, bottom: 1}
         }
-      ]
+      ],
+      game_options: %{"foo" => "bar"}
     }
 
     Task.async(fn ->
@@ -181,7 +182,8 @@ defmodule TeiserverWeb.Tachyon.Autohost do
                "engineVersion" => "engineversion",
                "gameName" => "game name",
                "mapName" => "very map",
-               "startPosType" => "fixed"
+               "startPosType" => "fixed",
+               "gameOptions" => %{"foo" => "bar"}
              }
   end
 

--- a/test/teiserver_web/tachyon/lobby_test.exs
+++ b/test/teiserver_web/tachyon/lobby_test.exs
@@ -405,7 +405,8 @@ defmodule TeiserverWeb.Tachyon.LobbyTest do
         %{
           name: "test lobby",
           map_name: "test-map",
-          ally_team_config: Tachyon.mk_ally_team_config(2, 2)
+          ally_team_config: Tachyon.mk_ally_team_config(2, 2),
+          game_options: %{"foo" => "bar1", "oops" => "to be deleted"}
         }
 
       %{"status" => "success", "data" => %{"id" => lobby_id}} =
@@ -414,7 +415,8 @@ defmodule TeiserverWeb.Tachyon.LobbyTest do
       update_data = %{
         name: "new name",
         mapName: "new map name",
-        allyTeamConfig: Tachyon.mk_ally_team_config(1, 1)
+        allyTeamConfig: Tachyon.mk_ally_team_config(1, 1),
+        gameOptions: %{"foo" => %{"value" => "bar2"}, "oops" => nil}
       }
 
       %{"status" => "success"} = Tachyon.lobby_update!(client, update_data)
@@ -432,7 +434,8 @@ defmodule TeiserverWeb.Tachyon.LobbyTest do
         },
         "id" => lobby_id,
         "mapName" => "new map name",
-        "name" => "new name"
+        "name" => "new name",
+        "gameOptions" => %{"foo" => %{"value" => "bar2"}, "oops" => nil}
       }
 
       assert data == expected

--- a/test/teiserver_web/tachyon/lobby_test.exs
+++ b/test/teiserver_web/tachyon/lobby_test.exs
@@ -15,7 +15,8 @@ defmodule TeiserverWeb.Tachyon.LobbyTest do
       lobby_data = %{
         name: "test lobby",
         map_name: "test-map",
-        ally_team_config: Tachyon.mk_ally_team_config(2, 1)
+        ally_team_config: Tachyon.mk_ally_team_config(2, 1),
+        game_options: %{"foo" => "bar"}
       }
 
       %{"status" => "success", "data" => data} = Tachyon.create_lobby!(client, lobby_data)
@@ -28,6 +29,8 @@ defmodule TeiserverWeb.Tachyon.LobbyTest do
                data["allyTeamConfig"][player_data["allyTeam"]]["teams"],
                player_data["team"]
              )
+
+      assert data["gameOptions"] == %{"foo" => %{"value" => "bar"}}
     end
 
     test "cannot create lobby when already in lobby", %{client: client} do


### PR DESCRIPTION
Add support for game options (aka modoptions) in tachyon, implements https://github.com/beyond-all-reason/tachyon/pull/102 (with follow up https://github.com/beyond-all-reason/tachyon/pull/130)