### PR TITLE
Add `data` field to CacheUser as first stage of removal

### DIFF
--- a/lib/teiserver/account/caches/user_cache_lib.ex
+++ b/lib/teiserver/account/caches/user_cache_lib.ex
@@ -231,6 +231,7 @@ defmodule Teiserver.Account.UserCacheLib do
       steam_id: user.steam_id,
       smurf_of_id: user.smurf_of_id,
       inserted_at: user.inserted_at,
+      data: user.data,
 
       # User data fields
       rank: user_data.rank,

--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -42,7 +42,7 @@ defmodule Teiserver.CacheUser do
   @spec keys() :: [atom]
   def keys,
     do:
-      ~w(id name password email inserted_at permissions colour icon smurf_of_id last_login last_played last_logout roles discord_id)a
+      ~w(id name password email inserted_at permissions colour icon smurf_of_id last_login last_played last_logout roles discord_id data)a
 
   defstruct [
     # Fields from the User struct itself
@@ -65,6 +65,11 @@ defmodule Teiserver.CacheUser do
     :steam_id,
     :smurf_of_id,
     :inserted_at,
+
+    # We get the data field itself as we transition away from
+    # the converted CacheUser fields, long term we want to
+    # be using `user.data["key"]` rather than `cache_user.key`
+    :data,
 
     # Fields from user data
     :rank,
@@ -102,6 +107,7 @@ defmodule Teiserver.CacheUser do
           steam_id: String.t() | nil,
           smurf_of_id: integer() | nil,
           inserted_at: Timex.DateTime.t(),
+          data: map(),
 
           # Data attributes
           rank: non_neg_integer(),

--- a/lib/teiserver/data/client.ex
+++ b/lib/teiserver/data/client.ex
@@ -150,11 +150,11 @@ defmodule Teiserver.Client do
     )
 
     # Message logging
-    if user.print_client_messages do
+    if user.data["print_client_messages"] do
       enable_client_message_print(user.id)
     end
 
-    if user.print_server_messages do
+    if user.data["print_server_messages"] do
       enable_server_message_print(user.id)
     end
 


### PR DESCRIPTION
This is a step towards removing the CacheUser, putting a data field into it as a mirror of the User. Given the cache sizes being so small I do not anticipate memory issues while we transition.

This PR changes over `print_client_messages` and `print_server_messages` to the new access method.

Edit: Thinking about an alternate approach.