### PR TITLE
Add download replay button to match page

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -221,6 +221,11 @@ config :logger, :notice_log, path: "#{log_root_path}/notice.log"
 
 config :logger, :info_log, path: "#{log_root_path}/info.log"
 
+config :teiserver, TeiserverWeb,
+  api_url: "https://api.bar-rts.com/replays/",
+  storage_url:
+    "https://storage.uk.cloud.ovh.net/v1/AUTH_10286efc0d334efd917d476d7183232e/BAR/demos/"
+
 enable_discord_bridge =
   Teiserver.ConfigHelpers.get_env("TEI_ENABLE_DISCORD_BRIDGE", false, :bool)
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -222,8 +222,16 @@ config :logger, :notice_log, path: "#{log_root_path}/notice.log"
 config :logger, :info_log, path: "#{log_root_path}/info.log"
 
 config :teiserver, TeiserverWeb,
-  api_url: Teiserver.ConfigHelpers.get_env("BAR_LIVE_SERVICES_API_URL"),
-  storage_url: Teiserver.ConfigHelpers.get_env("BAR_REPLAY_STORAGE_URL")
+  api_url:
+    Teiserver.ConfigHelpers.get_env(
+      "BAR_LIVE_SERVICES_API_URL",
+      "https://api.bar-rts.com/replays/"
+    ),
+  storage_url:
+    Teiserver.ConfigHelpers.get_env(
+      "BAR_REPLAY_STORAGE_URL",
+      "https://storage.uk.cloud.ovh.net/v1/AUTH_10286efc0d334efd917d476d7183232e/BAR/demos/"
+    )
 
 enable_discord_bridge =
   Teiserver.ConfigHelpers.get_env("TEI_ENABLE_DISCORD_BRIDGE", false, :bool)

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -222,9 +222,8 @@ config :logger, :notice_log, path: "#{log_root_path}/notice.log"
 config :logger, :info_log, path: "#{log_root_path}/info.log"
 
 config :teiserver, TeiserverWeb,
-  api_url: "https://api.bar-rts.com/replays/",
-  storage_url:
-    "https://storage.uk.cloud.ovh.net/v1/AUTH_10286efc0d334efd917d476d7183232e/BAR/demos/"
+  api_url: Teiserver.ConfigHelpers.get_env("BAR_LIVE_SERVICES_API_URL"),
+  storage_url: Teiserver.ConfigHelpers.get_env("BAR_REPLAY_STORAGE_URL")
 
 enable_discord_bridge =
   Teiserver.ConfigHelpers.get_env("TEI_ENABLE_DISCORD_BRIDGE", false, :bool)

--- a/lib/teiserver_web/live/battles/match/match_components.ex
+++ b/lib/teiserver_web/live/battles/match/match_components.ex
@@ -12,7 +12,26 @@ defmodule TeiserverWeb.Battle.MatchComponents do
   attr :match_id, :integer, default: nil
   attr :replay, :string, default: nil
 
+  defp build_download_link(nil), do: nil
+
+  defp build_download_link(match_id) do
+    url = "https://api.bar-rts.com/replays/" <> match_id
+
+    json =
+      HTTPoison.get!(url).body
+      |> Jason.decode!()
+
+    filename =
+      json["fileName"]
+      |> String.replace(" ", "%20")
+
+    "https://storage.uk.cloud.ovh.net/v1/AUTH_10286efc0d334efd917d476d7183232e/BAR/demos/" <>
+      filename
+  end
+
   def section_menu(assigns) do
+    assigns = assign(assigns, :download_link, fn -> build_download_link(assigns.match_id) end)
+
     ~H"""
     <.section_menu_button
       bsname={@view_colour}
@@ -61,6 +80,18 @@ defmodule TeiserverWeb.Battle.MatchComponents do
         Chat
       </.section_menu_button>
     <% end %>
+
+    <div class="float-end">
+      <.section_menu_button
+        :if={@download_link != nil}
+        bsname={@view_colour}
+        icon={StylingHelper.icon(:replay)}
+        active={false}
+        url={@download_link}
+      >
+        Download Replay
+      </.section_menu_button>
+    </div>
 
     <div class="float-end">
       <.section_menu_button

--- a/lib/teiserver_web/live/battles/match/match_components.ex
+++ b/lib/teiserver_web/live/battles/match/match_components.ex
@@ -6,7 +6,7 @@ defmodule TeiserverWeb.Battle.MatchComponents do
   defp build_download_link(nil), do: nil
 
   defp build_download_link(match_id) do
-    url = "https://api.bar-rts.com/replays/" <> match_id
+    url = Application.get_env(:teiserver, :replay)[:api_url] <> match_id
 
     json =
       HTTPoison.get!(url).body
@@ -16,8 +16,7 @@ defmodule TeiserverWeb.Battle.MatchComponents do
       json["fileName"]
       |> String.replace(" ", "%20")
 
-    "https://storage.uk.cloud.ovh.net/v1/AUTH_10286efc0d334efd917d476d7183232e/BAR/demos/" <>
-      filename
+    Application.get_env(:teiserver, :replay)[:storage_url] <> filename
   end
 
   @doc """
@@ -85,7 +84,7 @@ defmodule TeiserverWeb.Battle.MatchComponents do
       <.section_menu_button
         :if={@download_link != nil}
         bsname={@view_colour}
-        icon={StylingHelper.icon(:replay)}
+        icon={StylingHelper.icon(:export)}
         active={false}
         url={@download_link}
       >

--- a/lib/teiserver_web/live/battles/match/match_components.ex
+++ b/lib/teiserver_web/live/battles/match/match_components.ex
@@ -6,17 +6,18 @@ defmodule TeiserverWeb.Battle.MatchComponents do
   defp build_download_link(nil), do: nil
 
   defp build_download_link(match_id) do
-    url = Application.get_env(:teiserver, :replay)[:api_url] <> match_id
+    url = Application.get_env(:teiserver, :replay)[:api_url] <> game_id
 
-    json =
-      HTTPoison.get!(url).body
-      |> Jason.decode!()
+    with {:ok, response} <- HTTPoison.get(url).body,
+         {:ok, json} <- Jason.decode() do
+      filename =
+        json["fileName"]
+        |> String.replace(" ", "%20")
 
-    filename =
-      json["fileName"]
-      |> String.replace(" ", "%20")
-
-    Application.get_env(:teiserver, :replay)[:storage_url] <> filename
+      Application.get_env(:teiserver, :replay)[:storage_url] <> filename
+    else
+      {:error, _} -> nil
+    end
   end
 
   @doc """

--- a/lib/teiserver_web/live/battles/match/match_components.ex
+++ b/lib/teiserver_web/live/battles/match/match_components.ex
@@ -5,11 +5,11 @@ defmodule TeiserverWeb.Battle.MatchComponents do
 
   defp build_download_link(nil), do: nil
 
-  defp build_download_link(match_id) do
+  defp build_download_link(game_id) do
     url = Application.get_env(:teiserver, :replay)[:api_url] <> game_id
 
     with {:ok, response} <- HTTPoison.get(url).body,
-         {:ok, json} <- Jason.decode() do
+         {:ok, json} <- Jason.decode(response) do
       filename =
         json["fileName"]
         |> String.replace(" ", "%20")
@@ -30,7 +30,9 @@ defmodule TeiserverWeb.Battle.MatchComponents do
   attr :replay, :string, default: nil
 
   def section_menu(assigns) do
-    assigns = assign(assigns, :download_link, fn -> build_download_link(assigns.match_id) end)
+    match = Teiserver.get_match(assigns.match_id)
+    download_link = build_download_link(match.game_id)
+    assigns = assign(assigns, :download_link, download_link)
 
     ~H"""
     <.section_menu_button

--- a/lib/teiserver_web/live/battles/match/match_components.ex
+++ b/lib/teiserver_web/live/battles/match/match_components.ex
@@ -3,15 +3,6 @@ defmodule TeiserverWeb.Battle.MatchComponents do
   use TeiserverWeb, :component
   import TeiserverWeb.NavComponents, only: [section_menu_button: 1]
 
-  @doc """
-  <TeiserverWeb.Battle.MatchComponents.section_menu active={active} bsname={} />
-  """
-  attr :view_colour, :string, required: true
-  attr :active, :string, required: true
-  attr :current_user, :map, required: true
-  attr :match_id, :integer, default: nil
-  attr :replay, :string, default: nil
-
   defp build_download_link(nil), do: nil
 
   defp build_download_link(match_id) do
@@ -28,6 +19,15 @@ defmodule TeiserverWeb.Battle.MatchComponents do
     "https://storage.uk.cloud.ovh.net/v1/AUTH_10286efc0d334efd917d476d7183232e/BAR/demos/" <>
       filename
   end
+
+  @doc """
+  <TeiserverWeb.Battle.MatchComponents.section_menu active={active} bsname={} />
+  """
+  attr :view_colour, :string, required: true
+  attr :active, :string, required: true
+  attr :current_user, :map, required: true
+  attr :match_id, :integer, default: nil
+  attr :replay, :string, default: nil
 
   def section_menu(assigns) do
     assigns = assign(assigns, :download_link, fn -> build_download_link(assigns.match_id) end)

--- a/lib/teiserver_web/live/battles/match/match_components.ex
+++ b/lib/teiserver_web/live/battles/match/match_components.ex
@@ -1,6 +1,7 @@
 defmodule TeiserverWeb.Battle.MatchComponents do
   @moduledoc false
   use TeiserverWeb, :component
+  alias Teiserver.Battle
   import TeiserverWeb.NavComponents, only: [section_menu_button: 1]
 
   defp build_download_link(nil), do: nil
@@ -30,14 +31,11 @@ defmodule TeiserverWeb.Battle.MatchComponents do
   attr :replay, :string, default: nil
 
   def section_menu(assigns) do
-    case Teiserver.Battle.get_match(assigns.match_id).game_id do
-      nil ->
-        nil
+    download_link =
+      Battle.get_match(assigns.match_id).game_id
+      |> build_download_link()
 
-      game_id ->
-        download_link = build_download_link(game_id)
-        assign(assigns, :download_link, download_link)
-    end
+    assign(assigns, :download_link, download_link)
 
     ~H"""
     <.section_menu_button

--- a/lib/teiserver_web/live/battles/match/match_components.ex
+++ b/lib/teiserver_web/live/battles/match/match_components.ex
@@ -30,14 +30,12 @@ defmodule TeiserverWeb.Battle.MatchComponents do
   attr :replay, :string, default: nil
 
   def section_menu(assigns) do
-    match = Teiserver.get_match(assigns.match_id)
-
-    case match.game_id do
+    case Teiserver.Battle.get_match(assigns.match_id).game_id do
       nil ->
         nil
 
       game_id ->
-        download_link = build_download_link(match.game_id)
+        download_link = build_download_link(game_id)
         assign(assigns, :download_link, download_link)
     end
 

--- a/lib/teiserver_web/live/battles/match/match_components.ex
+++ b/lib/teiserver_web/live/battles/match/match_components.ex
@@ -31,8 +31,15 @@ defmodule TeiserverWeb.Battle.MatchComponents do
 
   def section_menu(assigns) do
     match = Teiserver.get_match(assigns.match_id)
-    download_link = build_download_link(match.game_id)
-    assigns = assign(assigns, :download_link, download_link)
+
+    case match.game_id do
+      nil ->
+        nil
+
+      game_id ->
+        download_link = build_download_link(match.game_id)
+        assign(assigns, :download_link, download_link)
+    end
 
     ~H"""
     <.section_menu_button

--- a/lib/teiserver_web/live/battles/match/match_components.ex
+++ b/lib/teiserver_web/live/battles/match/match_components.ex
@@ -1,7 +1,7 @@
 defmodule TeiserverWeb.Battle.MatchComponents do
   @moduledoc false
-  use TeiserverWeb, :component
   alias Teiserver.Battle
+  use TeiserverWeb, :component
   import TeiserverWeb.NavComponents, only: [section_menu_button: 1]
 
   defp build_download_link(nil), do: nil
@@ -17,7 +17,7 @@ defmodule TeiserverWeb.Battle.MatchComponents do
 
       Application.get_env(:teiserver, :replay)[:storage_url] <> filename
     else
-      {:error, _} -> nil
+      {:error, _message} -> nil
     end
   end
 


### PR DESCRIPTION
This PR adds a download replay button to the match page.

This will need testing on the integration server, as I can not properly test it locally