### PR TITLE
Fix password reset form

### DIFF
--- a/lib/teiserver_web/controllers/account/session_controller.ex
+++ b/lib/teiserver_web/controllers/account/session_controller.ex
@@ -298,6 +298,7 @@ defmodule TeiserverWeb.Account.SessionController do
   @spec password_reset_form(Conn.t(), map()) :: Conn.t()
   def password_reset_form(conn, %{"value" => value}) do
     code = Account.get_code(value, preload: [:user])
+    changeset = Account.change_user(code.user)
 
     cond do
       code == nil ->
@@ -320,13 +321,16 @@ defmodule TeiserverWeb.Account.SessionController do
 
       true ->
         conn
+        |> add_breadcrumb(name: "Password", url: conn.request_path)
+        |> assign(:changeset, changeset)
+        |> assign(:user, code.user)
         |> assign(:value, value)
         |> render("password_reset_form.html")
     end
   end
 
-  @spec password_reset_post(Conn.t(), map()) :: Conn.t()
-  def password_reset_post(conn, %{"value" => value, "pass1" => pass1, "pass2" => pass2}) do
+  @spec update_password(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def update_password(conn, %{"value" => value, "user" => user_params}) do
     code = Account.get_code(value, preload: [:user])
 
     cond do
@@ -345,17 +349,7 @@ defmodule TeiserverWeb.Account.SessionController do
         |> put_flash(:danger, "Link has expired")
         |> redirect(to: "/")
 
-      pass1 != pass2 ->
-        conn
-        |> assign(:value, value)
-        |> put_flash(:danger, "Passwords need to match")
-        |> render("password_reset_form.html")
-
       true ->
-        user_params = %{
-          "password" => pass1
-        }
-
         case Account.password_reset_update_user(code.user, user_params) do
           {:ok, user} ->
             LoggingHelpers.add_anonymous_audit_log(
@@ -379,8 +373,12 @@ defmodule TeiserverWeb.Account.SessionController do
             |> GuardianPlug.sign_out(clear_remember_me: true)
             |> redirect(to: "/")
 
-          {:error, _changeset} ->
-            raise "Error updating user password from password reset form"
+          {:error, %Ecto.Changeset{} = changeset} ->
+            render(conn, "password_reset_form.html",
+              user: code.user,
+              changeset: changeset,
+              value: value
+            )
         end
     end
   end

--- a/lib/teiserver_web/router.ex
+++ b/lib/teiserver_web/router.ex
@@ -143,7 +143,7 @@ defmodule TeiserverWeb.Router do
     get("/forgot_password", SessionController, :forgot_password)
     post("/send_password_reset", SessionController, :send_password_reset)
     get("/password_reset/:value", SessionController, :password_reset_form)
-    post("/password_reset/:value", SessionController, :password_reset_post)
+    put("/password_reset/:value", SessionController, :update_password)
     get("/one_time_login/:value", SessionController, :one_time_login)
 
     get("/register", RegistrationController, :new)

--- a/lib/teiserver_web/templates/account/session/password_reset_form.html.heex
+++ b/lib/teiserver_web/templates/account/session/password_reset_form.html.heex
@@ -14,40 +14,30 @@
       <div class="card-body">
         Please enter your new password. <br /><br />
 
-        <form action={~p"/password_reset/:value"} method="post" class="">
+        <%= form_for @changeset, ~p"/password_reset/#{@value}", fn f -> %>
+          <%= if @changeset.action do %>
+            <div class="alert alert-danger">
+              <p>Oops, something went wrong! Please check the errors below.</p>
+            </div>
+          <% end %>
           <input type="hidden" name="_csrf_token" value={get_csrf_token()} />
-          <div class="row">
-            <div class="col-md-12">
-              <label for="pass1" class="control-label">Password:</label>
-              <input
-                type="password"
-                name="pass1"
-                id="pass1"
-                value=""
-                placeholder=""
-                class="form-control"
-              />
-            </div>
 
-            <div class="col-md-12" style="padding-top: 10px;">
-              <label for="pass2" class="control-label">Confirm password:</label>
-              <input
-                type="password"
-                name="pass2"
-                id="pass2"
-                value=""
-                placeholder=""
-                class="form-control"
-              />
-            </div>
-
-            <div class="col-md-12" style="padding-top: 10px;">
-              <button type="submit" class="btn btn-primary btn-block">
-                Update password
-              </button>
-            </div>
+          <div class="form-group mt-3">
+            {label(f, :password)}
+            {password_input(f, :password, class: "form-control", required: true)}
+            {error_tag(f, :password)}
           </div>
-        </form>
+
+          <div class="form-group mt-3">
+            {label(f, :password_confirmation)}
+            {password_input(f, :password_confirmation, class: "form-control", required: true)}
+            {error_tag(f, :password_confirmation)}
+          </div>
+
+          <div class="col-md-12" style="padding-top: 30px;">
+            {submit("Update password", class: "btn btn-danger float-end")}
+          </div>
+        <% end %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Latest change to routes was sending `:value` instead of the actual code value, additionally changeset errors didn't show up on the form.