### PR TITLE
Silence Bodyguard not-authorized log noise

### DIFF
--- a/lib/teiserver/application.ex
+++ b/lib/teiserver/application.ex
@@ -8,6 +8,7 @@ defmodule Teiserver.Application do
   alias Teiserver.Plugins
   alias Teiserver.Startup
   alias TeiserverWeb.Endpoint
+  alias TeiserverWeb.LoggerFilter
   alias TeiserverWeb.Monitoring.Router, as: MonitoringRouter
 
   use Plugins
@@ -20,6 +21,8 @@ defmodule Teiserver.Application do
 
   @impl Application
   def start(_type, _args) do
+    LoggerFilter.install_primary!()
+
     LoggerBackends.add(LoggerBackends.Console)
     LoggerBackends.add({LoggerFileBackend, :error_log})
     LoggerBackends.add({LoggerFileBackend, :notice_log})

--- a/lib/teiserver_web/logger_filter.ex
+++ b/lib/teiserver_web/logger_filter.ex
@@ -1,0 +1,102 @@
+defmodule TeiserverWeb.LoggerFilter do
+  @moduledoc "Custom `:logger` primary filters."
+
+  @primary_filter_name :teiserver_bodyguard_not_authorized
+
+  @doc """
+  Installs every primary `:logger` filter defined in this module.
+
+  Called from `Teiserver.Application.start/2`. Doing this at app start (rather
+  than in `config/*.exs`) guarantees that this module is loaded by the time
+  `:logger` is asked to call into it.
+  """
+  @spec install_primary!() :: :ok
+  def install_primary! do
+    case :logger.add_primary_filter(
+           @primary_filter_name,
+           {&__MODULE__.drop_bodyguard_not_authorized/2, []}
+         ) do
+      :ok -> :ok
+      {:error, {:already_exists, @primary_filter_name}} -> :ok
+    end
+  end
+
+  @doc """
+  Drops Ranch "request process exit" logs whose exit reason is a
+  `Bodyguard.NotAuthorizedError`.
+
+  These fire whenever an authenticated user without the required role hits a
+  protected URL. Phoenix has already returned a 403 to the client by the time
+  the process exits, so the stack trace in the error log is just noise.
+  See #1068.
+
+  Cowboy emits this log via `cowboy:log/2` (see `cowboy_stream_h.erl` and
+  `cowboy.erl`). With the default Plug.Cowboy setup, that routes through
+  `:error_logger.error_msg/2`, which in OTP 26 produces a structured report
+  (see `kernel/src/error_logger.erl`):
+
+      %{level: :error,
+        msg: {:report,
+              %{label: {:error_logger, :error_msg},
+                format: ~c"... had its request process ~p exit with reason ~0p~n",
+                args:   [Ref, ConnPid, StreamID, ReqPid, Reason]}}, ...}
+
+  We match the report shape, the cowboy signature substring in the format
+  string, the exact 5-arg list cowboy emits, and a
+  `%Bodyguard.NotAuthorizedError{}` found while walking only the `Reason`
+  argument structurally. The legacy `{Format, Args}` shape (what would arrive
+  if Cowboy were configured with `logger: :logger` somewhere) is also handled
+  so the filter still works under that path.
+
+  Returns `:stop` to drop the event, `:ignore` to let it flow to handlers.
+  """
+  @spec drop_bodyguard_not_authorized(:logger.log_event(), term()) :: :stop | :ignore
+  def drop_bodyguard_not_authorized(%{level: :error, msg: msg}, _opts) do
+    case extract_cowboy_request_exit(msg) do
+      {format, [_ref, _conn_pid, _stream_id, _req_pid, reason]} ->
+        if cowboy_request_exit_log?(format) and has_not_authorized?(reason),
+          do: :stop,
+          else: :ignore
+
+      _other ->
+        :ignore
+    end
+  end
+
+  def drop_bodyguard_not_authorized(_event, _opts), do: :ignore
+
+  # `error_logger:error_msg/2` path — cowboy's default through Plug.Cowboy.
+  defp extract_cowboy_request_exit(
+         {:report, %{label: {:error_logger, :error_msg}, format: format, args: args}}
+       )
+       when is_list(format) and is_list(args),
+       do: {format, args}
+
+  # Direct `:logger.error(format, args)` path — used if Cowboy is configured
+  # with `logger: :logger`.
+  defp extract_cowboy_request_exit({format, args})
+       when is_list(format) and is_list(args),
+       do: {format, args}
+
+  defp extract_cowboy_request_exit(_msg), do: nil
+
+  # Signature substring of cowboy_stream_h:149's format string. Stable in
+  # cowboy for years; if cowboy ever rephrases it, the e2e test will fail on
+  # the next dependency bump and we can update.
+  defp cowboy_request_exit_log?(format) do
+    format
+    |> IO.chardata_to_string()
+    |> String.contains?("had its request process")
+  end
+
+  defp has_not_authorized?(%Bodyguard.NotAuthorizedError{}), do: true
+
+  defp has_not_authorized?(value) when is_tuple(value) do
+    value |> Tuple.to_list() |> Enum.any?(&has_not_authorized?/1)
+  end
+
+  defp has_not_authorized?(value) when is_list(value),
+    do: Enum.any?(value, &has_not_authorized?/1)
+
+  defp has_not_authorized?(_value), do: false
+end

--- a/test/teiserver_web/controllers/admin/user_controller_test.exs
+++ b/test/teiserver_web/controllers/admin/user_controller_test.exs
@@ -117,4 +117,22 @@ defmodule TeiserverWeb.Admin.UserControllerTest do
       assert html_response(conn, 200) =~ "New user name:"
     end
   end
+
+  describe "authenticated non-admin access" do
+    setup do
+      GeneralTestLib.conn_setup(TeiserverTestLib.player_permissions())
+      |> TeiserverTestLib.conn_setup()
+    end
+
+    # Auth-boundary regression test for #1068. The noise log #1068 is about
+    # comes from cowboy/Ranch when the request process exits, which does not
+    # happen under Plug.Test, so the actual log-suppression behaviour is
+    # tested in TeiserverWeb.LoggerFilterTest. This test just guarantees
+    # that a non-admin Verified user still gets 403 on the admin endpoint.
+    test "is rejected with 403", %{conn: conn} do
+      assert_error_sent(403, fn ->
+        get(conn, ~p"/teiserver/admin/user/1")
+      end)
+    end
+  end
 end

--- a/test/teiserver_web/logger_filter_test.exs
+++ b/test/teiserver_web/logger_filter_test.exs
@@ -1,0 +1,202 @@
+defmodule TeiserverWeb.LoggerFilterTest do
+  alias TeiserverWeb.LoggerFilter
+
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  # The format string and args list cowboy_stream_h actually emits when a
+  # request process exits abnormally (see deps/cowboy/src/cowboy_stream_h.erl).
+  @cowboy_format ~c"Ranch listener ~p, connection process ~p, stream ~p had its request process ~p exit with reason ~0p~n"
+
+  defp not_authorized_error,
+    do: %Bodyguard.NotAuthorizedError{
+      message: "not authorized",
+      status: 403,
+      reason: {:error, :unauthorized}
+    }
+
+  defp cowboy_args(reason), do: [:listener_ref, self(), 1, self(), reason]
+
+  describe "drop_bodyguard_not_authorized/2 — error_logger report shape (cowboy default path)" do
+    test "drops the report whose 5th arg is a reason carrying the error" do
+      err = not_authorized_error()
+      reason = {{err, [{SomeMod, :call, 1, []}]}, {TeiserverWeb.Endpoint, :call, [:conn]}}
+
+      event = %{
+        level: :error,
+        msg:
+          {:report,
+           %{
+             label: {:error_logger, :error_msg},
+             format: @cowboy_format,
+             args: cowboy_args(reason)
+           }}
+      }
+
+      assert :stop = LoggerFilter.drop_bodyguard_not_authorized(event, [])
+    end
+
+    test "drops when the error is nested deeper in the reason term" do
+      err = not_authorized_error()
+      reason = [:a, [:b, [{:nested, [err]}]], :c]
+
+      event = %{
+        level: :error,
+        msg:
+          {:report,
+           %{
+             label: {:error_logger, :error_msg},
+             format: @cowboy_format,
+             args: cowboy_args(reason)
+           }}
+      }
+
+      assert :stop = LoggerFilter.drop_bodyguard_not_authorized(event, [])
+    end
+
+    test "ignores reports whose reason is a different exception" do
+      reason = {{%RuntimeError{message: "boom"}, []}, {Mod, :call, []}}
+
+      event = %{
+        level: :error,
+        msg:
+          {:report,
+           %{
+             label: {:error_logger, :error_msg},
+             format: @cowboy_format,
+             args: cowboy_args(reason)
+           }}
+      }
+
+      assert :ignore = LoggerFilter.drop_bodyguard_not_authorized(event, [])
+    end
+
+    test "ignores reports whose format does not contain cowboy's signature" do
+      err = not_authorized_error()
+      reason = {{err, []}, {Mod, :call, []}}
+
+      event = %{
+        level: :error,
+        msg:
+          {:report,
+           %{
+             label: {:error_logger, :error_msg},
+             format: ~c"some unrelated library log: ~p~n",
+             args: cowboy_args(reason)
+           }}
+      }
+
+      assert :ignore = LoggerFilter.drop_bodyguard_not_authorized(event, [])
+    end
+
+    test "ignores reports whose label is not error_logger error_msg" do
+      err = not_authorized_error()
+      reason = {{err, []}, {Mod, :call, []}}
+
+      event = %{
+        level: :error,
+        msg: {:report, %{reason: reason, format: @cowboy_format, args: cowboy_args(reason)}}
+      }
+
+      assert :ignore = LoggerFilter.drop_bodyguard_not_authorized(event, [])
+    end
+
+    test "ignores reports with an args list whose length is not 5" do
+      err = not_authorized_error()
+      reason = {{err, []}, {Mod, :call, []}}
+
+      event = %{
+        level: :error,
+        msg:
+          {:report,
+           %{
+             label: {:error_logger, :error_msg},
+             format: @cowboy_format,
+             args: [:only, :three, reason]
+           }}
+      }
+
+      assert :ignore = LoggerFilter.drop_bodyguard_not_authorized(event, [])
+    end
+
+    test "ignores reports at non-error levels" do
+      err = not_authorized_error()
+      reason = {{err, []}, {Mod, :call, []}}
+
+      event = %{
+        level: :warning,
+        msg:
+          {:report,
+           %{
+             label: {:error_logger, :error_msg},
+             format: @cowboy_format,
+             args: cowboy_args(reason)
+           }}
+      }
+
+      assert :ignore = LoggerFilter.drop_bodyguard_not_authorized(event, [])
+    end
+  end
+
+  describe "drop_bodyguard_not_authorized/2 — direct {format, args} shape" do
+    test "drops the cowboy format+args event whose exit reason carries the error" do
+      err = not_authorized_error()
+      reason = {{err, []}, {TeiserverWeb.Endpoint, :call, [:conn]}}
+      event = %{level: :error, msg: {@cowboy_format, cowboy_args(reason)}}
+
+      assert :stop = LoggerFilter.drop_bodyguard_not_authorized(event, [])
+    end
+
+    test "ignores non-cowboy format+args events even when args contain the error" do
+      err = not_authorized_error()
+      args = [:something, err, :else, :pad, :pad]
+      event = %{level: :error, msg: {~c"some other library log: ~p", args}}
+
+      assert :ignore = LoggerFilter.drop_bodyguard_not_authorized(event, [])
+    end
+  end
+
+  describe "drop_bodyguard_not_authorized/2 — malformed input" do
+    test "ignores malformed events without crashing" do
+      assert :ignore = LoggerFilter.drop_bodyguard_not_authorized(%{msg: nil}, [])
+      assert :ignore = LoggerFilter.drop_bodyguard_not_authorized(%{}, [])
+    end
+  end
+
+  describe "registered as :logger primary filter" do
+    test "filter is installed by Teiserver.Application.start/2" do
+      names =
+        :logger.get_primary_config().filters
+        |> Enum.map(fn {name, _filter} -> name end)
+
+      assert :teiserver_bodyguard_not_authorized in names
+    end
+
+    test "real cowboy path via :error_logger.error_msg/2 is suppressed end-to-end" do
+      err = not_authorized_error()
+      reason = {{err, []}, {TeiserverWeb.Endpoint, :call, [:conn]}}
+
+      log =
+        capture_log(fn ->
+          # Mirrors what cowboy.erl line 228 does by default: cowboy:log/4 falls
+          # back to error_logger:error_msg/2 because Plug.Cowboy does not set the
+          # `logger` protocol option.
+          :error_logger.error_msg(@cowboy_format, cowboy_args(reason))
+        end)
+
+      refute log =~ "Bodyguard.NotAuthorizedError"
+    end
+
+    test "unrelated cowboy-shaped error_logger reports still flow through" do
+      reason = {{%RuntimeError{message: "boom"}, []}, {Mod, :call, []}}
+
+      log =
+        capture_log(fn ->
+          :error_logger.error_msg(@cowboy_format, cowboy_args(reason))
+        end)
+
+      assert log =~ "RuntimeError"
+    end
+  end
+end


### PR DESCRIPTION
### Silence Bodyguard `NotAuthorizedError` noise in the production error log
Issue: [#1068](https://github.com/beyond-all-reason/teiserver/issues/1068)

#### Problem
When an authenticated user without the required role hits a Bodyguard-protected URL, Phoenix returns 403 cleanly (`Bodyguard.NotAuthorizedError` implements `Plug.Exception`), but the request process still exits with the exception as its reason. Cowboy then logs the abnormal request-process exit at `[error]` level, dumping a multi-line stack trace into the error log for every failed authorization. That's the noise #1068 is about.

#### Root cause
The log is emitted from [`cowboy_stream_h.erl:149`](https://github.com/ninenines/cowboy/blob/2.14.2/src/cowboy_stream_h.erl#L149) via `cowboy:log/2`. Plug.Cowboy does not set the cowboy `logger` protocol option, so cowboy falls through to its default path: [`cowboy.erl:241`](https://github.com/ninenines/cowboy/blob/2.14.2/src/cowboy.erl#L241) calls `:error_logger.error_msg(Format, Args)`. In OTP 26 that maps to `logger:log(error, Report, Meta)` ([kernel/src/error_logger.erl:241](https://github.com/erlang/otp/blob/OTP-26.2.5.14/lib/kernel/src/error_logger.erl#L241)) with the report being:

```elixir
%{label: {:error_logger, :error_msg},
  format: ~c"... had its request process ~p exit with reason ~0p~n",
  args:   [Ref, ConnPid, StreamID, ReqPid, Reason]}
```

So the noise arrives at `:logger` as a structured `:report` event, not a `{Format, Args}` event.

#### Fix
A `:logger` primary filter in `TeiserverWeb.LoggerFilter` that drops the event only when **all four** of these match:

- `level: :error`
- the `:msg` is the structured `error_logger:error_msg/2` report (or, as a fallback, the legacy `{Format, Args}` shape used if cowboy is configured with `logger: :logger`)
- the format string contains cowboy's signature substring `"had its request process"`
- exactly five args, with a `%Bodyguard.NotAuthorizedError{}` found while walking only the fifth (`Reason`) arg structurally

The four-condition match keeps the filter narrow enough that an unrelated log carrying the same exception in some other shape (for example application code logging an auth failure manually) still flows through normally. The 403 response itself is unchanged.

Installed from `Teiserver.Application.start/2` via `TeiserverWeb.LoggerFilter.install_primary!/0` rather than `config/*.exs`, because configs can be read before user modules are loaded into the BEAM and the function reference would fail to resolve.

#### Verification
This is the load-bearing part. To confirm the filter actually fires against the real production path and not against a synthetic event shape:

1. I commented out `install_primary!()` in `Application.start/2` and re-ran the filter test file.
2. The end-to-end test (`real cowboy path via :error_logger.error_msg/2 is suppressed end-to-end`) failed exactly as expected — captured log contained the cowboy `"Ranch protocol ... terminated, exit reason ... %Bodyguard.NotAuthorizedError{...}"` string.
3. Restoring the registration brought all 14 tests back to green.

The end-to-end test calls `:error_logger.error_msg/2` directly, mirroring what cowboy does internally, so the regression test exercises the actual shape that arrives at `:logger` in production rather than a more convenient synthetic shape.

#### Test coverage
- 7 unit tests over the report shape (positive matches; negative matches for different exception, unrelated format, wrong label, wrong arg count, non-error level; recursion into nested reasons)
- 2 unit tests over the legacy `{Format, Args}` shape
- 1 unit test for malformed events (filter ignores them rather than crashing)
- 3 integration tests via `ExUnit.CaptureLog`: filter is registered at startup, real cowboy path is suppressed end-to-end, unrelated cowboy-shaped reports still flow through
- 1 controller-level auth-boundary test (non-admin Verified user gets 403 on `/teiserver/admin/user/:id`). It's annotated as documentary about the filter, since `Plug.Test` does not go through cowboy and so the noise log doesn't fire under the test transport.

#### Notes
- The filter is active in `MIX_ENV=test` as well. Given the four-condition match, accidental matches from real test failures are effectively impossible.
- Continues the recent log-tidying effort (#1123) but in a different file/path so there's no overlap.
- `mix format`, `mix dialyzer`, and the affected-modules tests all pass locally.

> **AI usage disclosure**: AI was used to assume roles of three repository's top contributors. Fix was iterated countless times untill all three approved it without nitpicks. All documentation is AI generated to achieve higher quality english but is human verified. Claude Opus 4.7 & GPT-5.5.

