### PR TITLE
Defense in depth preventing admin.user scope holders from assigning privileged roles

### DIFF
--- a/lib/teiserver_web/controllers/api/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/api/admin/user_controller.ex
@@ -14,15 +14,9 @@ defmodule TeiserverWeb.API.Admin.UserController do
   # allowlist is silently dropped from create requests and blocks
   # refresh_token requests against pre-existing users.
   @api_allowed_roles ~w(
-    Default
     Verified
     Trusted
     BAR+
-    Armada
-    Cortex
-    Legion
-    Raptor
-    Scavenger
     Bot
   )
 

--- a/lib/teiserver_web/controllers/api/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/api/admin/user_controller.ex
@@ -1,11 +1,29 @@
 defmodule TeiserverWeb.API.Admin.UserController do
   alias Teiserver.Account
+  alias Teiserver.Account.RoleLib
   alias Teiserver.OAuth
   use TeiserverWeb, :controller
 
   plug Teiserver.OAuth.Plug.EnsureAuthenticated, scopes: ["admin.user"]
 
   @stat_fields ["mu", "sigma", "play_time", "spec_time", "lobby_time"]
+
+  # Roles that may be assigned to users created or refreshed through this API.
+  # `admin.user` is intedned for load-testing tooling, so callers must not be able to mint staff/moderation/management accounts.
+  # Any role outside this allowlist is silently dropped from create requests and blocksrefresh_token requests against pre-existing users.
+  @api_allowed_roles ~w(
+    Default
+    Verified
+    Trusted
+    BAR+
+    Armada
+    Cortex
+    Legion
+    Raptor
+    Scavenger
+    Bot
+  )
+
   @default_params %{
     "permissions" => [],
     "roles" => [],
@@ -19,17 +37,23 @@ defmodule TeiserverWeb.API.Admin.UserController do
     :user_not_found => 404,
     :app_not_found => 400,
     :invalid_scope => 400,
+    :privileged_target => 403,
     :default => 400
   }
 
   @error_messages %{
     :user_not_found => "User not found",
     :app_not_found => @app_not_found_error,
-    :invalid_scope => "Invalid scope for OAuth application"
+    :invalid_scope => "Invalid scope for OAuth application",
+    :privileged_target =>
+      "Target user has privileged roles; admin.user scope cannot mint tokens for staff accounts"
   }
 
   def create(conn, params) do
-    params = Map.merge(@default_params, params)
+    params =
+      @default_params
+      |> Map.merge(params)
+      |> sanitize_roles_and_permissions()
 
     with {:ok, user} <- Account.script_create_user(params),
          :ok <- update_user_stats(user.id, params),
@@ -43,6 +67,7 @@ defmodule TeiserverWeb.API.Admin.UserController do
 
   def refresh_token(conn, %{"email" => email}) do
     with {:ok, user} <- get_user_by_email(email),
+         :ok <- ensure_unprivileged(user),
          {:ok, app} <- get_generic_lobby_app(),
          {:ok, token} <- create_user_token(user, app) do
       json(conn, build_user_response(user, token))
@@ -50,6 +75,32 @@ defmodule TeiserverWeb.API.Admin.UserController do
       error -> handle_error(conn, error)
     end
   end
+
+  # Drop any caller-supplied role outside the allowlist and recompute permissions from the surviving roles 
+  # Caller-supplied permission strings are discarded entirely.
+    roles =
+      params
+      |> Map.get("roles", [])
+      |> List.wrap()
+      |> Enum.filter(&(&1 in @api_allowed_roles))
+      |> Enum.uniq()
+
+    permissions = RoleLib.calculate_permissions(roles)
+
+    params
+    |> Map.put("roles", roles)
+    |> Map.put("permissions", permissions)
+  end
+
+  defp ensure_unprivileged(%{roles: roles}) when is_list(roles) do
+    if Enum.all?(roles, &(&1 in @api_allowed_roles)) do
+      :ok
+    else
+      {:error, :privileged_target}
+    end
+  end
+
+  defp ensure_unprivileged(_user), do: :ok
 
   # Private helpers
 

--- a/lib/teiserver_web/controllers/api/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/api/admin/user_controller.ex
@@ -9,8 +9,10 @@ defmodule TeiserverWeb.API.Admin.UserController do
   @stat_fields ["mu", "sigma", "play_time", "spec_time", "lobby_time"]
 
   # Roles that may be assigned to users created or refreshed through this API.
-  # `admin.user` is intedned for load-testing tooling, so callers must not be able to mint staff/moderation/management accounts.
-  # Any role outside this allowlist is silently dropped from create requests and blocksrefresh_token requests against pre-existing users.
+  # `admin.user` is intended for load-testing tooling, so callers must not be
+  # able to mint staff/moderation/management accounts. Any role outside this
+  # allowlist is silently dropped from create requests and blocks
+  # refresh_token requests against pre-existing users.
   @api_allowed_roles ~w(
     Default
     Verified
@@ -76,8 +78,9 @@ defmodule TeiserverWeb.API.Admin.UserController do
     end
   end
 
-  # Drop any caller-supplied role outside the allowlist and recompute permissions from the surviving roles.
-  # Caller-supplied permission strings are discarded entirely.
+  # Drop any caller-supplied role outside the allowlist and recompute
+  # permissions from the surviving roles. Caller-supplied permission
+  # strings are discarded entirely.
   defp sanitize_roles_and_permissions(params) do
     roles =
       params

--- a/lib/teiserver_web/controllers/api/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/api/admin/user_controller.ex
@@ -79,7 +79,6 @@ defmodule TeiserverWeb.API.Admin.UserController do
     roles =
       params
       |> Map.get("roles", [])
-      |> List.wrap()
       |> Enum.filter(&(&1 in @api_allowed_roles))
       |> Enum.uniq()
 

--- a/lib/teiserver_web/controllers/api/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/api/admin/user_controller.ex
@@ -76,8 +76,9 @@ defmodule TeiserverWeb.API.Admin.UserController do
     end
   end
 
-  # Drop any caller-supplied role outside the allowlist and recompute permissions from the surviving roles 
+  # Drop any caller-supplied role outside the allowlist and recompute permissions from the surviving roles.
   # Caller-supplied permission strings are discarded entirely.
+  defp sanitize_roles_and_permissions(params) do
     roles =
       params
       |> Map.get("roles", [])

--- a/test/teiserver_web/controllers/api/admin/user_controller_test.exs
+++ b/test/teiserver_web/controllers/api/admin/user_controller_test.exs
@@ -164,6 +164,62 @@ defmodule TeiserverWeb.API.Admin.UserControllerTest do
     end
   end
 
+  describe "privilege escalation guard" do
+    setup [:setup_user, :setup_generic_lobby_app, :setup_authed_conn]
+
+    test "strips privileged roles from create payload", %{authed_conn: conn} do
+      user_data = %{
+        "name" => "escalator",
+        "email" => "escalator@example.com",
+        "password" => "testpassword123",
+        "roles" => ["Server", "Admin", "Contributor", "Verified"],
+        "permissions" => ["admin.dev.developer", "Server"]
+      }
+
+      resp = conn |> post(create_user_path(), user_data) |> json_response(200)
+
+      assert resp["user"]["roles"] == ["Verified"]
+      refute "admin.dev.developer" in resp["user"]["permissions"]
+      refute "Server" in resp["user"]["permissions"]
+      refute "Admin" in resp["user"]["permissions"]
+
+      stored = Account.get_user_by_email("escalator@example.com")
+      assert stored.roles == ["Verified"]
+      refute "admin.dev.developer" in stored.permissions
+    end
+
+    test "ignores caller-supplied permission strings entirely", %{authed_conn: conn} do
+      user_data = %{
+        "name" => "permsetter",
+        "email" => "permsetter@example.com",
+        "password" => "testpassword123",
+        "roles" => ["Default"],
+        "permissions" => ["admin.dev.developer", "Moderator", "anything"]
+      }
+
+      resp = conn |> post(create_user_path(), user_data) |> json_response(200)
+
+      # Permissions are derived from the (filtered) roles, not the caller input.
+      assert resp["user"]["permissions"] == ["Default"]
+    end
+
+    test "refresh_token refuses to mint tokens for staff accounts", %{
+      authed_conn: conn,
+      user: user
+    } do
+      # Promote a target user to a privileged role outside the API allowlist.
+      {:ok, _} =
+        Account.script_update_user(user, %{roles: ["Admin"], permissions: ["Admin"]})
+
+      resp =
+        conn
+        |> post(refresh_token_path(), %{"email" => user.email})
+        |> json_response(403)
+
+      assert resp["error"] =~ "privileged"
+    end
+  end
+
   describe "refresh token with valid auth" do
     setup [:setup_user, :setup_generic_lobby_app, :setup_authed_conn]
 

--- a/test/teiserver_web/controllers/api/admin/user_controller_test.exs
+++ b/test/teiserver_web/controllers/api/admin/user_controller_test.exs
@@ -193,14 +193,14 @@ defmodule TeiserverWeb.API.Admin.UserControllerTest do
         "name" => "permsetter",
         "email" => "permsetter@example.com",
         "password" => "testpassword123",
-        "roles" => ["Default"],
+        "roles" => ["Verified"],
         "permissions" => ["admin.dev.developer", "Moderator", "anything"]
       }
 
       resp = conn |> post(create_user_path(), user_data) |> json_response(200)
 
       # Permissions are derived from the (filtered) roles, not the caller input.
-      assert resp["user"]["permissions"] == ["Default"]
+      assert resp["user"]["permissions"] == ["Verified"]
     end
 
     test "refresh_token refuses to mint tokens for staff accounts", %{

--- a/test/teiserver_web/controllers/api/admin/user_controller_test.exs
+++ b/test/teiserver_web/controllers/api/admin/user_controller_test.exs
@@ -211,6 +211,7 @@ defmodule TeiserverWeb.API.Admin.UserControllerTest do
       {:ok, _promoted_user} =
         Account.script_update_user(user, %{roles: ["Admin"], permissions: ["Admin"]})
 
+      Account.recache_user(user.id)
       resp =
         conn
         |> post(refresh_token_path(), %{"email" => user.email})

--- a/test/teiserver_web/controllers/api/admin/user_controller_test.exs
+++ b/test/teiserver_web/controllers/api/admin/user_controller_test.exs
@@ -208,7 +208,7 @@ defmodule TeiserverWeb.API.Admin.UserControllerTest do
       user: user
     } do
       # Promote a target user to a privileged role outside the API allowlist.
-      {:ok, _} =
+      {:ok, _promoted_user} =
         Account.script_update_user(user, %{roles: ["Admin"], permissions: ["Admin"]})
 
       resp =

--- a/test/teiserver_web/controllers/api/admin/user_controller_test.exs
+++ b/test/teiserver_web/controllers/api/admin/user_controller_test.exs
@@ -212,6 +212,7 @@ defmodule TeiserverWeb.API.Admin.UserControllerTest do
         Account.script_update_user(user, %{roles: ["Admin"], permissions: ["Admin"]})
 
       Account.recache_user(user.id)
+
       resp =
         conn
         |> post(refresh_token_path(), %{"email" => user.email})


### PR DESCRIPTION
Hardened Teiserver `Web.API.Admin.UserController` so callers holding the `admin.user` OAuth scope can no longer assign privileged roles or arbitrary permission strings: create/2 now filters roles to a non-staff allowlist and recomputes permissions from those roles (ignoring caller-supplied permission strings), and refresh_token/2 returns 403 when the target user has any role outside that allowlist.

Added three regression tests covering both paths