### PR TITLE
Fixed logging aggregation functions

### DIFF
--- a/lib/teiserver/logging/lib/server_day_log_lib.ex
+++ b/lib/teiserver/logging/lib/server_day_log_lib.ex
@@ -2,6 +2,7 @@ defmodule Teiserver.Logging.ServerDayLogLib do
   @moduledoc false
 
   alias Teiserver.Logging.ServerDayLog
+  alias Teiserver.Logging.UserActivityDayLog
 
   use TeiserverWeb, :library
 
@@ -112,28 +113,40 @@ defmodule Teiserver.Logging.ServerDayLogLib do
   end
 
   # Given an existing segment and a batch of logs, calculate the segment and add them together
-  defp extend_segment(existing, %{data: data} = _server_log) do
+  defp extend_segment(
+         existing,
+         {%ServerDayLog{} = server_log, %UserActivityDayLog{} = user_activity_log}
+       ) do
+    %ServerDayLog{data: log_data} = server_log
+    %UserActivityDayLog{data: user_data} = user_activity_log
+
+    unique_user_ids =
+      user_data
+      |> Map.get("total", [])
+      |> Map.keys()
+
+    unique_player_ids =
+      user_data
+      |> Map.get("player", [])
+      |> Map.keys()
+
     %{
       # Used to make calculating the end of day stats easier,
       # this will not appear in the final result
       tmp_reduction: %{
-        battles: existing.tmp_reduction.battles + get_in(data, ~w(aggregates stats battles)),
-        unique_users:
-          existing.tmp_reduction.unique_users ||
-            0 + get_in(data, ~w(aggregates stats unique_users)),
-        unique_players:
-          existing.tmp_reduction.unique_players ||
-            0 + get_in(data, ~w(aggregates stats unique_players)),
+        battles: existing.tmp_reduction.battles + get_in(log_data, ~w(aggregates stats battles)),
+        unique_users: unique_user_ids ++ existing.tmp_reduction.unique_users,
+        unique_players: unique_player_ids ++ existing.tmp_reduction.unique_players,
         accounts_created:
           existing.tmp_reduction.accounts_created +
-            get_in(data, ~w(aggregates stats accounts_created)),
+            get_in(log_data, ~w(aggregates stats accounts_created)),
         peak_user_counts:
           @user_types
           |> Map.new(fn type ->
             {type,
              max(
                get_in(existing, [:tmp_reduction, :peak_user_counts, type]),
-               get_in(data, ["aggregates", "stats", "peak_user_counts", to_string(type)])
+               get_in(log_data, ["aggregates", "stats", "peak_user_counts", to_string(type)])
              )}
           end)
       },
@@ -141,24 +154,25 @@ defmodule Teiserver.Logging.ServerDayLogLib do
       # Telemetry events
       events: %{
         complex_client:
-          add_maps(existing.events.complex_client, get_in(data, ~w(events complex_client))),
+          add_maps(existing.events.complex_client, get_in(log_data, ~w(events complex_client))),
         simple_client:
-          add_maps(existing.events.simple_client, get_in(data, ~w(events simple_client))),
+          add_maps(existing.events.simple_client, get_in(log_data, ~w(events simple_client))),
         complex_anon:
-          add_maps(existing.events.complex_anon, get_in(data, ~w(events complex_anon))),
-        simple_anon: add_maps(existing.events.simple_anon, get_in(data, ~w(events simple_anon))),
+          add_maps(existing.events.complex_anon, get_in(log_data, ~w(events complex_anon))),
+        simple_anon:
+          add_maps(existing.events.simple_anon, get_in(log_data, ~w(events simple_anon))),
         complex_server:
-          add_maps(existing.events.complex_server, get_in(data, ~w(events complex_server))),
+          add_maps(existing.events.complex_server, get_in(log_data, ~w(events complex_server))),
         simple_server:
-          add_maps(existing.events.simple_server, get_in(data, ~w(events simple_server))),
+          add_maps(existing.events.simple_server, get_in(log_data, ~w(events simple_server))),
         complex_lobby:
-          add_maps(existing.events.complex_lobby, get_in(data, ~w(events complex_lobby))),
+          add_maps(existing.events.complex_lobby, get_in(log_data, ~w(events complex_lobby))),
         simple_lobby:
-          add_maps(existing.events.simple_lobby, get_in(data, ~w(events simple_lobby))),
+          add_maps(existing.events.simple_lobby, get_in(log_data, ~w(events simple_lobby))),
         complex_match:
-          add_maps(existing.events.complex_match, get_in(data, ~w(events complex_match))),
+          add_maps(existing.events.complex_match, get_in(log_data, ~w(events complex_match))),
         simple_match:
-          add_maps(existing.events.simple_match, get_in(data, ~w(events simple_match)))
+          add_maps(existing.events.simple_match, get_in(log_data, ~w(events simple_match)))
       },
 
       # Monthly totals
@@ -168,12 +182,15 @@ defmodule Teiserver.Logging.ServerDayLogLib do
         # Total number of minutes spent doing that across all players that month
         minutes: %{
           player:
-            existing.aggregates.minutes.player + get_in(data, ~w(aggregates minutes player)),
+            existing.aggregates.minutes.player + get_in(log_data, ~w(aggregates minutes player)),
           spectator:
-            existing.aggregates.minutes.spectator + get_in(data, ~w(aggregates minutes spectator)),
-          lobby: existing.aggregates.minutes.lobby + get_in(data, ~w(aggregates minutes lobby)),
-          menu: existing.aggregates.minutes.menu + get_in(data, ~w(aggregates minutes menu)),
-          total: existing.aggregates.minutes.total + get_in(data, ~w(aggregates minutes total))
+            existing.aggregates.minutes.spectator +
+              get_in(log_data, ~w(aggregates minutes spectator)),
+          lobby:
+            existing.aggregates.minutes.lobby + get_in(log_data, ~w(aggregates minutes lobby)),
+          menu: existing.aggregates.minutes.menu + get_in(log_data, ~w(aggregates minutes menu)),
+          total:
+            existing.aggregates.minutes.total + get_in(log_data, ~w(aggregates minutes total))
         }
       }
     }

--- a/lib/teiserver/logging/tasks/persist_server_day_task.ex
+++ b/lib/teiserver/logging/tasks/persist_server_day_task.ex
@@ -72,15 +72,6 @@ defmodule Teiserver.Logging.Tasks.PersistServerDayTask do
       lobby: [],
       menu: [],
       total: []
-    },
-
-    # Per user minute counts for the day as a whole
-    old_minutes_per_user: %{
-      total: %{},
-      player: %{},
-      spectator: %{},
-      lobby: %{},
-      menu: %{}
     }
   }
 
@@ -133,15 +124,6 @@ defmodule Teiserver.Logging.Tasks.PersistServerDayTask do
       lobby: 0,
       menu: 0,
       total: 0
-    },
-
-    # Per user minute counts for the day as a whole
-    old_minutes_per_user: %{
-      total: %{},
-      player: %{},
-      spectator: %{},
-      lobby: %{},
-      menu: %{}
     }
   }
 
@@ -275,16 +257,6 @@ defmodule Teiserver.Logging.Tasks.PersistServerDayTask do
         lobby: segment.peak_user_counts.lobby ++ [extend.peak_user_counts.lobby],
         menu: segment.peak_user_counts.menu ++ [extend.peak_user_counts.menu],
         total: segment.peak_user_counts.total ++ [extend.peak_user_counts.total]
-      },
-
-      # Per user minute counts for the day as a whole
-      old_minutes_per_user: %{
-        total: add_maps(segment.old_minutes_per_user.total, extend.old_minutes_per_user.total),
-        player: add_maps(segment.old_minutes_per_user.player, extend.old_minutes_per_user.player),
-        spectator:
-          add_maps(segment.old_minutes_per_user.spectator, extend.old_minutes_per_user.spectator),
-        lobby: add_maps(segment.old_minutes_per_user.lobby, extend.old_minutes_per_user.lobby),
-        menu: add_maps(segment.old_minutes_per_user.menu, extend.old_minutes_per_user.menu)
       }
     }
   end
@@ -294,43 +266,6 @@ defmodule Teiserver.Logging.Tasks.PersistServerDayTask do
 
   defp calculate_segment_parts(logs) do
     count = Enum.count(logs)
-
-    empty_user_maps = %{
-      total: %{},
-      player: %{},
-      spectator: %{},
-      lobby: %{},
-      menu: %{}
-    }
-
-    user_maps =
-      logs
-      |> Enum.reduce(empty_user_maps, fn log, acc ->
-        %{
-          total:
-            add_maps(
-              acc.total,
-              Map.new(log["client"]["total"] || [], fn userid -> {userid, 1} end)
-            ),
-          player:
-            add_maps(
-              acc.player,
-              Map.new(log["client"]["player"] || [], fn userid -> {userid, 1} end)
-            ),
-          spectator:
-            add_maps(
-              acc.spectator,
-              Map.new(log["client"]["spectator"] || [], fn userid -> {userid, 1} end)
-            ),
-          lobby:
-            add_maps(
-              acc.lobby,
-              Map.new(log["client"]["lobby"] || [], fn userid -> {userid, 1} end)
-            ),
-          menu:
-            add_maps(acc.menu, Map.new(log["client"]["menu"] || [], fn userid -> {userid, 1} end))
-        }
-      end)
 
     %{
       # Average battle counts per segment
@@ -380,10 +315,7 @@ defmodule Teiserver.Logging.Tasks.PersistServerDayTask do
         lobby: max_counts(logs, ~w(client lobby)),
         menu: max_counts(logs, ~w(client menu)),
         total: max_counts(logs, ~w(client total))
-      },
-
-      # Per user minute counts for the day as a whole
-      old_minutes_per_user: user_maps
+      }
     }
   end
 
@@ -483,12 +415,6 @@ defmodule Teiserver.Logging.Tasks.PersistServerDayTask do
     |> Enum.reduce(0, fn row, acc ->
       acc + (get_in(row, path) || 0)
     end)
-  end
-
-  defp add_maps(m1, nil), do: m1
-
-  defp add_maps(m1, m2) do
-    Map.merge(m1, m2, fn _k, v1, v2 -> v1 + v2 end)
   end
 
   @match_blank_acc %{

--- a/lib/teiserver/logging/tasks/persist_user_activity_day_task.ex
+++ b/lib/teiserver/logging/tasks/persist_user_activity_day_task.ex
@@ -83,36 +83,33 @@ defmodule Teiserver.Logging.Tasks.PersistUserActivityDayTask do
       @client_states
       |> Map.new(fn key -> {key, []} end)
 
-    result =
-      logs
-      |> Enum.reduce(start_data, fn log, acc ->
-        %{
-          total: log["client"]["total"] ++ acc.total,
-          player: log["client"]["player"] ++ acc.player,
-          spectator: log["client"]["spectator"] ++ acc.spectator,
-          lobby: log["client"]["lobby"] ++ acc.lobby,
-          menu: log["client"]["menu"] ++ acc.menu
-        }
-      end)
-      |> Map.new(fn {key, userids} ->
-        result =
-          userids
-          |> List.flatten()
-          |> Enum.group_by(
-            fn key ->
-              key
-            end,
-            fn _value ->
-              1
-            end
-          )
-          |> Map.new(fn {key, ones} ->
-            {key, Enum.count(ones)}
-          end)
+    logs
+    |> Enum.reduce(start_data, fn log, acc ->
+      %{
+        total: log["client"]["total"] ++ acc.total,
+        player: log["client"]["player"] ++ acc.player,
+        spectator: log["client"]["spectator"] ++ acc.spectator,
+        lobby: log["client"]["lobby"] ++ acc.lobby,
+        menu: log["client"]["menu"] ++ acc.menu
+      }
+    end)
+    |> Map.new(fn {key, userids} ->
+      result =
+        userids
+        |> List.flatten()
+        |> Enum.group_by(
+          fn key ->
+            key
+          end,
+          fn _value ->
+            1
+          end
+        )
+        |> Map.new(fn {key, ones} ->
+          {key, Enum.count(ones)}
+        end)
 
-        {key, result}
-      end)
-
-    result
+      {key, result}
+    end)
   end
 end

--- a/test/teiserver/logging/persist_server_month_task_test.exs
+++ b/test/teiserver/logging/persist_server_month_task_test.exs
@@ -2,15 +2,18 @@ defmodule Teiserver.Logging.Tasks.PersistServerMonthTaskTest do
   @moduledoc false
 
   alias Teiserver.Account
+  alias Teiserver.AccountFixtures
   alias Teiserver.CacheUser
   alias Teiserver.Logging
   alias Teiserver.Logging.Tasks.PersistServerDayTask
   alias Teiserver.Logging.Tasks.PersistServerMonthTask
+
   use Teiserver.DataCase
 
-  @tag :needs_attention
   test "perform task" do
-    flunk("We do not create the user_activity_log data so this always fails")
+    AccountFixtures.user_fixture()
+    AccountFixtures.user_fixture()
+    AccountFixtures.user_fixture()
 
     # Make some data
     create_day_data(1)
@@ -25,7 +28,8 @@ defmodule Teiserver.Logging.Tasks.PersistServerMonthTaskTest do
 
     assert log.year == 2021
     assert log.month == 1
-    assert log.data["aggregates"]["minutes"]["lobby"] == 42
+    assert Map.keys(log.data) == ["aggregates", "events"]
+    assert Map.keys(log.data["aggregates"]) == ["minutes", "stats"]
   end
 
   defp create_day_data(day) do
@@ -100,7 +104,32 @@ defmodule Teiserver.Logging.Tasks.PersistServerMonthTaskTest do
       Logging.create_server_minute_log(params)
     end)
 
+    create_activity_data(day)
+
     # Now create the day data
     assert :ok == PersistServerDayTask.perform(%{})
+  end
+
+  defp create_activity_data(day) do
+    user_ids =
+      Account.list_users()
+      |> Enum.map(fn u -> u.id end)
+      |> CacheUser.list_users()
+      |> Enum.filter(fn u -> u.bot == false end)
+      |> Enum.map(fn u -> u.id end)
+
+    activity_data = %{
+      total: Map.new(user_ids, fn id -> {id, :rand.uniform(100)} end),
+      player: Map.new(user_ids, fn id -> {id, :rand.uniform(100)} end),
+      spectator: Map.new(user_ids, fn id -> {id, :rand.uniform(100)} end),
+      lobby: Map.new(user_ids, fn id -> {id, :rand.uniform(100)} end),
+      menu: Map.new(user_ids, fn id -> {id, :rand.uniform(100)} end)
+    }
+
+    # Next, user activity data
+    Logging.create_user_activity_day_log(%{
+      "date" => Date.new(2021, 1, day),
+      "data" => activity_data
+    })
   end
 end


### PR DESCRIPTION
Server logs are now correctly aggregated again. After deploying this fix I would advise running the following query on the database to allow a rebuild of the affected aggregate data to take place.

```sql
DELETE FROM teiserver_server_week_logs WHERE date >= '2024-04-01';
DELETE FROM teiserver_server_month_logs WHERE date >= '2024-04-01';
DELETE FROM teiserver_server_quarter_logs WHERE date >= '2024-04-01';
DELETE FROM teiserver_server_year_logs WHERE year >= 2024;
```