### PR TITLE
Fixed month match log persistence

### DIFF
--- a/lib/teiserver/logging/tasks/persist_match_month_task.ex
+++ b/lib/teiserver/logging/tasks/persist_match_month_task.ex
@@ -157,10 +157,10 @@ defmodule Teiserver.Logging.Tasks.PersistMatchMonthTask do
         weighted_count:
           existing.aggregate.weighted_count + (data["aggregate"]["weighted_count"] || 0)
       },
-      duration: sum_maps(existing.duration, data["duration"] || 0),
-      maps: sum_maps(existing.maps, data["maps"] || 0),
-      matches_per_hour: sum_maps(existing.matches_per_hour, data["matches_per_hour"] || 0),
-      team_sizes: sum_maps(existing.team_sizes, data["team_sizes"] || 0)
+      duration: sum_maps(existing.duration, data["duration"] || %{}),
+      maps: sum_maps(existing.maps, data["maps"] || %{}),
+      matches_per_hour: sum_maps(existing.matches_per_hour, data["matches_per_hour"] || %{}),
+      team_sizes: sum_maps(existing.team_sizes, data["team_sizes"] || %{})
     }
   end
 

--- a/lib/teiserver_web/controllers/logging/match_log_controller.ex
+++ b/lib/teiserver_web/controllers/logging/match_log_controller.ex
@@ -162,7 +162,10 @@ defmodule TeiserverWeb.Logging.MatchLogController do
         {Timex.today().year, Timex.today().month - 1}
       end
 
-    last_month = Logging.get_match_month_log({lyear, lmonth}).data
+    last_month_data =
+      {lyear, lmonth}
+      |> Logging.get_match_month_log()
+      |> Map.get(:data)
 
     days_in_month = Timex.days_in_month(Timex.now())
     progress = round(Timex.today().day / days_in_month * 100)
@@ -171,7 +174,7 @@ defmodule TeiserverWeb.Logging.MatchLogController do
     |> assign(:year, Timex.today().year)
     |> assign(:month, Timex.today().month)
     |> assign(:data, data)
-    |> assign(:last_month, last_month)
+    |> assign(:last_month, last_month_data)
     |> assign(:progress, progress)
     |> add_breadcrumb(name: "Monthly - This month (partial)", url: conn.request_path)
     |> render("month_metrics_today_show.html")

--- a/lib/teiserver_web/templates/logging/match_log/day_metrics_show.html.heex
+++ b/lib/teiserver_web/templates/logging/match_log/day_metrics_show.html.heex
@@ -64,9 +64,21 @@
                 </a>
               </li>
 
-              <li class="nav-item">
+              <li :if={Map.has_key?(@data, "team")} class="nav-item">
                 <a href="#team_tab" role="tab" class="nav-link" data-bs-toggle="tab">
                   <i class="fa-solid fa-fw fa-dice-d20"></i> Team
+                </a>
+              </li>
+
+              <li :if={Map.has_key?(@data, "small_team")} class="nav-item">
+                <a href="#small_team_tab" role="tab" class="nav-link" data-bs-toggle="tab">
+                  <i class="fa-solid fa-fw fa-dice-d6"></i> Small Team
+                </a>
+              </li>
+
+              <li :if={Map.has_key?(@data, "large_team")} class="nav-item">
+                <a href="#large_team_tab" role="tab" class="nav-link" data-bs-toggle="tab">
+                  <i class="fa-solid fa-fw fa-dice-d20"></i> Large Team
                 </a>
               </li>
 
@@ -110,8 +122,31 @@
                 {render("tab_duel.html", %{data: @data["duel"]})}
               </div>
 
-              <div class="tab-pane" id="team_tab" style="padding:5px;">
+              <div
+                :if={Map.has_key?(@data, "team")}
+                class="tab-pane"
+                id="team_tab"
+                style="padding:5px;"
+              >
                 {render("tab_team.html", %{data: @data["team"]})}
+              </div>
+
+              <div
+                :if={Map.has_key?(@data, "small_team")}
+                class="tab-pane"
+                id="small_team_tab"
+                style="padding:5px;"
+              >
+                {render("tab_team.html", %{data: @data["small_team"]})}
+              </div>
+
+              <div
+                :if={Map.has_key?(@data, "large_team")}
+                class="tab-pane"
+                id="large_team_tab"
+                style="padding:5px;"
+              >
+                {render("tab_team.html", %{data: @data["large_team"]})}
               </div>
 
               <div class="tab-pane" id="ffa_tab" style="padding:5px;">

--- a/lib/teiserver_web/templates/logging/match_log/month_metrics_show.html.heex
+++ b/lib/teiserver_web/templates/logging/match_log/month_metrics_show.html.heex
@@ -34,7 +34,7 @@
           Map.merge(assigns, %{
             quick_search: "",
             show_search: false,
-            active: "this_month"
+            active: "month_metrics"
           })
         )}
 

--- a/lib/teiserver_web/templates/logging/match_log/tab_month_details.html.heex
+++ b/lib/teiserver_web/templates/logging/match_log/tab_month_details.html.heex
@@ -19,6 +19,11 @@
     )}
 
     {central_component("detail_line",
+      label: "Team (All)",
+      value: format_number(@data["team"]["aggregate"]["total_count"])
+    )}
+
+    {central_component("detail_line",
       label: "Small Team",
       value: format_number(@data["small_team"]["aggregate"]["total_count"])
     )}
@@ -61,6 +66,11 @@
     {central_component("detail_line",
       label: "FFA",
       value: format_number(@data["ffa"]["aggregate"]["weighted_count"])
+    )}
+
+    {central_component("detail_line",
+      label: "Team (All)",
+      value: format_number(@data["team"]["aggregate"]["weighted_count"])
     )}
 
     {central_component("detail_line",


### PR DESCRIPTION
Fixes the view and aggregation of match logs. After deploying suggest running the following query to force a re-aggregation of the relevant logs:

```sql
DELETE FROM teiserver_match_month_logs WHERE year >= 2024;
```