### PR TITLE
Disable mfa warning based on config

### DIFF
--- a/lib/teiserver/account/libs/auth_lib.ex
+++ b/lib/teiserver/account/libs/auth_lib.ex
@@ -206,7 +206,7 @@ defmodule Teiserver.Account.AuthLib do
     end)
   end
 
-  defp mfa_required? do
+  def mfa_required? do
     Application.get_env(:teiserver, Teiserver)[:require_mfa_for_privileged_roles]
   end
 

--- a/lib/teiserver_web/controllers/account/security_controller.ex
+++ b/lib/teiserver_web/controllers/account/security_controller.ex
@@ -41,11 +41,7 @@ defmodule TeiserverWeb.Account.SecurityController do
   def totp(conn, _params) do
     user = Account.get_user!(conn.assigns.current_user.id)
 
-    mfa_required = Application.get_env(:teiserver, Teiserver)[:require_mfa_for_privileged_roles]
-
-    show_mfa_warning =
-      mfa_required == true and
-        AuthLib.contains_mfa_role?(user.roles)
+    show_mfa_warning = AuthLib.mfa_required?() and AuthLib.contains_mfa_role?(user.roles)
 
     conn
     |> add_breadcrumb(name: "totp", url: conn.request_path)

--- a/lib/teiserver_web/live/general/home/index_live.ex
+++ b/lib/teiserver_web/live/general/home/index_live.ex
@@ -7,14 +7,11 @@ defmodule TeiserverWeb.General.HomeLive.Index do
   def mount(_params, _session, socket) do
     %{current_user: user} = socket.assigns
 
-    socket =
-      if AuthLib.contains_mfa_role?(user.roles) and not has_active_mfa?(user.id) do
-        socket
-        |> assign(mfa_warning?: true)
-      else
-        socket
-        |> assign(mfa_warning?: false)
-      end
+    mfa_warning? =
+      AuthLib.mfa_required?() and AuthLib.contains_mfa_role?(user.roles) and
+        not has_active_mfa?(user.id)
+
+    socket = assign(socket, :mfa_warning?, mfa_warning?)
 
     socket =
       socket


### PR DESCRIPTION
Small fix to avoid showing the warning about permission if no mfa in dev environment.