### PR TITLE
Fix auth check invalid header

### DIFF
--- a/lib/teiserver/plugs/basic_auth_bot_plug.ex
+++ b/lib/teiserver/plugs/basic_auth_bot_plug.ex
@@ -11,9 +11,9 @@ defmodule Teiserver.Plugs.BasicAuthBotPlug do
   def call(conn, _opts) do
     case get_req_header(conn, "authorization") do
       ["Basic " <> encoded] ->
-        [username, password] = Base.decode64!(encoded) |> String.split(":", parts: 2)
-
-        with %{id: id} <- Account.get_user_by_name(username),
+        with {:ok, decoded} <- Base.decode64(encoded),
+             [username, password] <- String.split(decoded, ":", parts: 2),
+             %{id: id} <- Account.get_user_by_name(username),
              %User{} = db_user <- Account.get_user(id),
              true <- Auth.is_bot?(db_user),
              true <- Account.verify_plain_password(password, db_user.password) do

--- a/lib/teiserver/plugs/basic_auth_bot_plug.ex
+++ b/lib/teiserver/plugs/basic_auth_bot_plug.ex
@@ -9,21 +9,16 @@ defmodule Teiserver.Plugs.BasicAuthBotPlug do
   def init(opts), do: opts
 
   def call(conn, _opts) do
-    case get_req_header(conn, "authorization") do
-      ["Basic " <> encoded] ->
-        with {:ok, decoded} <- Base.decode64(encoded),
-             [username, password] <- String.split(decoded, ":", parts: 2),
-             %{id: id} <- Account.get_user_by_name(username),
-             %User{} = db_user <- Account.get_user(id),
-             true <- Auth.is_bot?(db_user),
-             true <- Account.verify_plain_password(password, db_user.password) do
-          conn
-        else
-          _error -> unauthorized(conn)
-        end
-
-      _other ->
-        unauthorized(conn)
+    with ["Basic " <> encoded] <- get_req_header(conn, "authorization"),
+         {:ok, decoded} <- Base.decode64(encoded),
+         [username, password] <- String.split(decoded, ":", parts: 2),
+         %{id: id} <- Account.get_user_by_name(username),
+         %User{} = db_user <- Account.get_user(id),
+         true <- Auth.is_bot?(db_user),
+         true <- Account.verify_plain_password(password, db_user.password) do
+      conn
+    else
+      _error -> unauthorized(conn)
     end
   end
 

--- a/test/teiserver_web/plugs/basic_auth_bot_plug_test.exs
+++ b/test/teiserver_web/plugs/basic_auth_bot_plug_test.exs
@@ -9,6 +9,27 @@ defmodule TeiserverWeb.BasicAuthBotPlugTest do
     assert resp.status == 401
   end
 
+  test "invalid auth header", %{conn: conn} do
+    conn = put_req_header(conn, "authorization", "Basic this-is-garbage")
+
+    %Plug.Conn{} = resp = BasicAuthBotPlug.call(conn, %{})
+    assert resp.status == 401
+  end
+
+  test "encoded auth header but invalid format", %{conn: conn} do
+    conn = put_req_header(conn, "authorization", Base.encode64("invalidformat"))
+
+    %Plug.Conn{} = resp = BasicAuthBotPlug.call(conn, %{})
+    assert resp.status == 401
+  end
+
+  test "basic auth invalid encoded value", %{conn: conn} do
+    conn = put_req_header(conn, "authorization", "Basic #{Base.encode64("invalidformat")}")
+
+    %Plug.Conn{} = resp = BasicAuthBotPlug.call(conn, %{})
+    assert resp.status == 401
+  end
+
   test "no account", %{conn: conn} do
     conn = put_auth_header(conn, "username", "password")
     %Plug.Conn{} = resp = BasicAuthBotPlug.call(conn, %{})

--- a/test/teiserver_web/plugs/basic_auth_bot_plug_test.exs
+++ b/test/teiserver_web/plugs/basic_auth_bot_plug_test.exs
@@ -1,0 +1,46 @@
+defmodule TeiserverWeb.BasicAuthBotPlugTest do
+  alias Teiserver.Account.Auth
+  alias Teiserver.Plugs.BasicAuthBotPlug
+
+  use TeiserverWeb.ConnCase, async: false
+
+  test "no auth header", %{conn: conn} do
+    %Plug.Conn{} = resp = BasicAuthBotPlug.call(conn, %{})
+    assert resp.status == 401
+  end
+
+  test "no account", %{conn: conn} do
+    conn = put_auth_header(conn, "username", "password")
+    %Plug.Conn{} = resp = BasicAuthBotPlug.call(conn, %{})
+    assert resp.status == 401
+  end
+
+  test "not a bot", %{conn: conn} do
+    user = TeiserverTestLib.new_user()
+    conn = put_auth_header(conn, user.name, "password")
+    %Plug.Conn{} = resp = BasicAuthBotPlug.call(conn, %{})
+    assert resp.status == 401
+  end
+
+  test "invalid password", %{conn: conn} do
+    user = TeiserverTestLib.new_user()
+    Auth.add_roles(user.id, ["Bot"])
+    conn = put_auth_header(conn, user.name, "not the correct password")
+    %Plug.Conn{} = resp = BasicAuthBotPlug.call(conn, %{})
+    assert resp.status == 401
+  end
+
+  test "happy path", %{conn: conn} do
+    user = TeiserverTestLib.new_user()
+    Auth.add_roles(user.id, ["Bot"])
+    conn = put_auth_header(conn, user.name, "password")
+    %Plug.Conn{} = resp = BasicAuthBotPlug.call(conn, %{})
+    assert resp.status != 401
+    refute resp.halted
+  end
+
+  defp put_auth_header(conn, username, password) do
+    encoded = Base.encode64("#{username}:#{password}")
+    put_req_header(conn, "authorization", "Basic #{encoded}")
+  end
+end


### PR DESCRIPTION
fix a few problems where teiserver would return a 500 when it shouldn't:
* malformed auth header
* invalid header format

and added some tests for all that