### PR TITLE
Tighten oauth permissions

### DIFF
--- a/lib/teiserver_web/controllers/admin/bot_controller.ex
+++ b/lib/teiserver_web/controllers/admin/bot_controller.ex
@@ -16,10 +16,7 @@ defmodule TeiserverWeb.Admin.BotController do
 
   plug Bodyguard.Plug.Authorize,
     fallback: TeiserverWeb.Controllers.BodyguardFallback,
-    # The policy should be Admin or something fairly high. But while we're
-    # developping the new lobby, it's easier if this is allowed for any
-    # contributors
-    policy: Teiserver.Staff,
+    policy: Teiserver.Staff.Admin,
     action: {Phoenix.Controller, :action_name},
     user: {AuthLib, :current_user}
 

--- a/lib/teiserver_web/controllers/admin/o_auth_application_controller.ex
+++ b/lib/teiserver_web/controllers/admin/o_auth_application_controller.ex
@@ -5,16 +5,12 @@ defmodule TeiserverWeb.Admin.OAuthApplicationController do
   alias Teiserver.OAuth
   alias Teiserver.OAuth.Application
   alias Teiserver.OAuth.ApplicationQueries
-  alias Teiserver.Staff
 
   use TeiserverWeb, :controller
 
   plug Bodyguard.Plug.Authorize,
     fallback: TeiserverWeb.Controllers.BodyguardFallback,
-    # The policy should be Admin or something fairly high. But while we're
-    # developping the new lobby, it's easier if this is allowed for any
-    # contributors
-    policy: Staff,
+    policy: Teiserver.Staff.Admin,
     action: {Phoenix.Controller, :action_name},
     user: {AuthLib, :current_user}
 
@@ -90,6 +86,7 @@ defmodule TeiserverWeb.Admin.OAuthApplicationController do
   defp scope_description("tachyon.lobby"), do: "for autohost"
   defp scope_description("admin.map"), do: "for CI, to setup maps data in teiserver"
   defp scope_description("admin.engine"), do: "for CI, to setup engine data in teiserver"
+  defp scope_description("admin.user"), do: "create users programatically. for load testing"
   defp scope_description(_scope), do: nil
 
   @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()

--- a/lib/teiserver_web/templates/admin/general/index.html.heex
+++ b/lib/teiserver_web/templates/admin/general/index.html.heex
@@ -102,6 +102,7 @@
   </.menu_card>
 
   <.menu_card
+    :if={allow_any?(@conn, ~w(Admin))}
     icon={Teiserver.OAuth.ApplicationLib.icon()}
     url={~p"/teiserver/admin/oauth_application"}
     size={:small}
@@ -109,7 +110,12 @@
     OAuth applications
   </.menu_card>
 
-  <.menu_card icon={Teiserver.BotLib.icon()} url={~p"/teiserver/admin/bot"} size={:small}>
+  <.menu_card
+    :if={allow_any?(@conn, ~w(Admin))}
+    icon={Teiserver.BotLib.icon()}
+    url={~p"/teiserver/admin/bot"}
+    size={:small}
+  >
     Bots
   </.menu_card>
 

--- a/test/teiserver/battle/match_monitor_test.exs
+++ b/test/teiserver/battle/match_monitor_test.exs
@@ -4,15 +4,6 @@ defmodule Teiserver.Battle.MatchMonitorTest do
   alias Teiserver.Support.Polling
   use Teiserver.ServerCase, async: false
 
-  import Teiserver.TeiserverTestLib,
-    only: [
-      auth_setup: 1,
-      _send_raw: 2,
-      _recv_raw: 1,
-      _recv_until: 1,
-      start_spring_server: 0
-    ]
-
   setup do
     Battle.start_match_monitor()
 


### PR DESCRIPTION
This is a first quick fix to avoid a privilege escalation where one could create an oauth app that would then allow them to create user with whatever permissions they want.
There are no such app in any live environment (yet), so this is enough of a fix for now.