### PR TITLE
fix: extend max length for complex client events

### DIFF
--- a/lib/teiserver/protocols/spring/spring_telemetry_in.ex
+++ b/lib/teiserver/protocols/spring/spring_telemetry_in.ex
@@ -12,6 +12,8 @@ defmodule Teiserver.Protocols.Spring.TelemetryIn do
   import SpringIn, only: [_no_match: 4]
   # import Teiserver.Helper.NumberHelper, only: [int_parse: 1]
 
+  @complex_client_event_max_length 4096
+
   # TODO: Less nested hackyness
   @spec do_handle(String.t(), String.t(), String.t() | nil, map()) :: map()
   def do_handle("upload_infolog", data, msg_id, state) do
@@ -145,8 +147,6 @@ defmodule Teiserver.Protocols.Spring.TelemetryIn do
     end
   end
 
-  @complex_client_event_max_length 4096
-
   defp do_complex_client_event(data, state) do
     if String.length(data) < @complex_client_event_max_length do
       case Regex.run(~r/(\S+) (\S+) (\S+)/u, data) do
@@ -172,8 +172,7 @@ defmodule Teiserver.Protocols.Spring.TelemetryIn do
       end
     else
       Logger.warning(
-        "log_client_event exceeds max_length: length=#{String.length(data)} " <>
-          "max=#{@complex_client_event_max_length}"
+        "log_client_event exceeds max_length: length=#{String.length(data)} max=#{@complex_client_event_max_length}"
       )
 
       "exceeds max_length"

--- a/lib/teiserver/protocols/spring/spring_telemetry_in.ex
+++ b/lib/teiserver/protocols/spring/spring_telemetry_in.ex
@@ -145,8 +145,10 @@ defmodule Teiserver.Protocols.Spring.TelemetryIn do
     end
   end
 
+  @complex_client_event_max_length 4096
+
   defp do_complex_client_event(data, state) do
-    if String.length(data) < 1024 do
+    if String.length(data) < @complex_client_event_max_length do
       case Regex.run(~r/(\S+) (\S+) (\S+)/u, data) do
         [_full_match, event_name, value64, hash] ->
           case Spring.decode_value(value64) do
@@ -169,6 +171,11 @@ defmodule Teiserver.Protocols.Spring.TelemetryIn do
           "no match"
       end
     else
+      Logger.warning(
+        "log_client_event exceeds max_length: length=#{String.length(data)} " <>
+          "max=#{@complex_client_event_max_length}"
+      )
+
       "exceeds max_length"
     end
   end


### PR DESCRIPTION
Complex_client_events were silently dropped if they were above the 1024 length limit. Benchmark results are in the neighborhood of ~1500 characters.

Added a log for when they're dropped, and increased the drop threshold to 4096 for JUST complex events. Other payloads remain at a threshold of 1024.

Tested: data makes it into my local db! 
<img width="921" height="371" alt="image" src="https://github.com/user-attachments/assets/82749cd1-2fdd-428a-9fb4-9188adcbc1c1" />
