### PR TITLE
Oauth confidential clients

### DIFF
--- a/lib/teiserver/o_auth.ex
+++ b/lib/teiserver/o_auth.ex
@@ -119,7 +119,7 @@ defmodule Teiserver.OAuth do
   @spec create_code(
           User.t(),
           %{
-            id: integer(),
+            application: Application.t(),
             scopes: Application.scopes(),
             redirect_uri: String.t(),
             challenge: String.t(),
@@ -132,15 +132,15 @@ defmodule Teiserver.OAuth do
 
   def create_code(%User{} = user, attrs, opts) do
     now = Keyword.get(opts, :now, DateTime.utc_now())
-    app_id = attrs.id
+    %Application{} = app = attrs.application
 
-    if ApplicationQueries.application_allows_code?(app_id) do
+    if ApplicationQueries.application_allows_code?(app) do
       # don't do any validation on the challenge yet, this is done when exchanging
       # the code for a token
       attrs = %{
         value: :crypto.strong_rand_bytes(32) |> Base.hex_encode32(),
         owner: user,
-        application_id: app_id,
+        application: attrs.application,
         scopes: attrs.scopes,
         expires_at: DateTime.shift(now, minute: 5),
         redirect_uri: Map.get(attrs, :redirect_uri),

--- a/lib/teiserver/o_auth.ex
+++ b/lib/teiserver/o_auth.ex
@@ -119,11 +119,11 @@ defmodule Teiserver.OAuth do
   @spec create_code(
           User.t(),
           %{
-            application: Application.t(),
-            scopes: Application.scopes(),
-            redirect_uri: String.t(),
-            challenge: String.t(),
-            challenge_method: String.t()
+            required(:application) => Application.t(),
+            required(:scopes) => Application.scopes(),
+            required(:redirect_uri) => String.t(),
+            optional(:challenge) => String.t(),
+            optional(:challenge_method) => String.t()
           },
           options()
         ) ::

--- a/lib/teiserver/o_auth.ex
+++ b/lib/teiserver/o_auth.ex
@@ -387,39 +387,36 @@ defmodule Teiserver.OAuth do
   def refresh_token(token, opts) do
     now = Keyword.get(opts, :now, DateTime.utc_now())
 
-    case check_expiry(token, now) do
-      {:error, :expired} ->
-        {:error, :expired}
-
-      _result ->
-        token =
-          if Enum.all?([:application, :bot, :owner], &Ecto.assoc_loaded?(Map.get(token, &1))) do
-            token
-          else
-            TokenQueries.get_token(token.value)
-          end
-
-        scopes = Keyword.get(opts, :scopes, token.scopes)
-
-        refresh_attr = %{
-          id: token.application.id,
-          scopes: scopes,
-          original_scopes: token.original_scopes
-        }
-
-        tx_result =
-          Repo.transaction(fn ->
-            with {:ok, new_token} <-
-                   create_token(token.owner, refresh_attr, Keyword.put(opts, :scopes, scopes)) do
-              TokenQueries.delete_refresh_token(token)
-              new_token
-            end
-          end)
-
-        case tx_result do
-          {:ok, {:error, err}} -> {:error, err}
-          other -> other
+    with {:ok, _tok} <- check_expiry(token, now),
+         :ok <- check_client_secret(token.application, opts[:client_secret]) do
+      token =
+        if Enum.all?([:application, :bot, :owner], &Ecto.assoc_loaded?(Map.get(token, &1))) do
+          token
+        else
+          TokenQueries.get_token(token.value)
         end
+
+      scopes = Keyword.get(opts, :scopes, token.scopes)
+
+      refresh_attr = %{
+        id: token.application.id,
+        scopes: scopes,
+        original_scopes: token.original_scopes
+      }
+
+      tx_result =
+        Repo.transaction(fn ->
+          with {:ok, new_token} <-
+                 create_token(token.owner, refresh_attr, Keyword.put(opts, :scopes, scopes)) do
+            TokenQueries.delete_refresh_token(token)
+            new_token
+          end
+        end)
+
+      case tx_result do
+        {:ok, {:error, err}} -> {:error, err}
+        other -> other
+      end
     end
   end
 

--- a/lib/teiserver/o_auth.ex
+++ b/lib/teiserver/o_auth.ex
@@ -258,15 +258,18 @@ defmodule Teiserver.OAuth do
   Given an authorization code, creates and return an authentication token
   (and its associated refresh token).
   """
-  @spec exchange_code(Code.t(), String.t(), String.t() | nil, options()) ::
+  @type exchange_arg :: {:verifier, String.t()} | {:redirect_uri, String.t()}
+  @type exchange_args :: [exchange_arg()]
+  @spec exchange_code(Code.t(), args :: exchange_args(), options()) ::
           {:ok, Token.t()} | {:error, term()}
-  def exchange_code(code, verifier, redirect_uri \\ nil, opts \\ []) do
+  def exchange_code(code, args, opts \\ []) do
     now = Keyword.get(opts, :now, DateTime.utc_now())
+    redirect_uri = args[:redirect_uri]
 
     with {:ok, code} <- check_expiry(code, now),
          :ok <-
            if(code.redirect_uri == redirect_uri, do: :ok, else: {:error, :redirect_uri_mismatch}),
-         :ok <- check_verifier(code, verifier) do
+         :ok <- check_verifier(code, args[:verifier]) do
       Repo.transaction(fn ->
         Repo.delete!(code)
 
@@ -283,6 +286,8 @@ defmodule Teiserver.OAuth do
   end
 
   @spec check_verifier(Code.t(), String.t()) :: :ok | {:error, term()}
+  defp check_verifier(_code, nil), do: {:error, "missing code verifier, PKCE is required"}
+
   defp check_verifier(%Code{challenge_method: :plain, challenge: challenge}, verifier) do
     with :ok <- valid_verifier(verifier) do
       compare_hash(challenge, verifier)

--- a/lib/teiserver/o_auth.ex
+++ b/lib/teiserver/o_auth.ex
@@ -286,22 +286,38 @@ defmodule Teiserver.OAuth do
   end
 
   @spec check_verifier(Code.t(), String.t()) :: :ok | {:error, term()}
-  defp check_verifier(_code, nil), do: {:error, "missing code verifier, PKCE is required"}
+  defp check_verifier(%Code{} = code, verifier) do
+    case {code.challenge, verifier} do
+      # only confidential clients can create code without a challenge, not
+      # passing a verifier is thus OK
+      {nil, nil} ->
+        :ok
 
-  defp check_verifier(%Code{challenge_method: :plain, challenge: challenge}, verifier) do
+      {nil, _not_nil} ->
+        {:error, "unexpected code verifier"}
+
+      {_challenge, nil} ->
+        {:error, "missing code verifier, PKCE is required"}
+
+      _x ->
+        do_check_verifier(code, verifier)
+    end
+  end
+
+  defp do_check_verifier(%Code{challenge_method: :plain, challenge: challenge}, verifier) do
     with :ok <- valid_verifier(verifier) do
       compare_hash(challenge, verifier)
     end
   end
 
-  defp check_verifier(%Code{challenge_method: :S256, challenge: challenge}, verifier) do
+  defp do_check_verifier(%Code{challenge_method: :S256, challenge: challenge}, verifier) do
     with :ok <- valid_verifier(verifier),
          {:ok, challenge} <- Base.url_decode64(challenge, padding: false, ignore: :whitespace) do
       compare_hash(challenge, :crypto.hash(:sha256, verifier))
     end
   end
 
-  defp check_verifier(_code, _verifier), do: {:error, :invalid_verifier}
+  defp do_check_verifier(_code, _verifier), do: {:error, :invalid_verifier}
 
   # A-Z, a-z, 0-9, and the punctuation characters -._~
   defp valid_verifier(verifier) do

--- a/lib/teiserver/o_auth.ex
+++ b/lib/teiserver/o_auth.ex
@@ -5,6 +5,7 @@ defmodule Teiserver.OAuth do
   alias Teiserver.Bot.Bot
 
   alias Teiserver.OAuth.Application
+  alias Teiserver.OAuth.ApplicationLib
   alias Teiserver.OAuth.ApplicationQueries
   alias Teiserver.OAuth.Code
   alias Teiserver.OAuth.CodeQueries
@@ -258,7 +259,8 @@ defmodule Teiserver.OAuth do
   Given an authorization code, creates and return an authentication token
   (and its associated refresh token).
   """
-  @type exchange_arg :: {:verifier, String.t()} | {:redirect_uri, String.t()}
+  @type exchange_arg ::
+          {:verifier, String.t()} | {:redirect_uri, String.t() | {:client_secret, String.t()}}
   @type exchange_args :: [exchange_arg()]
   @spec exchange_code(Code.t(), args :: exchange_args(), options()) ::
           {:ok, Token.t()} | {:error, term()}
@@ -269,7 +271,8 @@ defmodule Teiserver.OAuth do
     with {:ok, code} <- check_expiry(code, now),
          :ok <-
            if(code.redirect_uri == redirect_uri, do: :ok, else: {:error, :redirect_uri_mismatch}),
-         :ok <- check_verifier(code, args[:verifier]) do
+         :ok <- check_verifier(code, args[:verifier]),
+         :ok <- check_client_secret(code.application, args[:client_secret]) do
       Repo.transaction(fn ->
         Repo.delete!(code)
 
@@ -351,7 +354,29 @@ defmodule Teiserver.OAuth do
     end
   end
 
-  @spec refresh_token(Token.t(), [option() | {:scopes, Application.scopes()}]) ::
+  defp check_client_secret(%Application{} = app, client_secret) do
+    case {ApplicationLib.confidential?(app), client_secret} do
+      {false, nil} ->
+        :ok
+
+      {false, _s} ->
+        {:error, "public client don't have client_secret"}
+
+      {true, nil} ->
+        {:error, "missing required client_secret"}
+
+      {true, s} ->
+        if ApplicationLib.verify_secret(s, app) do
+          :ok
+        else
+          {:error, "invalid client_secret"}
+        end
+    end
+  end
+
+  @spec refresh_token(Token.t(), [
+          option() | {:scopes, Application.scopes()} | {:client_secret, String.t()}
+        ]) ::
           {:ok, Token.t()} | {:error, term()}
   def refresh_token(token, opts \\ [])
 

--- a/lib/teiserver/o_auth/libs/application_lib.ex
+++ b/lib/teiserver/o_auth/libs/application_lib.ex
@@ -15,4 +15,7 @@ defmodule Teiserver.OAuth.ApplicationLib do
   """
   @spec confidential?(Application.t()) :: boolean()
   def confidential?(%Application{} = app), do: app.secret != nil
+
+  @spec verify_secret(String.t(), Application.t()) :: boolean()
+  def verify_secret(secret, %Application{} = app), do: Argon2.verify_pass(secret, app.secret)
 end

--- a/lib/teiserver/o_auth/libs/application_lib.ex
+++ b/lib/teiserver/o_auth/libs/application_lib.ex
@@ -1,8 +1,18 @@
 defmodule Teiserver.OAuth.ApplicationLib do
   @moduledoc false
+
+  alias Teiserver.OAuth.Application
+
   @spec icon :: String.t()
   def icon, do: "fa-solid fa-passport"
 
   @spec colours :: atom
   def colours, do: :success2
+
+  @doc """
+  An app is considered confidential when it can keep a secret. For example not
+  a web client.
+  """
+  @spec confidential?(Application.t()) :: boolean()
+  def confidential?(%Application{} = app), do: app.secret != nil
 end

--- a/lib/teiserver/o_auth/queries/token_query.ex
+++ b/lib/teiserver/o_auth/queries/token_query.ex
@@ -13,9 +13,7 @@ defmodule Teiserver.OAuth.TokenQueries do
   def get_token(value) do
     base_query()
     |> where_token(value)
-    |> preload(:application)
-    |> preload(:owner)
-    |> preload(:bot)
+    |> preload([:application, :owner, :bot, refresh_token: [:application, :owner, :bot]])
     |> Repo.one()
   end
 

--- a/lib/teiserver/o_auth/schemas/code.ex
+++ b/lib/teiserver/o_auth/schemas/code.ex
@@ -29,6 +29,12 @@ defmodule Teiserver.OAuth.Code do
       attrs
       |> uniq_lists(~w(scopes)a)
       |> Map.put(:owner_id, owner.id)
+      |> then(fn attrs ->
+        case Map.get(attrs, :application) do
+          nil -> attrs
+          app -> Map.put(attrs, :application_id, app.id)
+        end
+      end)
 
     code
     |> cast(attrs, [
@@ -50,6 +56,7 @@ defmodule Teiserver.OAuth.Code do
       :challenge,
       :challenge_method
     ])
+    |> Changeset.assoc_constraint(:application)
     |> Changeset.validate_subset(:scopes, OAuth.allowed_scopes())
     |> Changeset.validate_change(:scopes, fn :scopes, scopes ->
       case ScopeLib.all_scopes_allowed?(owner, scopes) do

--- a/lib/teiserver/o_auth/schemas/code.ex
+++ b/lib/teiserver/o_auth/schemas/code.ex
@@ -5,6 +5,7 @@ defmodule Teiserver.OAuth.Code do
   alias Teiserver.Account
   alias Teiserver.Account.User
   alias Teiserver.OAuth
+  alias Teiserver.OAuth.ApplicationLib
   alias Teiserver.OAuth.Libs.ScopeLib
 
   use TeiserverWeb, :schema
@@ -25,12 +26,14 @@ defmodule Teiserver.OAuth.Code do
   def changeset(code, attrs) do
     owner = get_owner(code, attrs)
 
+    app = Map.get(attrs, :application) || Map.get(code, :application)
+
     attrs =
       attrs
       |> uniq_lists(~w(scopes)a)
       |> Map.put(:owner_id, owner.id)
       |> then(fn attrs ->
-        case Map.get(attrs, :application) do
+        case app do
           nil -> attrs
           app -> Map.put(attrs, :application_id, app.id)
         end
@@ -52,11 +55,11 @@ defmodule Teiserver.OAuth.Code do
       :owner_id,
       :application_id,
       :scopes,
-      :expires_at,
-      :challenge,
-      :challenge_method
+      :expires_at
     ])
     |> Changeset.assoc_constraint(:application)
+    |> validate_required_together([:challenge, :challenge_method])
+    |> ensure_challenge_public_apps(app)
     |> Changeset.validate_subset(:scopes, OAuth.allowed_scopes())
     |> Changeset.validate_change(:scopes, fn :scopes, scopes ->
       case ScopeLib.all_scopes_allowed?(owner, scopes) do
@@ -71,4 +74,22 @@ defmodule Teiserver.OAuth.Code do
 
   defp get_owner(_app, %{owner: %Account.User{} = owner}), do: owner
   defp get_owner(%__MODULE__{owner: %Account.User{} = owner}, _attrs), do: owner
+
+  # ensure that if one of the given attr is given, then all of them must be
+  # present in the changeset
+  defp validate_required_together(changeset, attrs) do
+    if Enum.any?(attrs, &Changeset.get_change(changeset, &1)) do
+      Changeset.validate_required(changeset, attrs)
+    else
+      changeset
+    end
+  end
+
+  defp ensure_challenge_public_apps(changeset, %OAuth.Application{} = app) do
+    if ApplicationLib.confidential?(app) do
+      changeset
+    else
+      validate_required(changeset, [:challenge, :challenge_method])
+    end
+  end
 end

--- a/lib/teiserver_web/controllers/o_auth/authorize_controller.ex
+++ b/lib/teiserver_web/controllers/o_auth/authorize_controller.ex
@@ -82,7 +82,7 @@ defmodule TeiserverWeb.OAuth.AuthorizeController do
 
       true ->
         code_params = %{
-          id: app.id,
+          application: app,
           redirect_uri: URI.to_string(redir_url),
           scopes: app.scopes,
           challenge: Map.get(params, "code_challenge"),

--- a/lib/teiserver_web/controllers/o_auth/authorize_controller.ex
+++ b/lib/teiserver_web/controllers/o_auth/authorize_controller.ex
@@ -1,4 +1,5 @@
 defmodule TeiserverWeb.OAuth.AuthorizeController do
+  alias Ecto.Changeset
   alias Teiserver.OAuth
 
   use TeiserverWeb, :controller
@@ -76,9 +77,6 @@ defmodule TeiserverWeb.OAuth.AuthorizeController do
       Map.get(params, "response_type") != "code" ->
         error_redirect(conn, redir_url, "unsupported_response_type", "only code is supported")
 
-      Map.get(params, "code_challenge_method") != "S256" ->
-        error_redirect(conn, redir_url, "invalid_request", "only S256 is supported")
-
       Map.get(params, "code_challenge") == nil ->
         error_redirect(conn, redir_url, "invalid_request", "a code challenge must be provided")
 
@@ -88,10 +86,21 @@ defmodule TeiserverWeb.OAuth.AuthorizeController do
           redirect_uri: URI.to_string(redir_url),
           scopes: app.scopes,
           challenge: Map.get(params, "code_challenge"),
-          challenge_method: "S256"
+          challenge_method: Map.get(params, "code_challenge_method")
         }
 
         case OAuth.create_code(conn.assigns.current_user, code_params) do
+          {:error, %Changeset{} = err} ->
+            errors =
+              Changeset.traverse_errors(err, fn {msg, _opts} -> msg end)
+              |> Enum.map(fn {k, msgs} ->
+                errs = Enum.join(msgs, ", ")
+                "#{k}: #{errs}"
+              end)
+
+            reason = Enum.join(errors, " - ")
+            bad_request(conn, reason)
+
           {:error, _reason} ->
             error_redirect(conn, redir_url, "server_error", "something went wrong")
 

--- a/lib/teiserver_web/controllers/o_auth/code_controller.ex
+++ b/lib/teiserver_web/controllers/o_auth/code_controller.ex
@@ -88,7 +88,8 @@ defmodule TeiserverWeb.OAuth.CodeController do
              do: :ok,
              else: {:error, "token doesn't match application. Invalid token for this client_id"}
            ),
-         {:ok, new_token} <- OAuth.refresh_token(token, scopes: scopes) do
+         {:ok, new_token} <-
+           OAuth.refresh_token(token, scopes: scopes, client_secret: params["client_secret"]) do
       conn |> put_status(200) |> render(:token, token: new_token)
     else
       error ->

--- a/lib/teiserver_web/controllers/o_auth/code_controller.ex
+++ b/lib/teiserver_web/controllers/o_auth/code_controller.ex
@@ -9,7 +9,7 @@ defmodule TeiserverWeb.OAuth.CodeController do
 
   def token(conn, %{"grant_type" => "authorization_code"} = params) do
     with :ok <-
-           check_required_keys(params, ["code", "redirect_uri", "code_verifier", "grant_type"]),
+           check_required_keys(params, ["code", "redirect_uri", "grant_type"]),
          {:ok, client_id} <- get_client_id(conn, params) do
       exchange_token(conn, client_id, params)
     else
@@ -65,7 +65,10 @@ defmodule TeiserverWeb.OAuth.CodeController do
              else: {:error, "code doesn't match application. Invalid code for this client_id"}
            ),
          {:ok, token} <-
-           OAuth.exchange_code(code, params["code_verifier"], params["redirect_uri"]) do
+           OAuth.exchange_code(code,
+             verifier: params["code_verifier"],
+             redirect_uri: params["redirect_uri"]
+           ) do
       conn |> put_status(200) |> render(:token, token: token)
     else
       {:error, err} ->

--- a/lib/teiserver_web/controllers/o_auth/code_controller.ex
+++ b/lib/teiserver_web/controllers/o_auth/code_controller.ex
@@ -67,7 +67,8 @@ defmodule TeiserverWeb.OAuth.CodeController do
          {:ok, token} <-
            OAuth.exchange_code(code,
              verifier: params["code_verifier"],
-             redirect_uri: params["redirect_uri"]
+             redirect_uri: params["redirect_uri"],
+             client_secret: params["client_secret"]
            ) do
       conn |> put_status(200) |> render(:token, token: token)
     else

--- a/lib/teiserver_web/controllers/o_auth/userinfo_controller.ex
+++ b/lib/teiserver_web/controllers/o_auth/userinfo_controller.ex
@@ -16,7 +16,7 @@ defmodule TeiserverWeb.OAuth.UserinfoController do
         true -> raise "token has no owner nor bot!"
       end
 
-    claims = %{sub: sub, id: sub}
+    claims = %{sub: sub}
     info_scopes = ["profile", "email", "groups"]
 
     claims =

--- a/test/support/fixtures/o_auth/o_auth_fixtures.ex
+++ b/test/support/fixtures/o_auth/o_auth_fixtures.ex
@@ -37,7 +37,7 @@ defmodule Teiserver.OAuthFixtures do
       value: :crypto.strong_rand_bytes(32) |> Base.hex_encode32(),
       owner: user,
       owner_id: user.id,
-      application_id: app.id,
+      application: app,
       scopes: app.scopes,
       expires_at: DateTime.shift(now, minute: 5),
       redirect_uri: List.first(app.redirect_uris),

--- a/test/teiserver/o_auth/code_test.exs
+++ b/test/teiserver/o_auth/code_test.exs
@@ -23,7 +23,41 @@ defmodule Teiserver.OAuth.CodeTest do
         redirect_uris: ["http://localhost/foo"]
       })
 
-    {:ok, user: user, app: app}
+    {:ok, confidential_app} =
+      OAuth.create_application(%{
+        name: "Testing app",
+        uid: "confidential_uid",
+        owner_id: user.id,
+        scopes: ["tachyon.lobby"],
+        redirect_uris: ["http://localhost/foo"],
+        confidential?: true
+      })
+
+    {:ok, user: user, app: app, confidential_app: confidential_app}
+  end
+
+  test "challenge_method required if challenge is set", %{user: user, app: app} do
+    code_attrs = %{
+      application: app,
+      scopes: app.scopes,
+      redirect_uri: List.first(app.redirect_uris),
+      challenge: "vqIld9nxOPe5uX_ndiRlwafYdt94ogYOZDlGIyj68jc"
+    }
+
+    {:error, err} = OAuth.create_code(user, code_attrs)
+    assert Keyword.has_key?(err.errors, :challenge_method)
+  end
+
+  test "challenge required if challenge_method is set", %{user: user, app: app} do
+    code_attrs = %{
+      application: app,
+      scopes: app.scopes,
+      redirect_uri: List.first(app.redirect_uris),
+      challenge_method: "S256"
+    }
+
+    {:error, err} = OAuth.create_code(user, code_attrs)
+    assert Keyword.has_key?(err.errors, :challenge)
   end
 
   test "can get valid code", %{user: user, app: app} do
@@ -68,6 +102,27 @@ defmodule Teiserver.OAuth.CodeTest do
     assert token.owner_id == user.id
     # the code is now consumed and not available anymore
     assert {:error, :no_code} = OAuth.get_valid_code(code.value)
+  end
+
+  test "pkce is required for public apps", %{user: user, app: app} do
+    code_attrs = %{
+      application: app,
+      scopes: app.scopes,
+      redirect_uri: List.first(app.redirect_uris)
+    }
+
+    {:error, err} = OAuth.create_code(user, code_attrs)
+    assert Keyword.has_key?(err.errors, :challenge)
+  end
+
+  test "pkce is optional for confidential apps", %{user: user, confidential_app: app} do
+    code_attrs = %{
+      application: app,
+      scopes: app.scopes,
+      redirect_uri: List.first(app.redirect_uris)
+    }
+
+    {:ok, _code} = OAuth.create_code(user, code_attrs)
   end
 
   test "cannot exchange expired code for token", %{user: user, app: app} do

--- a/test/teiserver/o_auth/code_test.exs
+++ b/test/teiserver/o_auth/code_test.exs
@@ -194,7 +194,7 @@ defmodule Teiserver.OAuth.CodeTest do
 
     assert {:ok, %Token{}} =
              OAuth.exchange_code(code,
-               client_secret: app.secret,
+               client_secret: app.plain_text_secret,
                redirect_uri: List.first(app.redirect_uris)
              )
   end
@@ -210,9 +210,46 @@ defmodule Teiserver.OAuth.CodeTest do
 
     assert {:error, _err} =
              OAuth.exchange_code(code,
-               client_secret: app.secret,
+               client_secret: app.plain_text_secret,
                verifier: "hello",
                redirect_uri: List.first(app.redirect_uris)
+             )
+  end
+
+  test "confidential client must provide client secret", %{user: user, confidential_app: app} do
+    code =
+      OAuthFixtures.code_attrs(user, app)
+      |> Map.drop([:challenge, :challenge_method, :_verifier])
+      |> OAuthFixtures.create_code()
+
+    assert {:error, _err} = OAuth.exchange_code(code, redirect_uri: List.first(app.redirect_uris))
+  end
+
+  test "confidential client must provide correct client secret", %{
+    user: user,
+    confidential_app: app
+  } do
+    code =
+      OAuthFixtures.code_attrs(user, app)
+      |> Map.drop([:challenge, :challenge_method, :_verifier])
+      |> OAuthFixtures.create_code()
+
+    assert {:error, _err} =
+             OAuth.exchange_code(code,
+               client_secret: "this is not it",
+               redirect_uri: List.first(app.redirect_uris)
+             )
+  end
+
+  test "public client must not provide a client secret", %{user: user, app: app} do
+    assert {:ok, code, attrs} = create_code(user, app)
+    attrs = Map.put(attrs, :id, app.id)
+
+    assert {:error, _reason} =
+             OAuth.exchange_code(code,
+               verifier: attrs._verifier,
+               redirect_uri: List.first(app.redirect_uris),
+               client_secret: "hello"
              )
   end
 

--- a/test/teiserver/o_auth/code_test.exs
+++ b/test/teiserver/o_auth/code_test.exs
@@ -57,7 +57,13 @@ defmodule Teiserver.OAuth.CodeTest do
 
   test "can exchange valid code for token", %{user: user, app: app} do
     assert {:ok, code, attrs} = create_code(user, app)
-    assert {:ok, token} = OAuth.exchange_code(code, attrs._verifier, attrs.redirect_uri)
+
+    assert {:ok, token} =
+             OAuth.exchange_code(code,
+               verifier: attrs._verifier,
+               redirect_uri: attrs.redirect_uri
+             )
+
     assert token.scopes == code.scopes
     assert token.owner_id == user.id
     # the code is now consumed and not available anymore
@@ -67,19 +73,21 @@ defmodule Teiserver.OAuth.CodeTest do
   test "cannot exchange expired code for token", %{user: user, app: app} do
     yesterday = DateTime.shift(DateTime.utc_now(), day: -1)
     assert {:ok, code, attrs} = create_code(user, app, expires_at: yesterday)
-    assert {:error, :expired} = OAuth.exchange_code(code, attrs._verifier)
+    assert {:error, :expired} = OAuth.exchange_code(code, verifier: attrs._verifier)
   end
 
   test "must use valid verifier", %{user: user, app: app} do
     assert {:ok, code, attrs} = create_code(user, app)
     attrs = Map.put(attrs, :id, app.id)
     no_match = :crypto.strong_rand_bytes(38) |> Base.hex_encode32(padding: false)
-    assert {:error, _reason} = OAuth.exchange_code(code, no_match)
+    assert {:error, _reason} = OAuth.exchange_code(code, verifier: no_match)
 
     no_match =
       "lollollollollollollollollollollollollollollollollollollollollollollollollollollollollollollollollollollollollollollollollollol"
 
-    assert {:error, err} = OAuth.exchange_code(code, no_match, attrs.redirect_uri)
+    assert {:error, err} =
+             OAuth.exchange_code(code, verifier: no_match, redirect_uri: attrs.redirect_uri)
+
     assert err =~ "doesn't match"
   end
 
@@ -89,7 +97,10 @@ defmodule Teiserver.OAuth.CodeTest do
     verifier = "TOO_SHORT"
     challenge = OAuthFixtures.hash_verifier(verifier)
     {:ok, code} = OAuth.create_code(user, %{attrs | challenge: challenge})
-    assert {:error, err} = OAuth.exchange_code(code, verifier, attrs.redirect_uri)
+
+    assert {:error, err} =
+             OAuth.exchange_code(code, verifier: verifier, redirect_uri: attrs.redirect_uri)
+
     assert err =~ "cannot be less than"
   end
 
@@ -99,7 +110,10 @@ defmodule Teiserver.OAuth.CodeTest do
     verifier = String.duplicate("a", 129)
     challenge = OAuthFixtures.hash_verifier(verifier)
     {:ok, code} = OAuth.create_code(user, %{attrs | challenge: challenge})
-    assert {:error, err} = OAuth.exchange_code(code, verifier, attrs.redirect_uri)
+
+    assert {:error, err} =
+             OAuth.exchange_code(code, verifier: verifier, redirect_uri: attrs.redirect_uri)
+
     assert err =~ "cannot be more than"
   end
 

--- a/test/teiserver/o_auth/code_test.exs
+++ b/test/teiserver/o_auth/code_test.exs
@@ -45,7 +45,7 @@ defmodule Teiserver.OAuth.CodeTest do
     attrs = create_code_attrs(user, updated_app)
 
     code_attrs = %{
-      id: app.id,
+      application: updated_app,
       scopes: app.scopes,
       redirect_uri: nil,
       challenge: attrs.challenge,
@@ -119,7 +119,7 @@ defmodule Teiserver.OAuth.CodeTest do
 
   test "must pass valid challenge method", %{user: user, app: app} do
     code_attrs = %{
-      id: app.id,
+      application: app,
       redirect_uri: List.first(app.redirect_uris),
       scopes: app.scopes,
       challenge: OAuthFixtures.code_attrs(user, app).challenge,

--- a/test/teiserver/o_auth/code_test.exs
+++ b/test/teiserver/o_auth/code_test.exs
@@ -117,6 +117,19 @@ defmodule Teiserver.OAuth.CodeTest do
     assert err =~ "cannot be more than"
   end
 
+  test "must pass valid challenge method", %{user: user, app: app} do
+    code_attrs = %{
+      id: app.id,
+      redirect_uri: List.first(app.redirect_uris),
+      scopes: app.scopes,
+      challenge: OAuthFixtures.code_attrs(user, app).challenge,
+      challenge_method: "lolnope that's not supported"
+    }
+
+    {:error, err} = OAuth.create_code(user, code_attrs)
+    assert Keyword.has_key?(err.errors, :challenge_method)
+  end
+
   test "can delete expired codes", %{user: user, app: app} do
     assert {:ok, expired_code, _expired_attrs} =
              create_code(user, app, expires_at: ~U[1980-01-01 12:23:34Z])

--- a/test/teiserver/o_auth/code_test.exs
+++ b/test/teiserver/o_auth/code_test.exs
@@ -4,6 +4,7 @@ defmodule Teiserver.OAuth.CodeTest do
   alias Teiserver.Account
   alias Teiserver.Account.Auth
   alias Teiserver.OAuth
+  alias Teiserver.OAuth.Token
   alias Teiserver.OAuthFixtures
   alias Teiserver.TeiserverTestLib
   use Teiserver.DataCase, async: true
@@ -183,6 +184,36 @@ defmodule Teiserver.OAuth.CodeTest do
 
     {:error, err} = OAuth.create_code(user, code_attrs)
     assert Keyword.has_key?(err.errors, :challenge_method)
+  end
+
+  test "confidential clients don't need pkce for tokens", %{user: user, confidential_app: app} do
+    code =
+      OAuthFixtures.code_attrs(user, app)
+      |> Map.drop([:challenge, :challenge_method, :_verifier])
+      |> OAuthFixtures.create_code()
+
+    assert {:ok, %Token{}} =
+             OAuth.exchange_code(code,
+               client_secret: app.secret,
+               redirect_uri: List.first(app.redirect_uris)
+             )
+  end
+
+  test "confidential clients must not provide verifier when no challenge", %{
+    user: user,
+    confidential_app: app
+  } do
+    code =
+      OAuthFixtures.code_attrs(user, app)
+      |> Map.drop([:challenge, :challenge_method, :_verifier])
+      |> OAuthFixtures.create_code()
+
+    assert {:error, _err} =
+             OAuth.exchange_code(code,
+               client_secret: app.secret,
+               verifier: "hello",
+               redirect_uri: List.first(app.redirect_uris)
+             )
   end
 
   test "can delete expired codes", %{user: user, app: app} do

--- a/test/teiserver/o_auth/token_test.exs
+++ b/test/teiserver/o_auth/token_test.exs
@@ -19,7 +19,17 @@ defmodule Teiserver.OAuth.TokenTest do
         scopes: ["tachyon.lobby", "admin.map"]
       })
 
-    {:ok, user: user, app: app}
+    {:ok, confidential_app} =
+      OAuth.create_application(%{
+        name: "Testing app",
+        uid: "confidential_uid",
+        owner_id: user.id,
+        scopes: ["tachyon.lobby"],
+        redirect_uris: ["http://localhost/foo"],
+        confidential?: true
+      })
+
+    {:ok, user: user, app: app, confidential_app: confidential_app}
   end
 
   test "token must have an owner", %{app: app} do
@@ -71,8 +81,8 @@ defmodule Teiserver.OAuth.TokenTest do
 
   test "can refresh a token", %{user: user, app: app} do
     assert {:ok, token} = OAuth.create_token(user, app, scopes: app.scopes)
-    assert {:ok, _token} = OAuth.get_valid_token(token.refresh_token.value)
-    assert {:ok, new_token} = OAuth.refresh_token(token.refresh_token)
+    assert {:ok, refresh_token} = OAuth.get_valid_token(token.refresh_token.value)
+    assert {:ok, new_token} = OAuth.refresh_token(refresh_token)
 
     # the previous token and its refresh token should have been invalidated
     assert {:error, :no_token} = OAuth.get_valid_token(token.value)
@@ -83,20 +93,43 @@ defmodule Teiserver.OAuth.TokenTest do
     assert new_token_fresh.id == new_token.id
   end
 
+  test "confidential clients can get refresh tokens", %{user: user, confidential_app: app} do
+    assert {:ok, token} = OAuth.create_token(user, app, scopes: app.scopes)
+    assert {:ok, refresh_token} = OAuth.get_valid_token(token.refresh_token.value)
+
+    assert {:ok, %Token{}} =
+             OAuth.refresh_token(refresh_token, client_secret: app.plain_text_secret)
+  end
+
+  test "confidential clients must provide client secret", %{user: user, confidential_app: app} do
+    assert {:ok, token} = OAuth.create_token(user, app, scopes: app.scopes)
+    assert {:ok, refresh_token} = OAuth.get_valid_token(token.refresh_token.value)
+    assert {:error, _err} = OAuth.refresh_token(refresh_token)
+  end
+
+  test "confidential clients must provide correct client secret", %{
+    user: user,
+    confidential_app: app
+  } do
+    assert {:ok, token} = OAuth.create_token(user, app, scopes: app.scopes)
+    assert {:ok, refresh_token} = OAuth.get_valid_token(token.refresh_token.value)
+    assert {:error, _err} = OAuth.refresh_token(refresh_token, client_secret: "nope")
+  end
+
   test "can change scopes at refresh", %{user: user, app: app} do
     assert {:ok, token} = OAuth.create_token(user, app, scopes: app.scopes)
-    assert {:ok, _token} = OAuth.get_valid_token(token.refresh_token.value)
-    assert {:ok, new_token} = OAuth.refresh_token(token.refresh_token, scopes: ["tachyon.lobby"])
+    assert {:ok, refresh_token} = OAuth.get_valid_token(token.refresh_token.value)
+    assert {:ok, new_token} = OAuth.refresh_token(refresh_token, scopes: ["tachyon.lobby"])
     assert MapSet.new(new_token.scopes) == MapSet.new(["tachyon.lobby"])
     assert MapSet.new(token.scopes) == MapSet.new(new_token.original_scopes)
   end
 
   test "cannot get more scopes than originally", %{user: user, app: app} do
     assert {:ok, token} = OAuth.create_token(user, app, scopes: app.scopes)
-    assert {:ok, _token} = OAuth.get_valid_token(token.refresh_token.value)
+    assert {:ok, refresh_token} = OAuth.get_valid_token(token.refresh_token.value)
 
     {:error, changeset} =
-      OAuth.refresh_token(token.refresh_token, scopes: ["tachyon.lobby", "lolscope"])
+      OAuth.refresh_token(refresh_token, scopes: ["tachyon.lobby", "lolscope"])
 
     assert Keyword.get(changeset.errors, :scopes) != nil
   end
@@ -110,8 +143,8 @@ defmodule Teiserver.OAuth.TokenTest do
   test "cannot get scopes at refresh without correct roles", %{user: user, app: app} do
     {:ok, user} = Auth.remove_roles(user, ["Admin"])
     assert {:ok, token} = OAuth.create_token(user, app, scopes: ["tachyon.lobby"])
-    assert {:ok, _token} = OAuth.get_valid_token(token.refresh_token.value)
-    assert {:error, err} = OAuth.refresh_token(token.refresh_token, scopes: ["admin.map"])
+    assert {:ok, refresh_token} = OAuth.get_valid_token(token.refresh_token.value)
+    assert {:error, err} = OAuth.refresh_token(refresh_token, scopes: ["admin.map"])
     assert Keyword.has_key?(err.errors, :scopes)
   end
 

--- a/test/teiserver_web/controllers/o_auth/authorize_controller_test.exs
+++ b/test/teiserver_web/controllers/o_auth/authorize_controller_test.exs
@@ -104,6 +104,20 @@ defmodule TeiserverWeb.OAuth.AuthorizeControllerTest do
       assert html_response(resp, 400) =~ "invalid client_id"
     end
 
+    test "invalid request when incorrect challenge method", %{conn: conn, app: app} do
+      data = %{
+        client_id: app.uid,
+        response_type: "code",
+        code_challenge: "blah",
+        code_challenge_method: "this is not valid",
+        redirect_uri: hd(app.redirect_uris),
+        state: "some random state"
+      }
+
+      resp = post(conn, ~p"/oauth/authorize", data)
+      assert html_response(resp, 400) =~ "Bad request"
+    end
+
     test "redirected for invalid response type", %{conn: conn, app: app} do
       data = %{
         client_id: app.uid,

--- a/test/teiserver_web/controllers/o_auth/code_controller_test.exs
+++ b/test/teiserver_web/controllers/o_auth/code_controller_test.exs
@@ -102,6 +102,52 @@ defmodule TeiserverWeb.OAuth.CodeControllerTest do
       assert is_binary(json_resp["access_token"]), "has access_token"
     end
 
+    test "can use a client secret instead of PKCE", ctx do
+      app =
+        OAuthFixtures.app_attrs(ctx[:user].id)
+        |> Map.put(:confidential?, true)
+        |> OAuthFixtures.create_app()
+
+      code =
+        OAuthFixtures.code_attrs(ctx[:user], app)
+        |> Map.drop([:challenge, :challenge_method])
+        |> OAuthFixtures.create_code()
+
+      data = %{
+        grant_type: "authorization_code",
+        code: code.value,
+        redirect_uri: code.redirect_uri,
+        client_id: app.uid,
+        client_secret: app.plain_text_secret
+      }
+
+      resp = post(ctx[:conn], ~p"/oauth/token", data) |> json_response(200)
+      assert resp["token_type"] == "Bearer", "bearer token type"
+    end
+
+    test "must use client secret for confidential clients", ctx do
+      app =
+        OAuthFixtures.app_attrs(ctx[:user].id)
+        |> Map.put(:confidential?, true)
+        |> OAuthFixtures.create_app()
+
+      code =
+        OAuthFixtures.code_attrs(ctx[:user], app)
+        |> Map.drop([:challenge, :challenge_method])
+        |> OAuthFixtures.create_code()
+
+      data = %{
+        grant_type: "authorization_code",
+        code: code.value,
+        redirect_uri: code.redirect_uri,
+        client_id: app.uid
+        # ! no client secret
+      }
+
+      resp = post(ctx[:conn], ~p"/oauth/token", data) |> json_response(400)
+      assert resp["error_description"] =~ "missing required client_secret"
+    end
+
     test "must not provide client_id twice", %{conn: conn} = setup_data do
       data = get_valid_data(setup_data)
 

--- a/test/teiserver_web/controllers/o_auth/code_controller_test.exs
+++ b/test/teiserver_web/controllers/o_auth/code_controller_test.exs
@@ -385,6 +385,26 @@ defmodule TeiserverWeb.OAuth.CodeControllerTest do
       resp = post(conn, ~p"/oauth/token", data)
       assert %{"error" => "invalid_request"} = json_response(resp, 400)
     end
+
+    # https://datatracker.ietf.org/doc/html/rfc6749#section-3.2.1
+    test "confidential client can get refresh token", ctx do
+      app =
+        OAuthFixtures.app_attrs(ctx[:user].id)
+        |> Map.put(:confidential?, true)
+        |> OAuthFixtures.create_app()
+
+      {:ok, token} = OAuth.create_token(ctx[:user], app, scopes: app.scopes)
+
+      data = %{
+        grant_type: "refresh_token",
+        client_id: app.uid,
+        client_secret: app.plain_text_secret,
+        refresh_token: token.refresh_token.value
+      }
+
+      resp = post(ctx[:conn], ~p"/oauth/token", data) |> json_response(200)
+      assert resp["token_type"] == "Bearer"
+    end
   end
 
   describe "medatata endpoint" do


### PR DESCRIPTION
This is the logic to actually make use of [confidential clients](https://github.com/beyond-all-reason/teiserver/pull/1182).

The final result of all of that is that we can create a confidential client for other app, say grafana for example. And then we can use dex as an openID connect proxy. So grafana connects to dex, which uses this confidential client to perform the oauth dances, and finally grafana can use accounts in teiserver for login.