### PR TITLE
Auth checks run through AuthLib

### DIFF
--- a/lib/teiserver/account/auth.ex
+++ b/lib/teiserver/account/auth.ex
@@ -49,7 +49,7 @@ defmodule Teiserver.Account.Auth do
   def moderator?(userid) when is_integer(userid),
     do: moderator?(Account.get_user(userid))
 
-  def moderator?(%User{} = %{roles: roles}), do: Enum.member?(roles, "Moderator")
+  def moderator?(%User{} = user), do: allow?(user, "Moderator")
   def moderator?(_user), do: false
 
   # credo:disable-for-lines:8 Credo.Check.Readability.PredicateFunctionNames
@@ -59,7 +59,7 @@ defmodule Teiserver.Account.Auth do
   def is_event_organizer?(userid) when is_integer(userid),
     do: is_event_organizer?(Account.get_user(userid))
 
-  def is_event_organizer?(%User{} = %{roles: roles}), do: Enum.member?(roles, "Event Organizer")
+  def is_event_organizer?(%User{} = user), do: allow?(user, "Event Organizer")
   def is_event_organizer?(_user), do: false
 
   @spec contributor?(User.id() | User.t() | nil) :: boolean()
@@ -68,7 +68,7 @@ defmodule Teiserver.Account.Auth do
   def contributor?(userid) when is_integer(userid),
     do: contributor?(Account.get_user(userid))
 
-  def contributor?(%User{} = %{roles: roles}), do: Enum.member?(roles, "Contributor")
+  def contributor?(%User{} = user), do: allow?(user, "Contributor")
   def contributor?(_user), do: false
 
   @spec verified?(User.id() | User.t() | nil) :: boolean()
@@ -83,13 +83,13 @@ defmodule Teiserver.Account.Auth do
   @spec admin?(User.id() | User.t() | nil) :: boolean()
   def admin?(nil), do: false
   def admin?(userid) when is_integer(userid), do: admin?(Account.get_user(userid))
-  def admin?(%User{} = %{roles: roles}), do: Enum.member?(roles, "Admin")
+  def admin?(%User{} = user), do: allow?(user, "Admin")
   def admin?(_user), do: false
 
   @spec vip?(User.id() | User.t() | nil) :: boolean()
   def vip?(nil), do: false
   def vip?(userid) when is_integer(userid), do: vip?(Account.get_user(userid))
-  def vip?(%User{} = %{roles: roles}), do: Enum.member?(roles, "VIP")
+  def vip?(%User{} = user), do: allow?(user, "VIP")
   def vip?(_user), do: false
 
   @doc """

--- a/lib/teiserver/account/libs/auth_lib.ex
+++ b/lib/teiserver/account/libs/auth_lib.ex
@@ -7,6 +7,7 @@ defmodule Teiserver.Account.AuthLib do
   alias Phoenix.LiveView.Socket
   alias Plug.Conn
   alias Teiserver.Account
+  alias Teiserver.Account.RoleLib
 
   require Logger
 
@@ -41,6 +42,17 @@ defmodule Teiserver.Account.AuthLib do
       |> Enum.uniq()
 
     permission_list ++ sections ++ modules
+  end
+
+  @spec get_permissions_from_roles([String.t()]) :: [String.t()]
+  def get_permissions_from_roles(roles) do
+    roles
+    |> Enum.map(fn role_name ->
+      role_def = RoleLib.role_data(role_name)
+      [role_name | role_def.contains]
+    end)
+    |> List.flatten()
+    |> Enum.uniq()
   end
 
   @spec get_permission_set({String.t(), String.t()}) :: [String.t()]
@@ -82,7 +94,8 @@ defmodule Teiserver.Account.AuthLib do
 
   # Handle conn
   def allow?(%Conn{} = conn, permissions_required) do
-    %{id: id, permissions: permissions_held} = conn.assigns[:current_user]
+    %{id: id, roles: roles} = conn.assigns[:current_user]
+    permissions_held = get_permissions_from_roles(roles)
 
     mfa_test(id, permissions_required) and
       permission_test(permissions_held, permissions_required)
@@ -90,14 +103,17 @@ defmodule Teiserver.Account.AuthLib do
 
   # Socket
   def allow?(%Socket{} = socket, permissions_required) do
-    %{id: id, permissions: permissions_held} = socket.assigns[:current_user]
+    %{id: id, roles: roles} = socket.assigns[:current_user]
+    permissions_held = get_permissions_from_roles(roles)
 
     mfa_test(id, permissions_required) and
       permission_test(permissions_held, permissions_required)
   end
 
   # User and CacheUser
-  def allow?(%{id: id, permissions: permissions_held}, permissions_required) do
+  def allow?(%{id: id, roles: roles}, permissions_required) do
+    permissions_held = get_permissions_from_roles(roles)
+
     mfa_test(id, permissions_required) and
       permission_test(permissions_held, permissions_required)
   end
@@ -122,8 +138,7 @@ defmodule Teiserver.Account.AuthLib do
     )
 
     cond do
-      # Enum.member?(Application.get_env(:teiserver, TeiserverWeb)[:universal_permissions], permission_required) -> true
-      permissions_held == nil ->
+      Enum.empty?(permissions_held) ->
         Logger.debug("AuthLib.allow?() -> No permissions held")
         false
 

--- a/lib/teiserver/helpers/general_test_lib.ex
+++ b/lib/teiserver/helpers/general_test_lib.ex
@@ -2,7 +2,6 @@ defmodule Teiserver.Helpers.GeneralTestLib do
   @moduledoc false
 
   alias Teiserver.Account
-  alias Teiserver.Account.AuthLib
   alias Teiserver.Account.Guardian
   alias TeiserverWeb.UserSocket
   import Phoenix.ChannelTest
@@ -15,17 +14,13 @@ defmodule Teiserver.Helpers.GeneralTestLib do
   def user_fixture, do: make_user(%{"permissions" => []})
 
   def make_user(params \\ %{}) do
-    permissions =
-      (params["permissions"] || [])
-      |> AuthLib.split_permissions()
-
     {:ok, u} =
       Account.create_user(%{
         "name" => params["name"] || "Test",
         "email" => params["email"] || "email@email#{:rand.uniform(999_999_999_999)}",
         "colour" => params["colour"] || "#00AA00",
         "icon" => params["icon"] || "fa-solid fa-user",
-        "permissions" => permissions,
+        "permissions" => [],
         "roles" => params["roles"] || [],
         "password" =>
           params["password"] ||
@@ -72,7 +67,7 @@ defmodule Teiserver.Helpers.GeneralTestLib do
   end
 
   # @spec general_setup(list, ) :: tuple
-  def conn_setup(permissions \\ [], flags \\ []) do
+  def conn_setup(roles \\ [], flags \\ []) do
     {:ok, _data} = data_setup(flags)
 
     r = :rand.uniform(999_999_999)
@@ -85,7 +80,7 @@ defmodule Teiserver.Helpers.GeneralTestLib do
           make_user(%{
             "name" => "Current user",
             "email" => "current_user#{r}@current_user#{r}.com",
-            "permissions" => permissions
+            "roles" => roles
           })
 
         # Tokens

--- a/test/teiserver_web/controllers/logging/audit_log_controller_test.exs
+++ b/test/teiserver_web/controllers/logging/audit_log_controller_test.exs
@@ -6,7 +6,7 @@ defmodule TeiserverWeb.Logging.AuditLogControllerTest do
   use TeiserverWeb.ConnCase
 
   setup do
-    GeneralTestLib.conn_setup(~w(logging.audit.show))
+    GeneralTestLib.conn_setup(["Server"])
     |> LoggingTestLib.logging_setup()
   end
 

--- a/test/teiserver_web/controllers/logging/page_view_log_controller_test.exs
+++ b/test/teiserver_web/controllers/logging/page_view_log_controller_test.exs
@@ -7,7 +7,7 @@ defmodule TeiserverWeb.Logging.PageViewLogControllerTest do
   use TeiserverWeb.ConnCase, async: false
 
   setup do
-    GeneralTestLib.conn_setup(~w(logging.page_view.show))
+    GeneralTestLib.conn_setup(["Server"])
   end
 
   test "lists all entries on index", %{conn: conn} do


### PR DESCRIPTION
Fixes some of the auth checks to run through common code thus also enforcing the MFA requirement in places it was not currently being enforced.

As part of this I broke some tests so I have simultaneously taken the first step to removing the need to store permissions separately from roles in the User struct.