### PR TITLE
Check oauth scopes with roles

### DIFF
--- a/lib/teiserver/o_auth.ex
+++ b/lib/teiserver/o_auth.ex
@@ -114,7 +114,7 @@ defmodule Teiserver.OAuth do
   The token scopes are the same as the application
   """
   @spec create_code(
-          User.t() | T.userid(),
+          User.t(),
           %{
             id: integer(),
             scopes: Application.scopes(),
@@ -128,14 +128,6 @@ defmodule Teiserver.OAuth do
   def create_code(user, attrs, opts \\ [])
 
   def create_code(%User{} = user, attrs, opts) do
-    create_code(user.id, attrs, opts)
-  end
-
-  def create_code(user, attrs, opts) when is_map(user) do
-    create_code(user.id, attrs, opts)
-  end
-
-  def create_code(user_id, attrs, opts) do
     now = Keyword.get(opts, :now, Timex.now())
     app_id = attrs.id
 
@@ -144,7 +136,7 @@ defmodule Teiserver.OAuth do
       # the code for a token
       attrs = %{
         value: :crypto.strong_rand_bytes(32) |> Base.hex_encode32(),
-        owner_id: user_id,
+        owner_id: user.id,
         application_id: app_id,
         scopes: attrs.scopes,
         expires_at: Timex.add(now, Duration.from_minutes(5)),

--- a/lib/teiserver/o_auth.ex
+++ b/lib/teiserver/o_auth.ex
@@ -10,6 +10,7 @@ defmodule Teiserver.OAuth do
   alias Teiserver.OAuth.CodeQueries
   alias Teiserver.OAuth.Credential
   alias Teiserver.OAuth.CredentialQueries
+  alias Teiserver.OAuth.Libs.ScopeLib
   alias Teiserver.OAuth.Token
   alias Teiserver.OAuth.TokenQueries
 
@@ -17,6 +18,8 @@ defmodule Teiserver.OAuth do
   alias Teiserver.Account.User
   alias Teiserver.Data.Types, as: T
   alias Timex.Duration
+
+  defdelegate allowed_scopes(), to: ScopeLib
 
   # @spec change_application(Application.t(), map() | nil) :: Ecto.Changeset
   def change_application(%Application{} = app, attrs \\ %{}) do

--- a/lib/teiserver/o_auth.ex
+++ b/lib/teiserver/o_auth.ex
@@ -139,7 +139,7 @@ defmodule Teiserver.OAuth do
       # the code for a token
       attrs = %{
         value: :crypto.strong_rand_bytes(32) |> Base.hex_encode32(),
-        owner_id: user.id,
+        owner: user,
         application_id: app_id,
         scopes: attrs.scopes,
         expires_at: Timex.add(now, Duration.from_minutes(5)),
@@ -175,7 +175,7 @@ defmodule Teiserver.OAuth do
   end
 
   @spec create_token(
-          User.t() | T.userid(),
+          User.t() | Bot.t(),
           %{
             :id => integer(),
             :scopes => Application.scopes(),
@@ -185,23 +185,15 @@ defmodule Teiserver.OAuth do
           scopes: Application.scopes()
         ) ::
           {:ok, Token.t()} | {:error, :invalid_scope | Ecto.Changeset.t()}
-  def create_token(user_id, application, opts \\ [])
-
-  def create_token(%User{} = user, application, opts) do
-    create_token(user.id, application, opts)
-  end
-
-  def create_token(user, application, opts) when is_map(user) do
-    create_token(user.id, application, opts)
-  end
-
-  def create_token(user_id, application, opts) do
-    do_create_token(%{owner_id: user_id}, application, opts)
-  end
-
-  defp do_create_token(owner_attr, application, opts) do
+  def create_token(owner, application, opts) do
     now = Keyword.get(opts, :now, DateTime.utc_now())
     scopes = opts[:scopes]
+
+    owner_attrs =
+      case owner do
+        %User{} = user -> %{owner: user, owner_id: user.id}
+        %Bot{} = bot -> %{bot: bot, bot_id: bot.id}
+      end
 
     if Enum.empty?(scopes) ||
          not (MapSet.new(scopes) |> MapSet.subset?(MapSet.new(application.scopes))) do
@@ -216,7 +208,7 @@ defmodule Teiserver.OAuth do
           expires_at: Timex.add(now, Duration.from_minutes(30)),
           type: :access
         }
-        |> Map.merge(owner_attr)
+        |> Map.merge(owner_attrs)
 
       refresh_attrs =
         if Keyword.get(opts, :create_refresh, true) do
@@ -231,7 +223,7 @@ defmodule Teiserver.OAuth do
             type: :refresh,
             refresh_token: nil
           }
-          |> Map.merge(owner_attr)
+          |> Map.merge(owner_attrs)
         else
           nil
         end
@@ -280,7 +272,7 @@ defmodule Teiserver.OAuth do
 
         {:ok, token} =
           create_token(
-            code.owner_id,
+            code.owner,
             %{id: code.application_id, scopes: code.scopes},
             Keyword.put(opts, :scopes, code.scopes)
           )
@@ -355,7 +347,7 @@ defmodule Teiserver.OAuth do
 
       _result ->
         token =
-          if Ecto.assoc_loaded?(token.application) do
+          if Enum.all?([:application, :bot, :owner], &Ecto.assoc_loaded?(Map.get(token, &1))) do
             token
           else
             TokenQueries.get_token(token.value)
@@ -372,7 +364,7 @@ defmodule Teiserver.OAuth do
         tx_result =
           Repo.transaction(fn ->
             with {:ok, new_token} <-
-                   create_token(token.owner_id, refresh_attr, Keyword.put(opts, :scopes, scopes)) do
+                   create_token(token.owner, refresh_attr, Keyword.put(opts, :scopes, scopes)) do
               TokenQueries.delete_refresh_token(token)
               new_token
             end
@@ -453,10 +445,14 @@ defmodule Teiserver.OAuth do
   @spec get_token_from_credentials(Credential.t(), Application.scopes()) ::
           {:ok, Token.t()} | {:error, term()}
   def get_token_from_credentials(credential, scopes) do
-    do_create_token(%{bot_id: credential.bot_id}, credential.application,
-      create_refresh: false,
-      scopes: scopes
-    )
+    bot =
+      if Ecto.assoc_loaded?(credential.bot) do
+        credential.bot
+      else
+        Repo.preload(credential, [:bot]).bot
+      end
+
+    create_token(bot, credential.application, create_refresh: false, scopes: scopes)
   end
 
   @doc """

--- a/lib/teiserver/o_auth/libs/scope_lib.ex
+++ b/lib/teiserver/o_auth/libs/scope_lib.ex
@@ -1,0 +1,34 @@
+defmodule Teiserver.OAuth.Libs.ScopeLib do
+  @moduledoc """
+  OAuth scope related utilities, like auth checks
+  """
+
+  alias Teiserver.Account
+  alias Teiserver.Account.Auth
+
+  @spec allowed_scopes() :: [String.t()]
+  def allowed_scopes do
+    ["tachyon.lobby", "admin.map", "admin.engine", "admin.user"]
+  end
+
+  @spec all_scopes_allowed?(%Account.User{}, [String.t()]) :: :ok | {:error, [String.t()]}
+  def all_scopes_allowed?(%Account.User{} = user, scopes) do
+    invalid_scopes =
+      Enum.reduce(scopes, [], fn scope, invalid_scopes ->
+        if scope_allowed?(scope, user),
+          do: invalid_scopes,
+          else: [scope | invalid_scopes]
+      end)
+
+    if Enum.empty?(invalid_scopes),
+      do: :ok,
+      else: {:error, invalid_scopes}
+  end
+
+  @spec scope_allowed?(scope :: String.t(), Account.User.t()) :: boolean()
+  def scope_allowed?("tachyon.lobby", _user), do: true
+  def scope_allowed?("admin.map", user), do: Auth.admin?(user)
+  def scope_allowed?("admin.engine", user), do: Auth.admin?(user)
+  def scope_allowed?("admin.user", user), do: Auth.admin?(user)
+  def scope_allowed?(_scope, _user), do: false
+end

--- a/lib/teiserver/o_auth/libs/scope_lib.ex
+++ b/lib/teiserver/o_auth/libs/scope_lib.ex
@@ -5,13 +5,21 @@ defmodule Teiserver.OAuth.Libs.ScopeLib do
 
   alias Teiserver.Account
   alias Teiserver.Account.Auth
+  alias Teiserver.Bot.Bot
 
   @spec allowed_scopes() :: [String.t()]
   def allowed_scopes do
     ["tachyon.lobby", "admin.map", "admin.engine", "admin.user"]
   end
 
-  @spec all_scopes_allowed?(%Account.User{}, [String.t()]) :: :ok | {:error, [String.t()]}
+  @spec all_scopes_allowed?(Account.User.t() | Bot.t(), [String.t()]) ::
+          :ok | {:error, [String.t()]}
+  # bots don't have a concept of permission/roles (yet?) so for now, just
+  # assume that whatever scope they request is fine
+  # they should not request scopes outside the app they are associated with,
+  # but that's checked elsewhere
+  def all_scopes_allowed?(%Bot{}, _scopes), do: :ok
+
   def all_scopes_allowed?(%Account.User{} = user, scopes) do
     invalid_scopes =
       Enum.reduce(scopes, [], fn scope, invalid_scopes ->

--- a/lib/teiserver/o_auth/queries/code_query.ex
+++ b/lib/teiserver/o_auth/queries/code_query.ex
@@ -12,7 +12,7 @@ defmodule Teiserver.OAuth.CodeQueries do
   def get_code(nil), do: nil
 
   def get_code(code) do
-    base_query() |> where_code(code) |> Repo.one()
+    base_query() |> where_code(code) |> preload(:owner) |> preload(:application) |> Repo.one()
   end
 
   def base_query do

--- a/lib/teiserver/o_auth/schemas/application.ex
+++ b/lib/teiserver/o_auth/schemas/application.ex
@@ -2,6 +2,8 @@ defmodule Teiserver.OAuth.Application do
   @moduledoc false
 
   alias Ecto.Changeset
+  alias Teiserver.Account
+  alias Teiserver.OAuth.Libs.ScopeLib
 
   use TeiserverWeb, :schema
 
@@ -20,10 +22,6 @@ defmodule Teiserver.OAuth.Application do
     timestamps(type: :utc_datetime)
   end
 
-  def allowed_scopes do
-    ["tachyon.lobby", "admin.map", "admin.engine", "admin.user"]
-  end
-
   def changeset(application, attrs) do
     attrs = attrs |> uniq_lists(~w(scopes)a)
 
@@ -40,9 +38,31 @@ defmodule Teiserver.OAuth.Application do
       end
     end)
     |> Changeset.unique_constraint(:uid)
-    |> Changeset.validate_subset(:scopes, allowed_scopes(),
-      message: "Must a subset of #{Enum.join(allowed_scopes(), ", ")}"
+    |> Changeset.validate_subset(:scopes, ScopeLib.allowed_scopes(),
+      message: "Must a subset of #{Enum.join(ScopeLib.allowed_scopes(), ", ")}"
     )
+    |> Changeset.validate_change(:scopes, fn :scopes, scopes ->
+      with owner when not is_nil(owner) <- get_owner(application, attrs),
+           :ok <- ScopeLib.all_scopes_allowed?(owner, scopes) do
+        []
+      else
+        nil ->
+          # this is going to fail anyway because the owner foreign key is mandatory
+          []
+
+        {:error, invalid_scopes} ->
+          [scopes: "not authorized for scopes #{Enum.join(invalid_scopes, ", ")}"]
+      end
+    end)
     |> Changeset.validate_length(:scopes, min: 1)
   end
+
+  defp get_owner(_app, %{owner: %Account.User{} = owner}), do: owner
+  defp get_owner(_app, %{owner_id: nil}), do: nil
+  defp get_owner(_app, %{"owner_id" => nil}), do: nil
+  defp get_owner(_app, %{owner_id: owner_id}), do: Account.get_user(owner_id)
+  defp get_owner(_app, %{"owner_id" => owner_id}), do: Account.get_user(owner_id)
+  defp get_owner(%__MODULE__{owner_id: nil}, _attrs), do: nil
+  defp get_owner(%__MODULE__{owner_id: owner_id}, _attrs), do: Account.get_user(owner_id)
+  defp get_owner(%__MODULE__{owner: %Account.User{} = owner}, _attrs), do: owner
 end

--- a/lib/teiserver/o_auth/schemas/code.ex
+++ b/lib/teiserver/o_auth/schemas/code.ex
@@ -2,8 +2,10 @@ defmodule Teiserver.OAuth.Code do
   @moduledoc false
 
   alias Ecto.Changeset
+  alias Teiserver.Account
   alias Teiserver.Account.User
   alias Teiserver.OAuth
+  alias Teiserver.OAuth.Libs.ScopeLib
 
   use TeiserverWeb, :schema
 
@@ -21,7 +23,12 @@ defmodule Teiserver.OAuth.Code do
   end
 
   def changeset(code, attrs) do
-    attrs = attrs |> uniq_lists(~w(scopes)a)
+    owner = get_owner(code, attrs)
+
+    attrs =
+      attrs
+      |> uniq_lists(~w(scopes)a)
+      |> Map.put(:owner_id, owner.id)
 
     code
     |> cast(attrs, [
@@ -43,6 +50,18 @@ defmodule Teiserver.OAuth.Code do
       :challenge,
       :challenge_method
     ])
-    |> Changeset.validate_subset(:scopes, OAuth.Application.allowed_scopes())
+    |> Changeset.validate_subset(:scopes, OAuth.allowed_scopes())
+    |> Changeset.validate_change(:scopes, fn :scopes, scopes ->
+      case ScopeLib.all_scopes_allowed?(owner, scopes) do
+        :ok ->
+          []
+
+        {:error, invalid_scopes} ->
+          [scopes: "not authorized for scopes #{Enum.join(invalid_scopes, ", ")}"]
+      end
+    end)
   end
+
+  defp get_owner(_app, %{owner: %Account.User{} = owner}), do: owner
+  defp get_owner(%__MODULE__{owner: %Account.User{} = owner}, _attrs), do: owner
 end

--- a/lib/teiserver/o_auth/schemas/token.ex
+++ b/lib/teiserver/o_auth/schemas/token.ex
@@ -2,6 +2,7 @@ defmodule Teiserver.OAuth.Token do
   @moduledoc false
 
   alias Ecto.Changeset
+  alias Teiserver.Account
   alias Teiserver.OAuth
   alias Teiserver.OAuth.Libs.ScopeLib
 
@@ -40,6 +41,25 @@ defmodule Teiserver.OAuth.Token do
     ])
     |> cast_assoc(:refresh_token)
     |> validate_required([:value, :application_id, :scopes, :expires_at, :type])
-    |> Changeset.validate_subset(:scopes, ScopeLib.allowed_scopes())
+    |> Changeset.validate_subset(:scopes, attrs.original_scopes)
+    |> Changeset.validate_change(:scopes, fn :scopes, scopes ->
+      with owner when not is_nil(owner) <- get_owner(token, attrs),
+           :ok <- ScopeLib.all_scopes_allowed?(owner, scopes) do
+        []
+      else
+        # no owner will be caught by the other checks
+        nil ->
+          []
+
+        {:error, invalid_scopes} ->
+          [scopes: "not authorized for scopes #{Enum.join(invalid_scopes, ", ")}"]
+      end
+    end)
   end
+
+  defp get_owner(_tok, %{owner: %Account.User{} = owner}), do: owner
+  defp get_owner(_tok, %{bot: %Teiserver.Bot.Bot{} = bot}), do: bot
+  defp get_owner(%__MODULE__{owner: %Account.User{} = owner}, _attrs), do: owner
+  defp get_owner(%__MODULE__{bot: %Teiserver.Bot.Bot{} = bot}, _attrs), do: bot
+  defp get_owner(_tok, _attrs), do: nil
 end

--- a/lib/teiserver/o_auth/schemas/token.ex
+++ b/lib/teiserver/o_auth/schemas/token.ex
@@ -3,6 +3,7 @@ defmodule Teiserver.OAuth.Token do
 
   alias Ecto.Changeset
   alias Teiserver.OAuth
+  alias Teiserver.OAuth.Libs.ScopeLib
 
   use TeiserverWeb, :schema
 
@@ -39,6 +40,6 @@ defmodule Teiserver.OAuth.Token do
     ])
     |> cast_assoc(:refresh_token)
     |> validate_required([:value, :application_id, :scopes, :expires_at, :type])
-    |> Changeset.validate_subset(:scopes, OAuth.Application.allowed_scopes())
+    |> Changeset.validate_subset(:scopes, ScopeLib.allowed_scopes())
   end
 end

--- a/lib/teiserver_web/controllers/admin/o_auth_application_controller.ex
+++ b/lib/teiserver_web/controllers/admin/o_auth_application_controller.ex
@@ -32,7 +32,7 @@ defmodule TeiserverWeb.Admin.OAuthApplicationController do
     defaults = %{
       name: "Generic Lobby Client",
       uid: "generic_lobby",
-      scopes: Application.allowed_scopes(),
+      scopes: OAuth.allowed_scopes(),
       owner_email: Map.get(conn.assigns[:current_user], :email)
     }
 
@@ -79,7 +79,7 @@ defmodule TeiserverWeb.Admin.OAuthApplicationController do
       )
 
   defp scopes_with_descriptions(enabled_scopes \\ []) do
-    Application.allowed_scopes()
+    OAuth.allowed_scopes()
     |> Enum.map(fn s -> {s, Enum.member?(enabled_scopes, s), scope_description(s)} end)
   end
 
@@ -190,7 +190,7 @@ defmodule TeiserverWeb.Admin.OAuthApplicationController do
     user_id = Map.get(Account.get_user_by_email(app["owner_email"]) || %{}, :id)
 
     scopes =
-      Enum.filter(Application.allowed_scopes(), fn scope ->
+      Enum.filter(OAuth.allowed_scopes(), fn scope ->
         Map.get(raw_scopes, scope, "false") == "true"
       end)
 

--- a/lib/teiserver_web/controllers/api/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/api/admin/user_controller.ex
@@ -124,8 +124,11 @@ defmodule TeiserverWeb.API.Admin.UserController do
     end
   end
 
+  defp get_user_by_email(nil), do: {:error, :user_not_found}
+  defp get_user_by_email(""), do: {:error, :user_not_found}
+
   defp get_user_by_email(email) do
-    case Account.get_user_by_email(email) do
+    case Account.query_user(search: [email_lower: email]) do
       nil -> {:error, :user_not_found}
       user -> {:ok, user}
     end

--- a/test/support/fixtures/o_auth/o_auth_fixtures.ex
+++ b/test/support/fixtures/o_auth/o_auth_fixtures.ex
@@ -1,5 +1,6 @@
 defmodule Teiserver.OAuthFixtures do
   @moduledoc false
+  alias Teiserver.Account
   alias Teiserver.OAuth.Application
   alias Teiserver.OAuth.Code
   alias Teiserver.OAuth.Credential
@@ -19,20 +20,24 @@ defmodule Teiserver.OAuthFixtures do
   end
 
   def create_app(attrs) do
-    %Application{} |> Application.changeset(attrs) |> Repo.insert!()
+    %Application{}
+    |> Application.changeset(attrs)
+    |> Repo.insert!()
+    |> Repo.preload([:owner])
   end
 
   def update_app(app, changes) do
     app |> Application.changeset(changes) |> Repo.update!()
   end
 
-  def code_attrs(user_id, app) do
+  def code_attrs(%Account.User{} = user, app) do
     now = DateTime.utc_now()
     {verifier, challenge, method} = generate_challenge()
 
     %{
       value: :crypto.strong_rand_bytes(32) |> Base.hex_encode32(),
-      owner_id: user_id,
+      owner: user,
+      owner_id: user.id,
       application_id: app.id,
       scopes: app.scopes,
       expires_at: Timex.add(now, Duration.from_minutes(5)),
@@ -44,15 +49,34 @@ defmodule Teiserver.OAuthFixtures do
   end
 
   def create_code(attrs) do
-    %Code{} |> Code.changeset(attrs) |> Repo.insert!()
+    %Code{}
+    |> Code.changeset(attrs)
+    |> Repo.insert!()
+    |> Repo.preload([:owner, :application])
   end
 
-  def token_attrs(user_id, application) do
+  def token_attrs(%Account.User{} = user, application) do
     now = DateTime.utc_now()
 
     %{
       value: :crypto.strong_rand_bytes(32) |> Base.hex_encode32(padding: false),
-      owner_id: user_id,
+      owner: user,
+      owner_id: user.id,
+      application_id: application.id,
+      scopes: application.scopes,
+      expires_at: Timex.add(now, Duration.from_days(60)),
+      type: :access,
+      refresh_token: nil
+    }
+  end
+
+  def token_attrs(%Teiserver.Bot.Bot{} = bot, application) do
+    now = DateTime.utc_now()
+
+    %{
+      value: :crypto.strong_rand_bytes(32) |> Base.hex_encode32(padding: false),
+      bot: bot,
+      bot_id: bot.id,
       application_id: application.id,
       scopes: application.scopes,
       expires_at: Timex.add(now, Duration.from_days(60)),
@@ -79,23 +103,19 @@ defmodule Teiserver.OAuthFixtures do
   end
 
   @doc """
-  given a user id, will create a OAuth application and a valid token for that
+  given a user, will create a OAuth application and a valid token for that
   user, returning both
   """
-  def setup_token(user_or_id, opts \\ [])
-  def setup_token(%{user: user}, opts), do: setup_token(user.id, opts)
-  def setup_token(%{id: id}, opts), do: setup_token(id, opts)
-
-  def setup_token(user_id, opts) do
+  def setup_token(%Account.User{} = user, opts \\ []) do
     uid = for _i <- 1..10, into: "", do: <<Enum.random(~c"abcdefghijklmnopqrstuvwxyz")>>
 
     app =
-      app_attrs(user_id)
+      app_attrs(user.id)
       |> Map.put(:uid, uid)
       |> Map.update!(:scopes, fn s -> Keyword.get(opts, :scopes, s) end)
       |> create_app()
 
-    token = token_attrs(user_id, app) |> create_token()
+    token = token_attrs(user, app) |> create_token()
     %{app: app, token: token}
   end
 

--- a/test/support/tachyon.ex
+++ b/test/support/tachyon.ex
@@ -106,9 +106,7 @@ defmodule Teiserver.Support.Tachyon do
     autohost = BotFixtures.create_bot()
 
     token =
-      OAuthFixtures.token_attrs(nil, context.app)
-      |> Map.drop([:owner_id])
-      |> Map.put(:bot_id, autohost.id)
+      OAuthFixtures.token_attrs(autohost, context.app)
       |> OAuthFixtures.create_token()
 
     client = connect_autohost!(token, 10, 0)

--- a/test/teiserver/o_auth/application_query_test.exs
+++ b/test/teiserver/o_auth/application_query_test.exs
@@ -1,17 +1,17 @@
 defmodule Teiserver.OAuth.ApplicationQueryTest do
   alias Teiserver.Bot.Bot
+  alias Teiserver.Helpers.GeneralTestLib
   alias Teiserver.OAuth
   alias Teiserver.OAuth.ApplicationQueries
   alias Teiserver.OAuth.CodeQueries
   alias Teiserver.OAuth.TokenQueries
   alias Teiserver.OAuthFixtures
   alias Teiserver.Repo
-  alias Teiserver.TeiserverTestLib
   alias Timex.Duration
   use Teiserver.DataCase
 
   defp setup_app(_context) do
-    user = TeiserverTestLib.new_user()
+    user = GeneralTestLib.make_user(%{"roles" => ["Verified", "Admin"]})
 
     app = OAuthFixtures.app_attrs(user.id) |> OAuthFixtures.create_app()
 
@@ -41,11 +41,11 @@ defmodule Teiserver.OAuth.ApplicationQueryTest do
     end
 
     test "bit of everything", %{app: app, bot: bot} do
-      OAuthFixtures.code_attrs(app.owner_id, app)
+      OAuthFixtures.code_attrs(app.owner, app)
       |> OAuthFixtures.create_code()
 
       Enum.each(1..2, fn _i ->
-        OAuthFixtures.token_attrs(app.owner_id, app)
+        OAuthFixtures.token_attrs(app.owner, app)
         |> OAuthFixtures.create_token()
       end)
 
@@ -69,7 +69,7 @@ defmodule Teiserver.OAuth.ApplicationQueryTest do
         |> Map.merge(%{name: "other app", uid: "other_app"})
         |> OAuthFixtures.create_app()
 
-      OAuthFixtures.code_attrs(user.id, other_app) |> OAuthFixtures.create_code()
+      OAuthFixtures.code_attrs(user, other_app) |> OAuthFixtures.create_code()
 
       assert [%{code_count: 1}] = ApplicationQueries.get_stats(other_app.id)
     end
@@ -77,11 +77,11 @@ defmodule Teiserver.OAuth.ApplicationQueryTest do
     test "ignore expired code and tokens", %{user: user, app: app} do
       yesterday = DateTime.utc_now() |> Timex.subtract(Duration.from_days(1))
 
-      OAuthFixtures.code_attrs(user.id, app)
+      OAuthFixtures.code_attrs(user, app)
       |> Map.put(:expires_at, yesterday)
       |> OAuthFixtures.create_code()
 
-      OAuthFixtures.token_attrs(user.id, app)
+      OAuthFixtures.token_attrs(user, app)
       |> Map.put(:expires_at, yesterday)
       |> OAuthFixtures.create_token()
 
@@ -94,11 +94,11 @@ defmodule Teiserver.OAuth.ApplicationQueryTest do
         |> Map.merge(%{name: "other app", uid: "other_app"})
         |> OAuthFixtures.create_app()
 
-      OAuthFixtures.code_attrs(user.id, app)
+      OAuthFixtures.code_attrs(user, app)
       |> OAuthFixtures.create_code()
 
       Enum.each(1..2, fn i ->
-        OAuthFixtures.code_attrs(user.id, other_app)
+        OAuthFixtures.code_attrs(user, other_app)
         |> Map.put(:value, "value_#{i}")
         |> OAuthFixtures.create_code()
       end)
@@ -116,7 +116,7 @@ defmodule Teiserver.OAuth.ApplicationQueryTest do
     setup [:setup_app]
 
     test "list_authorized_applications returns correct apps", %{user: user, app: app} do
-      OAuthFixtures.token_attrs(user.id, app) |> OAuthFixtures.create_token()
+      OAuthFixtures.token_attrs(user, app) |> OAuthFixtures.create_token()
 
       apps = ApplicationQueries.list_authorized_applications(user.id)
 
@@ -127,7 +127,7 @@ defmodule Teiserver.OAuth.ApplicationQueryTest do
     test "list_authorized_applications shows apps with expired tokens", %{user: user, app: app} do
       yesterday = DateTime.utc_now() |> Timex.subtract(Duration.from_days(1))
 
-      OAuthFixtures.token_attrs(user.id, app)
+      OAuthFixtures.token_attrs(user, app)
       |> Map.put(:expires_at, yesterday)
       |> OAuthFixtures.create_token()
 
@@ -140,7 +140,7 @@ defmodule Teiserver.OAuth.ApplicationQueryTest do
     test "get_application_token_counts returns correct token counts", %{user: user, app: app} do
       # Create multiple tokens
       Enum.each(1..2, fn _i ->
-        OAuthFixtures.token_attrs(user.id, app) |> OAuthFixtures.create_token()
+        OAuthFixtures.token_attrs(user, app) |> OAuthFixtures.create_token()
       end)
 
       counts = ApplicationQueries.get_application_token_counts(user.id)
@@ -149,14 +149,14 @@ defmodule Teiserver.OAuth.ApplicationQueryTest do
 
     test "revoke_application_access deletes correct tokens and codes", %{user: user, app: app} do
       # Create tokens for this user and app
-      user_token = OAuthFixtures.token_attrs(user.id, app) |> OAuthFixtures.create_token()
-      user_code = OAuthFixtures.code_attrs(user.id, app) |> OAuthFixtures.create_code()
+      user_token = OAuthFixtures.token_attrs(user, app) |> OAuthFixtures.create_token()
+      user_code = OAuthFixtures.code_attrs(user, app) |> OAuthFixtures.create_code()
 
       # Create tokens for different user, same app
-      other_user = TeiserverTestLib.new_user()
+      other_user = GeneralTestLib.make_user(%{"roles" => ["Verified", "Admin"]})
 
       other_user_token =
-        OAuthFixtures.token_attrs(other_user.id, app) |> OAuthFixtures.create_token()
+        OAuthFixtures.token_attrs(other_user, app) |> OAuthFixtures.create_token()
 
       # Create tokens for same user, different app
       other_app =
@@ -165,7 +165,7 @@ defmodule Teiserver.OAuth.ApplicationQueryTest do
         |> OAuthFixtures.create_app()
 
       other_app_token =
-        OAuthFixtures.token_attrs(user.id, other_app) |> OAuthFixtures.create_token()
+        OAuthFixtures.token_attrs(user, other_app) |> OAuthFixtures.create_token()
 
       # Revoke access for user and app
       assert :ok = OAuth.revoke_application_access(user.id, app.id)

--- a/test/teiserver/o_auth/application_test.exs
+++ b/test/teiserver/o_auth/application_test.exs
@@ -137,4 +137,24 @@ defmodule Teiserver.OAuth.ApplicationTest do
     assert {:ok, _uri1} = OAuth.get_redirect_uri(app, "http://some.host/callback")
     assert {:ok, _uri2} = OAuth.get_redirect_uri(app, "http://another.host/another/callback")
   end
+
+  test "cannot create app with scopes if user doesn't have permissions" do
+    user = TeiserverTestLib.new_user()
+
+    {:error, err} =
+      valid_attrs(user)
+      |> Map.put(:scopes, ["admin.user"])
+      |> OAuth.create_application()
+
+    assert Keyword.has_key?(err.errors, :scopes)
+  end
+
+  test "cannot update app with scopes if user doesn't have permissions" do
+    user = TeiserverTestLib.new_user()
+
+    {:ok, app} = valid_attrs(user) |> OAuth.create_application()
+
+    {:error, err} = OAuth.update_application(app, %{scopes: ["admin.map"]})
+    assert Keyword.has_key?(err.errors, :scopes)
+  end
 end

--- a/test/teiserver/o_auth/code_test.exs
+++ b/test/teiserver/o_auth/code_test.exs
@@ -9,6 +9,9 @@ defmodule Teiserver.OAuth.CodeTest do
 
   setup do
     user = TeiserverTestLib.new_user()
+    # because the o_auth logic expects a %User{} but new_user returns a
+    # CacheUser, and that is getting deprecated
+    user = Account.get_user!(user.id)
 
     {:ok, app} =
       OAuth.create_application(%{

--- a/test/teiserver/o_auth/code_test.exs
+++ b/test/teiserver/o_auth/code_test.exs
@@ -1,6 +1,8 @@
 defmodule Teiserver.OAuth.CodeTest do
   alias Plug.Conn
   alias Plug.Test
+  alias Teiserver.Account
+  alias Teiserver.Account.Auth
   alias Teiserver.OAuth
   alias Teiserver.OAuthFixtures
   alias Teiserver.TeiserverTestLib
@@ -144,11 +146,28 @@ defmodule Teiserver.OAuth.CodeTest do
     assert :error = OAuth.parse_basic_auth(conn)
   end
 
+  test "check scopes against user permissions", %{user: user} do
+    {:ok, admin_user} = Auth.add_roles(TeiserverTestLib.new_user().id, ["Admin"])
+
+    {:ok, app} =
+      OAuth.create_application(%{
+        name: "Testing app with scopes",
+        uid: "test_app_scopes_uid",
+        owner_id: admin_user.id,
+        scopes: ["tachyon.lobby", "admin.map"],
+        redirect_uris: ["http://localhost/foo"]
+      })
+
+    attrs = OAuthFixtures.code_attrs(user, app) |> Map.merge(app)
+    {:error, err} = OAuth.create_code(user, attrs)
+    assert Keyword.has_key?(err.errors, :scopes)
+  end
+
   defp create_code_attrs(user, app, opts \\ []) do
     expires_at =
       Keyword.get(opts, :expires_at, Timex.add(DateTime.utc_now(), Duration.from_days(1)))
 
-    OAuthFixtures.code_attrs(user.id, app)
+    OAuthFixtures.code_attrs(user, app)
     |> Map.put(:expires_at, expires_at)
   end
 

--- a/test/teiserver/o_auth/credential_test.exs
+++ b/test/teiserver/o_auth/credential_test.exs
@@ -1,4 +1,5 @@
 defmodule Teiserver.OAuth.CredentialTest do
+  alias Teiserver.Account.Auth
   alias Teiserver.Bot
   alias Teiserver.OAuth
   alias Teiserver.OAuthFixtures
@@ -11,7 +12,7 @@ defmodule Teiserver.OAuth.CredentialTest do
   end
 
   defp setup_app(_context) do
-    user = TeiserverTestLib.new_user()
+    {:ok, user} = Auth.add_roles(TeiserverTestLib.new_user().id, ["Admin"])
 
     {:ok, app} =
       OAuth.create_application(%{

--- a/test/teiserver/o_auth/token_test.exs
+++ b/test/teiserver/o_auth/token_test.exs
@@ -120,7 +120,7 @@ defmodule Teiserver.OAuth.TokenTest do
 
     attrs =
       Enum.into(opts, %{})
-      |> Map.merge(OAuthFixtures.token_attrs(user.id, app))
+      |> Map.merge(OAuthFixtures.token_attrs(user, app))
       |> Map.put(:expires_at, expires_at)
       |> Map.put(:scopes, Keyword.get(opts, :scopes, app.scopes))
 

--- a/test/teiserver/o_auth/token_test.exs
+++ b/test/teiserver/o_auth/token_test.exs
@@ -9,7 +9,7 @@ defmodule Teiserver.OAuth.TokenTest do
   use Teiserver.DataCase, async: true
 
   setup do
-    user = TeiserverTestLib.new_user()
+    {:ok, user} = Teiserver.Account.Auth.add_roles(TeiserverTestLib.new_user().id, ["Admin"])
 
     {:ok, app} =
       OAuth.create_application(%{

--- a/test/teiserver/o_auth/token_test.exs
+++ b/test/teiserver/o_auth/token_test.exs
@@ -1,5 +1,6 @@
 defmodule Teiserver.OAuth.TokenTest do
   alias Ecto.Changeset
+  alias Teiserver.Account.Auth
   alias Teiserver.OAuth
   alias Teiserver.OAuth.Token
   alias Teiserver.OAuthFixtures
@@ -9,7 +10,7 @@ defmodule Teiserver.OAuth.TokenTest do
   use Teiserver.DataCase, async: true
 
   setup do
-    {:ok, user} = Teiserver.Account.Auth.add_roles(TeiserverTestLib.new_user().id, ["Admin"])
+    {:ok, user} = Auth.add_roles(TeiserverTestLib.new_user().id, ["Admin"])
 
     {:ok, app} =
       OAuth.create_application(%{
@@ -99,6 +100,20 @@ defmodule Teiserver.OAuth.TokenTest do
       OAuth.refresh_token(token.refresh_token, scopes: ["tachyon.lobby", "lolscope"])
 
     assert Keyword.get(changeset.errors, :scopes) != nil
+  end
+
+  test "cannot get scopes without correct roles", %{user: user, app: app} do
+    {:ok, user} = Auth.remove_roles(user, ["Admin"])
+    assert {:error, err} = OAuth.create_token(user, app, scopes: app.scopes)
+    assert Keyword.has_key?(err.errors, :scopes)
+  end
+
+  test "cannot get scopes at refresh without correct roles", %{user: user, app: app} do
+    {:ok, user} = Auth.remove_roles(user, ["Admin"])
+    assert {:ok, token} = OAuth.create_token(user, app, scopes: ["tachyon.lobby"])
+    assert {:ok, _token} = OAuth.get_valid_token(token.refresh_token.value)
+    assert {:error, err} = OAuth.refresh_token(token.refresh_token, scopes: ["admin.map"])
+    assert Keyword.has_key?(err.errors, :scopes)
   end
 
   test "can delete expired token", %{user: user, app: app} do

--- a/test/teiserver/tachyon/tasks/setup_apps_test.exs
+++ b/test/teiserver/tachyon/tasks/setup_apps_test.exs
@@ -10,7 +10,7 @@ defmodule Teiserver.Tachyon.Tasks.SetupAppsTest do
     user =
       GeneralTestLib.make_user(%{
         "email" => "root@localhost",
-        "roles" => ["Verified"]
+        "roles" => ["Verified", "Admin"]
       })
 
     # because all the f*ing queries are using caches, without a way to disable that

--- a/test/teiserver_web/controllers/account/security_controller_test.exs
+++ b/test/teiserver_web/controllers/account/security_controller_test.exs
@@ -38,8 +38,8 @@ defmodule TeiserverWeb.Account.SecurityControllerTest do
           redirect_uris: ["http://localhost/callback"]
         })
 
-      token = OAuthFixtures.token_attrs(user.id, app) |> OAuthFixtures.create_token()
-      code = OAuthFixtures.code_attrs(user.id, app) |> OAuthFixtures.create_code()
+      token = OAuthFixtures.token_attrs(user, app) |> OAuthFixtures.create_token()
+      code = OAuthFixtures.code_attrs(user, app) |> OAuthFixtures.create_code()
 
       {:ok, conn: conn, user: user, app: app, token: token, code: code}
     end

--- a/test/teiserver_web/controllers/admin/o_auth_application_controller_test.exs
+++ b/test/teiserver_web/controllers/admin/o_auth_application_controller_test.exs
@@ -1,4 +1,5 @@
 defmodule TeiserverWeb.Admin.OAuthApplicationControllerTest do
+  alias Teiserver.Account.Auth
   alias Teiserver.Helpers.GeneralTestLib
   alias Teiserver.OAuth
   alias Teiserver.OAuth.Application
@@ -7,8 +8,12 @@ defmodule TeiserverWeb.Admin.OAuthApplicationControllerTest do
   use TeiserverWeb.ConnCase
 
   defp setup_user(_context) do
-    GeneralTestLib.conn_setup(TeiserverTestLib.admin_permissions())
-    |> TeiserverTestLib.conn_setup()
+    {:ok, ctx} =
+      GeneralTestLib.conn_setup(TeiserverTestLib.admin_permissions())
+      |> TeiserverTestLib.conn_setup()
+
+    Auth.add_roles(ctx[:user], ["Admin"])
+    {:ok, ctx}
   end
 
   defp setup_app(context) do

--- a/test/teiserver_web/controllers/api/admin/asset_controller_test.exs
+++ b/test/teiserver_web/controllers/api/admin/asset_controller_test.exs
@@ -4,7 +4,7 @@ defmodule TeiserverWeb.API.Admin.AssetControllerTest do
   use TeiserverWeb.ConnCase, async: false
 
   defp setup_user(_context) do
-    user = GeneralTestLib.make_user()
+    user = GeneralTestLib.make_user(%{"roles" => ["Verified", "Admin"]})
     {:ok, user: user}
   end
 

--- a/test/teiserver_web/controllers/api/admin/user_controller_test.exs
+++ b/test/teiserver_web/controllers/api/admin/user_controller_test.exs
@@ -1,11 +1,13 @@
 defmodule TeiserverWeb.API.Admin.UserControllerTest do
   alias Teiserver.Account
+  alias Teiserver.Account.Auth
   alias Teiserver.Helpers.GeneralTestLib
   alias Teiserver.OAuthFixtures
   use TeiserverWeb.ConnCase, async: false
 
   defp setup_user(_context) do
-    user = GeneralTestLib.make_user()
+    {:ok, user} = GeneralTestLib.make_user() |> Auth.add_roles(["Admin"])
+
     {:ok, user: user}
   end
 
@@ -300,7 +302,7 @@ defmodule TeiserverWeb.API.Admin.UserControllerTest do
 
     test "requires valid scopes", %{conn: conn} do
       # Create a user and token without the required scope
-      user = GeneralTestLib.make_user()
+      {:ok, user} = GeneralTestLib.make_user() |> Auth.add_roles(["Admin"])
 
       app =
         OAuthFixtures.app_attrs(user.id)
@@ -309,7 +311,7 @@ defmodule TeiserverWeb.API.Admin.UserControllerTest do
         |> OAuthFixtures.create_app()
 
       token =
-        OAuthFixtures.token_attrs(user.id, app)
+        OAuthFixtures.token_attrs(user, app)
         |> Map.put(:scopes, ["admin.map"])
         |> OAuthFixtures.create_token()
 

--- a/test/teiserver_web/controllers/o_auth/code_controller_test.exs
+++ b/test/teiserver_web/controllers/o_auth/code_controller_test.exs
@@ -37,7 +37,7 @@ defmodule TeiserverWeb.OAuth.CodeControllerTest do
   end
 
   defp setup_code(context) do
-    attrs = OAuthFixtures.code_attrs(context[:user].id, context[:app])
+    attrs = OAuthFixtures.code_attrs(context[:user], context[:app])
     code = OAuthFixtures.create_code(attrs)
 
     %{code: code, code_attrs: attrs}

--- a/test/teiserver_web/controllers/tachyon_controller_test.exs
+++ b/test/teiserver_web/controllers/tachyon_controller_test.exs
@@ -15,7 +15,7 @@ defmodule TeiserverWeb.TachyonControllerTest do
   defp setup_conn(_context) do
     conn = ConnTest.build_conn()
 
-    user = GeneralTestLib.make_user(%{"roles" => ["Verified"]})
+    user = GeneralTestLib.make_user(%{"roles" => ["Verified", "Admin"]})
 
     {:ok, conn: conn, user: user}
   end
@@ -43,7 +43,7 @@ defmodule TeiserverWeb.TachyonControllerTest do
       app = OAuthFixtures.app_attrs(user.id) |> OAuthFixtures.create_app()
 
       token =
-        OAuthFixtures.token_attrs(user.id, app)
+        OAuthFixtures.token_attrs(user, app)
         |> Map.put(:type, :refresh)
         |> OAuthFixtures.create_token()
 

--- a/test/teiserver_web/tachyon/autohost_test.exs
+++ b/test/teiserver_web/tachyon/autohost_test.exs
@@ -37,9 +37,7 @@ defmodule TeiserverWeb.Tachyon.Autohost do
       |> OAuthFixtures.create_credential()
 
     token =
-      OAuthFixtures.token_attrs(nil, context.app)
-      |> Map.drop([:owner_id])
-      |> Map.put(:bot_id, context.autohost.id)
+      OAuthFixtures.token_attrs(context.autohost, context.app)
       |> OAuthFixtures.create_token()
 
     {:ok, creds: creds, token: token}

--- a/test/teiserver_web/tachyon/matchmaking_test.exs
+++ b/test/teiserver_web/tachyon/matchmaking_test.exs
@@ -422,7 +422,7 @@ defmodule Teiserver.Tachyon.MatchmakingTest do
 
     defp setup_user(app) do
       user = GeneralTestLib.make_user(%{"roles" => ["Verified"]})
-      token = OAuthFixtures.token_attrs(user.id, app) |> OAuthFixtures.create_token()
+      token = OAuthFixtures.token_attrs(user, app) |> OAuthFixtures.create_token()
       client = Tachyon.connect(token)
       {:ok, %{user: user, token: token, client: client}}
     end

--- a/test/teiserver_web/tachyon/system_test.exs
+++ b/test/teiserver_web/tachyon/system_test.exs
@@ -19,7 +19,7 @@ defmodule TeiserverWeb.Tachyon.SystemTest do
 
     defp setup_user(app) do
       user = GeneralTestLib.make_user(%{"roles" => ["Verified"]})
-      token = OAuthFixtures.token_attrs(user.id, app) |> OAuthFixtures.create_token()
+      token = OAuthFixtures.token_attrs(user, app) |> OAuthFixtures.create_token()
       client = Tachyon.connect(token)
       {:ok, %{user: user, token: token, client: client}}
     end


### PR DESCRIPTION
Whenever an OAuth scope is involved, either at app creation or when getting tokens, these should be checked against the user's roles.
This prevent someone to get a token granting them admin scope when they would otherwise not be able to do so.