### PR TITLE
Oauth userinfo endpoint

### DIFF
--- a/lib/teiserver/o_auth/libs/scope_lib.ex
+++ b/lib/teiserver/o_auth/libs/scope_lib.ex
@@ -9,7 +9,19 @@ defmodule Teiserver.OAuth.Libs.ScopeLib do
 
   @spec allowed_scopes() :: [String.t()]
   def allowed_scopes do
-    ["tachyon.lobby", "admin.map", "admin.engine", "admin.user"]
+    [
+      # this is for blobby/new lobby
+      "tachyon.lobby",
+      # some scopes for bar specific administration and testing
+      "admin.map",
+      "admin.engine",
+      "admin.user",
+      # OpenID connect standard scopes (https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims)
+      "profile",
+      "email",
+      # that one isn't truly standard but is widely used in practice
+      "groups"
+    ]
   end
 
   @spec all_scopes_allowed?(Account.User.t() | Bot.t(), [String.t()]) ::
@@ -34,7 +46,9 @@ defmodule Teiserver.OAuth.Libs.ScopeLib do
   end
 
   @spec scope_allowed?(scope :: String.t(), Account.User.t()) :: boolean()
-  def scope_allowed?("tachyon.lobby", _user), do: true
+  def scope_allowed?(scope, _user) when scope in ["tachyon.lobby", "profile", "email", "groups"],
+    do: true
+
   def scope_allowed?("admin.map", user), do: Auth.admin?(user)
   def scope_allowed?("admin.engine", user), do: Auth.admin?(user)
   def scope_allowed?("admin.user", user), do: Auth.admin?(user)

--- a/lib/teiserver_web/controllers/admin/o_auth_application_controller.ex
+++ b/lib/teiserver_web/controllers/admin/o_auth_application_controller.ex
@@ -83,10 +83,13 @@ defmodule TeiserverWeb.Admin.OAuthApplicationController do
     |> Enum.map(fn s -> {s, Enum.member?(enabled_scopes, s), scope_description(s)} end)
   end
 
-  defp scope_description("tachyon.lobby"), do: "for autohost"
+  defp scope_description("tachyon.lobby"), do: "connect to tachyon for lobby and games"
   defp scope_description("admin.map"), do: "for CI, to setup maps data in teiserver"
   defp scope_description("admin.engine"), do: "for CI, to setup engine data in teiserver"
   defp scope_description("admin.user"), do: "create users programatically. for load testing"
+  defp scope_description("profile"), do: "can get in game username"
+  defp scope_description("email"), do: "can get email address"
+  defp scope_description("groups"), do: "can get the roles for this user"
   defp scope_description(_scope), do: nil
 
   @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()

--- a/lib/teiserver_web/controllers/api/admin/asset_controller.ex
+++ b/lib/teiserver_web/controllers/api/admin/asset_controller.ex
@@ -1,10 +1,10 @@
 defmodule TeiserverWeb.API.Admin.AssetController do
   alias JsonXema.ValidationError
   alias Teiserver.Asset
-  alias Teiserver.OAuth.Plug.EnsureAuthenticated
+  alias TeiserverWeb.Plugs.OAuthAuthenticatedPlug
   use TeiserverWeb, :controller
 
-  plug EnsureAuthenticated, scopes: ["admin.map"]
+  plug OAuthAuthenticatedPlug, scopes: ["admin.map"]
 
   def update_maps(conn, params) do
     with :ok <- validate_input(params),

--- a/lib/teiserver_web/controllers/api/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/api/admin/user_controller.ex
@@ -4,7 +4,7 @@ defmodule TeiserverWeb.API.Admin.UserController do
   alias Teiserver.OAuth
   use TeiserverWeb, :controller
 
-  plug Teiserver.OAuth.Plug.EnsureAuthenticated, scopes: ["admin.user"]
+  plug TeiserverWeb.Plugs.OAuthAuthenticatedPlug, scopes: ["admin.user"]
 
   @stat_fields ["mu", "sigma", "play_time", "spec_time", "lobby_time"]
 

--- a/lib/teiserver_web/controllers/o_auth/code_controller.ex
+++ b/lib/teiserver_web/controllers/o_auth/code_controller.ex
@@ -2,6 +2,8 @@ defmodule TeiserverWeb.OAuth.CodeController do
   alias Teiserver.OAuth
   use TeiserverWeb, :controller
 
+  require Logger
+
   # https://www.rfc-editor.org/rfc/rfc6749.html#section-4.1.3
   @spec token(Plug.Conn.t(), %{}) :: Plug.Conn.t()
 
@@ -85,7 +87,9 @@ defmodule TeiserverWeb.OAuth.CodeController do
          {:ok, new_token} <- OAuth.refresh_token(token, scopes: scopes) do
       conn |> put_status(200) |> render(:token, token: new_token)
     else
-      _other -> conn |> put_status(400) |> render(:error, error_description: "invalid request")
+      error ->
+        Logger.debug("refresh token error #{inspect(error)}")
+        conn |> put_status(400) |> render(:error, error_description: "invalid request")
     end
   end
 

--- a/lib/teiserver_web/controllers/o_auth/userinfo_controller.ex
+++ b/lib/teiserver_web/controllers/o_auth/userinfo_controller.ex
@@ -1,0 +1,23 @@
+defmodule TeiserverWeb.OAuth.UserinfoController do
+  use TeiserverWeb, :controller
+
+  # we don't check for scopes at that point, just that there is a valid token
+  plug TeiserverWeb.Plugs.OAuthAuthenticatedPlug, scopes: []
+
+  def get(conn, _params) do
+    token = conn.assigns[:token]
+
+    sub =
+      cond do
+        token.owner != nil -> to_string(token.owner.id)
+        token.bot != nil -> to_string(token.bot.id)
+        true -> raise "token has no owner nor bot!"
+      end
+
+    claims = %{
+      sub: sub
+    }
+
+    render(conn, :userinfo, claims: claims)
+  end
+end

--- a/lib/teiserver_web/controllers/o_auth/userinfo_controller.ex
+++ b/lib/teiserver_web/controllers/o_auth/userinfo_controller.ex
@@ -16,7 +16,7 @@ defmodule TeiserverWeb.OAuth.UserinfoController do
         true -> raise "token has no owner nor bot!"
       end
 
-    claims = %{sub: sub}
+    claims = %{sub: sub, id: sub}
     info_scopes = ["profile", "email", "groups"]
 
     claims =

--- a/lib/teiserver_web/controllers/o_auth/userinfo_controller.ex
+++ b/lib/teiserver_web/controllers/o_auth/userinfo_controller.ex
@@ -1,4 +1,6 @@
 defmodule TeiserverWeb.OAuth.UserinfoController do
+  alias Teiserver.Account.Auth
+
   use TeiserverWeb, :controller
 
   # we don't check for scopes at that point, just that there is a valid token
@@ -14,10 +16,38 @@ defmodule TeiserverWeb.OAuth.UserinfoController do
         true -> raise "token has no owner nor bot!"
       end
 
-    claims = %{
-      sub: sub
-    }
+    claims = %{sub: sub}
+    info_scopes = ["profile", "email", "groups"]
+
+    claims =
+      Enum.reduce(info_scopes, claims, fn scope, claims ->
+        if scope in token.scopes,
+          do: add_claims(claims, token, scope),
+          else: claims
+      end)
 
     render(conn, :userinfo, claims: claims)
+  end
+
+  defp add_claims(claims, token, "profile") do
+    case get_in(token.owner.name) do
+      nil -> claims
+      name -> Map.put(claims, :preferred_username, name)
+    end
+  end
+
+  defp add_claims(claims, %{owner: owner}, "email") when owner != nil do
+    claims
+    |> Map.put(:email, owner.email)
+    |> Map.put(:email_verified, Auth.verified?(owner))
+  end
+
+  defp add_claims(claims, _token, "email"), do: claims
+
+  defp add_claims(claims, token, "groups") do
+    groups = get_in(token.owner.roles) || []
+
+    claims
+    |> Map.put(:groups, Enum.map(groups, &String.downcase/1))
   end
 end

--- a/lib/teiserver_web/controllers/tachyon.ex
+++ b/lib/teiserver_web/controllers/tachyon.ex
@@ -9,7 +9,7 @@ defmodule TeiserverWeb.TachyonController do
   """
   use TeiserverWeb, :controller
 
-  plug Teiserver.OAuth.Plug.EnsureAuthenticated, scopes: ["tachyon.lobby"]
+  plug TeiserverWeb.Plugs.OAuthAuthenticatedPlug, scopes: ["tachyon.lobby"]
 
   @subprotocol_hdr_name "sec-websocket-protocol"
 

--- a/lib/teiserver_web/plugs/o_auth_authenticated_plug.ex
+++ b/lib/teiserver_web/plugs/o_auth_authenticated_plug.ex
@@ -1,4 +1,4 @@
-defmodule Teiserver.OAuth.Plug.EnsureAuthenticated do
+defmodule TeiserverWeb.Plugs.OAuthAuthenticatedPlug do
   @moduledoc false
   alias Teiserver.OAuth
 

--- a/lib/teiserver_web/router.ex
+++ b/lib/teiserver_web/router.ex
@@ -558,6 +558,7 @@ defmodule TeiserverWeb.Router do
   scope "/oauth/", TeiserverWeb.OAuth do
     pipe_through(:api)
     post("/token", CodeController, :token)
+    get("/userinfo", UserinfoController, :get)
   end
 
   scope "/", TeiserverWeb.OAuth do

--- a/lib/teiserver_web/router.ex
+++ b/lib/teiserver_web/router.ex
@@ -72,7 +72,7 @@ defmodule TeiserverWeb.Router do
   pipeline :oauth_api do
     plug(:accepts, ["json"])
     plug(Teiserver.Logging.LoggingPlug)
-    plug(Teiserver.OAuth.Plug.EnsureAuthenticated)
+    plug(TeiserverWeb.Plugs.OAuthAuthenticatedPlug)
   end
 
   scope "/", TeiserverWeb.General do

--- a/lib/teiserver_web/views/api/o_auth/code_view.ex
+++ b/lib/teiserver_web/views/api/o_auth/code_view.ex
@@ -41,7 +41,8 @@ defmodule TeiserverWeb.OAuth.CodeView do
         "client_credentials"
       ],
       code_challenge_methods_supported: ["S256"],
-      response_types_supported: ["code", "token"]
+      response_types_supported: ["code", "token"],
+      scopes_supported: OAuth.allowed_scopes()
     }
   end
 end

--- a/lib/teiserver_web/views/api/o_auth/code_view.ex
+++ b/lib/teiserver_web/views/api/o_auth/code_view.ex
@@ -35,6 +35,7 @@ defmodule TeiserverWeb.OAuth.CodeView do
       authorization_endpoint: base <> ~p"/oauth/authorize",
       token_endpoint: base <> ~p"/oauth/token",
       token_endpoint_auth_methods_supported: ["none", "client_secret_post", "client_secret_basic"],
+      userinfo_endpoint: base <> ~p"/oauth/userinfo",
       grant_types_supported: [
         "authorization_code",
         "refresh_token",

--- a/lib/teiserver_web/views/o_auth/userinfo_view.ex
+++ b/lib/teiserver_web/views/o_auth/userinfo_view.ex
@@ -1,0 +1,7 @@
+defmodule TeiserverWeb.OAuth.UserinfoView do
+  use TeiserverWeb, :view
+
+  def render("userinfo.json", data) do
+    data[:claims]
+  end
+end

--- a/test/teiserver_web/controllers/o_auth/code_controller_test.exs
+++ b/test/teiserver_web/controllers/o_auth/code_controller_test.exs
@@ -363,7 +363,8 @@ defmodule TeiserverWeb.OAuth.CodeControllerTest do
                  "client_credentials"
                ],
                "code_challenge_methods_supported" => ["S256"],
-               "response_types_supported" => ["code", "token"]
+               "response_types_supported" => ["code", "token"],
+               "scopes_supported" => ["tachyon.lobby", "admin.map", "admin.engine", "admin.user"]
              }
     end
   end

--- a/test/teiserver_web/controllers/o_auth/code_controller_test.exs
+++ b/test/teiserver_web/controllers/o_auth/code_controller_test.exs
@@ -357,6 +357,7 @@ defmodule TeiserverWeb.OAuth.CodeControllerTest do
                  "client_secret_post",
                  "client_secret_basic"
                ],
+               "userinfo_endpoint" => "#{endpoint}/oauth/userinfo",
                "grant_types_supported" => [
                  "authorization_code",
                  "refresh_token",

--- a/test/teiserver_web/controllers/o_auth/code_controller_test.exs
+++ b/test/teiserver_web/controllers/o_auth/code_controller_test.exs
@@ -365,7 +365,15 @@ defmodule TeiserverWeb.OAuth.CodeControllerTest do
                ],
                "code_challenge_methods_supported" => ["S256"],
                "response_types_supported" => ["code", "token"],
-               "scopes_supported" => ["tachyon.lobby", "admin.map", "admin.engine", "admin.user"]
+               "scopes_supported" => [
+                 "tachyon.lobby",
+                 "admin.map",
+                 "admin.engine",
+                 "admin.user",
+                 "profile",
+                 "email",
+                 "groups"
+               ]
              }
     end
   end

--- a/test/teiserver_web/controllers/o_auth/userinfo_controller_test.exs
+++ b/test/teiserver_web/controllers/o_auth/userinfo_controller_test.exs
@@ -1,10 +1,12 @@
 defmodule TeiserverWeb.OAuth.UserinfoControllerTest do
   alias Phoenix.ConnTest
   alias Teiserver.Account.Auth
-  alias Teiserver.Helpers.GeneralTestLib
+  alias Teiserver.BotFixtures
   alias Teiserver.OAuth
   alias Teiserver.OAuthFixtures
   use TeiserverWeb.ConnCase
+
+  @info_scopes ["profile", "email", "groups"]
 
   defp setup_app(_context) do
     {:ok, admin_user} = Auth.add_roles(TeiserverTestLib.new_user().id, ["Admin"])
@@ -23,8 +25,20 @@ defmodule TeiserverWeb.OAuth.UserinfoControllerTest do
 
   defp setup_conn(_context) do
     conn = ConnTest.build_conn()
-    user = GeneralTestLib.make_user()
+    {:ok, user} = Auth.add_roles(TeiserverTestLib.new_user().id, ["Verified", "Moderator"])
     {:ok, conn: conn, user: user}
+  end
+
+  defp request_userinfo(conn, user, app, scopes) do
+    token =
+      OAuthFixtures.token_attrs(user, app)
+      |> Map.put(:scopes, scopes)
+      |> OAuthFixtures.create_token()
+
+    conn
+    |> put_req_header("authorization", "Bearer #{token.value}")
+    |> get(~p"/oauth/userinfo")
+    |> json_response(200)
   end
 
   setup [:setup_conn, :setup_app]
@@ -35,16 +49,51 @@ defmodule TeiserverWeb.OAuth.UserinfoControllerTest do
   end
 
   test "can get user id", %{conn: conn, user: user, app: app} do
-    token =
-      OAuthFixtures.token_attrs(user, app)
-      |> Map.put(:scopes, [])
-      |> OAuthFixtures.create_token()
+    resp = request_userinfo(conn, user, app, @info_scopes)
 
-    resp =
-      conn
-      |> put_req_header("authorization", "Bearer #{token.value}")
-      |> get(~p"/oauth/userinfo")
+    assert resp["sub"] == to_string(user.id)
+    assert resp["preferred_username"] == user.name
+    assert resp["email"] == user.email
+    assert resp["email_verified"] == true
+    assert resp["groups"] == ["verified", "moderator"]
+  end
 
-    assert json_response(resp, 200)["sub"] == to_string(user.id)
+  test "bot infos", %{conn: conn, app: app} do
+    bot = BotFixtures.create_bot("testing_bot")
+    resp = request_userinfo(conn, bot, app, @info_scopes)
+
+    assert resp["sub"] == to_string(bot.id)
+    assert resp["groups"] == []
+  end
+
+  test "username requires profile scope", %{conn: conn, user: user, app: app} do
+    resp = request_userinfo(conn, user, app, Enum.reject(@info_scopes, &(&1 == "profile")))
+    refute is_map_key(resp, "preferred_username")
+  end
+
+  test "bots don't have username", %{conn: conn, app: app} do
+    bot = BotFixtures.create_bot("testing_bot")
+    resp = request_userinfo(conn, bot, app, @info_scopes)
+
+    refute is_map_key(resp, "preferred_username")
+  end
+
+  test "email requires email scope", %{conn: conn, user: user, app: app} do
+    resp = request_userinfo(conn, user, app, Enum.reject(@info_scopes, &(&1 == "email")))
+    refute is_map_key(resp, "email")
+    refute is_map_key(resp, "email_verified")
+  end
+
+  test "bots don't have emails", %{conn: conn, app: app} do
+    bot = BotFixtures.create_bot("testing_bot")
+    resp = request_userinfo(conn, bot, app, @info_scopes)
+
+    refute is_map_key(resp, "email")
+    refute is_map_key(resp, "email_verified")
+  end
+
+  test "requires groups scope for groups", %{conn: conn, user: user, app: app} do
+    resp = request_userinfo(conn, user, app, Enum.reject(@info_scopes, &(&1 == "groups")))
+    refute is_map_key(resp, "groups")
   end
 end

--- a/test/teiserver_web/controllers/o_auth/userinfo_controller_test.exs
+++ b/test/teiserver_web/controllers/o_auth/userinfo_controller_test.exs
@@ -1,0 +1,50 @@
+defmodule TeiserverWeb.OAuth.UserinfoControllerTest do
+  alias Phoenix.ConnTest
+  alias Teiserver.Account.Auth
+  alias Teiserver.Helpers.GeneralTestLib
+  alias Teiserver.OAuth
+  alias Teiserver.OAuthFixtures
+  use TeiserverWeb.ConnCase
+
+  defp setup_app(_context) do
+    {:ok, admin_user} = Auth.add_roles(TeiserverTestLib.new_user().id, ["Admin"])
+
+    {:ok, app} =
+      OAuth.create_application(%{
+        name: "testing app",
+        uid: "test_app_uid",
+        owner_id: admin_user.id,
+        scopes: OAuth.allowed_scopes(),
+        redirect_uris: ["http://127.0.0.1:6789/oauth/callback"]
+      })
+
+    %{app: app}
+  end
+
+  defp setup_conn(_context) do
+    conn = ConnTest.build_conn()
+    user = GeneralTestLib.make_user()
+    {:ok, conn: conn, user: user}
+  end
+
+  setup [:setup_conn, :setup_app]
+
+  test "requires a token", %{conn: conn} do
+    resp = get(conn, ~p"/oauth/userinfo")
+    assert resp.status == 401
+  end
+
+  test "can get user id", %{conn: conn, user: user, app: app} do
+    token =
+      OAuthFixtures.token_attrs(user, app)
+      |> Map.put(:scopes, [])
+      |> OAuthFixtures.create_token()
+
+    resp =
+      conn
+      |> put_req_header("authorization", "Bearer #{token.value}")
+      |> get(~p"/oauth/userinfo")
+
+    assert json_response(resp, 200)["sub"] == to_string(user.id)
+  end
+end


### PR DESCRIPTION
https://github.com/beyond-all-reason/teiserver/issues/1166

Add an endpoint to get some user info through a JSON API. The info are based on the scopes tied to the bearer token.