### PR TITLE
Lobby bosses

### DIFF
--- a/lib/teiserver/player/session.ex
+++ b/lib/teiserver/player/session.ex
@@ -550,6 +550,12 @@ defmodule Teiserver.Player.Session do
     user_id |> via_tuple() |> GenServer.call({:lobby, :vote_submit, vote_id, ballot})
   end
 
+  @spec lobby_appoint_boss(T.userid(), T.userid()) ::
+          :ok | {:error, :invalid_lobby | term()}
+  def lobby_appoint_boss(user_id, appointee_id) do
+    user_id |> via_tuple() |> GenServer.call({:lobby, :appoint_boss, appointee_id})
+  end
+
   @spec lobby_update_client_status(T.userid(), TachyonLobby.client_status_update_data()) ::
           :ok | {:error, :invalid_lobby | term()}
   def lobby_update_client_status(user_id, data) do
@@ -1203,6 +1209,14 @@ defmodule Teiserver.Player.Session do
 
   def handle_call({:lobby, :vote_submit, vote_id, ballot}, _from, state) do
     {:reply, TachyonLobby.vote_submit(state.lobby.id, state.user.id, {vote_id, ballot}), state}
+  end
+
+  def handle_call({:lobby, :appoint_boss, _appointee_id}, _from, state)
+      when is_nil(state.lobby),
+      do: {:reply, {:error, :not_in_lobby}, state}
+
+  def handle_call({:lobby, :appoint_boss, appointee_id}, _from, state) do
+    {:reply, TachyonLobby.appoint_boss(state.lobby.id, state.user.id, appointee_id), state}
   end
 
   def handle_call({:lobby, :update_client_status, _data}, _from, state) when is_nil(state.lobby),

--- a/lib/teiserver/player/session.ex
+++ b/lib/teiserver/player/session.ex
@@ -556,6 +556,12 @@ defmodule Teiserver.Player.Session do
     user_id |> via_tuple() |> GenServer.call({:lobby, :appoint_boss, appointee_id})
   end
 
+  @spec lobby_unboss(T.userid(), T.userid()) ::
+          :ok | {:error, :invalid_lobby | term()}
+  def lobby_unboss(user_id, boss_id) do
+    user_id |> via_tuple() |> GenServer.call({:lobby, :unboss, boss_id})
+  end
+
   @spec lobby_update_client_status(T.userid(), TachyonLobby.client_status_update_data()) ::
           :ok | {:error, :invalid_lobby | term()}
   def lobby_update_client_status(user_id, data) do
@@ -1217,6 +1223,14 @@ defmodule Teiserver.Player.Session do
 
   def handle_call({:lobby, :appoint_boss, appointee_id}, _from, state) do
     {:reply, TachyonLobby.appoint_boss(state.lobby.id, state.user.id, appointee_id), state}
+  end
+
+  def handle_call({:lobby, :unboss, _boss_id}, _from, state)
+      when is_nil(state.lobby),
+      do: {:reply, {:error, :not_in_lobby}, state}
+
+  def handle_call({:lobby, :unboss, boss_id}, _from, state) do
+    {:reply, TachyonLobby.unboss(state.lobby.id, state.user.id, boss_id), state}
   end
 
   def handle_call({:lobby, :update_client_status, _data}, _from, state) when is_nil(state.lobby),

--- a/lib/teiserver/player/session.ex
+++ b/lib/teiserver/player/session.ex
@@ -480,6 +480,7 @@ defmodule Teiserver.Player.Session do
           name: String.t(),
           map_name: String.t(),
           ally_team_config: TachyonLobby.ally_team_config(),
+          boss_enabled?: boolean(),
           game_options: %{String.t() => String.t()}
         }
   @spec create_lobby(T.userid(), lobby_start_params()) ::

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -1318,6 +1318,7 @@ defmodule Teiserver.Player.TachyonHandler do
       map_name: :mapName,
       engine_version: :engineVersion,
       game_version: :gameVersion,
+      boss_enabled?: :areBossesEnabled,
       current_battle:
         {:currentBattle,
          %{

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -1337,6 +1337,7 @@ defmodule Teiserver.Player.TachyonHandler do
   defp vote_action_to_tachyon(action) do
     case action do
       {:change_map, name} -> %{type: :changeMap, newMapName: name}
+      {:appoint_boss, boss_id} -> %{type: :appointBoss, bossId: to_string(boss_id)}
     end
   end
 

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -194,7 +194,9 @@ defmodule Teiserver.Player.TachyonHandler do
   def handle_info({:lobby, lobby_id, {:updated, update}}, state) do
     data = lobby_update_to_tachyon(lobby_id, update)
 
-    {:event, "lobby/updated", data, state}
+    if data != %{},
+      do: {:event, "lobby/updated", data, state},
+      else: {:ok, state}
   end
 
   def handle_info({:lobby, _lobby_id, {:vote_ended, vote_id, outcome}}, state) do
@@ -881,6 +883,15 @@ defmodule Teiserver.Player.TachyonHandler do
     end
   end
 
+  def handle_command("lobby/appointBoss", "request", _msg_id, %{"data" => data}, state) do
+    with {:ok, target_id} <- TachyonParser.parse_user_id(data["userId"]),
+         :ok <- Session.lobby_appoint_boss(state.user.id, target_id) do
+      {:response, state}
+    else
+      {:error, err} -> {:error_response, :invalid_request, to_string(err), state}
+    end
+  end
+
   def handle_command("lobby/updateClientStatus", "request", _msg_id, %{"data" => data}, state) do
     mappings = %{"isReady" => :ready?, "assetStatus" => {:asset_status, &parse_asset_status/1}}
     change_status = Collections.transform_map(data, mappings)
@@ -1171,12 +1182,17 @@ defmodule Teiserver.Player.TachyonHandler do
       name: :name,
       map_name: :mapName,
       ally_team_config: {:allyTeamConfig, &ally_team_config_to_tachyon/1},
+      bosses: :bosses,
       current_vote: {:currentVote, &vote_to_tachyon/1},
       vote_history: {:voteHistory, &vote_history_to_tachyon/1},
       game_options: {:gameOptions, &game_options_to_tachyon/1}
     }
 
-    Map.merge(%{id: lobby_id}, Collections.transform_map(update_map, mappings))
+    data = Collections.transform_map(update_map, mappings)
+
+    if data == %{},
+      do: %{},
+      else: Map.put(data, :id, lobby_id)
   end
 
   defp player_updates_to_tachyon(nil), do: nil

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -686,6 +686,7 @@ defmodule Teiserver.Player.TachyonHandler do
             teams: teams
           }
         end,
+      boss_enabled?: msg["data"]["areBossesEnabled"],
       game_options:
         Map.get(msg["data"], "gameOptions", %{})
         |> Enum.map(fn {k, v} -> {k, v["value"]} end)
@@ -1142,6 +1143,12 @@ defmodule Teiserver.Player.TachyonHandler do
       name: :name,
       map_name: :mapName,
       ally_team_config: {:allyTeamConfig, &ally_team_config_to_tachyon/1},
+      boss_enabled?: :areBossesEnabled,
+      bosses:
+        {:bosses,
+         fn bs ->
+           Enum.reduce(bs, %{}, fn id, acc -> Map.put(acc, to_string(id), %{}) end)
+         end},
       game_options: {:gameOptions, &game_options_to_tachyon/1},
       engine_version: :engineVersion,
       game_version: :gameVersion,

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -892,6 +892,21 @@ defmodule Teiserver.Player.TachyonHandler do
     end
   end
 
+  def handle_command("lobby/unboss", "request", _msg_id, %{"data" => data}, state) do
+    user_id =
+      case data["userId"] do
+        nil -> {:ok, state.user.id}
+        raw -> TachyonParser.parse_user_id(raw)
+      end
+
+    with {:ok, boss_id} <- user_id,
+         :ok <- Session.lobby_unboss(state.user.id, boss_id) do
+      {:response, state}
+    else
+      {:error, err} -> {:error_response, :invalid_request, to_string(err), state}
+    end
+  end
+
   def handle_command("lobby/updateClientStatus", "request", _msg_id, %{"data" => data}, state) do
     mappings = %{"isReady" => :ready?, "assetStatus" => {:asset_status, &parse_asset_status/1}}
     change_status = Collections.transform_map(data, mappings)

--- a/lib/teiserver/tachyon_lobby.ex
+++ b/lib/teiserver/tachyon_lobby.ex
@@ -152,4 +152,8 @@ defmodule Teiserver.TachyonLobby do
   @spec appoint_boss(id(), T.userid(), appointee_id :: T.userid()) ::
           :ok | {:error, :invalid_lobby | :not_in_lobby | :no_boss_allowed | :not_a_boss}
   defdelegate appoint_boss(lobby_id, user_id, appointee_id), to: Lobby
+
+  @spec unboss(id(), T.userid(), boss_id :: T.userid()) ::
+          :ok | {:error, :invalid_lobby | :not_in_lobby | :no_boss_allowed | :not_a_boss}
+  defdelegate unboss(lobby_id, user_id, boss_id), to: Lobby
 end

--- a/lib/teiserver/tachyon_lobby.ex
+++ b/lib/teiserver/tachyon_lobby.ex
@@ -145,4 +145,11 @@ defmodule Teiserver.TachyonLobby do
   @spec send_message(id(), T.userid(), String.t()) ::
           :ok | {:error, :invalid_request, reason :: term()}
   defdelegate send_message(lobby_id, from_id, msg_content), to: Lobby
+
+  @doc """
+  make the given player a boss. Only a boss can do that
+  """
+  @spec appoint_boss(id(), T.userid(), appointee_id :: T.userid()) ::
+          :ok | {:error, :invalid_lobby | :not_in_lobby | :no_boss_allowed | :not_a_boss}
+  defdelegate appoint_boss(lobby_id, user_id, appointee_id), to: Lobby
 end

--- a/lib/teiserver/tachyon_lobby/list.ex
+++ b/lib/teiserver/tachyon_lobby/list.ex
@@ -27,6 +27,7 @@ defmodule Teiserver.TachyonLobby.List do
           map_name: String.t(),
           engine_version: String.t(),
           game_version: String.t(),
+          boss_enabled?: boolean(),
           current_battle: nil | %{started_at: DateTime.t()}
         }
 

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -253,6 +253,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
            | {:start_vote, vote_state()}
            | {:cast_vote, T.userid(), vote_ballot()}
            | {:vote_ended, DateTime.t(), vote_outcome()}
+           | {:update_boss, :add | :remove, T.userid()}
 
   @spec gen_id() :: id()
   def gen_id, do: UUID.uuid4()
@@ -424,6 +425,12 @@ defmodule Teiserver.TachyonLobby.Lobby do
   @spec join_queue(id(), T.userid()) :: :ok | {:error, :invalid_lobby | :not_in_lobby}
   def join_queue(lobby_id, user_id) do
     call_lobby(lobby_id, {:join_queue, user_id})
+  end
+
+  @spec appoint_boss(id(), T.userid(), appointee_id :: T.userid()) ::
+          :ok | {:error, :invalid_lobby | :not_in_lobby | :no_boss_allowed | :not_a_boss}
+  def appoint_boss(lobby_id, user_id, appointee_id) do
+    call_lobby(lobby_id, {:appoint_boss, user_id, appointee_id})
   end
 
   @spec start_battle(id(), T.userid()) ::
@@ -972,6 +979,30 @@ defmodule Teiserver.TachyonLobby.Lobby do
     end
   end
 
+  def handle_event({:call, from}, {:appoint_boss, user_id, _appointee_id}, _state, data)
+      when not is_map_key(data.players, user_id) and not is_map_key(data.spectators, user_id),
+      do: {:keep_state, data, [{:reply, from, {:error, :not_in_lobby}}]}
+
+  def handle_event({:call, from}, {:appoint_boss, _user_id, appointee_id}, _state, data)
+      when not is_map_key(data.players, appointee_id) and
+             not is_map_key(data.spectators, appointee_id),
+      do: {:keep_state, data, [{:reply, from, {:error, :not_in_lobby}}]}
+
+  def handle_event({:call, from}, {:appoint_boss, user_id, appointee_id}, _state, data) do
+    cond do
+      not data.boss_enabled? ->
+        {:keep_state, data, [{:reply, from, {:error, :no_boss_allowed}}]}
+
+      not MapSet.member?(data.bosses, user_id) ->
+        {:keep_state, data, [{:reply, from, {:error, :not_a_boss}}]}
+
+      true ->
+        events = [{:update_boss, :add, appointee_id}]
+        data = process_events(events, data) |> broadcast_updates() |> Map.get(:data)
+        {:keep_state, data, [{:reply, from, :ok}]}
+    end
+  end
+
   def handle_event({:call, from}, {:start_battle, user_id}, _state, data)
       when not is_map_key(data.players, user_id) and not is_map_key(data.spectators, user_id),
       do: {:keep_state, data, [{:reply, from, {:error, :not_in_lobby}}]}
@@ -1473,6 +1504,16 @@ defmodule Teiserver.TachyonLobby.Lobby do
     |> Map.update!(:actions, &[vote_ev | &1])
   end
 
+  defp process_event({:update_boss, :add, appointee_id} = ev, aggregate) do
+    if MapSet.member?(aggregate.data.bosses, appointee_id) do
+      aggregate
+    else
+      aggregate
+      |> update_in([:data, :bosses], &MapSet.put(&1, appointee_id))
+      |> Map.update!(:updates, &[ev | &1])
+    end
+  end
+
   # avoid sending a useless lobby list update when the last member of the lobby
   # just left. The caller of this function will detect the lobby is empty and
   # terminate the process, which will trigger the final lobby list update for
@@ -1484,8 +1525,12 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   defp broadcast_updates(aggregate, sender_id \\ nil) do
     change_map = Enum.reduce(aggregate.updates, %{}, &update_change_from_event/2)
-    broadcast_update({:update, sender_id, change_map}, aggregate.data)
-    broadcast_list_updates(aggregate)
+
+    if change_map != %{} do
+      broadcast_update({:update, sender_id, change_map}, aggregate.data)
+      broadcast_list_updates(aggregate)
+    end
+
     aggregate
   end
 
@@ -1593,6 +1638,12 @@ defmodule Teiserver.TachyonLobby.Lobby do
       finished_at: record.finished_at,
       outcome: record.outcome
     })
+  end
+
+  defp update_change_from_event({:update_boss, :add, appointee_id}, change_map) do
+    change_map
+    |> Map.put_new(:bosses, %{})
+    |> put_in([:bosses, appointee_id], %{})
   end
 
   defp broadcast_list_updates(%{data: final_state})

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -76,6 +76,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
           required(:ally_team_config) => ally_team_config(),
           optional(:game_version) => String.t(),
           optional(:engine_version) => String.t(),
+          optional(:boss_enabled?) => boolean(),
           optional(:game_options) => %{String.t() => String.t()}
         }
 
@@ -115,6 +116,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
           map_name: String.t(),
           game_version: String.t(),
           engine_version: String.t(),
+          boss_enabled?: boolean(),
+          bosses: MapSet.t(T.userid()),
           ally_team_config: ally_team_config(),
           game_options: %{String.t() => String.t()},
           players: %{
@@ -202,6 +205,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
            map_name: String.t(),
            game_version: String.t(),
            engine_version: String.t(),
+           boss_enabled?: boolean(),
+           bosses: MapSet.t(T.userid()),
            ally_team_config: ally_team_config(),
            game_options: %{String.t() => String.t()},
            # used to track the players in the lobby.
@@ -446,6 +451,13 @@ defmodule Teiserver.TachyonLobby.Lobby do
     monitors =
       MC.new() |> MC.monitor(start_params.creator_pid, {:user, start_params.creator_data.id})
 
+    boss_enabled? = Map.get(start_params, :boss_enabled?) || false
+
+    bosses =
+      if boss_enabled?,
+        do: MapSet.new([start_params.creator_data.id]),
+        else: MapSet.new()
+
     state = %{
       id: id,
       monitors: monitors,
@@ -453,6 +465,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
       map_name: start_params.map_name,
       game_version: start_params.game_version,
       engine_version: start_params.engine_version,
+      boss_enabled?: boss_enabled?,
+      bosses: bosses,
       ally_team_config: start_params.ally_team_config,
       game_options: Map.get(start_params, :game_options, %{}),
       players: %{
@@ -1154,6 +1168,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
       :map_name,
       :game_version,
       :engine_version,
+      :boss_enabled?,
+      :bosses,
       :ally_team_config,
       :current_battle,
       :current_vote,

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -93,7 +93,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   @type asset_status :: :missing | :downloading | :complete
 
-  @type vote_action :: {:change_map, String.t()} | :start
+  @type vote_action :: {:change_map, String.t()} | {:appoint_boss, T.userid()} | :start
   @type vote_ballot :: :yes | :no | :abstain
   @type vote_state :: %{
           id: String.t(),
@@ -1000,8 +1000,18 @@ defmodule Teiserver.TachyonLobby.Lobby do
       not data.boss_enabled? ->
         {:keep_state, data, [{:reply, from, {:error, :no_boss_allowed}}]}
 
-      not MapSet.member?(data.bosses, user_id) ->
+      not Enum.empty?(data.bosses) and not MapSet.member?(data.bosses, user_id) ->
         {:keep_state, data, [{:reply, from, {:error, :not_a_boss}}]}
+
+      Enum.empty?(data.bosses) and Enum.count(data.players, &(!bot_id?(elem(&1, 0)))) > 1 ->
+        vote = new_vote(data, user_id, {:appoint_boss, appointee_id})
+
+        :timer.seconds(vote.duration_s)
+        |> :timer.send_after({:vote_timeout, vote.id})
+
+        events = [{:start_vote, vote}]
+        data = process_events(events, data) |> broadcast_updates() |> Map.get(:data)
+        {:keep_state, data, [{:reply, from, :ok}]}
 
       true ->
         events = [{:update_boss, :add, appointee_id}]
@@ -1500,6 +1510,9 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
           {:passed, {:change_map, new_map}} ->
             process_event({:update_map_name, new_map}, new_aggregate)
+
+          {:passed, {:appoint_boss, boss_id}} ->
+            process_event({:update_boss, :add, boss_id}, new_aggregate)
             # just let the thing crash if a new vote action shows up. It'll be easy
             # to spot and fix/add support. :start isn't yet supported
         end

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -851,24 +851,32 @@ defmodule Teiserver.TachyonLobby.Lobby do
       do: {:keep_state, fsm_data, [{:reply, from, :ok}]}
 
   def handle_event({:call, from}, {:update_properties, user_id, data}, _state, fsm_data) do
-    {events, errors} =
-      Enum.reduce(data, {[], []}, fn {k, v}, {events, errors} ->
-        case update_property(k, v, fsm_data, user_id) do
-          {:error, msg} ->
-            {events, [msg | errors]}
+    # for now, all properties can only be updated by bosses, so shortcut the reduce
+    is_allowed? = not fsm_data.boss_enabled? or MapSet.member?(fsm_data.bosses, user_id)
 
-          {:ok, new_events} ->
-            {events ++ new_events, errors}
-        end
-      end)
+    if is_allowed? do
+      {events, errors} =
+        Enum.reduce(data, {[], []}, fn {k, v}, {events, errors} ->
+          case update_property(k, v, fsm_data, user_id) do
+            {:error, msg} ->
+              {events, [msg | errors]}
 
-    if Enum.empty?(errors) do
-      final_data = process_events(events, fsm_data) |> broadcast_updates() |> Map.get(:data)
-      # broadcast_list_updates(events, fsm_data, final_data)
-      {:keep_state, final_data, [{:reply, from, :ok}]}
+            {:ok, new_events} ->
+              {events ++ new_events, errors}
+          end
+        end)
+
+      if Enum.empty?(errors) do
+        final_data = process_events(events, fsm_data) |> broadcast_updates() |> Map.get(:data)
+        # broadcast_list_updates(events, fsm_data, final_data)
+        {:keep_state, final_data, [{:reply, from, :ok}]}
+      else
+        message = Enum.join(errors, ", ")
+        {:keep_state, fsm_data, [{:reply, from, {:error, "Cannot update lobby: #{message}"}}]}
+      end
     else
-      message = Enum.join(errors, ", ")
-      {:keep_state, fsm_data, [{:reply, from, {:error, "Cannot update lobby: #{message}"}}]}
+      {:keep_state, fsm_data,
+       [{:reply, from, {:error, "Cannot update lobby: you are not a boss"}}]}
     end
   end
 

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -433,6 +433,12 @@ defmodule Teiserver.TachyonLobby.Lobby do
     call_lobby(lobby_id, {:appoint_boss, user_id, appointee_id})
   end
 
+  @spec unboss(id(), T.userid(), boss_id :: T.userid()) ::
+          :ok | {:error, :invalid_lobby | :not_in_lobby | :no_boss_allowed | :not_a_boss}
+  def unboss(lobby_id, user_id, boss_id) do
+    call_lobby(lobby_id, {:unboss, user_id, boss_id})
+  end
+
   @spec start_battle(id(), T.userid()) ::
           :ok | {:error, reason :: :not_in_lobby | :battle_already_started | term()}
   def start_battle(lobby_id, user_id) do
@@ -1003,6 +1009,29 @@ defmodule Teiserver.TachyonLobby.Lobby do
     end
   end
 
+  def handle_event({:call, from}, {:unboss, user_id, _boss_id}, _state, data)
+      when not is_map_key(data.players, user_id) and not is_map_key(data.spectators, user_id),
+      do: {:keep_state, data, [{:reply, from, {:error, :not_in_lobby}}]}
+
+  def handle_event({:call, from}, {:unboss, _user_id, boss_id}, _state, data)
+      when not is_map_key(data.players, boss_id) and not is_map_key(data.spectators, boss_id),
+      do: {:keep_state, data, [{:reply, from, {:error, :not_in_lobby}}]}
+
+  def handle_event({:call, from}, {:unboss, user_id, boss_id}, _state, data) do
+    cond do
+      not MapSet.member?(data.bosses, user_id) ->
+        {:keep_state, data, [{:reply, from, {:error, :not_a_boss}}]}
+
+      not MapSet.member?(data.bosses, boss_id) ->
+        {:keep_state, data, [{:reply, from, :ok}]}
+
+      true ->
+        events = [{:update_boss, :remove, boss_id}]
+        data = process_events(events, data) |> broadcast_updates() |> Map.get(:data)
+        {:keep_state, data, [{:reply, from, :ok}]}
+    end
+  end
+
   def handle_event({:call, from}, {:start_battle, user_id}, _state, data)
       when not is_map_key(data.players, user_id) and not is_map_key(data.spectators, user_id),
       do: {:keep_state, data, [{:reply, from, {:error, :not_in_lobby}}]}
@@ -1514,6 +1543,16 @@ defmodule Teiserver.TachyonLobby.Lobby do
     end
   end
 
+  defp process_event({:update_boss, :remove, boss_id} = ev, aggregate) do
+    if MapSet.member?(aggregate.data.bosses, boss_id) do
+      aggregate
+      |> update_in([:data, :bosses], &MapSet.delete(&1, boss_id))
+      |> Map.update!(:updates, &[ev | &1])
+    else
+      aggregate
+    end
+  end
+
   # avoid sending a useless lobby list update when the last member of the lobby
   # just left. The caller of this function will detect the lobby is empty and
   # terminate the process, which will trigger the final lobby list update for
@@ -1644,6 +1683,12 @@ defmodule Teiserver.TachyonLobby.Lobby do
     change_map
     |> Map.put_new(:bosses, %{})
     |> put_in([:bosses, appointee_id], %{})
+  end
+
+  defp update_change_from_event({:update_boss, :remove, boss_id}, change_map) do
+    change_map
+    |> Map.put_new(:bosses, %{})
+    |> put_in([:bosses, boss_id], nil)
   end
 
   defp broadcast_list_updates(%{data: final_state})

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -100,6 +100,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
           action: vote_action,
           initiator: T.userid(),
           voters: %{T.userid() => :pending | vote_ballot()},
+          duration_s: non_neg_integer(),
           until: DateTime.t(),
           quorum: non_neg_integer(),
           majority: non_neg_integer()
@@ -2010,29 +2011,10 @@ defmodule Teiserver.TachyonLobby.Lobby do
         end
 
       Enum.count(state.players, fn {_id, p} -> not bot_id?(p.id) end) > 1 ->
-        vote_duration_s = 60
+        vote = new_vote(state, user_id, {:change_map, new_name})
 
-        voters =
-          for {_id, p} <- state.players, !bot_id?(p.id), into: %{} do
-            if p.id == user_id, do: {p.id, :yes}, else: {p.id, :pending}
-          end
-
-        # ensure we need absolute majority.
-        # 0.501 works until 254 players, which is the hard limit of players
-        # in a game
-        quorum = (map_size(voters) * 0.501) |> :math.ceil() |> trunc()
-
-        vote = %{
-          id: "vote-#{state.vote_idx}",
-          action: {:change_map, new_name},
-          initiator: user_id,
-          voters: voters,
-          until: DateTime.utc_now() |> DateTime.shift(Duration.new!(second: vote_duration_s)),
-          quorum: quorum,
-          majority: quorum
-        }
-
-        :timer.send_after(vote_duration_s * 1000, {:vote_timeout, vote.id})
+        :timer.seconds(vote.duration_s)
+        |> :timer.send_after({:vote_timeout, vote.id})
 
         {:ok, [{:start_vote, vote}]}
 
@@ -2058,6 +2040,32 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   defp process_event_action({:vote_ended, vote, outcome}, fsm_data) do
     broadcast_to_members(fsm_data, nil, {:lobby, fsm_data.id, {:vote_ended, vote.id, outcome}})
+  end
+
+  # create a default vote object
+  defp new_vote(state, initiator_id, action) do
+    vote_duration_s = 60
+
+    voters =
+      for {_id, p} <- state.players, !bot_id?(p.id), into: %{} do
+        if p.id == initiator_id, do: {p.id, :yes}, else: {p.id, :pending}
+      end
+
+    # ensure we need absolute majority.
+    # 0.501 works until 254 players, which is the hard limit of players
+    # in a game
+    quorum = (map_size(voters) * 0.501) |> :math.ceil() |> trunc()
+
+    %{
+      id: "vote-#{state.vote_idx}",
+      action: action,
+      initiator: initiator_id,
+      voters: voters,
+      duration_s: vote_duration_s,
+      until: DateTime.utc_now() |> DateTime.shift(Duration.new!(second: vote_duration_s)),
+      quorum: quorum,
+      majority: quorum
+    }
   end
 
   @spec vote_result(vote_state()) :: :undecided | {:ended, :passed | :failed}

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -1135,6 +1135,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
       map_name: state.map_name,
       engine_version: state.engine_version,
       game_version: state.game_version,
+      boss_enabled?: state.boss_enabled?,
       current_battle: nil
     }
   end

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -1306,7 +1306,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
       |> update_in([:data, :monitors], &MC.demonitor_by_val(&1, {:user, p_id}))
       |> update_in([:updates], &[ev | &1])
 
-    process_event({:cast_vote, p_id, :abstain}, aggregate)
+    aggregate = process_event({:cast_vote, p_id, :abstain}, aggregate)
+    process_event({:update_boss, :remove, p_id}, aggregate)
   end
 
   defp process_event({:remove_spec_from_lobby, s_id} = ev, aggregate) do
@@ -1316,7 +1317,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
       |> update_in([:data, :monitors], &MC.demonitor_by_val(&1, {:user, s_id}))
       |> update_in([:updates], &[ev | &1])
 
-    process_event({:cast_vote, s_id, :abstain}, aggregate)
+    aggregate = process_event({:cast_vote, s_id, :abstain}, aggregate)
+    process_event({:update_boss, :remove, s_id}, aggregate)
   end
 
   defp process_event({:move_spec_to_player, p_id, player_data} = ev, aggregate) do

--- a/priv/tachyon/schema/definitions/lobbyDetails.json
+++ b/priv/tachyon/schema/definitions/lobbyDetails.json
@@ -49,6 +49,13 @@
                 }
             }
         },
+        "areBossesEnabled": { "type": "boolean" },
+        "bosses": {
+            "type": "object",
+            "patternProperties": {
+                "^.*$": { "type": "object", "properties": {} }
+            }
+        },
         "players": {
             "type": "object",
             "patternProperties": {
@@ -167,6 +174,22 @@
                 "until": { "$ref": "../definitions/unixTime.json" }
             },
             "required": ["id", "action", "initiator", "voters", "until"]
+        },
+        "voteHistory": {
+            "type": "object",
+            "patternProperties": {
+                "^.*$": {
+                    "type": "object",
+                    "properties": {
+                        "vote": { "$ref": "../definitions/voteActions.json" },
+                        "outcome": {
+                            "$ref": "../definitions/voteOutcomes.json"
+                        },
+                        "finishedAt": { "$ref": "../definitions/unixTime.json" }
+                    },
+                    "required": ["vote", "outcome", "finishedAt"]
+                }
+            }
         }
     },
     "required": [
@@ -175,7 +198,10 @@
         "mapName",
         "engineVersion",
         "gameVersion",
+        "gameOptions",
         "allyTeamConfig",
+        "areBossesEnabled",
+        "bosses",
         "players",
         "spectators",
         "bots"

--- a/priv/tachyon/schema/definitions/voteActions.json
+++ b/priv/tachyon/schema/definitions/voteActions.json
@@ -14,6 +14,14 @@
                 "newMapName": { "type": "string" }
             },
             "required": ["type", "newMapName"]
+        },
+        {
+            "type": "object",
+            "properties": {
+                "type": { "const": "appointBoss" },
+                "bossId": { "$ref": "../definitions/userId.json" }
+            },
+            "required": ["type", "bossId"]
         }
     ]
 }

--- a/priv/tachyon/schema/lobby/appointBoss/request.json
+++ b/priv/tachyon/schema/lobby/appointBoss/request.json
@@ -1,0 +1,25 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/appointBoss/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "LobbyAppointBossRequest",
+    "tachyon": {
+        "source": "user",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "lobby/appointBoss" },
+        "data": {
+            "title": "LobbyAppointBossRequestData",
+            "type": "object",
+            "properties": {
+                "userId": { "$ref": "../../definitions/userId.json" }
+            },
+            "required": ["userId"]
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/lobby/appointBoss/response.json
+++ b/priv/tachyon/schema/lobby/appointBoss/response.json
@@ -1,0 +1,44 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/appointBoss/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "LobbyAppointBossResponse",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "LobbyAppointBossOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "lobby/appointBoss" },
+                "status": { "const": "success" }
+            },
+            "required": ["type", "messageId", "commandId", "status"]
+        },
+        {
+            "title": "LobbyAppointBossFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "lobby/appointBoss" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "bosses_not_allowed",
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}

--- a/priv/tachyon/schema/lobby/create/request.json
+++ b/priv/tachyon/schema/lobby/create/request.json
@@ -21,6 +21,7 @@
                 "allyTeamConfig": {
                     "$ref": "../../definitions/allyTeamConfig.json"
                 },
+                "areBossesEnabled": { "type": "boolean"},
                 "gameOptions": {
                     "type": "object",
                     "patternProperties": {
@@ -32,11 +33,7 @@
                     }
                 }
             },
-            "required": [
-                "name",
-                "mapName",
-                "allyTeamConfig"
-            ]
+            "required": ["name", "mapName", "allyTeamConfig"]
         }
     },
     "required": ["type", "messageId", "commandId", "data"]

--- a/priv/tachyon/schema/lobby/listUpdated/event.json
+++ b/priv/tachyon/schema/lobby/listUpdated/event.json
@@ -31,6 +31,9 @@
                                         "mapName": { "type": "string" },
                                         "engineVersion": { "type": "string" },
                                         "gameVersion": { "type": "string" },
+                                        "areBossesEnabled": {
+                                            "type": "boolean"
+                                        },
                                         "currentBattle": {
                                             "anyOf": [
                                                 {

--- a/priv/tachyon/schema/lobby/unboss/request.json
+++ b/priv/tachyon/schema/lobby/unboss/request.json
@@ -1,0 +1,25 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/unboss/request.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "LobbyUnbossRequest",
+    "tachyon": {
+        "source": "user",
+        "target": "server",
+        "scopes": ["tachyon.lobby"]
+    },
+    "type": "object",
+    "properties": {
+        "type": { "const": "request" },
+        "messageId": { "type": "string" },
+        "commandId": { "const": "lobby/unboss" },
+        "data": {
+            "title": "LobbyUnbossRequestData",
+            "description": "if userId isn't provided, defaults to the current user",
+            "type": "object",
+            "properties": {
+                "userId": { "$ref": "../../definitions/userId.json" }
+            }
+        }
+    },
+    "required": ["type", "messageId", "commandId", "data"]
+}

--- a/priv/tachyon/schema/lobby/unboss/response.json
+++ b/priv/tachyon/schema/lobby/unboss/response.json
@@ -1,0 +1,44 @@
+{
+    "$id": "https://schema.beyondallreason.dev/tachyon/lobby/unboss/response.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "LobbyUnbossResponse",
+    "tachyon": {
+        "source": "server",
+        "target": "user",
+        "scopes": ["tachyon.lobby"]
+    },
+    "anyOf": [
+        {
+            "title": "LobbyUnbossOkResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "lobby/unboss" },
+                "status": { "const": "success" }
+            },
+            "required": ["type", "messageId", "commandId", "status"]
+        },
+        {
+            "title": "LobbyUnbossFailResponse",
+            "type": "object",
+            "properties": {
+                "type": { "const": "response" },
+                "messageId": { "type": "string" },
+                "commandId": { "const": "lobby/unboss" },
+                "status": { "const": "failed" },
+                "reason": {
+                    "enum": [
+                        "not_a_boss",
+                        "internal_error",
+                        "unauthorized",
+                        "invalid_request",
+                        "command_unimplemented"
+                    ]
+                },
+                "details": { "type": "string" }
+            },
+            "required": ["type", "messageId", "commandId", "status", "reason"]
+        }
+    ]
+}

--- a/priv/tachyon/schema/lobby/updated/event.json
+++ b/priv/tachyon/schema/lobby/updated/event.json
@@ -81,6 +81,17 @@
                         }
                     }
                 },
+                "bosses": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^.*$": {
+                            "anyOf": [
+                                { "type": "object", "properties": {} },
+                                { "type": "null" }
+                            ]
+                        }
+                    }
+                },
                 "players": {
                     "type": "object",
                     "patternProperties": {

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -633,6 +633,12 @@ defmodule Teiserver.Support.Tachyon do
     resp
   end
 
+  def lobby_appoint_boss(client, user_id) do
+    :ok = send_request(client, "lobby/appointBoss", %{userId: to_string(user_id)})
+    {:ok, resp} = recv_message(client)
+    resp
+  end
+
   def lobby_update_client_status(client, update_data) do
     :ok = send_request(client, "lobby/updateClientStatus", update_data)
     {:ok, resp} = recv_message(client)

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -6,12 +6,12 @@ defmodule Teiserver.Support.Tachyon do
   alias Teiserver.BotFixtures
   alias Teiserver.Game
   alias Teiserver.Game.MatchRatingLib
+  alias Teiserver.Helpers.Collections
   alias Teiserver.Helpers.GeneralTestLib
   alias Teiserver.OAuthFixtures
   alias Teiserver.Support.Polling
   alias Teiserver.Tachyon
   alias Teiserver.Tachyon.Schema
-  alias WebsocketSyncClient, as: WSC
   alias WebsocketSyncClient, as: WSC
 
   def tachyon_case_setup(tags) do
@@ -517,22 +517,15 @@ defmodule Teiserver.Support.Tachyon do
     }
 
   def create_lobby!(client, lobby_data) do
-    data = %{
-      name: lobby_data.name,
-      mapName: lobby_data.map_name,
-      allyTeamConfig: lobby_data.ally_team_config
+    mapping = %{
+      name: :name,
+      map_name: :mapName,
+      ally_team_config: :allyTeamConfig,
+      game_options:
+        {:gameOptions, &(Enum.map(&1, fn {k, v} -> {k, %{value: v}} end) |> Enum.into(%{}))}
     }
 
-    data =
-      if is_map_key(lobby_data, :game_options) do
-        opts =
-          Enum.map(lobby_data.game_options, fn {k, v} -> {k, %{value: v}} end) |> Enum.into(%{})
-
-        Map.put(data, :gameOptions, opts)
-      else
-        data
-      end
-
+    data = Collections.transform_map(lobby_data, mapping)
     :ok = send_request(client, "lobby/create", data)
     {:ok, resp} = recv_message(client)
     resp

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -521,6 +521,7 @@ defmodule Teiserver.Support.Tachyon do
       name: :name,
       map_name: :mapName,
       ally_team_config: :allyTeamConfig,
+      boss_enabled?: :areBossesEnabled,
       game_options:
         {:gameOptions, &(Enum.map(&1, fn {k, v} -> {k, %{value: v}} end) |> Enum.into(%{}))}
     }

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -639,6 +639,13 @@ defmodule Teiserver.Support.Tachyon do
     resp
   end
 
+  def lobby_unboss(client, user_id \\ nil) do
+    uid = if user_id, do: to_string(user_id), else: nil
+    :ok = send_request(client, "lobby/unboss", %{userId: uid})
+    {:ok, resp} = recv_message(client)
+    resp
+  end
+
   def lobby_update_client_status(client, update_data) do
     :ok = send_request(client, "lobby/updateClientStatus", update_data)
     {:ok, resp} = recv_message(client)

--- a/test/teiserver/tachyon_lobby/list_test.exs
+++ b/test/teiserver/tachyon_lobby/list_test.exs
@@ -252,6 +252,13 @@ defmodule Teiserver.TachyonLobby.ListTest do
       assert_receive %{event: :update_lobbies, changes: %{^id => %{map_name: "new map"}}}
     end
 
+    test "boss enabled?" do
+      assert {_initial_counter, %{}} = Lobby.subscribe_updates()
+      {_sink_pid, _id, _pid} = mk_lobby()
+      Lobby.List.broadcast_updates()
+      assert_receive %{event: :add_lobby, overview: %{boss_enabled?: false}}
+    end
+
     test "expand ally team config" do
       {_sink_pid, id, _pid} = mk_lobby([1, 1])
       assert {_initial_counter, %{}} = Lobby.subscribe_updates()
@@ -287,7 +294,8 @@ defmodule Teiserver.TachyonLobby.ListTest do
       max_player_count: 2,
       map_name: "new map",
       engine_version: "engine123",
-      game_version: "game123"
+      game_version: "game123",
+      boss_enabled?: false
     }
   end
 

--- a/test/teiserver/tachyon_lobby/lobby_test.exs
+++ b/test/teiserver/tachyon_lobby/lobby_test.exs
@@ -1242,6 +1242,17 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
       assert_receive {:lobby, ^id, {:updated, data}}
       assert data.bosses == %{"2" => %{}}
     end
+
+    test "leaving lobby unboss" do
+      %{id: id} = setup_full_lobby([1, 1], boss_enabled?: true)
+      :ok = Lobby.appoint_boss(id, @default_user_id, "2")
+      assert_receive {:lobby, ^id, {:updated, _data}}
+      :ok = Lobby.leave(id, "2")
+      assert_receive {:lobby, ^id, {:updated, data}}
+      assert data.bosses == %{"2" => nil}
+      {:ok, details} = LobbyProcess.get_details(id)
+      assert details.bosses == MapSet.new([@default_user_id])
+    end
   end
 
   describe "update ally team" do

--- a/test/teiserver/tachyon_lobby/lobby_test.exs
+++ b/test/teiserver/tachyon_lobby/lobby_test.exs
@@ -1191,6 +1191,28 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
       :ok = Lobby.appoint_boss(id, @default_user_id, "2")
       refute_receive _, 30
     end
+
+    test "unboss - invalid lobby" do
+      {:error, :invalid_lobby} = Lobby.unboss("not-a-lobby-id", @default_user_id, "2")
+    end
+
+    test "unboss - must be in lobby" do
+      %{id: id} = setup_full_lobby([1, 1], boss_enabled?: true)
+      {:error, :not_in_lobby} = Lobby.unboss(id, "not-in-lobby", @default_user_id)
+    end
+
+    test "unboss - no op if target not boss" do
+      %{id: id} = setup_full_lobby([1, 1], boss_enabled?: true)
+      :ok = Lobby.unboss(id, @default_user_id, "2")
+      refute_receive _, 30
+    end
+
+    test "unboss works" do
+      %{id: id} = setup_full_lobby([1, 1], boss_enabled?: true)
+      :ok = Lobby.unboss(id, @default_user_id, @default_user_id)
+      assert_receive {:lobby, ^id, {:updated, data}}
+      assert data == %{bosses: %{@default_user_id => nil}}
+    end
   end
 
   describe "update ally team" do

--- a/test/teiserver/tachyon_lobby/lobby_test.exs
+++ b/test/teiserver/tachyon_lobby/lobby_test.exs
@@ -1213,6 +1213,35 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
       assert_receive {:lobby, ^id, {:updated, data}}
       assert data == %{bosses: %{@default_user_id => nil}}
     end
+
+    test "can appoint boss when no boss" do
+      %{id: id} = setup_full_lobby([1, 1], boss_enabled?: true)
+      :ok = Lobby.unboss(id, @default_user_id, @default_user_id)
+      assert_receive {:lobby, ^id, {:updated, data}}
+      assert data == %{bosses: %{@default_user_id => nil}}
+
+      :ok = Lobby.appoint_boss(id, @default_user_id, "2")
+      assert_receive {:lobby, ^id, {:updated, data}}
+      assert data == %{bosses: %{"2" => %{}}}
+    end
+
+    test "appoint boss triggers vote for players" do
+      %{id: id} = setup_full_lobby([1, 1], boss_enabled?: true)
+      :ok = Lobby.unboss(id, @default_user_id, @default_user_id)
+      assert_receive {:lobby, ^id, {:updated, _}}
+      :ok = Lobby.join_queue(id, "2")
+      assert_receive {:lobby, ^id, {:updated, _}}
+
+      :ok = Lobby.appoint_boss(id, @default_user_id, "2")
+      assert_receive {:lobby, ^id, {:updated, data}}
+
+      %{action: {:appoint_boss, "2"}, voters: %{@default_user_id => :yes, "2" => :pending}} =
+        data.current_vote
+
+      :ok = Lobby.vote_submit(id, "2", {data.current_vote.id, :yes})
+      assert_receive {:lobby, ^id, {:updated, data}}
+      assert data.bosses == %{"2" => %{}}
+    end
   end
 
   describe "update ally team" do

--- a/test/teiserver/tachyon_lobby/lobby_test.exs
+++ b/test/teiserver/tachyon_lobby/lobby_test.exs
@@ -1143,6 +1143,13 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
       {:error, _reason} =
         Lobby.update_properties(id, @default_user_id, %{map_name: "different map"})
     end
+
+    test "only bosses can change map" do
+      %{id: id} = setup_full_lobby([1, 1], boss_enabled?: true)
+      :ok = Lobby.join_queue(id, "2")
+      {:error, err} = Lobby.update_properties(id, "2", %{map_name: "new map"})
+      assert err =~ "boss"
+    end
   end
 
   describe "update ally team" do
@@ -1687,8 +1694,11 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
 
   # create a lobby with a few specs already in. Simplify the logic when
   # it comes to testing in-lobby interaction
-  defp setup_full_lobby(teams \\ [2, 2]) do
-    {:ok, lobby_pid, %{id: id}} = mk_start_params(teams) |> Lobby.create()
+  defp setup_full_lobby(teams \\ [2, 2], opts \\ []) do
+    {:ok, lobby_pid, %{id: id}} =
+      mk_start_params(teams)
+      |> Map.put(:boss_enabled?, Keyword.get(opts, :boss_enabled?, false))
+      |> Lobby.create()
 
     users =
       Enum.map([2, 3, 4, 5], fn i ->

--- a/test/teiserver/tachyon_lobby/lobby_test.exs
+++ b/test/teiserver/tachyon_lobby/lobby_test.exs
@@ -63,6 +63,16 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     assert details.engine_version == engine.name
   end
 
+  test "create with defaults" do
+    {:ok, _pid, details} =
+      mk_start_params([1, 1])
+      |> Lobby.create()
+
+    assert details.boss_enabled? == false
+    assert details.bosses == MapSet.new()
+    assert details.game_options == %{}
+  end
+
   test "create lobby with game options" do
     {:ok, _pid, details} =
       mk_start_params([1, 1])
@@ -72,6 +82,16 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     assert details.game_options == %{"foo" => "bar"}
     {:ok, details2} = LobbyProcess.get_details(details.id)
     assert details2.game_options == %{"foo" => "bar"}
+  end
+
+  test "creator is boss when enabled" do
+    {:ok, _pid, details} =
+      mk_start_params([1, 1])
+      |> Map.put(:boss_enabled?, true)
+      |> Lobby.create()
+
+    assert details.boss_enabled? == true
+    assert details.bosses == MapSet.new([@default_user_id])
   end
 
   test "exit when no more players" do

--- a/test/teiserver/tachyon_lobby/lobby_test.exs
+++ b/test/teiserver/tachyon_lobby/lobby_test.exs
@@ -1152,6 +1152,47 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
   end
 
+  describe "boss manipulation" do
+    test "must be in lobby" do
+      {:error, :invalid_lobby} = Lobby.appoint_boss("not-a-lobby-id", @default_user_id, "2")
+    end
+
+    test "appointee must be in lobby" do
+      %{id: id} = setup_full_lobby([1, 1])
+      {:error, :not_in_lobby} = Lobby.appoint_boss(id, @default_user_id, "invalid-id")
+    end
+
+    test "bosses must be enabled" do
+      %{id: id} = setup_full_lobby([1, 1], boss_enabled?: false)
+      {:error, :no_boss_allowed} = Lobby.appoint_boss(id, @default_user_id, "2")
+    end
+
+    test "user must be a boss" do
+      %{id: id} = setup_full_lobby([1, 1], boss_enabled?: true)
+      {:error, :not_a_boss} = Lobby.appoint_boss(id, "2", "3")
+    end
+
+    test "can appoint boss" do
+      %{id: id} = setup_full_lobby([1, 1], boss_enabled?: true)
+      :ok = Lobby.appoint_boss(id, @default_user_id, "2")
+      assert_receive {:lobby, ^id, {:updated, data}}
+      assert data == %{bosses: %{"2" => %{}}}
+
+      {:ok, details} = LobbyProcess.get_details(id)
+      assert details.bosses == MapSet.new([@default_user_id, "2"])
+    end
+
+    test "appointing existing boss in no-op" do
+      %{id: id} = setup_full_lobby([1, 1], boss_enabled?: true)
+      :ok = Lobby.appoint_boss(id, @default_user_id, "2")
+      assert_receive {:lobby, ^id, {:updated, data}}
+      assert data == %{bosses: %{"2" => %{}}}
+
+      :ok = Lobby.appoint_boss(id, @default_user_id, "2")
+      refute_receive _, 30
+    end
+  end
+
   describe "update ally team" do
     test "work" do
       {:ok, _pid, %{id: id}} =

--- a/test/teiserver_web/tachyon/lobby_test.exs
+++ b/test/teiserver_web/tachyon/lobby_test.exs
@@ -16,6 +16,7 @@ defmodule TeiserverWeb.Tachyon.LobbyTest do
         name: "test lobby",
         map_name: "test-map",
         ally_team_config: Tachyon.mk_ally_team_config(2, 1),
+        boss_enabled?: true,
         game_options: %{"foo" => "bar"}
       }
 
@@ -30,6 +31,8 @@ defmodule TeiserverWeb.Tachyon.LobbyTest do
                player_data["team"]
              )
 
+      assert data["areBossesEnabled"] == true
+      assert data["bosses"] == %{to_string(user.id) => %{}}
       assert data["gameOptions"] == %{"foo" => %{"value" => "bar"}}
     end
 

--- a/test/teiserver_web/tachyon/lobby_test.exs
+++ b/test/teiserver_web/tachyon/lobby_test.exs
@@ -526,6 +526,16 @@ defmodule TeiserverWeb.Tachyon.LobbyTest do
 
       assert data["bosses"] == %{to_string(ctx2[:user].id) => %{}}
     end
+
+    test "can unboss" do
+      {:ok, ctx} = Tachyon.setup_client()
+      {:ok, _lobby_data} = setup_lobby(%{client: ctx[:client]}, %{boss_enabled?: true})
+
+      %{"status" => "success"} = Tachyon.lobby_unboss(ctx[:client], ctx[:user].id)
+      %{"commandId" => "lobby/updated", "data" => data} = Tachyon.recv_message!(ctx[:client])
+
+      assert data["bosses"] == %{to_string(ctx[:user].id) => nil}
+    end
   end
 
   describe "update client status" do

--- a/test/teiserver_web/tachyon/lobby_test.exs
+++ b/test/teiserver_web/tachyon/lobby_test.exs
@@ -561,6 +561,7 @@ defmodule TeiserverWeb.Tachyon.LobbyTest do
       } = Tachyon.recv_message!(client)
 
       assert lobbies[lobby_id]["maxPlayerCount"] == 4
+      assert lobbies[lobby_id]["areBossesEnabled"] == false
 
       {:ok, ctx3} = Tachyon.setup_client()
       %{"status" => "success", "data" => data} = Tachyon.join_lobby!(ctx3[:client], lobby_id)

--- a/test/teiserver_web/tachyon/lobby_test.exs
+++ b/test/teiserver_web/tachyon/lobby_test.exs
@@ -536,6 +536,28 @@ defmodule TeiserverWeb.Tachyon.LobbyTest do
 
       assert data["bosses"] == %{to_string(ctx[:user].id) => nil}
     end
+
+    test "trigger vote for new boss" do
+      {:ok, ctx} = Tachyon.setup_client()
+      {:ok, lobby_id: lobby_id} = setup_lobby(%{client: ctx[:client]}, %{boss_enabled?: true})
+
+      %{"status" => "success"} = Tachyon.lobby_unboss(ctx[:client], ctx[:user].id)
+      %{"commandId" => "lobby/updated", "data" => data} = Tachyon.recv_message!(ctx[:client])
+      assert data["bosses"] == %{to_string(ctx[:user].id) => nil}
+
+      {:ok, ctx2} = Tachyon.setup_client()
+      %{"status" => "success"} = Tachyon.join_lobby!(ctx2[:client], lobby_id)
+      %{"commandId" => "lobby/updated"} = Tachyon.recv_message!(ctx[:client])
+      Tachyon.lobby_join_queue!(ctx2[:client])
+      %{"commandId" => "lobby/updated"} = Tachyon.recv_message!(ctx[:client])
+
+      %{"status" => "success"} = Tachyon.lobby_appoint_boss(ctx[:client], ctx[:user].id)
+      %{"commandId" => "lobby/updated", "data" => data} = Tachyon.recv_message!(ctx[:client])
+      user_id = to_string(ctx[:user].id)
+
+      %{"currentVote" => %{"action" => %{"type" => "appointBoss", "bossId" => ^user_id}}} =
+        data
+    end
   end
 
   describe "update client status" do

--- a/test/teiserver_web/tachyon/lobby_test.exs
+++ b/test/teiserver_web/tachyon/lobby_test.exs
@@ -512,6 +512,22 @@ defmodule TeiserverWeb.Tachyon.LobbyTest do
     end
   end
 
+  describe "boss" do
+    test "can appoint boss" do
+      {:ok, ctx} = Tachyon.setup_client()
+      {:ok, lobby_data} = setup_lobby(%{client: ctx[:client]}, %{boss_enabled?: true})
+
+      {:ok, ctx2} = Tachyon.setup_client()
+      %{"status" => "success"} = Tachyon.join_lobby!(ctx2[:client], lobby_data[:lobby_id])
+      %{"commandId" => "lobby/updated"} = Tachyon.recv_message!(ctx[:client])
+
+      %{"status" => "success"} = Tachyon.lobby_appoint_boss(ctx[:client], ctx2[:user].id)
+      %{"commandId" => "lobby/updated", "data" => data} = Tachyon.recv_message!(ctx[:client])
+
+      assert data["bosses"] == %{to_string(ctx2[:user].id) => %{}}
+    end
+  end
+
   describe "update client status" do
     setup [:setup_lobby]
 


### PR DESCRIPTION
* can enable bosses for lobbies
* can appoint new bosses
* can unboss players. Currently there is no restriction, any boss can unboss any other boss. This will likely change
* only boss can change the map. We'll extend this to other operations later (they also need protocol support).
* leaving the lobby unboss