### PR TITLE
Expanded lobby naming logic

### DIFF
--- a/lib/teiserver/coordinator/consul_commands.ex
+++ b/lib/teiserver/coordinator/consul_commands.ex
@@ -714,7 +714,7 @@ defmodule Teiserver.Coordinator.ConsulCommands do
         %{command: "minchevlevel", remaining: remaining, senderid: senderid} = cmd,
         state
       ) do
-    result = LobbyRestrictions.allowed_to_set_restrictions(state)
+    result = LobbyRestrictions.allowed_to_set_restrictions(state, :min)
 
     case result do
       :ok ->
@@ -783,7 +783,7 @@ defmodule Teiserver.Coordinator.ConsulCommands do
         %{command: "maxchevlevel", remaining: remaining, senderid: senderid} = cmd,
         state
       ) do
-    result = LobbyRestrictions.allowed_to_set_restrictions(state)
+    result = LobbyRestrictions.allowed_to_set_restrictions(state, :max)
 
     case result do
       :ok ->
@@ -848,7 +848,7 @@ defmodule Teiserver.Coordinator.ConsulCommands do
         %{command: "minratinglevel", remaining: remaining, senderid: senderid} = cmd,
         state
       ) do
-    result = LobbyRestrictions.allowed_to_set_restrictions(state)
+    result = LobbyRestrictions.allowed_to_set_restrictions(state, :min)
 
     case result do
       :ok ->
@@ -896,7 +896,7 @@ defmodule Teiserver.Coordinator.ConsulCommands do
         %{command: "maxratinglevel", remaining: remaining, senderid: senderid} = cmd,
         state
       ) do
-    result = LobbyRestrictions.allowed_to_set_restrictions(state)
+    result = LobbyRestrictions.allowed_to_set_restrictions(state, :max)
 
     case result do
       :ok ->
@@ -968,7 +968,7 @@ defmodule Teiserver.Coordinator.ConsulCommands do
             state
 
           {{min_level_o, _rest1}, {max_level_o, _rest2}} ->
-            result = LobbyRestrictions.allowed_to_set_restrictions(state)
+            result = LobbyRestrictions.allowed_to_set_restrictions(state, :any)
 
             case result do
               :ok ->
@@ -1002,273 +1002,6 @@ defmodule Teiserver.Coordinator.ConsulCommands do
           senderid,
           [
             "setplaylevels takes two numbers, no more no less"
-          ],
-          state.lobby_id
-        )
-
-        state
-    end
-  end
-
-  def handle_command(%{command: "resetranklevels", remaining: ""} = cmd, state) do
-    ConsulServer.say_command(cmd, state)
-    LobbyLib.cast_lobby(state.lobby_id, :refresh_name)
-    %{state | minimum_rank_to_play: 0, maximum_rank_to_play: 1000}
-  end
-
-  def handle_command(%{command: "minranklevel", remaining: ""} = cmd, state) do
-    ConsulServer.say_command(cmd, state)
-    LobbyLib.cast_lobby(state.lobby_id, :refresh_name)
-    %{state | minimum_rank_to_play: 0}
-  end
-
-  def handle_command(
-        %{command: "minranklevel", remaining: remaining, senderid: senderid} = cmd,
-        state
-      ) do
-    case remaining |> String.trim() |> Integer.parse() do
-      :error ->
-        Lobby.sayprivateex(
-          state.coordinator_id,
-          senderid,
-          [
-            "Unable to turn '#{remaining}' into an integer"
-          ],
-          state.lobby_id
-        )
-
-        state
-
-      {level, _rest} ->
-        ConsulServer.say_command(cmd, state)
-        LobbyLib.cast_lobby(state.lobby_id, :refresh_name)
-        %{state | minimum_rank_to_play: level |> max(0) |> min(state.maximum_rank_to_play - 1)}
-    end
-  end
-
-  def handle_command(%{command: "maxranklevel", remaining: ""} = cmd, state) do
-    ConsulServer.say_command(cmd, state)
-    LobbyLib.cast_lobby(state.lobby_id, :refresh_name)
-    %{state | maximum_rank_to_play: 1000}
-  end
-
-  def handle_command(
-        %{command: "maxranklevel", remaining: remaining, senderid: senderid} = cmd,
-        state
-      ) do
-    case remaining |> String.trim() |> Integer.parse() do
-      :error ->
-        Lobby.sayprivateex(
-          state.coordinator_id,
-          senderid,
-          [
-            "Unable to turn '#{remaining}' into an integer"
-          ],
-          state.lobby_id
-        )
-
-        state
-
-      {level, _rest} ->
-        ConsulServer.say_command(cmd, state)
-        LobbyLib.cast_lobby(state.lobby_id, :refresh_name)
-
-        %{
-          state
-          | maximum_rank_to_play:
-              level
-              |> min(LobbyRestrictions.rating_upper_bound())
-              |> max(state.minimum_rank_to_play + 1)
-        }
-    end
-  end
-
-  def handle_command(
-        %{command: "setranklevels", remaining: remaining, senderid: senderid} = cmd,
-        state
-      ) do
-    case String.split(remaining, " ") do
-      [smin, smax] ->
-        case {smin |> String.trim() |> Integer.parse(), smax |> String.trim() |> Integer.parse()} do
-          {:error, _max_parse} ->
-            Lobby.sayprivateex(
-              state.coordinator_id,
-              senderid,
-              [
-                "Unable to turn '#{smin}' into an integer"
-              ],
-              state.lobby_id
-            )
-
-            state
-
-          {_min_parse, :error} ->
-            Lobby.sayprivateex(
-              state.coordinator_id,
-              senderid,
-              [
-                "Unable to turn '#{smax}' into an integer"
-              ],
-              state.lobby_id
-            )
-
-            state
-
-          {{min_level_o, _rest1}, {max_level_o, _rest2}} ->
-            min_level = min(min_level_o, max_level_o)
-            max_level = max(min_level_o, max_level_o)
-
-            ConsulServer.say_command(cmd, state)
-            LobbyLib.cast_lobby(state.lobby_id, :refresh_name)
-
-            %{
-              state
-              | minimum_rank_to_play: max(min_level, 0),
-                maximum_rank_to_play: min(max_level, LobbyRestrictions.rank_upper_bound())
-            }
-        end
-
-      _other ->
-        Lobby.sayprivateex(
-          state.coordinator_id,
-          senderid,
-          [
-            "setranklevels takes two numbers, no more no less"
-          ],
-          state.lobby_id
-        )
-
-        state
-    end
-  end
-
-  def handle_command(%{command: "resetuncertaintylevels", remaining: ""} = cmd, state) do
-    ConsulServer.say_command(cmd, state)
-    LobbyLib.cast_lobby(state.lobby_id, :refresh_name)
-    %{state | minimum_uncertainty_to_play: 0, maximum_uncertainty_to_play: 1000}
-  end
-
-  def handle_command(%{command: "minuncertaintylevel", remaining: ""} = cmd, state) do
-    ConsulServer.say_command(cmd, state)
-    LobbyLib.cast_lobby(state.lobby_id, :refresh_name)
-    %{state | minimum_uncertainty_to_play: 0}
-  end
-
-  def handle_command(
-        %{command: "minuncertaintylevel", remaining: remaining, senderid: senderid} = cmd,
-        state
-      ) do
-    case remaining |> String.trim() |> Integer.parse() do
-      :error ->
-        Lobby.sayprivateex(
-          state.coordinator_id,
-          senderid,
-          [
-            "Unable to turn '#{remaining}' into an integer"
-          ],
-          state.lobby_id
-        )
-
-        state
-
-      {level, _rest} ->
-        ConsulServer.say_command(cmd, state)
-        LobbyLib.cast_lobby(state.lobby_id, :refresh_name)
-
-        %{
-          state
-          | minimum_uncertainty_to_play:
-              level |> max(0) |> min(state.maximum_uncertainty_to_play - 1)
-        }
-    end
-  end
-
-  def handle_command(%{command: "maxuncertaintylevel", remaining: ""} = cmd, state) do
-    ConsulServer.say_command(cmd, state)
-    LobbyLib.cast_lobby(state.lobby_id, :refresh_name)
-    %{state | maximum_uncertainty_to_play: 1000}
-  end
-
-  def handle_command(
-        %{command: "maxuncertaintylevel", remaining: remaining, senderid: senderid} = cmd,
-        state
-      ) do
-    case remaining |> String.trim() |> Integer.parse() do
-      :error ->
-        Lobby.sayprivateex(
-          state.coordinator_id,
-          senderid,
-          [
-            "Unable to turn '#{remaining}' into an integer"
-          ],
-          state.lobby_id
-        )
-
-        state
-
-      {level, _rest} ->
-        ConsulServer.say_command(cmd, state)
-        LobbyLib.cast_lobby(state.lobby_id, :refresh_name)
-
-        %{
-          state
-          | maximum_uncertainty_to_play:
-              level |> min(1000) |> max(state.minimum_uncertainty_to_play + 1)
-        }
-    end
-  end
-
-  def handle_command(
-        %{command: "setuncertaintylevels", remaining: remaining, senderid: senderid} = cmd,
-        state
-      ) do
-    case String.split(remaining, " ") do
-      [smin, smax] ->
-        case {smin |> String.trim() |> Integer.parse(), smax |> String.trim() |> Integer.parse()} do
-          {:error, _max_parse} ->
-            Lobby.sayprivateex(
-              state.coordinator_id,
-              senderid,
-              [
-                "Unable to turn '#{smin}' into an integer"
-              ],
-              state.lobby_id
-            )
-
-            state
-
-          {_min_parse, :error} ->
-            Lobby.sayprivateex(
-              state.coordinator_id,
-              senderid,
-              [
-                "Unable to turn '#{smax}' into an integer"
-              ],
-              state.lobby_id
-            )
-
-            state
-
-          {{min_level_o, _rest1}, {max_level_o, _rest2}} ->
-            min_level = min(min_level_o, max_level_o)
-            max_level = max(min_level_o, max_level_o)
-
-            ConsulServer.say_command(cmd, state)
-            LobbyLib.cast_lobby(state.lobby_id, :refresh_name)
-
-            %{
-              state
-              | minimum_uncertainty_to_play: max(min_level, 0),
-                maximum_uncertainty_to_play: min(max_level, 1000)
-            }
-        end
-
-      _other ->
-        Lobby.sayprivateex(
-          state.coordinator_id,
-          senderid,
-          [
-            "setuncertaintylevels takes two numbers, no more no less"
           ],
           state.lobby_id
         )

--- a/lib/teiserver/coordinator/consul_server.ex
+++ b/lib/teiserver/coordinator/consul_server.ex
@@ -62,7 +62,7 @@ defmodule Teiserver.Coordinator.ConsulServer do
 
   def handle_call(:get_consul_state, _from, state) do
     result =
-      ~w(gatekeeper minimum_rating_to_play maximum_rating_to_play minimum_rank_to_play maximum_rank_to_play minimum_uncertainty_to_play maximum_uncertainty_to_play level_to_spectate locks bans timeouts welcome_message join_queue low_priority_join_queue approved_users host_bosses host_preset host_teamsize host_teamcount player_limit ranked)a
+      ~w(gatekeeper minimum_rating_to_play maximum_rating_to_play minimum_rank_to_play maximum_rank_to_play level_to_spectate locks bans timeouts welcome_message join_queue low_priority_join_queue approved_users host_bosses host_preset host_teamsize host_teamcount player_limit ranked)a
       |> Map.new(fn key ->
         {key, Map.get(state, key)}
       end)
@@ -76,7 +76,7 @@ defmodule Teiserver.Coordinator.ConsulServer do
 
   def handle_call(:get_chobby_extra_data, _from, state) do
     keys =
-      ~w(gatekeeper minimum_rating_to_play maximum_rating_to_play minimum_rank_to_play maximum_rank_to_play minimum_uncertainty_to_play maximum_uncertainty_to_play minimum_skill_to_play maximum_skill_to_play welcome_message player_limit)a
+      ~w(gatekeeper minimum_rating_to_play maximum_rating_to_play minimum_rank_to_play maximum_rank_to_play minimum_skill_to_play maximum_skill_to_play welcome_message player_limit)a
 
     result =
       state
@@ -1374,8 +1374,6 @@ defmodule Teiserver.Coordinator.ConsulServer do
       maximum_rating_to_play: 1000,
       minimum_rank_to_play: 0,
       maximum_rank_to_play: 1000,
-      minimum_uncertainty_to_play: 0,
-      maximum_uncertainty_to_play: 1000,
       minimum_skill_to_play: 0,
       maximum_skill_to_play: 1000,
       level_to_spectate: 0,

--- a/lib/teiserver/coordinator/coordinator_lib.ex
+++ b/lib/teiserver/coordinator/coordinator_lib.ex
@@ -82,11 +82,6 @@ or are following someone that voted yes are also moved to that lobby.", :everybo
       {"resetchevlevels", [],
        "Resets the chevron level restrictions to not exist. Requires boss privileges.",
        :everybody},
-      # credo:disable-for-lines:4 Credo.Check.Readability.MaxLineLength
-      # {"resetranklevels", [], "Resets the rank level limits to not exist. Player limiting commands are designed to be used with $rename, please be careful not to abuse them. Requires boss privileges.", :everybody},
-      # {"minranklevel", ["min-level"], "Sets the minimum rank level for players, you must be at least this rank to be a player. Requires boss privileges.", :everybody},
-      # {"maxranklevel", ["max-level"], "Sets the maximum rank level for players, you must be at below this rank to be a player. Requires boss privileges.", :everybody},
-      # {"setranklevels", ["min-level", "max-level"], "Sets the minimum and maximum rank levels for players. Requires boss privileges.", :everybody},
 
       # ---- "hosts" only ----
       {"lock", ["(team | player | spectator | side)"],

--- a/lib/teiserver/lobby/libs/lobby_restrictions.ex
+++ b/lib/teiserver/lobby/libs/lobby_restrictions.ex
@@ -279,19 +279,48 @@ defmodule Teiserver.Lobby.LobbyRestrictions do
     end
   end
 
-  # Teifion added code to prevent setting restrictions to All Welcome lobbies
-  @spec allowed_to_set_restrictions(map()) :: :ok | {:error, String.t()}
-  def allowed_to_set_restrictions(state) do
+  @spec allowed_to_set_restrictions(map(), :max | :min | :any) :: :ok | {:error, String.t()}
+  def allowed_to_set_restrictions(state, :any) do
+    case allowed_to_set_restrictions(state, :max) do
+      :ok -> allowed_to_set_restrictions(state, :min)
+      result -> result
+    end
+  end
+
+  def allowed_to_set_restrictions(state, :max) do
     name =
       (Battle.get_lobby(state.lobby_id) || %{})
       |> Map.get(:name)
 
     cond do
       not state.ranked and not Config.get_site_config_cache("lobby.Unranked lobby restrictions") ->
-        {:error, "You cannot set a limit if the lobby is unranked"}
+        {:error, "You cannot set a limit if the lobby is unranked."}
 
       allwelcome_name?(name) ->
-        {:error, "You cannot set a limit if all are welcome to the game"}
+        {:error, "You cannot set any rating limits if all are welcome to the game."}
+
+      pro_title?(name) ->
+        {:error, "You cannot set a maximum limit for lobby names referencing pros."}
+
+      true ->
+        :ok
+    end
+  end
+
+  def allowed_to_set_restrictions(state, :min) do
+    name =
+      (Battle.get_lobby(state.lobby_id) || %{})
+      |> Map.get(:name)
+
+    cond do
+      not state.ranked and not Config.get_site_config_cache("lobby.Unranked lobby restrictions") ->
+        {:error, "You cannot set a limit if the lobby is unranked."}
+
+      allwelcome_name?(name) ->
+        {:error, "You cannot set any rating limits if all are welcome to the game."}
+
+      noob_title?(name) ->
+        {:error, "You cannot set a maximum limit for lobby names referencing new players."}
 
       true ->
         :ok
@@ -305,6 +334,14 @@ defmodule Teiserver.Lobby.LobbyRestrictions do
     |> String.downcase()
     |> String.replace(" ", "")
     |> String.contains?("allwelcome")
+  end
+
+  @spec pro_title?(String.t()) :: boolean()
+  def pro_title?(name) do
+    name = String.replace(name, "0", "o")
+    pattern = ~r/\b(pro|professional)\b/i
+
+    Regex.match?(pattern, name)
   end
 
   @doc """

--- a/lib/teiserver/lobby/schemas/lobby_struct.ex
+++ b/lib/teiserver/lobby/schemas/lobby_struct.ex
@@ -55,8 +55,6 @@ defmodule Teiserver.Lobby.LobbyStruct do
     maximum_rating_to_play: 1000,
     minimum_rank_to_play: 0,
     maximum_rank_to_play: 1000,
-    minimum_uncertainty_to_play: 0,
-    maximum_uncertainty_to_play: 1000,
     minimum_skill_to_play: 0,
     maximum_skill_to_play: 1000,
     level_to_spectate: 0,


### PR DESCRIPTION
- Expands `allowed_to_set_restrictions/1` to also take an atom declaring if the limit check is a min, max or either
- Setting minimum limits is not allowed in noob games
- Setting maximum limits is not allowed in pro games
- Removed some consul commands related to these which are not used/supported
- Fixed a bug where using `setrating` would allow you to set a minimum rating even in a noob game