### PR TITLE
Expands the roles requiring MFA to include moderation, overwatch and contributor

### DIFF
--- a/lib/teiserver/account/libs/auth_lib.ex
+++ b/lib/teiserver/account/libs/auth_lib.ex
@@ -14,7 +14,7 @@ defmodule Teiserver.Account.AuthLib do
   def icon, do: "fa-solid fa-address-card"
 
   def mfa_roles do
-    ~w[Server Admin]s
+    ~w[Server Admin Moderator Overwatch Contributor]s
   end
 
   @spec get_all_permission_sets() :: list()


### PR DESCRIPTION
The existing implementation appears to be working. Once merged this will be communicated out by Teifion to all contributors and moderators (who will then inform the Overwatch team).