### PR TITLE
Update PhoenixLiveView to 1.1 and improve Hot reloads

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -66,10 +66,15 @@ config :teiserver, Teiserver,
 # Watch static and templates for browser reloading.
 config :teiserver, TeiserverWeb.Endpoint,
   live_reload: [
+    notify: [
+      live_view: [
+        ~r"lib/teiserver_web/(live|live_components|components)/.*(ex|heex)$"
+      ]
+    ],
     patterns: [
       ~r"priv/static/.*(js|css|png|jpeg|jpg|gif|svg)$",
       ~r"priv/gettext/.*(po)$",
-      ~r"lib/teiserver_web/(controllers|live|components|live_components|views|templates)/.*(ex|heex)$"
+      ~r"lib/teiserver_web/(controllers|views|templates)/.*(ex|heex)$"
     ]
   ]
 

--- a/mix.exs
+++ b/mix.exs
@@ -69,7 +69,7 @@ defmodule Teiserver.MixProject do
       {:postgrex, ">= 0.22.2"},
       {:phoenix_html, "~> 4.2"},
       {:phoenix_live_reload, "~> 1.5", only: :dev},
-      {:phoenix_live_view, "~> 1.0"},
+      {:phoenix_live_view, "~> 1.1"},
       {:lazy_html, ">= 0.1.0", only: :test},
       # see https://hexdocs.pm/phoenix_html/changelog.html#v4-0-0-2023-12-19
       {:phoenix_html_helpers, "~> 1.0"},


### PR DESCRIPTION
Updates Phoenix LiveView to 1.1 to solve a JS version mismatch I was experiencing.

At the same time updates the `dev.exs` config to improve the Hot Reload experience and not force reload the entire page, as per [Jakub Skałecki on LinkedIn](https://www.linkedin.com/posts/jskalec_phoenix-liveview-has-one-massive-dx-feature-share-7459520758126473216-glO8/)