### PR TITLE
chore: add warning logs for messages exceeding max length

### DIFF
--- a/lib/teiserver/protocols/spring/spring_telemetry_in.ex
+++ b/lib/teiserver/protocols/spring/spring_telemetry_in.ex
@@ -141,9 +141,7 @@ defmodule Teiserver.Protocols.Spring.TelemetryIn do
           "no match"
       end
     else
-      Logger.warning(
-        "simple_client_event exceeds max_length: length=#{String.length(data)} max=1024"
-      )
+      Logger.warning("simple_client_event exceeds max_length: length=#{String.length(data)} max=1024")
 
       "exceeds max_length"
     end
@@ -200,9 +198,7 @@ defmodule Teiserver.Protocols.Spring.TelemetryIn do
           "no match"
       end
     else
-      Logger.warning(
-        "live_client_event exceeds max_length: length=#{String.length(data)} max=1024"
-      )
+      Logger.warning("live_client_event exceeds max_length: length=#{String.length(data)} max=1024")
 
       "exceeds max_length"
     end
@@ -248,9 +244,7 @@ defmodule Teiserver.Protocols.Spring.TelemetryIn do
           "no match"
       end
     else
-      Logger.warning(
-        "client_property exceeds max_length: length=#{String.length(data)} max=1024"
-      )
+      Logger.warning("client_property exceeds max_length: length=#{String.length(data)} max=1024")
 
       "exceeds max_length"
     end

--- a/lib/teiserver/protocols/spring/spring_telemetry_in.ex
+++ b/lib/teiserver/protocols/spring/spring_telemetry_in.ex
@@ -141,6 +141,10 @@ defmodule Teiserver.Protocols.Spring.TelemetryIn do
           "no match"
       end
     else
+      Logger.warning(
+        "simple_client_event exceeds max_length: length=#{String.length(data)} max=1024"
+      )
+
       "exceeds max_length"
     end
   end
@@ -196,6 +200,10 @@ defmodule Teiserver.Protocols.Spring.TelemetryIn do
           "no match"
       end
     else
+      Logger.warning(
+        "live_client_event exceeds max_length: length=#{String.length(data)} max=1024"
+      )
+
       "exceeds max_length"
     end
   end
@@ -240,6 +248,10 @@ defmodule Teiserver.Protocols.Spring.TelemetryIn do
           "no match"
       end
     else
+      Logger.warning(
+        "client_property exceeds max_length: length=#{String.length(data)} max=1024"
+      )
+
       "exceeds max_length"
     end
   end

--- a/lib/teiserver/protocols/spring/spring_telemetry_in.ex
+++ b/lib/teiserver/protocols/spring/spring_telemetry_in.ex
@@ -141,7 +141,9 @@ defmodule Teiserver.Protocols.Spring.TelemetryIn do
           "no match"
       end
     else
-      Logger.warning("simple_client_event exceeds max_length: length=#{String.length(data)} max=1024")
+      Logger.warning(
+        "simple_client_event exceeds max_length: length=#{String.length(data)} max=1024"
+      )
 
       "exceeds max_length"
     end
@@ -198,7 +200,9 @@ defmodule Teiserver.Protocols.Spring.TelemetryIn do
           "no match"
       end
     else
-      Logger.warning("live_client_event exceeds max_length: length=#{String.length(data)} max=1024")
+      Logger.warning(
+        "live_client_event exceeds max_length: length=#{String.length(data)} max=1024"
+      )
 
       "exceeds max_length"
     end


### PR DESCRIPTION
# Purpose
An earlier PR (#1095) discovered that payloads too large were being silently dropped in a few places.

This PR adds warning logs to the remaining places so we can at least see when that happens.

Outside of these places, it seems we only have a 64KB buffer size limit which already has a log when exceeded.