### PR TITLE
Added struct to CacheUser module

### DIFF
--- a/lib/teiserver/account/caches/user_cache_lib.ex
+++ b/lib/teiserver/account/caches/user_cache_lib.ex
@@ -3,6 +3,7 @@ defmodule Teiserver.Account.UserCacheLib do
 
   alias Teiserver.Account
   alias Teiserver.Account.Guardian
+  alias Teiserver.Account.User
   alias Teiserver.CacheUser
   alias Teiserver.Data.Types, as: T
   require Logger
@@ -163,7 +164,7 @@ defmodule Teiserver.Account.UserCacheLib do
     |> Enum.filter(fn user -> user != nil end)
   end
 
-  @spec recache_user(T.userid() | CacheUser.t()) :: :ok
+  @spec recache_user(T.userid() | CacheUser.t() | map()) :: :ok
   def recache_user(id) when is_integer(id) do
     Teiserver.cache_delete(:account_user_cache, id)
     Teiserver.cache_delete(:account_user_cache_bang, id)
@@ -194,20 +195,61 @@ defmodule Teiserver.Account.UserCacheLib do
   Given a database user it will convert it into a cached user
   """
 
-  @spec convert_user(CacheUser.t() | nil) :: T.user() | nil
+  @spec convert_user(User.t() | nil) :: CacheUser.t() | nil
   def convert_user(nil), do: nil
 
-  def convert_user(%Account.User{} = user) do
+  def convert_user(%User{} = user) do
     data =
       CacheUser.data_keys()
       |> Map.new(fn k ->
         {k, Map.get(user.data || %{}, to_string(k), Account.default_data()[k])}
       end)
 
-    user
-    |> Map.take(CacheUser.keys())
-    |> Map.merge(Account.default_data())
-    |> Map.merge(data)
+    user_data =
+      user
+      |> Map.take(CacheUser.keys())
+      |> Map.merge(Account.default_data())
+      |> Map.merge(data)
+
+    %CacheUser{
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      password: user.password,
+      icon: user.icon,
+      colour: user.colour,
+      roles: user.roles,
+      permissions: user.permissions,
+      # For some reason the restrictions in user_data are different
+      # and using the user restrictions breaks tests so we will be using
+      # the data restrictions initially
+      restrictions: user_data.restrictions,
+      restricted_until: user.restricted_until,
+      shadowbanned: user.shadowbanned,
+      last_login: user.last_login,
+      last_played: user.last_played,
+      last_logout: user.last_logout,
+      discord_id: user.discord_id,
+      discord_dm_channel_id: user.discord_dm_channel_id,
+      steam_id: user.steam_id,
+      clan_id: user.clan_id,
+      smurf_of_id: user.smurf_of_id,
+      inserted_at: user.inserted_at,
+
+      # User data fields
+      rank: user_data.rank,
+      country: user_data.country,
+      bot: user_data.bot,
+      email_change_code: user_data.email_change_code,
+      last_login_mins: user_data.last_login_mins,
+      lobby_hash: user_data.lobby_hash,
+      hw_hash: user_data.hw_hash,
+      chobby_hash: user_data.chobby_hash,
+      lobby_client: user_data.lobby_client,
+      print_client_messages: user_data.print_client_messages,
+      print_server_messages: user_data.print_server_messages,
+      discord_dm_channel: user_data.discord_dm_channel
+    }
   end
 
   @doc """
@@ -232,7 +274,7 @@ defmodule Teiserver.Account.UserCacheLib do
   # Persists the changes into the database so they will
   # be pulled out next time the user is accessed/recached
   # The special case here is to prevent the benchmark and test users causing issues
-  @spec persist_user(CacheUser.t()) :: CacheUser.t() | nil
+  @spec persist_user(CacheUser.t() | map()) :: CacheUser.t() | map() | nil
   defp persist_user(%{name: "test_" <> _rest}), do: nil
 
   defp persist_user(user) do
@@ -249,7 +291,7 @@ defmodule Teiserver.Account.UserCacheLib do
     Account.script_update_user(db_user, Map.put(obj_attrs, "data", data))
   end
 
-  @spec update_user(CacheUser.t(), [persist: boolean()] | nil) :: CacheUser.t()
+  @spec update_user(CacheUser.t() | map(), [persist: boolean()] | nil) :: CacheUser.t() | map()
   def update_user(user, opts \\ []) do
     persist = Keyword.get(opts, :persist, false)
     Teiserver.cache_put(:users, user.id, user)
@@ -257,7 +299,7 @@ defmodule Teiserver.Account.UserCacheLib do
     user
   end
 
-  @spec update_cache_user(T.userid(), map()) :: CacheUser.t()
+  @spec update_cache_user(T.userid(), map()) :: CacheUser.t() | map()
   def update_cache_user(userid, data) do
     user = get_user_by_id(userid)
     new_user = Map.merge(user, data)

--- a/lib/teiserver/account/schemas/user.ex
+++ b/lib/teiserver/account/schemas/user.ex
@@ -52,7 +52,6 @@ defmodule Teiserver.Account.User do
     %{
       rank: 0,
       country: "??",
-      moderator: false,
       bot: false,
       email_change_code: nil,
       last_login: nil,

--- a/lib/teiserver/battle/servers/match_monitor_server.ex
+++ b/lib/teiserver/battle/servers/match_monitor_server.ex
@@ -485,7 +485,7 @@ defmodule Teiserver.Battle.MatchMonitorServer do
     state
   end
 
-  @spec get_match_monitor_account() :: Teiserver.CacheUser.t()
+  @spec get_match_monitor_account() :: Teiserver.CacheUser.t() | map()
   def get_match_monitor_account do
     user =
       Account.get_user(nil,

--- a/lib/teiserver/bridge/bridge_server.ex
+++ b/lib/teiserver/bridge/bridge_server.ex
@@ -414,7 +414,7 @@ defmodule Teiserver.Bridge.BridgeServer do
     |> String.replace(Map.keys(emoticon_map), fn text -> emoticon_map[text] end)
   end
 
-  @spec get_bridge_account() :: Teiserver.CacheUser.t()
+  @spec get_bridge_account() :: Teiserver.CacheUser.t() | map()
   def get_bridge_account do
     user =
       Account.get_user(nil,

--- a/lib/teiserver/coordinator/coordinator_server.ex
+++ b/lib/teiserver/coordinator/coordinator_server.ex
@@ -334,7 +334,7 @@ defmodule Teiserver.Coordinator.CoordinatorServer do
     account
   end
 
-  @spec get_coordinator_account() :: Teiserver.CacheUser.t()
+  @spec get_coordinator_account() :: Teiserver.CacheUser.t() | map()
   def get_coordinator_account do
     user =
       Account.get_user(nil,

--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -12,6 +12,7 @@ defmodule Teiserver.CacheUser do
   alias Teiserver.Account.LoginThrottleServer
   alias Teiserver.Account.UserCacheLib
   alias Teiserver.Battle
+  alias Teiserver.CacheUser
   alias Teiserver.Chat
   alias Teiserver.Chat.WordLib
   alias Teiserver.Client
@@ -29,8 +30,6 @@ defmodule Teiserver.CacheUser do
 
   import Teiserver.Helper.NumberHelper, only: [int_parse: 1]
 
-  @type t :: T.user()
-
   @timer_sleep 500
 
   @default_colour "#666666"
@@ -45,6 +44,82 @@ defmodule Teiserver.CacheUser do
   def keys,
     do:
       ~w(id name password email inserted_at clan_id permissions colour icon smurf_of_id last_login last_played last_logout roles discord_id)a
+
+  defstruct [
+    # Fields from the User struct itself
+    :id,
+    :name,
+    :email,
+    :password,
+    :icon,
+    :colour,
+    :roles,
+    :permissions,
+    :restrictions,
+    :restricted_until,
+    :shadowbanned,
+    :last_login,
+    :last_played,
+    :last_logout,
+    :discord_id,
+    :discord_dm_channel_id,
+    :steam_id,
+    :clan_id,
+    :smurf_of_id,
+    :inserted_at,
+
+    # Fields from user data
+    :rank,
+    :country,
+    :bot,
+    :email_change_code,
+    :last_login_mins,
+    :lobby_hash,
+    :hw_hash,
+    :chobby_hash,
+    :lobby_client,
+    :print_client_messages,
+    :print_server_messages,
+    :discord_dm_channel
+  ]
+
+  @type t() :: %CacheUser{
+          # User struct attributes
+          id: User.id(),
+          name: String.t(),
+          email: String.t() | nil,
+          password: String.t() | nil,
+          icon: String.t() | nil,
+          colour: String.t() | nil,
+          permissions: [String.t()],
+          roles: [String.t()],
+          restrictions: [String.t()],
+          restricted_until: Timex.DateTime.t(),
+          shadowbanned: boolean(),
+          last_login: Timex.DateTime.t(),
+          last_played: Timex.DateTime.t(),
+          last_logout: Timex.DateTime.t(),
+          discord_id: String.t() | nil,
+          discord_dm_channel_id: String.t() | nil,
+          steam_id: String.t() | nil,
+          smurf_of_id: integer() | nil,
+          clan_id: pos_integer() | nil,
+          inserted_at: Timex.DateTime.t(),
+
+          # Data attributes
+          rank: non_neg_integer(),
+          country: String.t(),
+          bot: boolean(),
+          email_change_code: [String.t()],
+          last_login_mins: integer(),
+          lobby_hash: String.t() | nil,
+          hw_hash: String.t() | nil,
+          chobby_hash: String.t() | nil,
+          lobby_client: String.t(),
+          print_client_messages: boolean(),
+          print_server_messages: boolean(),
+          discord_dm_channel: String.t() | nil
+        }
 
   @data_keys [
     :rank,

--- a/lib/teiserver/data/types.ex
+++ b/lib/teiserver/data/types.ex
@@ -6,6 +6,8 @@ defmodule Teiserver.Data.Types do
   alias Teiserver.Data.Types, as: T
   """
 
+  alias Teiserver.CacheUser
+
   @type userid() :: non_neg_integer()
   @type party_id() :: String.t()
   @type lobby_id() :: non_neg_integer()
@@ -21,7 +23,7 @@ defmodule Teiserver.Data.Types do
   @type client() :: map()
 
   # TODO: We should drop the next line and replace all calls with `Teiserver.Account.User.t()`.
-  @type user() :: map()
+  @type user() :: map() | CacheUser.t()
 
   @type spring_tcp_state() :: map()
   @type error_pair() :: {:error, String.t()}

--- a/lib/teiserver_web/teiserver_web.ex
+++ b/lib/teiserver_web/teiserver_web.ex
@@ -112,7 +112,6 @@ defmodule TeiserverWeb do
   def live_view do
     quote do
       use Phoenix.LiveView,
-        log: :warning,
         layout: {TeiserverWeb.Layouts, :app}
 
       use Breadcrumble

--- a/lib/teiserver_web/templates/admin/user/tab_raw.html.heex
+++ b/lib/teiserver_web/templates/admin/user/tab_raw.html.heex
@@ -5,7 +5,7 @@
   </div>
   <div class="col">
     <h4>Cache object</h4>
-    <textarea name="" id="" rows="40" cols="40" class="form-control monospace"><%= Jason.encode! @cache_user, pretty: true %></textarea>
+    <textarea name="" id="" rows="40" cols="40" class="form-control monospace"><%= Jason.encode! Map.from_struct(@cache_user), pretty: true %></textarea>
   </div>
 </div>
 


### PR DESCRIPTION
Still working through the bugs.

In hindsight having a different structure for the database user and a cached user was a bad idea but this is now used in so many places removing it will be a challenge.

This PR takes the unstructured map of the cached user and forces it into a (very comprehensive right now) struct. In the long run I want to start making the CacheUser and User structs aligned with the eventual aim being to only have the User struct exist.

No functionality change should come about from this PR.