### PR TITLE
Added BannedPhrase functionality

### DIFF
--- a/lib/teiserver.ex
+++ b/lib/teiserver.ex
@@ -38,8 +38,8 @@ defmodule Teiserver do
   end
 
   # Cache stuff
-  @spec cache_get(atom, any) :: any
-  defdelegate cache_get(table, key), to: CacheHelper
+  @spec cache_get(atom, any, any) :: any
+  defdelegate cache_get(table, key, default \\ nil), to: CacheHelper
 
   @spec cache_get_or_store(atom, any, function) :: any
   defdelegate cache_get_or_store(table, key, func), to: CacheHelper

--- a/lib/teiserver/chat/libs/word_lib.ex
+++ b/lib/teiserver/chat/libs/word_lib.ex
@@ -2,7 +2,6 @@ defmodule Teiserver.Chat.WordLib do
   @moduledoc false
   alias Teiserver.Config
   alias Teiserver.Helper.StringHelper
-  alias Teiserver.Moderation
   alias Teiserver.Plugins
 
   use Plugins
@@ -94,7 +93,7 @@ defmodule Teiserver.Chat.WordLib do
     end
   end
 
-  # TODO: Refactor this to return a BannedPhrase struct
+  # TODO: Replace all calls to this with BannedPhrase.message_severity
   @spec blacklisted_phrase?(String.t()) :: boolean()
   @decorate Plugins.plugin(:blacklisted_phrase?)
   def blacklisted_phrase?(text) do
@@ -110,13 +109,6 @@ defmodule Teiserver.Chat.WordLib do
           Regex.match?(r, text)
       end)
 
-    result || blacklisted_custom_phrase?(text)
-  end
-
-  defp blacklisted_custom_phrase?(text) do
-    Moderation.list_banned_phrases_cache(:regex)
-    |> Enum.any?(fn regex ->
-      not is_nil(Regex.run(regex, text))
-    end)
+    result
   end
 end

--- a/lib/teiserver/helpers/cache_helper.ex
+++ b/lib/teiserver/helpers/cache_helper.ex
@@ -3,13 +3,13 @@ defmodule Teiserver.Helpers.CacheHelper do
 
   require Logger
 
-  @spec cache_get(atom, any) :: any
-  def cache_get(table, key) do
-    ConCache.get(table, key)
+  @spec cache_get(atom, any, any) :: any
+  def cache_get(table, key, default \\ nil) do
+    ConCache.get(table, key) || default
   catch
     :exit, :noproc ->
       Logger.warning("Cache #{table} is down")
-      nil
+      default
   end
 
   @spec cache_get_or_store(atom, any, function) :: any

--- a/lib/teiserver/moderation.ex
+++ b/lib/teiserver/moderation.ex
@@ -880,7 +880,7 @@ defmodule Teiserver.Moderation do
 
   @spec list_banned_domains_cache :: [String.t()]
   def list_banned_domains_cache do
-    Teiserver.cache_get(:application_metadata_cache, "banned_domains") || []
+    Teiserver.cache_get(:application_metadata_cache, "banned_domains", [])
   end
 
   @spec banned_domain?(String.t()) :: boolean()
@@ -1003,7 +1003,7 @@ defmodule Teiserver.Moderation do
 
   @spec list_banned_ips_cache :: [BannedIP.t()]
   def list_banned_ips_cache do
-    Teiserver.cache_get(:application_metadata_cache, "banned_ips") || []
+    Teiserver.cache_get(:application_metadata_cache, "banned_ips", [])
   end
 
   @doc """
@@ -1113,11 +1113,9 @@ defmodule Teiserver.Moderation do
     Repo.all(BannedPhrase)
   end
 
-  @spec list_banned_phrases_cache(atom()) :: [BannedPhrase.t()]
-  def list_banned_phrases_cache(type) do
-    Teiserver.cache_get(:application_metadata_cache, "banned_phrases") ||
-      []
-      |> Enum.filter(fn bp -> bp.type == type end)
+  @spec list_banned_phrases_cache() :: [BannedPhrase.t()]
+  def list_banned_phrases_cache do
+    Teiserver.cache_get(:application_metadata_cache, "banned_phrases", [])
   end
 
   @doc """

--- a/lib/teiserver/moderation/queries/banned_phrase_queries.ex
+++ b/lib/teiserver/moderation/queries/banned_phrase_queries.ex
@@ -1,0 +1,23 @@
+defmodule Teiserver.Moderation.BannedPhraseQueries do
+  @moduledoc false
+  alias Ecto.Query
+  alias Teiserver.Moderation.BannedPhrase
+
+  use TeiserverWeb, :queries
+
+  @type t :: Query.t()
+
+  @spec banned_phrases() :: t()
+  def banned_phrases do
+    from(banned_phrases in BannedPhrase, as: :banned_phrases)
+  end
+
+  @spec order_by_severity(t(), :asc | :desc) :: t()
+  def order_by_severity(query, direction \\ :asc) do
+    if direction == :asc do
+      from(banned_phrases in query, order_by: [asc: banned_phrases.severity])
+    else
+      from(banned_phrases in query, order_by: [desc: banned_phrases.severity])
+    end
+  end
+end

--- a/lib/teiserver/moderation/schemas/banned_phrase.ex
+++ b/lib/teiserver/moderation/schemas/banned_phrase.ex
@@ -1,8 +1,26 @@
 defmodule Teiserver.Moderation.BannedPhrase do
   @moduledoc """
-  A phrase banned in the game which would warrant an action if detected.
+  A phrase banned in the game which could warrant an action if detected.
+
+  All tests are checked as case sensitive.
+
+  Types:
+    raw - if the phrase is present in the message it will trigger
+    fuzzy - uses * as wildcards for as many characters as needed
+            executed as a regex
+    regex - a regex, if the pattern matches it will trigger
+
+  Score threshold is not currently used but is intended to be used
+  in the future for partial match types.
   """
+  alias Ecto.Changeset
+  alias Teiserver.Moderation
+  alias Teiserver.Moderation.BannedPhrase
+
   use TeiserverWeb, :schema
+
+  @type severity :: :low | :medium | :high
+  @type search_type :: :raw | :fuzzy | :regex
 
   typed_schema "banned_phrases" do
     field :phrase, :string
@@ -26,5 +44,127 @@ defmodule Teiserver.Moderation.BannedPhrase do
     |> cast(attrs, [:phrase, :score_threshold, :type, :severity])
     |> validate_required([:phrase, :score_threshold, :type, :severity])
     |> unique_constraint([:phrase])
+    |> validate_phrase()
+  end
+
+  defp validate_phrase(%Changeset{} = changeset) do
+    case get_field(changeset, :type) do
+      :fuzzy -> validate_fuzzy_phrase(changeset)
+      :regex -> validate_regex_phrase(changeset)
+      _any_other -> changeset
+    end
+  end
+
+  defp validate_fuzzy_phrase(%Changeset{} = changeset) do
+    phrase = get_field(changeset, :phrase) || ""
+
+    {regex_result, possible_regex_error} =
+      phrase
+      |> Regex.escape()
+      |> String.replace("\\*", ".*")
+      |> Regex.compile()
+
+    cond do
+      not String.contains?(phrase, "*") ->
+        add_error(changeset, :phrase, "Fuzzy phrase needs to contain at least one wildcard (*)")
+
+      regex_result == :error ->
+        {error_chars, pos} = possible_regex_error
+
+        error_str = List.to_string(error_chars)
+        add_error(changeset, :phrase, "Invalid regex - #{error_str}, pos: #{pos}")
+
+      true ->
+        changeset
+    end
+  end
+
+  defp validate_regex_phrase(%Changeset{} = changeset) do
+    pattern = get_field(changeset, :phrase)
+
+    case Regex.compile(pattern) do
+      {:ok, _regex} ->
+        changeset
+
+      {:error, {error_chars, pos}} ->
+        error_str = List.to_string(error_chars)
+        add_error(changeset, :phrase, "Invalid regex - #{error_str}, pos: #{pos}")
+    end
+  end
+
+  @doc """
+  Given a BannedPhrase loaded from the database cache the loaded_phrase
+  field.
+  """
+  @spec load_phrase(BannedPhrase.t()) :: BannedPhrase.t()
+  def load_phrase(%BannedPhrase{type: :regex, phrase: phrase} = banned_phrase) do
+    {:ok, compiled_phrase} = Regex.compile(phrase)
+    %BannedPhrase{banned_phrase | loaded_phrase: compiled_phrase}
+  end
+
+  def load_phrase(%BannedPhrase{type: :fuzzy, phrase: phrase} = banned_phrase) do
+    pattern =
+      phrase
+      |> Regex.escape()
+      |> String.replace("\\*", ".*")
+
+    {:ok, compiled_phrase} = Regex.compile(pattern)
+    %BannedPhrase{banned_phrase | loaded_phrase: compiled_phrase}
+  end
+
+  def load_phrase(%BannedPhrase{phrase: phrase} = banned_phrase) do
+    %BannedPhrase{banned_phrase | loaded_phrase: phrase}
+  end
+
+  @doc """
+  Performs a more extended set of automated checks to see if the message
+  being posted is
+  """
+  @spec message_severity(String.t(), severity(), [search_type()]) :: nil | BannedPhrase.severity()
+  def message_severity(message, min_severity \\ :high, types \\ [:raw, :fuzzy, :regex]) do
+    # First get the list of phrases we want to check against
+    banned_phrases =
+      Moderation.list_banned_phrases_cache()
+      |> Enum.filter(fn %BannedPhrase{type: type, severity: severity} ->
+        severity_is_at_least(severity, min_severity) and Enum.member?(types, type)
+      end)
+
+    banned_phrases
+    |> Enum.reduce(nil, fn
+      phrase, nil ->
+        if phrase_match?(phrase, message) do
+          phrase.severity
+        else
+          nil
+        end
+
+      _phrase, found_severity ->
+        found_severity
+    end)
+  end
+
+  defp severity_is_at_least(severity_tested, severity_minimum) do
+    case severity_minimum do
+      :low -> true
+      :medium -> Enum.member?([:medium, :high], severity_tested)
+      :high -> :high == severity_tested
+    end
+  end
+
+  @doc """
+  Given a banned phrase and a message, does the message
+  trigger the banned phrase?
+  """
+  @spec phrase_match?(BannedPhrase.t(), String.t()) :: boolean()
+  def phrase_match?(%BannedPhrase{type: :raw, loaded_phrase: loaded_phrase}, message) do
+    String.contains?(message, loaded_phrase)
+  end
+
+  def phrase_match?(%BannedPhrase{type: :fuzzy, loaded_phrase: loaded_phrase}, message) do
+    Regex.match?(loaded_phrase, message)
+  end
+
+  def phrase_match?(%BannedPhrase{type: :regex, loaded_phrase: loaded_phrase}, message) do
+    Regex.match?(loaded_phrase, message)
   end
 end

--- a/lib/teiserver/moderation/schemas/banned_phrase.ex
+++ b/lib/teiserver/moderation/schemas/banned_phrase.ex
@@ -58,30 +58,21 @@ defmodule Teiserver.Moderation.BannedPhrase do
   defp validate_fuzzy_phrase(%Changeset{} = changeset) do
     phrase = get_field(changeset, :phrase) || ""
 
-    {regex_result, possible_regex_error} =
-      phrase
-      |> Regex.escape()
-      |> String.replace("\\*", ".*")
-      |> Regex.compile()
+    pattern = phrase |> Regex.escape() |> String.replace("\\*", ".*")
 
-    cond do
-      not String.contains?(phrase, "*") ->
-        add_error(changeset, :phrase, "Fuzzy phrase needs to contain at least one wildcard (*)")
-
-      regex_result == :error ->
-        {error_chars, pos} = possible_regex_error
-
-        error_str = List.to_string(error_chars)
-        add_error(changeset, :phrase, "Invalid regex - #{error_str}, pos: #{pos}")
-
-      true ->
-        changeset
+    if String.contains?(phrase, "*") do
+      validate_pattern(changeset, pattern)
+    else
+      add_error(changeset, :phrase, "Fuzzy phrase needs to contain at least one wildcard (*)")
     end
   end
 
   defp validate_regex_phrase(%Changeset{} = changeset) do
     pattern = get_field(changeset, :phrase)
+    validate_pattern(changeset, pattern)
+  end
 
+  defp validate_pattern(%Changeset{} = changeset, pattern) do
     case Regex.compile(pattern) do
       {:ok, _regex} ->
         changeset

--- a/lib/teiserver/moderation/schemas/banned_phrase.ex
+++ b/lib/teiserver/moderation/schemas/banned_phrase.ex
@@ -63,7 +63,11 @@ defmodule Teiserver.Moderation.BannedPhrase do
     if String.contains?(phrase, "*") do
       validate_pattern(changeset, pattern)
     else
-      add_error(changeset, :phrase, "Fuzzy phrase needs to contain at least one wildcard (*)")
+      add_error(
+        changeset,
+        :phrase,
+        "Fuzzy phrase needs to contain at least one wildcard (*), did you mean to use the 'raw' type?"
+      )
     end
   end
 

--- a/lib/teiserver/moderation/schemas/banned_phrase.ex
+++ b/lib/teiserver/moderation/schemas/banned_phrase.ex
@@ -117,30 +117,25 @@ defmodule Teiserver.Moderation.BannedPhrase do
   end
 
   @doc """
-  Performs a more extended set of automated checks to see if the message
-  being posted is
+  Runs through a filtered list of banned phrases and returns the highest severity
+  matched by the message.
   """
   @spec message_severity(String.t(), severity(), [search_type()]) :: nil | BannedPhrase.severity()
   def message_severity(message, min_severity \\ :high, types \\ [:raw, :fuzzy, :regex]) do
-    # First get the list of phrases we want to check against
-    banned_phrases =
+    found_phrase =
       Moderation.list_banned_phrases_cache()
       |> Enum.filter(fn %BannedPhrase{type: type, severity: severity} ->
         severity_is_at_least(severity, min_severity) and Enum.member?(types, type)
       end)
+      |> Enum.find(fn %BannedPhrase{type: type, severity: severity} = banned_phrase ->
+        severity_is_at_least(severity, min_severity) and
+          Enum.member?(types, type) and
+          phrase_match?(banned_phrase, message)
+      end)
 
-    banned_phrases
-    |> Enum.reduce(nil, fn
-      phrase, nil ->
-        if phrase_match?(phrase, message) do
-          phrase.severity
-        else
-          nil
-        end
-
-      _phrase, found_severity ->
-        found_severity
-    end)
+    if found_phrase do
+      found_phrase.severity
+    end
   end
 
   defp severity_is_at_least(severity_tested, severity_minimum) do
@@ -160,11 +155,8 @@ defmodule Teiserver.Moderation.BannedPhrase do
     String.contains?(message, loaded_phrase)
   end
 
-  def phrase_match?(%BannedPhrase{type: :fuzzy, loaded_phrase: loaded_phrase}, message) do
-    Regex.match?(loaded_phrase, message)
-  end
-
-  def phrase_match?(%BannedPhrase{type: :regex, loaded_phrase: loaded_phrase}, message) do
+  def phrase_match?(%BannedPhrase{type: type, loaded_phrase: loaded_phrase}, message)
+      when type in [:regex, :fuzzy] do
     Regex.match?(loaded_phrase, message)
   end
 end

--- a/lib/teiserver/moderation/tasks/load_banned_phrases_task.ex
+++ b/lib/teiserver/moderation/tasks/load_banned_phrases_task.ex
@@ -3,27 +3,21 @@ defmodule Teiserver.Moderation.LoadBannedPhrasesTask do
   Loads the list of banned phrases from the database into the cache.
   """
   alias Teiserver.Helpers.CacheHelper
-  alias Teiserver.Moderation
   alias Teiserver.Moderation.BannedPhrase
+  alias Teiserver.Moderation.BannedPhraseQueries
+  alias Teiserver.Repo
 
   def perform do
     banned_phrases =
-      Moderation.list_banned_phrases()
-      |> Enum.map(&load_phrase/1)
+      BannedPhraseQueries.banned_phrases()
+      |> BannedPhraseQueries.order_by_severity(:desc)
+      |> Repo.all()
+      |> Enum.map(&BannedPhrase.load_phrase/1)
 
     CacheHelper.store_put(
       :application_metadata_cache,
       "banned_phrases",
       banned_phrases
     )
-  end
-
-  defp load_phrase(%BannedPhrase{type: :regex, phrase: phrase} = banned_phrase) do
-    compiled_phrase = Regex.compile(phrase)
-    %BannedPhrase{banned_phrase | loaded_phrase: compiled_phrase}
-  end
-
-  defp load_phrase(%BannedPhrase{phrase: phrase} = banned_phrase) do
-    %BannedPhrase{banned_phrase | loaded_phrase: phrase}
   end
 end

--- a/lib/teiserver_web/components/core_components.ex
+++ b/lib/teiserver_web/components/core_components.ex
@@ -191,12 +191,12 @@ defmodule TeiserverWeb.CoreComponents do
     ~H"""
     <div aria-live="polite" aria-atomic="true" class="position-relative">
       <div class="toast-container top-0 end-0 p-3">
-        <.flash kind={:info} title="Information" role="alert" flash={@flash} />
-        <.flash kind={:success} title="Success!" role="alert" flash={@flash} />
-        <.flash kind={:warning} title="Warning!" role="alert" flash={@flash} />
-        <.flash kind={:error} title="Error!" role="alert" flash={@flash} />
+        <.flash id="flash-info" kind={:info} title="Information" role="alert" flash={@flash} />
+        <.flash id="flash-success" kind={:success} title="Success!" role="alert" flash={@flash} />
+        <.flash id="flash-warning" kind={:warning} title="Warning!" role="alert" flash={@flash} />
+        <.flash id="flash-error" kind={:error} title="Error!" role="alert" flash={@flash} />
         <.flash
-          id="disconnected"
+          id="flash-disconnected"
           kind={:error}
           title="Reconnecting to the server"
           close={false}
@@ -433,7 +433,7 @@ defmodule TeiserverWeb.CoreComponents do
 
   def error(assigns) do
     ~H"""
-    <p class="mt-3 flex gap-3 text-sm leading-6 text-rose-600">
+    <p class="mt-3 flex gap-3 text-sm leading-6 text-rose-600 bg-danger_transparent p-2">
       <Fontawesome.icon icon="circle-exclamation" style="solid" />
       {render_slot(@inner_block)}
     </p>

--- a/test/support/fixtures/moderation_fixtures.ex
+++ b/test/support/fixtures/moderation_fixtures.ex
@@ -11,10 +11,12 @@ defmodule Teiserver.ModerationFixtures do
   """
   def banned_domain_fixture(attrs \\ %{}) do
     {:ok, banned_domain} =
-      attrs
-      |> Enum.into(%{
-        domain: "some domain"
-      })
+      Map.merge(
+        %{
+          domain: "some domain"
+        },
+        attrs
+      )
       |> Moderation.create_banned_domain()
 
     banned_domain
@@ -25,10 +27,12 @@ defmodule Teiserver.ModerationFixtures do
   """
   def banned_ip_fixture(attrs \\ %{}) do
     {:ok, banned_ip} =
-      attrs
-      |> Enum.into(%{
-        cidr: "192.168.0.1/32"
-      })
+      Map.merge(
+        %{
+          cidr: "192.168.0.1/32"
+        },
+        attrs
+      )
       |> Moderation.create_banned_ip()
 
     banned_ip
@@ -39,13 +43,15 @@ defmodule Teiserver.ModerationFixtures do
   """
   def banned_phrase_fixture(attrs \\ %{}) do
     {:ok, banned_phrase} =
-      attrs
-      |> Enum.into(%{
-        phrase: "some phrase",
-        score_threshold: 42,
-        severity: :low,
-        type: :raw
-      })
+      Map.merge(
+        %{
+          phrase: "some phrase",
+          score_threshold: 42,
+          severity: :low,
+          type: :raw
+        },
+        attrs
+      )
       |> Moderation.create_banned_phrase()
 
     banned_phrase

--- a/test/teiserver/moderation/banned_phrase_test.exs
+++ b/test/teiserver/moderation/banned_phrase_test.exs
@@ -1,0 +1,272 @@
+defmodule Teiserver.ModerationTest do
+  alias Teiserver.Moderation
+  alias Teiserver.Moderation.BannedPhrase
+  alias Teiserver.Moderation.LoadBannedPhrasesTask
+
+  use Teiserver.DataCase, async: true
+
+  import Teiserver.ModerationFixtures
+
+  describe "banned_phrase standard utility functions" do
+    @invalid_attrs %{type: nil, severity: nil, phrase: nil, score_threshold: nil}
+
+    test "list_banned_phrases/0 returns all banned_phrases" do
+      banned_phrase = banned_phrase_fixture()
+      assert Moderation.list_banned_phrases() == [banned_phrase]
+    end
+
+    test "get_banned_phrase!/1 returns the banned_phrase with given id" do
+      banned_phrase = banned_phrase_fixture()
+      assert Moderation.get_banned_phrase!(banned_phrase.id) == banned_phrase
+    end
+
+    test "create_banned_phrase/1 with valid data creates a banned_phrase" do
+      valid_attrs = %{
+        type: "raw",
+        severity: "medium",
+        phrase: "some phrase",
+        score_threshold: 42
+      }
+
+      assert {:ok, %BannedPhrase{} = banned_phrase} = Moderation.create_banned_phrase(valid_attrs)
+      assert banned_phrase.type == :raw
+      assert banned_phrase.severity == :medium
+      assert banned_phrase.phrase == "some phrase"
+      assert banned_phrase.score_threshold == 42
+    end
+
+    test "create_banned_phrase/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Moderation.create_banned_phrase(@invalid_attrs)
+    end
+
+    test "update_banned_phrase/2 with valid data updates the banned_phrase" do
+      banned_phrase = banned_phrase_fixture()
+
+      update_attrs = %{
+        type: "raw",
+        severity: "medium",
+        phrase: "some updated phrase",
+        score_threshold: 43
+      }
+
+      assert {:ok, %BannedPhrase{} = banned_phrase} =
+               Moderation.update_banned_phrase(banned_phrase, update_attrs)
+
+      assert banned_phrase.type == :raw
+      assert banned_phrase.severity == :medium
+      assert banned_phrase.phrase == "some updated phrase"
+      assert banned_phrase.score_threshold == 43
+    end
+
+    test "update_banned_phrase/2 with invalid data returns error changeset" do
+      banned_phrase = banned_phrase_fixture()
+
+      assert {:error, %Ecto.Changeset{}} =
+               Moderation.update_banned_phrase(banned_phrase, @invalid_attrs)
+
+      assert banned_phrase == Moderation.get_banned_phrase!(banned_phrase.id)
+    end
+
+    test "delete_banned_phrase/1 deletes the banned_phrase" do
+      banned_phrase = banned_phrase_fixture()
+      assert {:ok, %BannedPhrase{}} = Moderation.delete_banned_phrase(banned_phrase)
+      assert_raise Ecto.NoResultsError, fn -> Moderation.get_banned_phrase!(banned_phrase.id) end
+    end
+
+    test "change_banned_phrase/1 returns a banned_phrase changeset" do
+      banned_phrase = banned_phrase_fixture()
+      assert %Ecto.Changeset{} = Moderation.change_banned_phrase(banned_phrase)
+    end
+  end
+
+  describe "banned_phrase changeset validation checks" do
+    test "create raw banned phrase" do
+      {:ok, phrase} =
+        Moderation.create_banned_phrase(%{
+          phrase: "abc",
+          type: :raw,
+          severity: :low,
+          score_threshold: 0
+        })
+
+      loaded = BannedPhrase.load_phrase(phrase)
+      assert loaded.loaded_phrase
+    end
+
+    test "create fuzzy banned phrase" do
+      {:ok, phrase} =
+        Moderation.create_banned_phrase(%{
+          phrase: "abc*",
+          type: :fuzzy,
+          severity: :low,
+          score_threshold: 0
+        })
+
+      loaded = BannedPhrase.load_phrase(phrase)
+      assert loaded.loaded_phrase
+    end
+
+    test "fuzzy banned phrase - no wildcard" do
+      {:error, changeset} =
+        Moderation.create_banned_phrase(%{
+          phrase: "abc",
+          type: :fuzzy,
+          severity: :low,
+          score_threshold: 0
+        })
+
+      assert changeset.errors == [
+               {:phrase, {"Fuzzy phrase needs to contain at least one wildcard (*)", []}}
+             ]
+    end
+
+    test "create regex banned phrase" do
+      {:ok, phrase} =
+        Moderation.create_banned_phrase(%{
+          phrase: "[abc]*",
+          type: :regex,
+          severity: :low,
+          score_threshold: 0
+        })
+
+      loaded = BannedPhrase.load_phrase(phrase)
+      assert loaded.loaded_phrase
+    end
+
+    test "regex banned phrase - bad regex" do
+      {:error, changeset} =
+        Moderation.create_banned_phrase(%{
+          phrase: "(abc",
+          type: :regex,
+          severity: :low,
+          score_threshold: 0
+        })
+
+      assert changeset.errors == [{:phrase, {"Invalid regex - missing ), pos: 4", []}}]
+    end
+  end
+
+  describe "test banned_phrase matches" do
+    test "raw" do
+      phrase =
+        banned_phrase_fixture(%{
+          phrase: "abc",
+          type: :raw
+        })
+        |> BannedPhrase.load_phrase()
+
+      refute BannedPhrase.phrase_match?(phrase, "the quick brown fox")
+      refute BannedPhrase.phrase_match?(phrase, "the quick Abc fox")
+      assert BannedPhrase.phrase_match?(phrase, "the quick abc fox")
+    end
+
+    test "fuzzy" do
+      phrase =
+        banned_phrase_fixture(%{
+          phrase: "abc*e",
+          type: :fuzzy
+        })
+        |> BannedPhrase.load_phrase()
+
+      refute BannedPhrase.phrase_match?(phrase, "the quick brown fox")
+      refute BannedPhrase.phrase_match?(phrase, "the quick abcdd fox")
+      assert BannedPhrase.phrase_match?(phrase, "the quick abcde fox")
+      assert BannedPhrase.phrase_match?(phrase, "the quick abcd-de fox")
+    end
+
+    test "regex" do
+      phrase =
+        banned_phrase_fixture(%{
+          phrase: "[abc]{3}",
+          type: :regex
+        })
+        |> BannedPhrase.load_phrase()
+
+      refute BannedPhrase.phrase_match?(phrase, "the quick brown fox")
+      refute BannedPhrase.phrase_match?(phrase, "the quick Abc fox")
+      assert BannedPhrase.phrase_match?(phrase, "the quick abc fox")
+    end
+  end
+
+  describe "load task" do
+    test "task loads messages in correct order" do
+      banned_phrase_fixture(%{
+        phrase: "low severity",
+        severity: :low
+      })
+
+      banned_phrase_fixture(%{
+        phrase: "low severity",
+        severity: :high
+      })
+
+      banned_phrase_fixture(%{
+        phrase: "low severity",
+        severity: :medium
+      })
+
+      LoadBannedPhrasesTask.perform()
+
+      [p1, p2, p3] = Moderation.list_banned_phrases_cache()
+      assert p1.severity == :high
+      assert p2.severity == :medium
+      assert p3.severity == :low
+    end
+  end
+
+  describe "message_severity" do
+    setup do
+      low =
+        banned_phrase_fixture(%{
+          phrase: "low severity",
+          severity: :low,
+          type: :raw
+        })
+        |> BannedPhrase.load_phrase()
+
+      medium =
+        banned_phrase_fixture(%{
+          phrase: "medium severity",
+          severity: :medium,
+          type: :raw
+        })
+        |> BannedPhrase.load_phrase()
+
+      high =
+        banned_phrase_fixture(%{
+          phrase: "high severity",
+          severity: :high,
+          type: :raw
+        })
+        |> BannedPhrase.load_phrase()
+
+      Teiserver.cache_put(:application_metadata_cache, "banned_phrases", [high, medium, low])
+
+      :ok
+    end
+
+    test "low phrase, check all" do
+      assert BannedPhrase.message_severity("low severity", :low) == :low
+    end
+
+    test "low phrase, check high" do
+      assert BannedPhrase.message_severity("low severity", :high) == nil
+    end
+
+    test "medium phrase, check all" do
+      assert BannedPhrase.message_severity("medium severity", :low) == :medium
+    end
+
+    test "medium phrase, check high" do
+      assert BannedPhrase.message_severity("medium severity", :high) == nil
+    end
+
+    test "high phrase, check all" do
+      assert BannedPhrase.message_severity("high severity", :low) == :high
+    end
+
+    test "high phrase, check high" do
+      assert BannedPhrase.message_severity("high severity", :high) == :high
+    end
+  end
+end

--- a/test/teiserver/moderation/banned_phrase_test.exs
+++ b/test/teiserver/moderation/banned_phrase_test.exs
@@ -72,11 +72,6 @@ defmodule Teiserver.ModerationTest do
       assert {:ok, %BannedPhrase{}} = Moderation.delete_banned_phrase(banned_phrase)
       assert_raise Ecto.NoResultsError, fn -> Moderation.get_banned_phrase!(banned_phrase.id) end
     end
-
-    test "change_banned_phrase/1 returns a banned_phrase changeset" do
-      banned_phrase = banned_phrase_fixture()
-      assert %Ecto.Changeset{} = Moderation.change_banned_phrase(banned_phrase)
-    end
   end
 
   describe "banned_phrase changeset validation checks" do
@@ -115,9 +110,7 @@ defmodule Teiserver.ModerationTest do
           score_threshold: 0
         })
 
-      assert changeset.errors == [
-               {:phrase, {"Fuzzy phrase needs to contain at least one wildcard (*)", []}}
-             ]
+      assert Keyword.has_key?(changeset.errors, :phrase)
     end
 
     test "create regex banned phrase" do
@@ -142,7 +135,7 @@ defmodule Teiserver.ModerationTest do
           score_threshold: 0
         })
 
-      assert changeset.errors == [{:phrase, {"Invalid regex - missing ), pos: 4", []}}]
+      assert Keyword.has_key?(changeset.errors, :phrase)
     end
   end
 

--- a/test/teiserver/moderation/moderation_test.exs
+++ b/test/teiserver/moderation/moderation_test.exs
@@ -5,7 +5,6 @@ defmodule Teiserver.ModerationTest do
   alias Teiserver.Moderation.Ban
   alias Teiserver.Moderation.BannedDomain
   alias Teiserver.Moderation.BannedIP
-  alias Teiserver.Moderation.BannedPhrase
   alias Teiserver.Moderation.ModerationTestLib
   alias Teiserver.Moderation.Report
 
@@ -304,78 +303,6 @@ defmodule Teiserver.ModerationTest do
     test "change_banned_ip/1 returns a banned_ip changeset" do
       banned_ip = banned_ip_fixture()
       assert %Ecto.Changeset{} = Moderation.change_banned_ip(banned_ip)
-    end
-  end
-
-  describe "banned_phrases" do
-    @invalid_attrs %{type: nil, severity: nil, phrase: nil, score_threshold: nil}
-
-    test "list_banned_phrases/0 returns all banned_phrases" do
-      banned_phrase = banned_phrase_fixture()
-      assert Moderation.list_banned_phrases() == [banned_phrase]
-    end
-
-    test "get_banned_phrase!/1 returns the banned_phrase with given id" do
-      banned_phrase = banned_phrase_fixture()
-      assert Moderation.get_banned_phrase!(banned_phrase.id) == banned_phrase
-    end
-
-    test "create_banned_phrase/1 with valid data creates a banned_phrase" do
-      valid_attrs = %{
-        type: "raw",
-        severity: "medium",
-        phrase: "some phrase",
-        score_threshold: 42
-      }
-
-      assert {:ok, %BannedPhrase{} = banned_phrase} = Moderation.create_banned_phrase(valid_attrs)
-      assert banned_phrase.type == :raw
-      assert banned_phrase.severity == :medium
-      assert banned_phrase.phrase == "some phrase"
-      assert banned_phrase.score_threshold == 42
-    end
-
-    test "create_banned_phrase/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = Moderation.create_banned_phrase(@invalid_attrs)
-    end
-
-    test "update_banned_phrase/2 with valid data updates the banned_phrase" do
-      banned_phrase = banned_phrase_fixture()
-
-      update_attrs = %{
-        type: "raw",
-        severity: "medium",
-        phrase: "some updated phrase",
-        score_threshold: 43
-      }
-
-      assert {:ok, %BannedPhrase{} = banned_phrase} =
-               Moderation.update_banned_phrase(banned_phrase, update_attrs)
-
-      assert banned_phrase.type == :raw
-      assert banned_phrase.severity == :medium
-      assert banned_phrase.phrase == "some updated phrase"
-      assert banned_phrase.score_threshold == 43
-    end
-
-    test "update_banned_phrase/2 with invalid data returns error changeset" do
-      banned_phrase = banned_phrase_fixture()
-
-      assert {:error, %Ecto.Changeset{}} =
-               Moderation.update_banned_phrase(banned_phrase, @invalid_attrs)
-
-      assert banned_phrase == Moderation.get_banned_phrase!(banned_phrase.id)
-    end
-
-    test "delete_banned_phrase/1 deletes the banned_phrase" do
-      banned_phrase = banned_phrase_fixture()
-      assert {:ok, %BannedPhrase{}} = Moderation.delete_banned_phrase(banned_phrase)
-      assert_raise Ecto.NoResultsError, fn -> Moderation.get_banned_phrase!(banned_phrase.id) end
-    end
-
-    test "change_banned_phrase/1 returns a banned_phrase changeset" do
-      banned_phrase = banned_phrase_fixture()
-      assert %Ecto.Changeset{} = Moderation.change_banned_phrase(banned_phrase)
     end
   end
 end

--- a/test/teiserver_web/live/moderation/banned_phrase_live_test.exs
+++ b/test/teiserver_web/live/moderation/banned_phrase_live_test.exs
@@ -11,7 +11,7 @@ defmodule TeiserverWeb.BannedPhraseLiveTest do
   @update_attrs %{
     type: :fuzzy,
     severity: :medium,
-    phrase: "some updated phrase",
+    phrase: "some updated phrase *",
     score_threshold: 43
   }
   @invalid_attrs %{type: :raw, severity: :low, phrase: nil, score_threshold: nil}


### PR DESCRIPTION
- Adds functionality to start making use of BannedPhrases
- Uses a new style of Query module I would like to start moving towards
- Removes use of BannedPhrases from WordLib
- Adds the option to have a default value when getting something from the Cache
- Fixes a sometimes occurring duplicate component ID error with flashes
- Improves form error message styling

Includes error messages for incorrectly formatted phrases:
<img width="768" height="555" alt="image" src="https://github.com/user-attachments/assets/3f030696-2481-49ef-b2a0-ebea15ae3d05" />

<img width="509" height="267" alt="image" src="https://github.com/user-attachments/assets/a7124396-a154-47ff-b190-268638a9291d" />
