### PR TITLE
Disconnect Teiserver Internal Clients before terminating

### DIFF
--- a/lib/teiserver/battle/servers/match_monitor_server.ex
+++ b/lib/teiserver/battle/servers/match_monitor_server.ex
@@ -528,6 +528,7 @@ defmodule Teiserver.Battle.MatchMonitorServer do
   @impl GenServer
   @spec init(map()) :: {:ok, map()}
   def init(_opts) do
+    Process.flag(:trap_exit, true)
     send(self(), :begin)
     Logger.metadata(request_id: "MatchMonitorServer")
 
@@ -538,6 +539,11 @@ defmodule Teiserver.Battle.MatchMonitorServer do
     )
 
     {:ok, %{}}
+  end
+
+  @impl GenServer
+  def terminate(_reason, state) do
+    Client.disconnect(state.userid, "match monitor terminate")
   end
 
   @spec get_match_monitor_pid() :: pid() | nil

--- a/lib/teiserver/bridge/bridge_server.ex
+++ b/lib/teiserver/bridge/bridge_server.ex
@@ -11,6 +11,7 @@ defmodule Teiserver.Bridge.BridgeServer do
   alias Teiserver.Bridge.DiscordBridgeBot
   alias Teiserver.CacheUser
   alias Teiserver.Chat.WordLib
+  alias Teiserver.Client
   alias Teiserver.Communication
   alias Teiserver.Config
   alias Teiserver.Data.Types, as: T
@@ -498,6 +499,7 @@ defmodule Teiserver.Bridge.BridgeServer do
   @spec init(map()) :: {:ok, map()}
   def init(_opts) do
     if Communication.use_discord?() do
+      Process.flag(:trap_exit, true)
       send(self(), :begin)
     end
 
@@ -511,6 +513,11 @@ defmodule Teiserver.Bridge.BridgeServer do
     )
 
     {:ok, %{}}
+  end
+
+  @impl GenServer
+  def terminate(_reason, state) do
+    Client.disconnect(state.userid, "bridge terminate")
   end
 
   @spec get_bridge_pid() :: pid

--- a/lib/teiserver/coordinator/coordinator_server.ex
+++ b/lib/teiserver/coordinator/coordinator_server.ex
@@ -371,6 +371,8 @@ defmodule Teiserver.Coordinator.CoordinatorServer do
   @impl GenServer
   @spec init(map()) :: {:ok, map()}
   def init(_opts) do
+    Process.flag(:trap_exit, true)
+
     Horde.Registry.register(
       Teiserver.ServerRegistry,
       "CoordinatorServer",
@@ -379,5 +381,10 @@ defmodule Teiserver.Coordinator.CoordinatorServer do
 
     send(self(), :begin)
     {:ok, %{client: %{}}}
+  end
+
+  @impl GenServer
+  def terminate(_reason, state) do
+    Client.disconnect(state.userid, "coordinator terminate")
   end
 end


### PR DESCRIPTION
Cleanly disconnect Teiserver bot accounts before terminating them by send the proper Spring protocol message otherwise SPADS hosts will disconnect.