### PR TITLE
Wrap hook server operations in a task

### DIFF
--- a/lib/teiserver/data/hook_server.ex
+++ b/lib/teiserver/data/hook_server.ex
@@ -13,7 +13,16 @@ defmodule Teiserver.HookServer do
   end
 
   @impl GenServer
-  def handle_info(%{channel: "global_moderation"} = data, state) do
+  def handle_info(ev, state) do
+    Task.async(fn -> do_handle_info(ev, state) end)
+    |> Task.await()
+  catch
+    :exit, {:timeout, _details} ->
+      Logger.error("Timeout while processing hook for event #{inspect(ev)}")
+      {:noreply, state}
+  end
+
+  defp do_handle_info(%{channel: "global_moderation"} = data, state) do
     case data.event do
       :new_report ->
         if Communication.use_discord?() do
@@ -51,7 +60,7 @@ defmodule Teiserver.HookServer do
     {:noreply, state}
   end
 
-  def handle_info({:account_hooks, event, payload, _reason}, state) do
+  defp do_handle_info({:account_hooks, event, payload, _reason}, state) do
     start_completed =
       Teiserver.cache_get(:application_metadata_cache, "teiserver_full_startup_completed") == true
 
@@ -80,7 +89,7 @@ defmodule Teiserver.HookServer do
     {:noreply, state}
   end
 
-  def handle_info(%{channel: "application", event: app_event}, state) do
+  defp do_handle_info(%{channel: "application", event: app_event}, state) do
     case app_event do
       :started ->
         :ok
@@ -111,6 +120,8 @@ defmodule Teiserver.HookServer do
   @impl GenServer
   @spec init(any) :: {:ok, %{}}
   def init(_opts) do
+    Logger.metadata(actor_type: :hook_server)
+
     if Application.get_env(:teiserver, Teiserver)[:enable_hooks] do
       :ok = PubSub.subscribe(Teiserver.PubSub, "account_hooks")
       :ok = PubSub.subscribe(Teiserver.PubSub, "global_moderation")


### PR DESCRIPTION
We are having mysterious timeout on some events. It's almost certainly related to the discord bridge, and with this change we'll know for sure. It should also avoid the hook server getting stuck forever on an event and becoming unresponsive to the other operations.

I've tested that by temporarily adding a new handler:
```elixir
  defp do_handle_info(:coucou, state) do
    :timer.sleep(:infinity)
    {:noreply, state}
  end
```

and then in a shell: `Process.whereis(Teiserver.HookServer) |> send(:coucou)`
I get
```
2026-04-24 08:47:09.072 [error] pid=<0.2623.0> actor_type=hook_server  Timeout while processing hook for event :coucou
```