### PR TITLE
Removed old handling of endGameData

### DIFF
--- a/lib/teiserver/battle/servers/match_monitor_server.ex
+++ b/lib/teiserver/battle/servers/match_monitor_server.ex
@@ -180,11 +180,6 @@ defmodule Teiserver.Battle.MatchMonitorServer do
     {:noreply, state}
   end
 
-  def handle_info({:direct_message, _from_id, "endGameData " <> data}, state) do
-    Battle.save_match_stats(data)
-    {:noreply, state}
-  end
-
   # Examples of accepted format:
   # match-event <playerName> <eventType> <gameTime>
   # match-event <Beherith> <commands:FirstLineMove> <67>

--- a/test/teiserver/battle/match_monitor_test.exs
+++ b/test/teiserver/battle/match_monitor_test.exs
@@ -27,53 +27,6 @@ defmodule Teiserver.Battle.MatchMonitorTest do
     {:ok, %{}}
   end
 
-  # This test is to ensure long messages are not being truncated
-  # it is currently flakey, but not in isolation :(
-  # error:
-  # test/teiserver/battle/match_monitor_test.exs:18
-  #    Assertion with == failed
-  #    code:  assert result == "SAYPRIVATE AutohostMonitor endGameData eyJrZXkiOiJ2YWx1ZSJ9\n"
-  #    left:  :closed
-  #    right: "SAYPRIVATE AutohostMonitor endGameData eyJrZXkiOiJ2YWx1ZSJ9\n"
-  #    stacktrace:
-  #      test/teiserver/battle/match_monitor_test.exs:31: (test)
-  # with seed 273979
-  @tag :needs_attention
-  test "spring send" do
-    {:ok, server_context} = start_spring_server()
-    %{socket: socket, user: _user} = auth_setup(server_context)
-
-    # Send a direct message to the match monitor server
-    short_data =
-      %{key: "value"}
-      |> Jason.encode!()
-      |> Base.url_encode64()
-
-    _send_raw(socket, "SAYPRIVATE AutohostMonitor endGameData #{short_data}\n")
-    result = _recv_raw(socket)
-    assert result == "SAYPRIVATE AutohostMonitor endGameData eyJrZXkiOiJ2YWx1ZSJ9\n"
-
-    # Now try longer data
-    long_start = %{key: "This is a very long string"}
-
-    long_data =
-      0..60
-      |> Enum.reduce(long_start, fn _index, acc ->
-        Map.put(acc, :sub, acc)
-      end)
-      |> Jason.encode!()
-      |> Base.url_encode64()
-
-    _send_raw(socket, "SAYPRIVATE AutohostMonitor endGameData #{long_data}\n")
-    result = _recv_until(socket)
-
-    assert result =~
-             "SAYPRIVATE AutohostMonitor endGameData eyJrZXkiOiJUaGlzIGlzIGEgdmVyeSBsb25nIHN0cmluZyIsInN1YiI6eyJrZXkiOiJ"
-
-    assert result =~ "X19fX19fX19fX19fX19fX19fQ==\n"
-    assert String.length(result) == 3588
-  end
-
   test "does not crash when lobby is unavailable" do
     # This test verifies that MatchMonitorServer doesn't crash when
     # trying to start a match for a non-existent lobby


### PR DESCRIPTION
Receiving `endGameData` has been changed with #746 and is now received over a POST request instead of a direct message to address issues where data was getting truncated nad matches not processed by the server. This code was left in place until all SPADS were updated (which should be the case by now 😅).