### PR TITLE
Add option to require MFA for privilaged accounts

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -155,7 +155,8 @@ config :teiserver, Teiserver,
     lobby_chat: 90,
     room_chat: 90,
     battle_minimum_seconds: 120
-  }
+  },
+  require_mfa_for_privileged_roles: true
 
 config :nostrum,
   youtubedl: false,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -60,7 +60,8 @@ config :teiserver, Teiserver,
     cacertfile: "priv/certs/localhost.crt"
   ],
   enable_discord_bridge: false,
-  accept_all_emails: true
+  accept_all_emails: true,
+  require_mfa_for_privileged_roles: false
 
 # Watch static and templates for browser reloading.
 config :teiserver, TeiserverWeb.Endpoint,

--- a/config/test.exs
+++ b/config/test.exs
@@ -39,7 +39,8 @@ config :teiserver, Teiserver,
   post_login_delay: 0,
   spring_post_state_change_delay: 0,
   automod_delay: 1_000,
-  user_agreement: "User agreement goes here."
+  user_agreement: "User agreement goes here.",
+  require_mfa_for_privileged_roles: false
 
 config :teiserver, DiscordBridgeBot,
   token: nil,

--- a/lib/teiserver/account/auth.ex
+++ b/lib/teiserver/account/auth.ex
@@ -3,7 +3,6 @@ defmodule Teiserver.Account.Auth do
 
   alias Teiserver.Account
   alias Teiserver.Account.User
-  alias Teiserver.Data.Types, as: T
   import Teiserver.Account.AuthLib, only: [allow?: 2]
   @behaviour Bodyguard.Policy
 
@@ -38,13 +37,13 @@ defmodule Teiserver.Account.Auth do
   def authorize(_action, conn, _data), do: allow?(conn, "admin.dev")
 
   # credo:disable-for-lines:5 Credo.Check.Readability.PredicateFunctionNames
-  @spec is_bot?(T.userid() | User.t() | nil) :: boolean()
+  @spec is_bot?(User.id() | User.t() | nil) :: boolean()
   def is_bot?(nil), do: false
   def is_bot?(userid) when is_integer(userid), do: is_bot?(Account.get_user(userid))
   def is_bot?(%User{} = %{roles: roles}), do: Enum.member?(roles, "Bot")
   def is_bot?(_user), do: false
 
-  @spec moderator?(T.userid() | User.t() | nil) :: boolean()
+  @spec moderator?(User.id() | User.t() | nil) :: boolean()
   def moderator?(nil), do: false
 
   def moderator?(userid) when is_integer(userid),
@@ -54,7 +53,7 @@ defmodule Teiserver.Account.Auth do
   def moderator?(_user), do: false
 
   # credo:disable-for-lines:8 Credo.Check.Readability.PredicateFunctionNames
-  @spec is_event_organizer?(T.userid() | User.t() | nil) :: boolean()
+  @spec is_event_organizer?(User.id() | User.t() | nil) :: boolean()
   def is_event_organizer?(nil), do: false
 
   def is_event_organizer?(userid) when is_integer(userid),
@@ -63,7 +62,7 @@ defmodule Teiserver.Account.Auth do
   def is_event_organizer?(%User{} = %{roles: roles}), do: Enum.member?(roles, "Event Organizer")
   def is_event_organizer?(_user), do: false
 
-  @spec contributor?(T.userid() | User.t() | nil) :: boolean()
+  @spec contributor?(User.id() | User.t() | nil) :: boolean()
   def contributor?(nil), do: false
 
   def contributor?(userid) when is_integer(userid),
@@ -72,7 +71,7 @@ defmodule Teiserver.Account.Auth do
   def contributor?(%User{} = %{roles: roles}), do: Enum.member?(roles, "Contributor")
   def contributor?(_user), do: false
 
-  @spec verified?(T.userid() | User.t() | nil) :: boolean()
+  @spec verified?(User.id() | User.t() | nil) :: boolean()
   def verified?(nil), do: false
 
   def verified?(userid) when is_integer(userid),
@@ -81,13 +80,13 @@ defmodule Teiserver.Account.Auth do
   def verified?(%User{} = %{roles: roles}), do: Enum.member?(roles, "Verified")
   def verified?(_user), do: false
 
-  @spec admin?(T.userid() | User.t() | nil) :: boolean()
+  @spec admin?(User.id() | User.t() | nil) :: boolean()
   def admin?(nil), do: false
   def admin?(userid) when is_integer(userid), do: admin?(Account.get_user(userid))
   def admin?(%User{} = %{roles: roles}), do: Enum.member?(roles, "Admin")
   def admin?(_user), do: false
 
-  @spec vip?(T.userid() | User.t() | nil) :: boolean()
+  @spec vip?(User.id() | User.t() | nil) :: boolean()
   def vip?(nil), do: false
   def vip?(userid) when is_integer(userid), do: vip?(Account.get_user(userid))
   def vip?(%User{} = %{roles: roles}), do: Enum.member?(roles, "VIP")
@@ -96,7 +95,7 @@ defmodule Teiserver.Account.Auth do
   @doc """
   If a user possesses any of these roles it returns true
   """
-  @spec has_any_role?(T.userid() | User.t() | nil, String.t() | [String.t()]) :: boolean()
+  @spec has_any_role?(User.id() | User.t() | nil, String.t() | [String.t()]) :: boolean()
   def has_any_role?(nil, _roles), do: false
 
   def has_any_role?(userid, roles) when is_integer(userid),
@@ -113,7 +112,7 @@ defmodule Teiserver.Account.Auth do
   @doc """
   If a user possesses all of these roles it returns true, if any are lacking it returns false
   """
-  @spec has_all_roles?(T.userid() | User.t() | nil, String.t() | [String.t()]) :: boolean()
+  @spec has_all_roles?(User.id() | User.t() | nil, String.t() | [String.t()]) :: boolean()
   def has_all_roles?(nil, _roles), do: false
 
   def has_all_roles?(userid, roles) when is_integer(userid),
@@ -127,7 +126,7 @@ defmodule Teiserver.Account.Auth do
 
   def has_all_roles?(user, role), do: has_all_roles?(user, [role])
 
-  @spec add_roles(T.userid() | User.t() | nil, [String.t()]) :: nil | {:ok, User.t()}
+  @spec add_roles(User.id() | User.t() | nil, [String.t()]) :: nil | {:ok, User.t()}
   def add_roles(nil, _roles), do: nil
   def add_roles(_user, []), do: nil
   def add_roles(_user, nil), do: nil
@@ -140,7 +139,7 @@ defmodule Teiserver.Account.Auth do
     Account.script_update_user(user, %{roles: new_roles})
   end
 
-  @spec remove_roles(T.userid() | User.t() | nil, [String.t()]) :: nil | User.t()
+  @spec remove_roles(User.id() | User.t() | nil, [String.t()]) :: nil | User.t()
   def remove_roles(nil, _roles), do: nil
   def remove_roles(_user, []), do: nil
 

--- a/lib/teiserver/account/libs/auth_lib.ex
+++ b/lib/teiserver/account/libs/auth_lib.ex
@@ -75,7 +75,7 @@ defmodule Teiserver.Account.AuthLib do
           map() | Conn.t() | Socket.t() | Teiserver.Account.User.t(),
           String.t() | [String.t()]
         ) :: boolean
-  def allow?(nil, []), do: false
+  def allow?(nil, _any), do: false
   def allow?(_permissions, nil), do: true
   def allow?(_permissions, ""), do: true
   def allow?(_permissions, []), do: true
@@ -199,8 +199,8 @@ defmodule Teiserver.Account.AuthLib do
   Returns true if the user_id in question has an active totp
   """
   @spec has_active_mfa?(Teiserver.Account.User.id()) :: boolean()
-  def has_active_mfa?(userid) do
-    Account.get_user_totp_status(userid) == :active
+  def has_active_mfa?(user_id) do
+    user_id != nil and Account.get_user_totp_status(user_id) == :active
   end
 
   @doc """
@@ -208,16 +208,20 @@ defmodule Teiserver.Account.AuthLib do
   are possessed then also checks for MFA. If no MFA is present then the
   roles are removed.
   """
-  @spec maybe_remove_mfa_roles(Teiserver.Account.User.t()) :: Teiserver.Account.User.t()
-  def maybe_remove_mfa_roles(user) do
-    if contains_mfa_role?(user.roles) do
-      IO.puts("")
-      IO.inspect("CONTAINS", label: "#{__MODULE__}:#{__ENV__.line}")
-      IO.puts("")
+  @spec maybe_remove_mfa_roles(Teiserver.Account.User.id()) :: :removed | :nochange
+  def maybe_remove_mfa_roles(user_id) do
+    user = Account.get_user(user_id)
+    mfa_required = Application.get_env(:teiserver, Teiserver)[:require_mfa_for_privileged_roles]
 
+    if mfa_required and contains_mfa_role?(user.roles) do
+      # If the user has an MFA role then do an empty update
+      # and the update code will decide if how to alter the user
       user
+      |> Account.script_update_user(%{})
+
+      :removed
     else
-      user
+      :nochange
     end
   end
 

--- a/lib/teiserver/account/libs/auth_lib.ex
+++ b/lib/teiserver/account/libs/auth_lib.ex
@@ -1,6 +1,6 @@
 defmodule Teiserver.Account.AuthLib do
   @moduledoc """
-
+  Module with functions for working with authorisation/permission checks
   """
 
   alias Phoenix.LiveView
@@ -12,6 +12,10 @@ defmodule Teiserver.Account.AuthLib do
 
   @spec icon :: String.t()
   def icon, do: "fa-solid fa-address-card"
+
+  def mfa_roles do
+    ~w[Server Admin]s
+  end
 
   @spec get_all_permission_sets() :: list()
   def get_all_permission_sets do

--- a/lib/teiserver/account/libs/auth_lib.ex
+++ b/lib/teiserver/account/libs/auth_lib.ex
@@ -224,16 +224,6 @@ defmodule Teiserver.Account.AuthLib do
     Application.get_env(:teiserver, Teiserver)[:require_mfa_for_privileged_roles]
   end
 
-  @doc """
-  Given a list of roles, remove any MFA guarded roles from the list
-  """
-  @spec remove_mfa_roles_from_list([String.t()]) :: [String.t()]
-  def remove_mfa_roles_from_list(roles) do
-    Enum.reject(roles, fn role ->
-      Enum.member?(mfa_roles(), role)
-    end)
-  end
-
   @spec contains_mfa_role?([String.t()]) :: boolean()
   def contains_mfa_role?(role_list) do
     role_set = List.wrap(role_list) |> MapSet.new()

--- a/lib/teiserver/account/libs/auth_lib.ex
+++ b/lib/teiserver/account/libs/auth_lib.ex
@@ -82,21 +82,24 @@ defmodule Teiserver.Account.AuthLib do
 
   # Handle conn
   def allow?(%Conn{} = conn, permissions_required) do
-    %{permissions: permissions_held} = conn.assigns[:current_user]
+    %{id: id, permissions: permissions_held} = conn.assigns[:current_user]
 
-    permission_test(permissions_held, permissions_required)
+    mfa_test(id, permissions_required) and
+      permission_test(permissions_held, permissions_required)
   end
 
   # Socket
   def allow?(%Socket{} = socket, permissions_required) do
-    %{permissions: permissions_held} = socket.assigns[:current_user]
+    %{id: id, permissions: permissions_held} = socket.assigns[:current_user]
 
-    permission_test(permissions_held, permissions_required)
+    mfa_test(id, permissions_required) and
+      permission_test(permissions_held, permissions_required)
   end
 
-  # This allows us to use something with permissions in it
-  def allow?(%{permissions: permissions_held}, permissions_required) do
-    permission_test(permissions_held, permissions_required)
+  # User and CacheUser
+  def allow?(%{id: id, permissions: permissions_held}, permissions_required) do
+    mfa_test(id, permissions_required) and
+      permission_test(permissions_held, permissions_required)
   end
 
   # The testing of permissions required against permissions held
@@ -195,34 +198,30 @@ defmodule Teiserver.Account.AuthLib do
     )
   end
 
+  # If the permission requires MFA then check for it, otherwise return true
+  # as their MFA status doesn't matter
+  # if mfa_required? is not set then it will always return true
+  defp mfa_test(user, permissions_required) do
+    if mfa_required?() and contains_mfa_role?(permissions_required) do
+      has_active_mfa?(user)
+    else
+      true
+    end
+  end
+
   @doc """
   Returns true if the user_id in question has an active totp
   """
   @spec has_active_mfa?(Teiserver.Account.User.id()) :: boolean()
   def has_active_mfa?(user_id) do
-    user_id != nil and Account.get_user_totp_status(user_id) == :active
+    Teiserver.cache_get_or_store(:user_mfa_active, user_id, fn ->
+      user_id != nil and
+        Account.get_user_totp_status(user_id) == :active
+    end)
   end
 
-  @doc """
-  Given a user_id, checks for the presence of any MFA gated roles, if any
-  are possessed then also checks for MFA. If no MFA is present then the
-  roles are removed.
-  """
-  @spec maybe_remove_mfa_roles(Teiserver.Account.User.id()) :: :removed | :nochange
-  def maybe_remove_mfa_roles(user_id) do
-    user = Account.get_user(user_id)
-    mfa_required = Application.get_env(:teiserver, Teiserver)[:require_mfa_for_privileged_roles]
-
-    if mfa_required and contains_mfa_role?(user.roles) do
-      # If the user has an MFA role then do an empty update
-      # and the update code will decide if how to alter the user
-      user
-      |> Account.script_update_user(%{})
-
-      :removed
-    else
-      :nochange
-    end
+  defp mfa_required? do
+    Application.get_env(:teiserver, Teiserver)[:require_mfa_for_privileged_roles]
   end
 
   @doc """
@@ -237,7 +236,7 @@ defmodule Teiserver.Account.AuthLib do
 
   @spec contains_mfa_role?([String.t()]) :: boolean()
   def contains_mfa_role?(role_list) do
-    role_set = MapSet.new(role_list)
+    role_set = List.wrap(role_list) |> MapSet.new()
     mfa_role_set = MapSet.new(mfa_roles())
     intersection = MapSet.intersection(role_set, mfa_role_set)
 

--- a/lib/teiserver/account/libs/auth_lib.ex
+++ b/lib/teiserver/account/libs/auth_lib.ex
@@ -1,6 +1,13 @@
 defmodule Teiserver.Account.AuthLib do
-  @moduledoc false
+  @moduledoc """
+
+  """
+
   alias Phoenix.LiveView
+  alias Phoenix.LiveView.Socket
+  alias Plug.Conn
+  alias Teiserver.Account
+
   require Logger
 
   @spec icon :: String.t()
@@ -60,46 +67,46 @@ defmodule Teiserver.Account.AuthLib do
   end
 
   # If you don't need permissions then lets not bother checking
-  @spec allow?(map() | Plug.Conn.t() | [String.t()], String.t() | [String.t()]) :: boolean
+  @spec allow?(map() | Conn.t() | Socket.t() | User.t(), String.t() | [String.t()]) :: boolean
   def allow?(nil, []), do: false
   def allow?(_permissions, nil), do: true
   def allow?(_permissions, ""), do: true
   def allow?(_permissions, []), do: true
 
   # Handle conn
-  def allow?(%Plug.Conn{} = conn, permission_required) do
-    allow?(conn.assigns[:current_user], permission_required)
+  def allow?(%Conn{} = conn, permissions_required) do
+    %{permissions: permissions_held} = conn.assigns[:current_user]
+
+    permission_test(permissions_held, permissions_required)
   end
 
   # Socket
-  def allow?(%Phoenix.LiveView.Socket{} = socket, permission_required) do
-    allow?(socket.assigns[:current_user], permission_required)
+  def allow?(%Socket{} = socket, permissions_required) do
+    %{permissions: permissions_held} = socket.assigns[:current_user]
+
+    permission_test(permissions_held, permissions_required)
   end
 
   # This allows us to use something with permissions in it
-  def allow?(%{permissions: permissions}, permission_required) do
-    allow?(permissions, permission_required)
+  def allow?(%{permissions: permissions_held}, permissions_required) do
+    permission_test(permissions_held, permissions_required)
   end
 
-  # Handle users
-  def allow?(%{} = user, permission_required) do
-    allow?(user.permissions, permission_required)
-  end
-
-  def allow?(permissions_held, permission_required) when is_list(permission_required) do
+  # The testing of permissions required against permissions held
+  defp permission_test(permissions_held, permission_required) when is_list(permission_required) do
     Enum.all?(
       permission_required,
       fn p ->
-        allow?(permissions_held, p)
+        permission_test(permissions_held, p)
       end
     )
   end
 
-  def allow?(_permissions, "account") do
+  defp permission_test(_permissions, "account") do
     true
   end
 
-  def allow?(permissions_held, permission_required) do
+  defp permission_test(permissions_held, permission_required) do
     Logger.debug(
       "Permission test, has: #{Kernel.inspect(permissions_held)}, needs: #{Kernel.inspect(permission_required)}"
     )
@@ -110,10 +117,7 @@ defmodule Teiserver.Account.AuthLib do
         Logger.debug("AuthLib.allow?() -> No permissions held")
         false
 
-      # Developers always have permission
-      Enum.member?(permissions_held, "admin.dev.developer") && permission_required != "debug" ->
-        true
-
+      # Server devs always have permission
       Enum.member?(permissions_held, "Server") && permission_required != "debug" ->
         true
 
@@ -182,6 +186,14 @@ defmodule Teiserver.Account.AuthLib do
         allow?(permissions_held, p)
       end
     )
+  end
+
+  @doc """
+  Returns true if the user_id in question has an active totp
+  """
+  @spec has_active_mfa?(User.id()) :: boolean()
+  def has_active_mfa?(userid) do
+    Account.get_user_totp_status(userid) == :active
   end
 
   # This is used as part of the permission system getting the current user

--- a/lib/teiserver/account/libs/auth_lib.ex
+++ b/lib/teiserver/account/libs/auth_lib.ex
@@ -71,7 +71,10 @@ defmodule Teiserver.Account.AuthLib do
   end
 
   # If you don't need permissions then lets not bother checking
-  @spec allow?(map() | Conn.t() | Socket.t() | User.t(), String.t() | [String.t()]) :: boolean
+  @spec allow?(
+          map() | Conn.t() | Socket.t() | Teiserver.Account.User.t(),
+          String.t() | [String.t()]
+        ) :: boolean
   def allow?(nil, []), do: false
   def allow?(_permissions, nil), do: true
   def allow?(_permissions, ""), do: true
@@ -195,9 +198,46 @@ defmodule Teiserver.Account.AuthLib do
   @doc """
   Returns true if the user_id in question has an active totp
   """
-  @spec has_active_mfa?(User.id()) :: boolean()
+  @spec has_active_mfa?(Teiserver.Account.User.id()) :: boolean()
   def has_active_mfa?(userid) do
     Account.get_user_totp_status(userid) == :active
+  end
+
+  @doc """
+  Given a user_id, checks for the presence of any MFA gated roles, if any
+  are possessed then also checks for MFA. If no MFA is present then the
+  roles are removed.
+  """
+  @spec maybe_remove_mfa_roles(Teiserver.Account.User.t()) :: Teiserver.Account.User.t()
+  def maybe_remove_mfa_roles(user) do
+    if contains_mfa_role?(user.roles) do
+      IO.puts("")
+      IO.inspect("CONTAINS", label: "#{__MODULE__}:#{__ENV__.line}")
+      IO.puts("")
+
+      user
+    else
+      user
+    end
+  end
+
+  @doc """
+  Given a list of roles, remove any MFA guarded roles from the list
+  """
+  @spec remove_mfa_roles_from_list([String.t()]) :: [String.t()]
+  def remove_mfa_roles_from_list(roles) do
+    Enum.reject(roles, fn role ->
+      Enum.member?(mfa_roles(), role)
+    end)
+  end
+
+  @spec contains_mfa_role?([String.t()]) :: boolean()
+  def contains_mfa_role?(role_list) do
+    role_set = MapSet.new(role_list)
+    mfa_role_set = MapSet.new(mfa_roles())
+    intersection = MapSet.intersection(role_set, mfa_role_set)
+
+    not Enum.empty?(intersection)
   end
 
   # This is used as part of the permission system getting the current user

--- a/lib/teiserver/account/libs/user_lib.ex
+++ b/lib/teiserver/account/libs/user_lib.ex
@@ -422,10 +422,10 @@ defmodule Teiserver.Account.UserLib do
 
       Account.get_account_locked(user.id) ->
         {:error,
-         "The 2FA one time password has been entered wrong too many times. Please reset your password to remove 2FA from your account."}
+         "The MFA one time password has been entered wrong too many times. Please reset your password to remove MFA from your account."}
 
       Account.get_user_totp_status(user.id) == :active ->
-        {:requires_2fa, user}
+        {:requires_mfa, user}
 
       true ->
         :ok

--- a/lib/teiserver/account/libs/user_totp_lib.ex
+++ b/lib/teiserver/account/libs/user_totp_lib.ex
@@ -1,8 +1,10 @@
 defmodule Teiserver.Account.TOTPLib do
   @moduledoc false
+  alias Teiserver.Account.AuthLib
   alias Teiserver.Account.TOTP
   alias Teiserver.Account.User
   alias Teiserver.Data.Types, as: T
+
   use TeiserverWeb, :library
 
   @allowed_invalid_attempts 5
@@ -124,6 +126,7 @@ defmodule Teiserver.Account.TOTPLib do
       {:active, totp} ->
         case Repo.delete(totp) do
           {:ok, _totp} ->
+            AuthLib.maybe_remove_mfa_roles(user_id)
             :ok
 
           {:error, changeset} ->

--- a/lib/teiserver/account/libs/user_totp_lib.ex
+++ b/lib/teiserver/account/libs/user_totp_lib.ex
@@ -100,7 +100,9 @@ defmodule Teiserver.Account.TOTPLib do
 
   @spec set_secret(T.userid(), binary()) :: {:ok, TOTP.t()} | {:error, Ecto.Changeset.t()}
   def set_secret(user_id, secret) do
-    set_totp(user_id, %{user_id: user_id, secret: secret})
+    result = set_totp(user_id, %{user_id: user_id, secret: secret})
+    Teiserver.cache_delete(:user_mfa_active, user_id)
+    result
   end
 
   @spec set_last_used(T.userid(), DateTime.t()) ::
@@ -125,6 +127,7 @@ defmodule Teiserver.Account.TOTPLib do
       {:active, totp} ->
         case Repo.delete(totp) do
           {:ok, _totp} ->
+            Teiserver.cache_delete(:user_mfa_active, user_id)
             :ok
 
           {:error, changeset} ->

--- a/lib/teiserver/account/libs/user_totp_lib.ex
+++ b/lib/teiserver/account/libs/user_totp_lib.ex
@@ -1,6 +1,5 @@
 defmodule Teiserver.Account.TOTPLib do
   @moduledoc false
-  alias Teiserver.Account.AuthLib
   alias Teiserver.Account.TOTP
   alias Teiserver.Account.User
   alias Teiserver.Data.Types, as: T
@@ -126,7 +125,6 @@ defmodule Teiserver.Account.TOTPLib do
       {:active, totp} ->
         case Repo.delete(totp) do
           {:ok, _totp} ->
-            AuthLib.maybe_remove_mfa_roles(user_id)
             :ok
 
           {:error, changeset} ->

--- a/lib/teiserver/account/reports/mfa_report.ex
+++ b/lib/teiserver/account/reports/mfa_report.ex
@@ -1,0 +1,67 @@
+defmodule Teiserver.Account.MFAReport do
+  @moduledoc """
+  A report listing users with heightened permissions who are not using MFA.
+  """
+  alias Ecto.Adapters.SQL
+  alias Teiserver.Account.AuthLib
+  alias Teiserver.Repo
+
+  @spec icon() :: String.t()
+  def icon, do: "fa-solid fa-key"
+
+  @spec permissions() :: String.t()
+  def permissions, do: "Moderator"
+
+  @spec run(Plug.Conn.t(), map()) :: {nil, map()}
+  def run(_conn, _params) do
+    users = query_data()
+
+    assigns = %{
+      params: %{},
+      users: users
+    }
+
+    {nil, assigns}
+  end
+
+  defp query_data do
+    roles = AuthLib.mfa_roles()
+
+    query = """
+    SELECT
+      users.id,
+      users.name,
+      users.last_login,
+      users.roles
+    FROM
+      account_users AS users
+    LEFT JOIN
+      teiserver_account_user_totps AS totps
+      ON totps.user_id = users.id
+    WHERE
+      users.roles && $1::varchar[]
+      AND totps.user_id IS NULL -- Remove anybody with a TOTPS entry
+    ORDER BY
+      users.name ASC
+    LIMIT 50;
+    """
+
+    IO.puts(query)
+
+    case SQL.query(Repo, query, [roles]) do
+      {:ok, results} ->
+        results.rows
+        |> Enum.map(fn [id, name, last_login, roles] ->
+          %{
+            id: id,
+            name: name,
+            last_login: last_login,
+            roles: roles
+          }
+        end)
+
+      {a, b} ->
+        raise "ERR: #{inspect(a)}, #{inspect(b)}"
+    end
+  end
+end

--- a/lib/teiserver/account/reports/mfa_report.ex
+++ b/lib/teiserver/account/reports/mfa_report.ex
@@ -43,10 +43,8 @@ defmodule Teiserver.Account.MFAReport do
       AND totps.user_id IS NULL -- Remove anybody with a TOTPS entry
     ORDER BY
       users.name ASC
-    LIMIT 50;
+    LIMIT 200;
     """
-
-    IO.puts(query)
 
     case SQL.query(Repo, query, [roles]) do
       {:ok, results} ->

--- a/lib/teiserver/account/schemas/user.ex
+++ b/lib/teiserver/account/schemas/user.ex
@@ -3,7 +3,6 @@ defmodule Teiserver.Account.User do
 
   alias Argon2
   alias Teiserver.Account
-  alias Teiserver.Account.AuthLib
   alias Teiserver.CacheUser
   alias Teiserver.Helper.StylingHelper
 
@@ -87,7 +86,6 @@ defmodule Teiserver.Account.User do
     )
     |> validate_required([:name, :email, :password, :permissions])
     |> unique_constraint(:email)
-    |> limit_mfa_roles()
     |> put_md5_password_hash()
   end
 
@@ -104,7 +102,6 @@ defmodule Teiserver.Account.User do
     )
     |> validate_required([:name, :email, :password, :permissions])
     |> unique_constraint(:email)
-    |> limit_mfa_roles()
     |> validate_change(:email, fn :email, email ->
       case CacheUser.valid_email?(email) do
         :ok -> []
@@ -130,7 +127,6 @@ defmodule Teiserver.Account.User do
       attrs,
       ~w(name email icon colour data roles permissions)a
     )
-    |> limit_mfa_roles()
     |> validate_required(~w(name email)a)
     |> unique_constraint(:email)
   end
@@ -244,7 +240,6 @@ defmodule Teiserver.Account.User do
     )
     |> validate_required([:name, :email, :password, :permissions])
     |> unique_constraint(:email)
-    |> limit_mfa_roles()
     |> validate_change(:email, fn :email, email ->
       case CacheUser.valid_email?(email) do
         :ok -> []
@@ -301,23 +296,6 @@ defmodule Teiserver.Account.User do
         :md5_password -> put_md5_password_hash(changeset)
       end
     end)
-  end
-
-  defp limit_mfa_roles(changeset) do
-    mfa_required = Application.get_env(:teiserver, Teiserver)[:require_mfa_for_privileged_roles]
-    user_id = get_field(changeset, :id)
-    roles = get_field(changeset, :roles)
-
-    condition =
-      mfa_required and AuthLib.contains_mfa_role?(roles) and not AuthLib.has_active_mfa?(user_id)
-
-    if condition do
-      new_roles = AuthLib.remove_mfa_roles_from_list(roles)
-
-      put_change(changeset, :roles, new_roles)
-    else
-      changeset
-    end
   end
 
   defp change_plain_password(user, attrs) do

--- a/lib/teiserver/account/schemas/user.ex
+++ b/lib/teiserver/account/schemas/user.ex
@@ -3,12 +3,15 @@ defmodule Teiserver.Account.User do
 
   alias Argon2
   alias Teiserver.Account
+  alias Teiserver.Account.AuthLib
   alias Teiserver.CacheUser
   alias Teiserver.Helper.StylingHelper
 
   use TeiserverWeb, :schema
 
   @behaviour Bodyguard.Policy
+
+  @type id :: pos_integer()
 
   typed_schema "account_users" do
     field :name, :string
@@ -84,6 +87,7 @@ defmodule Teiserver.Account.User do
     )
     |> validate_required([:name, :email, :password, :permissions])
     |> unique_constraint(:email)
+    |> limit_mfa_roles()
     |> put_md5_password_hash()
   end
 
@@ -100,6 +104,7 @@ defmodule Teiserver.Account.User do
     )
     |> validate_required([:name, :email, :password, :permissions])
     |> unique_constraint(:email)
+    |> limit_mfa_roles()
     |> validate_change(:email, fn :email, email ->
       case CacheUser.valid_email?(email) do
         :ok -> []
@@ -125,6 +130,7 @@ defmodule Teiserver.Account.User do
       attrs,
       ~w(name email icon colour data roles permissions)a
     )
+    |> limit_mfa_roles()
     |> validate_required(~w(name email)a)
     |> unique_constraint(:email)
   end
@@ -238,6 +244,7 @@ defmodule Teiserver.Account.User do
     )
     |> validate_required([:name, :email, :password, :permissions])
     |> unique_constraint(:email)
+    |> limit_mfa_roles()
     |> validate_change(:email, fn :email, email ->
       case CacheUser.valid_email?(email) do
         :ok -> []
@@ -294,6 +301,19 @@ defmodule Teiserver.Account.User do
         :md5_password -> put_md5_password_hash(changeset)
       end
     end)
+  end
+
+  defp limit_mfa_roles(changeset) do
+    user_id = get_field(changeset, :id)
+    roles = get_field(changeset, :roles)
+
+    if AuthLib.contains_mfa_role?(roles) and not AuthLib.has_active_mfa?(user_id) do
+      new_roles = AuthLib.remove_mfa_roles_from_list(roles)
+
+      put_change(changeset, :roles, new_roles)
+    else
+      changeset
+    end
   end
 
   defp change_plain_password(user, attrs) do

--- a/lib/teiserver/account/schemas/user.ex
+++ b/lib/teiserver/account/schemas/user.ex
@@ -304,10 +304,14 @@ defmodule Teiserver.Account.User do
   end
 
   defp limit_mfa_roles(changeset) do
+    mfa_required = Application.get_env(:teiserver, Teiserver)[:require_mfa_for_privileged_roles]
     user_id = get_field(changeset, :id)
     roles = get_field(changeset, :roles)
 
-    if AuthLib.contains_mfa_role?(roles) and not AuthLib.has_active_mfa?(user_id) do
+    condition =
+      mfa_required and AuthLib.contains_mfa_role?(roles) and not AuthLib.has_active_mfa?(user_id)
+
+    if condition do
       new_roles = AuthLib.remove_mfa_roles_from_list(roles)
 
       put_change(changeset, :roles, new_roles)

--- a/lib/teiserver/application.ex
+++ b/lib/teiserver/application.ex
@@ -115,6 +115,7 @@ defmodule Teiserver.Application do
         concache_perm_sup(:users),
         concache_sup(:teiserver_login_count, global_ttl: 10_000),
         concache_sup(:teiserver_user_stat_cache),
+        concache_sup(:user_mfa_active),
 
         # Caches - Chat
         Teiserver.Chat.RoomSystem,

--- a/lib/teiserver/config/user_config_types/profile_configs.ex
+++ b/lib/teiserver/config/user_config_types/profile_configs.ex
@@ -41,7 +41,7 @@ defmodule Teiserver.Config.UserConfigTypes.ProfileConfigs do
       section: "General",
       type: "integer",
       visible: false,
-      permissions: ["admin.dev.developer"],
+      permissions: ["Server"],
       description: "Page rate limit per minute",
       opts: [],
       default: nil
@@ -52,7 +52,7 @@ defmodule Teiserver.Config.UserConfigTypes.ProfileConfigs do
       section: "General",
       type: "string",
       visible: false,
-      permissions: ["admin.dev.developer"],
+      permissions: ["Server"],
       description:
         "Last recorded screen size of the user, used for sizing certain windows accordingly",
       opts: [],
@@ -64,7 +64,7 @@ defmodule Teiserver.Config.UserConfigTypes.ProfileConfigs do
       section: "General",
       type: "boolean",
       visible: false,
-      permissions: ["admin.dev.developer"],
+      permissions: ["Server"],
       description:
         "Changes the default behaviour of showing or hiding advanced options on the forms supporting them.",
       opts: [],

--- a/lib/teiserver/libs/teiserver_configs.ex
+++ b/lib/teiserver/libs/teiserver_configs.ex
@@ -97,7 +97,7 @@ defmodule Teiserver.TeiserverConfigs do
       key: "teiserver.Require email verification",
       section: "Registrations",
       type: "boolean",
-      permissions: ["admin.dev.developer"],
+      permissions: ["Server"],
       description: "When enabled, users must verify their account via email",
       default: true
     })
@@ -106,7 +106,7 @@ defmodule Teiserver.TeiserverConfigs do
       key: "teiserver.Enable registrations",
       section: "Registrations",
       type: "boolean",
-      permissions: ["admin.dev.developer"],
+      permissions: ["Server"],
       description: "Allows users to register",
       default: true
     })
@@ -115,7 +115,7 @@ defmodule Teiserver.TeiserverConfigs do
       key: "teiserver.Require Chobby registration",
       section: "Registrations",
       type: "boolean",
-      permissions: ["admin.dev.developer"],
+      permissions: ["Server"],
       description: "Prevents users registering with anything other than Chobby",
       default: false
     })
@@ -133,7 +133,7 @@ defmodule Teiserver.TeiserverConfigs do
       key: "teiserver.Require Chobby login",
       section: "Registrations",
       type: "boolean",
-      permissions: ["admin.dev.developer"],
+      permissions: ["Server"],
       description: "Prevents users logging in with anything other than Chobby",
       default: false
     })

--- a/lib/teiserver/mix_tasks/fake_data.ex
+++ b/lib/teiserver/mix_tasks/fake_data.ex
@@ -68,7 +68,7 @@ defmodule Mix.Tasks.Teiserver.Fakedata do
         email: "root@localhost",
         password: Account.spring_md5_password("password"),
         roles: ["Server", "Verified"],
-        permissions: ["admin.dev.developer", "Server"],
+        permissions: ["Server"],
         icon: "fa-solid fa-power-off",
         colour: "#00AA00",
         data: %{

--- a/lib/teiserver_web/controllers/account/security_controller.ex
+++ b/lib/teiserver_web/controllers/account/security_controller.ex
@@ -41,12 +41,16 @@ defmodule TeiserverWeb.Account.SecurityController do
   def totp(conn, _params) do
     user = Account.get_user!(conn.assigns.current_user.id)
 
-    has_mfa_role? = AuthLib.contains_mfa_role?(user.roles)
+    mfa_required = Application.get_env(:teiserver, Teiserver)[:require_mfa_for_privileged_roles]
+
+    show_mfa_warning =
+      mfa_required == true and
+        AuthLib.contains_mfa_role?(user.roles)
 
     conn
     |> add_breadcrumb(name: "totp", url: conn.request_path)
     |> assign(:user, user)
-    |> assign(:has_mfa_role?, has_mfa_role?)
+    |> assign(:show_mfa_warning, show_mfa_warning)
     |> render("totp.html")
   end
 

--- a/lib/teiserver_web/controllers/account/security_controller.ex
+++ b/lib/teiserver_web/controllers/account/security_controller.ex
@@ -1,5 +1,6 @@
 defmodule TeiserverWeb.Account.SecurityController do
   alias Teiserver.Account
+  alias Teiserver.Account.AuthLib
   alias Teiserver.Account.TOTP
   alias Teiserver.OAuth
 
@@ -32,6 +33,7 @@ defmodule TeiserverWeb.Account.SecurityController do
     |> assign(:user_tokens, user_tokens)
     |> assign(:oauth_applications, oauth_applications)
     |> assign(:oauth_token_counts, oauth_token_counts)
+    |> assign(:has_active_mfa?, has_active_mfa?(conn.assigns.current_user.id))
     |> render("index.html")
   end
 
@@ -39,9 +41,12 @@ defmodule TeiserverWeb.Account.SecurityController do
   def totp(conn, _params) do
     user = Account.get_user!(conn.assigns.current_user.id)
 
+    has_mfa_role? = AuthLib.contains_mfa_role?(user.roles)
+
     conn
     |> add_breadcrumb(name: "totp", url: conn.request_path)
     |> assign(:user, user)
+    |> assign(:has_mfa_role?, has_mfa_role?)
     |> render("totp.html")
   end
 

--- a/lib/teiserver_web/controllers/account/security_controller.ex
+++ b/lib/teiserver_web/controllers/account/security_controller.ex
@@ -88,7 +88,7 @@ defmodule TeiserverWeb.Account.SecurityController do
         Account.set_secret(user.id, decoded_secret)
 
         conn
-        |> put_flash(:info, "2FA set successfully.")
+        |> put_flash(:info, "MFA set successfully.")
         |> redirect(to: ~p"/teiserver/account/security/totp")
 
       {:error, _reason} ->

--- a/lib/teiserver_web/controllers/account/session_controller.ex
+++ b/lib/teiserver_web/controllers/account/session_controller.ex
@@ -43,9 +43,9 @@ defmodule TeiserverWeb.Account.SessionController do
       {:ok, user} ->
         login_reply({:ok, user}, conn)
 
-      {:requires_2fa, user} ->
+      {:requires_mfa, user} ->
         conn
-        |> put_session(:pending_2fa_user_id, user.id)
+        |> put_session(:pending_mfa_user_id, user.id)
         |> redirect(to: ~p"/otp")
 
       {:error, reason} ->
@@ -54,7 +54,7 @@ defmodule TeiserverWeb.Account.SessionController do
   end
 
   def otp(conn, _params) do
-    user_id = get_session(conn, :pending_2fa_user_id)
+    user_id = get_session(conn, :pending_mfa_user_id)
     user = Account.get_user!(user_id)
 
     conn
@@ -67,7 +67,7 @@ defmodule TeiserverWeb.Account.SessionController do
 
     case Account.validate_totp(user, otp) do
       :ok ->
-        delete_session(conn, :pending_2fa_user_id)
+        delete_session(conn, :pending_mfa_user_id)
         login_reply({:ok, user}, conn)
 
       {:error, reason} ->
@@ -82,7 +82,7 @@ defmodule TeiserverWeb.Account.SessionController do
             :locked ->
               login_reply(
                 {:error,
-                 "The 2FA one time password has been entered wrong too many times. Please reset your password to remove 2FA from your account."},
+                 "The MFA one time password has been entered wrong too many times. Please reset your password to remove MFA from your account."},
                 conn
               )
 

--- a/lib/teiserver_web/controllers/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/admin/user_controller.ex
@@ -277,6 +277,7 @@ defmodule TeiserverWeb.Admin.UserController do
         |> assign(:privileged_roles, RoleLib.privileged_roles())
         |> assign(:property_roles, RoleLib.property_roles())
         |> assign(:role_styling_map, RoleLib.role_data())
+        |> assign(:has_active_mfa?, has_active_mfa?(user.id))
         |> add_breadcrumb(name: "Edit: #{user.name}", url: conn.request_path)
         |> render("edit.html")
 

--- a/lib/teiserver_web/controllers/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/admin/user_controller.ex
@@ -243,6 +243,7 @@ defmodule TeiserverWeb.Admin.UserController do
         |> assign(:json_user, json_user)
         |> assign(:cache_user, cache_user)
         |> assign(:extra_cache_keys, extra_cache_keys)
+        |> assign(:has_active_mfa?, has_active_mfa?(user.id))
         |> add_breadcrumb(name: "Show: #{user.name}", url: conn.request_path)
         |> render("show.html")
 

--- a/lib/teiserver_web/controllers/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/admin/user_controller.ex
@@ -391,6 +391,7 @@ defmodule TeiserverWeb.Admin.UserController do
             |> assign(:privileged_roles, RoleLib.privileged_roles())
             |> assign(:property_roles, RoleLib.property_roles())
             |> assign(:role_styling_map, RoleLib.role_data())
+            |> assign(:has_active_mfa?, has_active_mfa?(user.id))
             |> render("edit.html", user: user, changeset: changeset)
         end
 

--- a/lib/teiserver_web/controllers/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/admin/user_controller.ex
@@ -442,7 +442,7 @@ defmodule TeiserverWeb.Admin.UserController do
     TOTPLib.disable_totp(user.id)
 
     conn
-    |> put_flash(:info, "Disabled 2FA for #{user.name}")
+    |> put_flash(:info, "Disabled MFA for #{user.name}")
     |> redirect(to: ~p"/teiserver/admin/user/#{user}")
   end
 

--- a/lib/teiserver_web/controllers/report/report_controller.ex
+++ b/lib/teiserver_web/controllers/report/report_controller.ex
@@ -81,6 +81,9 @@ defmodule TeiserverWeb.Report.ReportController do
         "microblog" ->
           Teiserver.Communication.MicroblogReport
 
+        "mfa" ->
+          Teiserver.Account.MFAReport
+
         # Moderation
         "moderation_activity" ->
           Teiserver.Moderation.ActivityReport

--- a/lib/teiserver_web/live/clients/show.html.heex
+++ b/lib/teiserver_web/live/clients/show.html.heex
@@ -43,7 +43,7 @@
           </li>
         </ul>
 
-        <%= if allow?(@current_user, "admin.dev.developer") do %>
+        <%= if allow?(@current_user, "Server") do %>
           <div class="row">
             <div class="col-md-6">
               <h4>Client</h4>

--- a/lib/teiserver_web/live/general/home/index.html.heex
+++ b/lib/teiserver_web/live/general/home/index.html.heex
@@ -1,5 +1,13 @@
 <div style="height: 15px;">&nbsp;</div>
 
+<div :if={@mfa_warning?} class="alert alert-warning">
+  <a href={~p"/teiserver/account/security/totp"} class="btn btn-sm btn-warning me-2">
+    <i class="fa-fw fa-solid fa-lock"></i> &nbsp;
+    Enable MFA
+  </a>
+  You have elevated privileges but do not have MFA enabled. The permissions are temporarily disabled until MFA is enabled.
+</div>
+
 <div class="row">
   <.menu_card
     :if={allow?(@current_user, "Contributor")}

--- a/lib/teiserver_web/live/general/home/index_live.ex
+++ b/lib/teiserver_web/live/general/home/index_live.ex
@@ -1,9 +1,21 @@
 defmodule TeiserverWeb.General.HomeLive.Index do
+  alias Teiserver.Account.AuthLib
+
   use TeiserverWeb, :live_view
-  # alias Teiserver.{Account, Battle}
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
+    %{current_user: user} = socket.assigns
+
+    socket =
+      if AuthLib.contains_mfa_role?(user.roles) and not has_active_mfa?(user.id) do
+        socket
+        |> assign(mfa_warning?: true)
+      else
+        socket
+        |> assign(mfa_warning?: false)
+      end
+
     socket =
       socket
       |> get_server_data()
@@ -12,11 +24,6 @@ defmodule TeiserverWeb.General.HomeLive.Index do
 
     {:ok, socket}
   end
-
-  # @impl Phoenix.LiveView
-  # def handle_event(_cmd, _event, %{assigns: _assigns} = socket) do
-  #   {:noreply, socket}
-  # end
 
   defp get_server_data(%{assigns: %{current_user: current_user}} = socket) do
     if allow?(current_user, "Server") do

--- a/lib/teiserver_web/teiserver_web.ex
+++ b/lib/teiserver_web/teiserver_web.ex
@@ -42,7 +42,7 @@ defmodule TeiserverWeb do
       alias Bodyguard.Plug.Authorize
 
       alias TeiserverWeb.Router.Helpers, as: Routes
-      import Teiserver.Account.AuthLib, only: [allow?: 2, allow_any?: 2]
+      import Teiserver.Account.AuthLib, only: [allow?: 2, allow_any?: 2, has_active_mfa?: 1]
 
       unquote(verified_routes())
 
@@ -78,7 +78,7 @@ defmodule TeiserverWeb do
       use Gettext, backend: TeiserverWeb.Gettext
       alias TeiserverWeb.Router.Helpers, as: Routes
 
-      import Teiserver.Account.AuthLib, only: [allow?: 2, allow_any?: 2]
+      import Teiserver.Account.AuthLib, only: [allow?: 2, allow_any?: 2, has_active_mfa?: 1]
 
       import Teiserver.Helper.NumberHelper,
         only: [normalize: 1, round: 2, c_round: 2, percent: 1, percent: 2]
@@ -118,7 +118,13 @@ defmodule TeiserverWeb do
       alias Teiserver.Account.AuthPlug
 
       import Teiserver.Account.AuthLib,
-        only: [allow?: 2, allow_any?: 2, mount_require_all: 2, mount_require_any: 2]
+        only: [
+          allow?: 2,
+          allow_any?: 2,
+          mount_require_all: 2,
+          mount_require_any: 2,
+          has_active_mfa?: 1
+        ]
 
       import Teiserver.Helper.ColourHelper, only: [rgba_css: 1, rgba_css: 2]
 
@@ -159,7 +165,7 @@ defmodule TeiserverWeb do
       import TeiserverWeb.Gettext
 
       alias Teiserver.Helper.StylingHelper
-      import Teiserver.Account.AuthLib, only: [allow?: 2, allow_any?: 2]
+      import Teiserver.Account.AuthLib, only: [allow?: 2, allow_any?: 2, has_active_mfa?: 1]
 
       unquote(verified_routes())
     end
@@ -181,7 +187,7 @@ defmodule TeiserverWeb do
       alias Ecto.Multi
 
       import Teiserver.Helper.QueryHelpers
-      import Teiserver.Account.AuthLib, only: [allow?: 2, allow_any?: 2]
+      import Teiserver.Account.AuthLib, only: [allow?: 2, allow_any?: 2, has_active_mfa?: 1]
       alias Teiserver.Data.Types, as: T
       alias Teiserver.Helper.StylingHelper
     end
@@ -191,7 +197,7 @@ defmodule TeiserverWeb do
     quote do
       alias Teiserver.Data.Types, as: T
       alias Teiserver.Repo
-      import Teiserver.Account.AuthLib, only: [allow?: 2, allow_any?: 2]
+      import Teiserver.Account.AuthLib, only: [allow?: 2, allow_any?: 2, has_active_mfa?: 1]
       alias Teiserver.Helper.QueryHelpers
       alias Teiserver.Helper.StylingHelper
     end
@@ -223,7 +229,7 @@ defmodule TeiserverWeb do
     quote do
       use TypedEctoSchema
       import Ecto.Changeset
-      import Teiserver.Account.AuthLib, only: [allow?: 2, allow_any?: 2]
+      import Teiserver.Account.AuthLib, only: [allow?: 2, allow_any?: 2, has_active_mfa?: 1]
       import Teiserver.Helper.SchemaHelper
     end
   end

--- a/lib/teiserver_web/templates/account/security/index.html.heex
+++ b/lib/teiserver_web/templates/account/security/index.html.heex
@@ -4,15 +4,27 @@
   <div class="col-md-12">
     <div class="card card-primary mb-4">
       <div class="card-body">
-        <a
-          href={~p"/teiserver/account/security/edit_password"}
-          class="btn float-end btn-danger m-2"
-        >
-          <i class="fa-fw fa-solid fa-lock"></i> Change password
-        </a>
-        <a href={~p"/teiserver/account/security/totp"} class="btn float-end btn-danger m-2">
-          <i class="fa-fw fa-solid fa-lock"></i> 2FA Settings
-        </a>
+        <div class="float-end m-2">
+          <a
+            :if={@has_active_mfa?}
+            href={~p"/teiserver/account/security/totp"}
+            class="btn btn-outline-danger"
+          >
+            <i class="fa-fw fa-solid fa-check"></i> MFA enabled
+          </a>
+
+          <a
+            :if={not @has_active_mfa?}
+            href={~p"/teiserver/account/security/totp"}
+            class="btn btn-danger"
+          >
+            <i class="fa-fw fa-solid fa-lock"></i> MFA Settings
+          </a>
+
+          <a href={~p"/teiserver/account/security/edit_password"} class="btn btn-danger">
+            <i class="fa-fw fa-solid fa-lock"></i> Change password
+          </a>
+        </div>
 
         <h4>User tokens</h4>
         <%= if Enum.empty?(@user_tokens) do %>

--- a/lib/teiserver_web/templates/account/security/totp.html.heex
+++ b/lib/teiserver_web/templates/account/security/totp.html.heex
@@ -28,7 +28,7 @@
 
         <div :if={@totp_status == :active and @show_mfa_warning} class="alert alert-warning mb-4">
           <strong>Warning:</strong>
-          Disabling or resetting your MFA will remove any privilaged roles. You will need to have them re-added after your MFA is setup again.
+          Disabling or resetting your MFA will remove any privileged roles. You will need to have them re-added after your MFA is setup again.
         </div>
 
         <div class="d-flex justify-content-between align-items-center">

--- a/lib/teiserver_web/templates/account/security/totp.html.heex
+++ b/lib/teiserver_web/templates/account/security/totp.html.heex
@@ -26,7 +26,7 @@
 
         <div class="flex-grow-1"></div>
 
-        <div :if={@totp_status == :active and @has_mfa_role?} class="alert alert-warning mb-4">
+        <div :if={@totp_status == :active and @show_mfa_warning} class="alert alert-warning mb-4">
           <strong>Warning:</strong>
           Disabling or resetting your MFA will remove any privilaged roles. You will need to have them re-added after your MFA is setup again.
         </div>

--- a/lib/teiserver_web/templates/account/security/totp.html.heex
+++ b/lib/teiserver_web/templates/account/security/totp.html.heex
@@ -26,6 +26,11 @@
 
         <div class="flex-grow-1"></div>
 
+        <div :if={@totp_status == :active and @has_mfa_role?} class="alert alert-warning mb-4">
+          <strong>Warning:</strong>
+          Disabling or resetting your MFA will remove any privilaged roles. You will need to have them re-added after your MFA is setup again.
+        </div>
+
         <div class="d-flex justify-content-between align-items-center">
           <div>
             {link("Back",

--- a/lib/teiserver_web/templates/account/security/totp.html.heex
+++ b/lib/teiserver_web/templates/account/security/totp.html.heex
@@ -28,7 +28,7 @@
 
         <div :if={@totp_status == :active and @show_mfa_warning} class="alert alert-warning mb-4">
           <strong>Warning:</strong>
-          Disabling or resetting your MFA will remove any privileged roles. You will need to have them re-added after your MFA is setup again.
+          Disabling your MFA will temporarily prevent you from using privileged permissions until it is re-enabled.
         </div>
 
         <div class="d-flex justify-content-between align-items-center">

--- a/lib/teiserver_web/templates/account/security/totp.html.heex
+++ b/lib/teiserver_web/templates/account/security/totp.html.heex
@@ -41,17 +41,17 @@
 
           <div class="d-flex gap-2">
             <%= if @totp_status == :inactive do %>
-              {link("Enable 2FA",
+              {link("Enable MFA",
                 to: ~p"/teiserver/account/security/totp/edit",
                 class: "btn btn-primary"
               )}
             <% else %>
-              {link("Reset 2FA",
+              {link("Reset MFA",
                 to: ~p"/teiserver/account/security/totp/reset",
                 class: "btn btn-primary"
               )}
               <%= form_for @conn, ~p"/teiserver/account/security/totp/disable", [method: :post], fn _f -> %>
-                {submit("Disable 2FA", class: "btn btn-danger")}
+                {submit("Disable MFA", class: "btn btn-danger")}
               <% end %>
             <% end %>
           </div>

--- a/lib/teiserver_web/templates/admin/user/actions.html.heex
+++ b/lib/teiserver_web/templates/admin/user/actions.html.heex
@@ -64,6 +64,6 @@
     class="dropdown-item bg-danger_transparent"
   >
     <Fontawesome.icon icon="broom-wide" style="solid" /> &nbsp;
-    Disable 2FA
+    Disable MFA
   </.link>
 </div>

--- a/lib/teiserver_web/templates/admin/user/form.html.heex
+++ b/lib/teiserver_web/templates/admin/user/form.html.heex
@@ -34,6 +34,10 @@
   </div>
 
   <div class="form-group row px-3 py-2">
+    <div :if={not @has_active_mfa?} class="alert alert-warning">
+      No MFA, cannot give privileged roles.
+    </div>
+
     <div :if={allow?(@conn, "Server")} class="col">
       <h5>Management</h5>
       <%= for r <- @management_roles do %>

--- a/lib/teiserver_web/templates/admin/user/tab_overview.html.heex
+++ b/lib/teiserver_web/templates/admin/user/tab_overview.html.heex
@@ -10,16 +10,25 @@
 <div class="row">
   <div class="col-md-12 col-lg-4">
     <h4>Status</h4>
-    <%= for role <- @user.roles do %>
-      <% data = @role_data[role] %>
-      <%= if data != nil and Map.get(data, :badge) != false do %>
-        <div class="role-badge">
-          <i class={"fa-fw fa-2x #{data.icon}"} style={"color: #{data.colour}"} title={role}></i>
-          <br />
-          {role}
-        </div>
+    <ul>
+      <%= for role <- @user.roles do %>
+        <% data = @role_data[role] %>
+        <%= if data != nil and Map.get(data, :badge) != false do %>
+          <li>
+            <i class={"fa-fw #{data.icon}"} style={"color: #{data.colour}"} title={role}></i>
+            {role}
+          </li>
+        <% end %>
       <% end %>
-    <% end %>
+
+      <li :if={@has_active_mfa?}>
+        <i class="fa-fw fa-lock" style="color: #00AA00" title="MFA enabled"></i> Active MFA
+      </li>
+
+      <li :if={not @has_active_mfa?}>
+        <i class="fa-fw fa-lock-open" style="color: #AA0000" title="MFA enabled"></i> No MFA
+      </li>
+    </ul>
   </div>
 
   <div class="col-md-12 col-lg-4">

--- a/lib/teiserver_web/templates/error/500_internal.html.heex
+++ b/lib/teiserver_web/templates/error/500_internal.html.heex
@@ -48,7 +48,7 @@
                 <br /><br />
 
                 <%= if assigns[:current_user] do %>
-                  <%= if allow?(assigns[:current_user], "debug") or allow?(assigns[:current_user], "admin.dev.developer") do %>
+                  <%= if allow?(assigns[:current_user], "debug") or allow?(assigns[:current_user], "Server") do %>
                     <h4>Debug traceback info</h4>
                     <textarea rows="40" class="form-control" style="font-family: monospace;">Reason: <%= @error.reason |> Kernel.inspect |> String.replace("\\n", "\n") %>
 ------

--- a/lib/teiserver_web/templates/report/general/index.html.heex
+++ b/lib/teiserver_web/templates/report/general/index.html.heex
@@ -257,6 +257,15 @@
   >
     Microblog
   </.menu_card>
+
+  <.menu_card
+    :if={allow?(@current_user, Teiserver.Account.MFAReport.permissions())}
+    icon={Teiserver.Account.MFAReport.icon()}
+    url={~p"/teiserver/reports/show/mfa"}
+    size={:small}
+  >
+    MFA Usage
+  </.menu_card>
 </div>
 
 <div class="row mt-2">

--- a/lib/teiserver_web/templates/report/report/mfa.html.heex
+++ b/lib/teiserver_web/templates/report/report/mfa.html.heex
@@ -1,0 +1,39 @@
+<% bsname = view_colour() %>
+
+{render(
+  TeiserverWeb.Report.GeneralView,
+  "sub_menu.html",
+  Map.merge(assigns, %{active: "reports"})
+)}
+
+<div class="row section-menu">
+  <div class="col-md-12">
+    <div class={"card border-#{bsname}"}>
+      <div class="card-body">
+        {render(
+          TeiserverWeb.Report.ReportView,
+          "section_menu.html",
+          Map.merge(assigns, %{
+            quick_search: "",
+            show_search: false,
+            active: "mfa"
+          })
+        )}
+        <br /><br />
+
+        <.table id="users-table" rows={@users} table_class="table-sm table-hover">
+          <:col :let={user} label="Name">{user.name}</:col>
+          <:col :let={user} label="Last login">
+            {date_to_str(user.last_login, format: :hms_or_ymd)}
+          </:col>
+          <:col :let={user} label="Roles">{Enum.join(user.roles, ", ")}</:col>
+          <:col :let={user} label="">
+            <a href={~p"/teiserver/admin/user/#{user.id}"} class="btn btn-secondary btn-sm">
+              Show
+            </a>
+          </:col>
+        </.table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/test/teiserver/account/auth_test.exs
+++ b/test/teiserver/account/auth_test.exs
@@ -1,0 +1,34 @@
+defmodule Teiserver.Account.AuthTest do
+  alias Teiserver.Account
+  alias Teiserver.Account.AuthLib
+  alias Teiserver.AccountFixtures
+
+  use Teiserver.DataCase, async: false
+
+  setup %{} do
+    config = Application.get_env(:teiserver, Teiserver)
+    new_config = Keyword.put(config, :require_mfa_for_privileged_roles, true)
+    Application.put_env(:teiserver, Teiserver, new_config)
+
+    user = AccountFixtures.user_fixture(%{roles: ["Server"], permissions: ["Server"]})
+
+    on_exit(fn ->
+      Application.put_env(:teiserver, Teiserver, config)
+    end)
+
+    %{user: user}
+  end
+
+  describe "MFA functions" do
+    test "allow when no MFA", %{user: user} do
+      refute AuthLib.has_active_mfa?(user.id)
+      refute AuthLib.allow?(user, "Server")
+    end
+
+    test "allow when MFA present", %{user: user} do
+      Account.set_secret(user.id, "secret")
+      assert AuthLib.has_active_mfa?(user.id)
+      assert AuthLib.allow?(user, "Server")
+    end
+  end
+end

--- a/test/teiserver/account/auth_test.exs
+++ b/test/teiserver/account/auth_test.exs
@@ -5,7 +5,7 @@ defmodule Teiserver.Account.AuthTest do
 
   use Teiserver.DataCase, async: false
 
-  setup %{} do
+  setup do
     config = Application.get_env(:teiserver, Teiserver)
     new_config = Keyword.put(config, :require_mfa_for_privileged_roles, true)
     Application.put_env(:teiserver, Teiserver, new_config)
@@ -20,12 +20,12 @@ defmodule Teiserver.Account.AuthTest do
   end
 
   describe "MFA functions" do
-    test "allow when no MFA", %{user: user} do
+    test "allow?/2 - no MFA present", %{user: user} do
       refute AuthLib.has_active_mfa?(user.id)
       refute AuthLib.allow?(user, "Server")
     end
 
-    test "allow when MFA present", %{user: user} do
+    test "allow?/2 - MFA present", %{user: user} do
       Account.set_secret(user.id, "secret")
       assert AuthLib.has_active_mfa?(user.id)
       assert AuthLib.allow?(user, "Server")

--- a/test/teiserver_web/controllers/account/session_controller_test.exs
+++ b/test/teiserver_web/controllers/account/session_controller_test.exs
@@ -25,7 +25,7 @@ defmodule TeiserverWeb.Account.SessionControllerTest do
       conn = GeneralTestLib.login(conn, user.email)
 
       assert is_nil(Plug.current_resource(conn))
-      assert get_session(conn, :pending_2fa_user_id) == user.id
+      assert get_session(conn, :pending_mfa_user_id) == user.id
     end
 
     test "OTP check for user", %{conn: conn, user: user} do

--- a/test/teiserver_web/controllers/admin/tool_controller_test.exs
+++ b/test/teiserver_web/controllers/admin/tool_controller_test.exs
@@ -4,7 +4,7 @@ defmodule TeiserverWeb.Admin.ToolControllerTest do
   use TeiserverWeb.ConnCase
 
   setup do
-    GeneralTestLib.conn_setup(~w(admin.dev.developer))
+    GeneralTestLib.conn_setup(~w(Server))
   end
 
   test "index", %{conn: conn} do


### PR DESCRIPTION
- Adds a report for listing users with MFA guarded roles without MFA enabled
- Setting set from an elixir config value (to prevent it being disabled without observation)
- A user without MFA will not pass any permission checks for `Server` or `Admin` tests

When you have MFA enabled and an MFA guarded role, the security screen now shows that:
<img width="1139" height="400" alt="image" src="https://github.com/user-attachments/assets/4d81e449-99ce-4cce-be7e-6e06bfea97ad" />

When MFA is not enabled, on the homepage you will see this warning:
<img width="1050" height="94" alt="image" src="https://github.com/user-attachments/assets/2b7dd80e-6314-4d2b-9350-6103b617bd55" />


MFA usage report (names left out intentionally):
<img width="619" height="385" alt="image" src="https://github.com/user-attachments/assets/031b2253-e004-4e4e-b017-a5396faf08d9" />
