### PR TITLE
Addressing warnings from Elixir 1.20

### DIFF
--- a/lib/teiserver/account/caches/user_cache_lib.ex
+++ b/lib/teiserver/account/caches/user_cache_lib.ex
@@ -6,7 +6,7 @@ defmodule Teiserver.Account.UserCacheLib do
   alias Teiserver.Account.User
   alias Teiserver.CacheUser
   alias Teiserver.Data.Types, as: T
-  require Logger
+
   import Teiserver.Helper.NumberHelper, only: [int_parse: 1]
 
   @spec get_username(T.userid() | nil) :: String.t() | nil

--- a/lib/teiserver/account/libs/accolade_lib.ex
+++ b/lib/teiserver/account/libs/accolade_lib.ex
@@ -5,8 +5,8 @@ defmodule Teiserver.Account.AccoladeLib do
   alias Teiserver.Account
   alias Teiserver.Account.Accolade
   alias Teiserver.Data.Types, as: T
+
   use TeiserverWeb, :library
-  require Logger
 
   def miss_count_limit, do: 20
 

--- a/lib/teiserver/account/libs/auth_lib.ex
+++ b/lib/teiserver/account/libs/auth_lib.ex
@@ -9,8 +9,6 @@ defmodule Teiserver.Account.AuthLib do
   alias Teiserver.Account
   alias Teiserver.Account.RoleLib
 
-  require Logger
-
   @spec icon :: String.t()
   def icon, do: "fa-solid fa-address-card"
 

--- a/lib/teiserver/account/libs/rating_lib.ex
+++ b/lib/teiserver/account/libs/rating_lib.ex
@@ -8,8 +8,6 @@ defmodule Teiserver.Account.RatingLib do
 
   use TeiserverWeb, :library
 
-  require Logger
-
   # Functions
   @spec icon :: String.t()
   def icon, do: "fa-solid fa-chart-column"

--- a/lib/teiserver/account/libs/user_lib.ex
+++ b/lib/teiserver/account/libs/user_lib.ex
@@ -10,8 +10,8 @@ defmodule Teiserver.Account.UserLib do
   alias Teiserver.Config
   alias Teiserver.Helper.StylingHelper
   alias Teiserver.Logging
+
   use TeiserverWeb, :library_newform
-  require Logger
 
   # Functions
   @spec icon :: String.t()

--- a/lib/teiserver/account/plugs/auth_plug.ex
+++ b/lib/teiserver/account/plugs/auth_plug.ex
@@ -15,8 +15,6 @@ defmodule Teiserver.Account.AuthPlug do
 
   use TeiserverWeb, :verified_routes
 
-  require Logger
-
   import Plug.Conn
 
   def init(_opts) do

--- a/lib/teiserver/account/reports/ban_evasion_report.ex
+++ b/lib/teiserver/account/reports/ban_evasion_report.ex
@@ -2,7 +2,7 @@ defmodule Teiserver.Account.BanEvasionReport do
   @moduledoc false
 
   alias Teiserver.Account
-  require Logger
+
   import Teiserver.Helper.NumberHelper, only: [int_parse: 1]
 
   @spec icon() :: String.t()

--- a/lib/teiserver/account/reports/growth_report.ex
+++ b/lib/teiserver/account/reports/growth_report.ex
@@ -3,8 +3,9 @@ defmodule Teiserver.Account.GrowthReport do
 
   alias Teiserver.Helper.ChartHelper
   alias Teiserver.Logging
-  require Logger
+
   import Teiserver.Helper.NumberHelper, only: [int_parse: 1]
+
   @behaviour Teiserver.Common.WebReportBehaviour
 
   @spec name() :: String.t()

--- a/lib/teiserver/account/reports/new_smurf_report.ex
+++ b/lib/teiserver/account/reports/new_smurf_report.ex
@@ -2,7 +2,7 @@ defmodule Teiserver.Account.NewSmurfReport do
   @moduledoc false
   alias Teiserver.Account
   alias Teiserver.Account.Auth
-  require Logger
+
   import Teiserver.Helper.NumberHelper, only: [int_parse: 1]
 
   @spec icon() :: String.t()

--- a/lib/teiserver/account/reports/time_compare_report.ex
+++ b/lib/teiserver/account/reports/time_compare_report.ex
@@ -36,27 +36,6 @@ defmodule Teiserver.Account.TimeCompareReport do
     })
   end
 
-  defp get_data(_params, {nil, _end_date}) do
-    %{}
-  end
-
-  defp get_data(%{"tabular" => "true"} = params, {start_date, end_date}) do
-    end_date = DateTime.shift(end_date, day: 7)
-    logs = get_logs(params, {start_date, end_date})
-
-    usernames =
-      params
-      |> get_user_ids()
-      |> Map.new(fn userid -> {userid, Account.get_username_by_id(userid)} end)
-
-    stats = get_stats(params, logs)
-
-    %{
-      usernames: usernames,
-      stats: stats
-    }
-  end
-
   defp get_data(params, {start_date, end_date}) do
     logs = get_logs(params, {start_date, end_date})
 
@@ -242,8 +221,7 @@ defmodule Teiserver.Account.TimeCompareReport do
     |> Map.merge(%{
       "the_date" => today,
       "overlap" => "false",
-      "skip_nil" => "false",
-      "tabular" => "false"
+      "skip_nil" => "false"
     })
     |> Map.merge(Map.get(params, "report", %{}))
   end

--- a/lib/teiserver/account/tasks/merge_accounts_task.ex
+++ b/lib/teiserver/account/tasks/merge_accounts_task.ex
@@ -6,8 +6,6 @@ defmodule Teiserver.Account.MergeAccountsTask do
   alias Teiserver.Data.Types, as: T
   alias Teiserver.Repo
 
-  require Logger
-
   @spec perform(T.userid(), T.userid()) :: :no_user | :ok
   def perform(deleting_id, keeping_id) do
     query = "UPDATE teiserver_telemetry_complex_client_events SET user_id = $1 WHERE user_id = $2"

--- a/lib/teiserver/battle.ex
+++ b/lib/teiserver/battle.ex
@@ -129,8 +129,6 @@ defmodule Teiserver.Battle do
     |> Repo.one()
   end
 
-  def get_match(nil), do: nil
-
   def get_match(args) do
     match_query(nil, args)
     |> Repo.one()

--- a/lib/teiserver/battle/balance/brute_force_avoid.ex
+++ b/lib/teiserver/battle/balance/brute_force_avoid.ex
@@ -15,7 +15,6 @@ defmodule Teiserver.Battle.Balance.BruteForceAvoid do
   alias Teiserver.Battle.Balance.BruteForceAvoidTypes, as: BF
   alias Teiserver.Config
   alias Teiserver.Helpers.Combi
-  require Integer
 
   # Parties will be split if team diff is too large. It either uses absolute value or percentage
   # See get_max_team_diff function below for full details

--- a/lib/teiserver/battle/libs/balance_lib.ex
+++ b/lib/teiserver/battle/libs/balance_lib.ex
@@ -8,7 +8,7 @@ defmodule Teiserver.Battle.BalanceLib do
   alias Teiserver.Config
   alias Teiserver.Data.Types, as: T
   alias Teiserver.Game.MatchRatingLib
-  require Logger
+
   import Teiserver.Helper.NumberHelper, only: [int_parse: 1, round: 2]
   # These are default values and can be overridden as part of the call to create_balance()
 

--- a/lib/teiserver/benchmark/user_client.ex
+++ b/lib/teiserver/benchmark/user_client.ex
@@ -6,7 +6,7 @@ defmodule Teiserver.Benchmark.UserClient do
   """
 
   use GenServer
-  require Logger
+
   import Teiserver.Helper.NumberHelper, only: [int_parse: 1]
 
   @statuses ~w(4195330 4195394 4194374)

--- a/lib/teiserver/bridge/chat_commands.ex
+++ b/lib/teiserver/bridge/chat_commands.ex
@@ -7,7 +7,6 @@ defmodule Teiserver.Bridge.ChatCommands do
   alias Teiserver.Communication
   alias Teiserver.Data.Types, as: T
   alias Teiserver.Logging
-  require Logger
 
   @always_allow ~w(whatwas unit define text)
 

--- a/lib/teiserver/bridge/commands/post_command.ex
+++ b/lib/teiserver/bridge/commands/post_command.ex
@@ -8,7 +8,6 @@ defmodule Teiserver.Bridge.Commands.PostCommand do
   alias Teiserver.Config
   alias Teiserver.Moderation
   alias Teiserver.Moderation.ActionLib
-  require Logger
 
   @behaviour Teiserver.Bridge.BridgeCommandBehaviour
 

--- a/lib/teiserver/chat/chat_room_cache.ex
+++ b/lib/teiserver/chat/chat_room_cache.ex
@@ -18,8 +18,6 @@ defmodule Teiserver.Room do
 
   use Plugins
 
-  require Logger
-
   @type room :: Chat.RoomServer.room()
 
   @spec create_room(map()) :: map()

--- a/lib/teiserver/chat/room_server.ex
+++ b/lib/teiserver/chat/room_server.ex
@@ -8,8 +8,6 @@ defmodule Teiserver.Chat.RoomServer do
 
   use GenServer, restart: :temporary
 
-  require Logger
-
   @type room :: %{
           name: String.t(),
           members: MapSet.t(T.userid()),

--- a/lib/teiserver/coordinator.ex
+++ b/lib/teiserver/coordinator.ex
@@ -4,7 +4,6 @@ defmodule Teiserver.Coordinator do
   alias Teiserver.CacheUser
   alias Teiserver.Data.Types, as: T
   alias Teiserver.Throttles
-  require Logger
 
   @spec start_coordinator() ::
           {:error, {:already_started, pid()}} | DynamicSupervisor.on_start_child()

--- a/lib/teiserver/coordinator/coordinator_parser.ex
+++ b/lib/teiserver/coordinator/coordinator_parser.ex
@@ -3,7 +3,6 @@ defmodule Teiserver.Coordinator.Parser do
   alias Teiserver.Battle
   alias Teiserver.Coordinator
   alias Teiserver.Data.Types, as: T
-  require Logger
 
   @passthrough ~w(explain)
 

--- a/lib/teiserver/lobby.ex
+++ b/lib/teiserver/lobby.ex
@@ -171,8 +171,6 @@ defmodule Teiserver.Lobby do
 
   # Used to send the user PID a join battle command
   @spec do_force_add_user_to_lobby(T.client(), T.lobby_id()) :: :ok | nil
-  defp do_force_add_user_to_lobby(nil, _lobby_id), do: nil
-
   defp do_force_add_user_to_lobby(client, lobby_id) do
     Telemetry.log_simple_server_event(client.userid, "lobby.force_add_user_to_lobby")
     remove_user_from_any_lobby(client.userid)
@@ -192,11 +190,11 @@ defmodule Teiserver.Lobby do
     )
 
     # TODO: Depreciate this
-    if client != nil and client.protocol == :spring do
+    if client.protocol == :spring do
       send(client.tcp_pid, {:force_join_battle, lobby_id, script_password})
     end
 
-    if client != nil and client.protocol != :spring do
+    if client.protocol != :spring do
       add_user_to_battle(client.userid, lobby_id)
     end
 

--- a/lib/teiserver/lobby/libs/command_lib.ex
+++ b/lib/teiserver/lobby/libs/command_lib.ex
@@ -5,7 +5,6 @@ defmodule Teiserver.Lobby.CommandLib do
   alias Teiserver.Battle
   alias Teiserver.Data.Types, as: T
   alias Teiserver.Lobby.ChatLib
-  require Logger
 
   @spec handle_command(T.lobby_server_state(), T.userid(), String.t()) :: T.lobby_server_state()
   def handle_command(state, userid, message) do
@@ -47,7 +46,6 @@ defmodule Teiserver.Lobby.CommandLib do
         exports = function_exported?(m, :name, 0) && function_exported?(m, :execute, 2)
 
         # if not exports do
-        #   Logger.error("LobbyCommand #{inspect m} does not export all the required functions")
         # end
 
         exports

--- a/lib/teiserver/lobby/libs/lobby_restrictions.ex
+++ b/lib/teiserver/lobby/libs/lobby_restrictions.ex
@@ -10,8 +10,6 @@ defmodule Teiserver.Lobby.LobbyRestrictions do
   alias Teiserver.Config
   alias Teiserver.Helper.StringHelper
 
-  require Logger
-
   @rank_upper_bound 7
   @rating_upper_bound 1000
   @splitter "------------------------------------------------------"

--- a/lib/teiserver/lobby/servers/lobby_server.ex
+++ b/lib/teiserver/lobby/servers/lobby_server.ex
@@ -11,8 +11,8 @@ defmodule Teiserver.Battle.LobbyServer do
   alias Teiserver.Lobby.CommandLib
   alias Teiserver.Lobby.LobbyRestrictions
   alias Teiserver.Telemetry
+
   use GenServer
-  require Logger
 
   @player_list_cache_age_max 200
 

--- a/lib/teiserver/lobby/servers/lobby_throttle.ex
+++ b/lib/teiserver/lobby/servers/lobby_throttle.ex
@@ -5,8 +5,8 @@ defmodule Teiserver.Battle.LobbyThrottle do
   player_changes lists players that have changed (added, updated or removed!)
   """
   alias Phoenix.PubSub
+
   use GenServer
-  require Logger
 
   @update_interval 500
 

--- a/lib/teiserver/mix_tasks/fake_data.ex
+++ b/lib/teiserver/mix_tasks/fake_data.ex
@@ -23,8 +23,6 @@ defmodule Mix.Tasks.Teiserver.Fakedata do
 
   use Mix.Task
 
-  require Logger
-
   @settings %{
     # days: 365,
     days: 5,

--- a/lib/teiserver/mix_tasks/update_user_permissions.ex
+++ b/lib/teiserver/mix_tasks/update_user_permissions.ex
@@ -11,8 +11,6 @@ defmodule Mix.Tasks.Teiserver.UpdateUserPermissions do
 
   use Mix.Task
 
-  require Logger
-
   def run(_args) do
     Application.ensure_all_started(:teiserver)
     user_ids = get_user_ids()

--- a/lib/teiserver/party.ex
+++ b/lib/teiserver/party.ex
@@ -16,8 +16,6 @@ defmodule Teiserver.Party do
   alias Teiserver.Party.Supervisor
   alias Teiserver.Tachyon.System
 
-  require Logger
-
   @type id :: Server.id()
   @type state :: Server.state()
 

--- a/lib/teiserver/player/login_queue.ex
+++ b/lib/teiserver/player/login_queue.ex
@@ -17,8 +17,6 @@ defmodule Teiserver.Player.LoginQueue do
 
   use GenServer
 
-  require Logger
-
   @limit_config_key "tachyon.Login queue limit"
   @default_tick_period 1_000
 

--- a/lib/teiserver/protocols/spring/spring_auth_in.ex
+++ b/lib/teiserver/protocols/spring/spring_auth_in.ex
@@ -3,8 +3,6 @@ defmodule Teiserver.Protocols.Spring.AuthIn do
 
   alias Teiserver.Protocols.SpringIn
 
-  require Logger
-
   import Teiserver.Protocols.SpringOut, only: [reply: 5]
 
   @spec do_handle(String.t(), String.t(), String.t() | nil, map()) :: map()

--- a/lib/teiserver/protocols/spring/spring_out.ex
+++ b/lib/teiserver/protocols/spring/spring_out.ex
@@ -798,7 +798,7 @@ defmodule Teiserver.Protocols.SpringOut do
     Logger.metadata(request_id: "SpringTcpServer##{user.id}")
 
     exempt_from_cmd_throttle =
-      Auth.admin?(user) or Auth.moderator?(user) or Auth.is_bot?(user) == true
+      Auth.admin?(user.id) or Auth.moderator?(user.id) or Auth.is_bot?(user.id) == true
 
     %{
       state

--- a/lib/teiserver/protocols/spring/spring_system_in.ex
+++ b/lib/teiserver/protocols/spring/spring_system_in.ex
@@ -2,7 +2,6 @@ defmodule Teiserver.Protocols.Spring.SystemIn do
   @moduledoc false
 
   alias Teiserver.Protocols.SpringIn
-  require Logger
 
   @spec do_handle(String.t(), String.t(), String.t() | nil, map()) :: map()
   # def do_handle("command", _, _msg_id, state) do

--- a/lib/teiserver/protocols/spring/spring_user_in.ex
+++ b/lib/teiserver/protocols/spring/spring_user_in.ex
@@ -4,7 +4,7 @@ defmodule Teiserver.Protocols.Spring.UserIn do
   alias Teiserver.Account
   alias Teiserver.Account.FriendRequestLib
   alias Teiserver.Protocols.SpringIn
-  require Logger
+
   import Teiserver.Protocols.SpringOut, only: [reply: 5]
   import Teiserver.Helper.NumberHelper, only: [int_parse: 1]
 

--- a/lib/teiserver/servers/telemetry_server.ex
+++ b/lib/teiserver/servers/telemetry_server.ex
@@ -4,8 +4,8 @@ defmodule Teiserver.Telemetry.TelemetryServer do
   alias Teiserver.Account.LoginThrottleServer
   alias Teiserver.Client
   alias Teiserver.Lobby
+
   use GenServer
-  require Logger
 
   @client_states ~w(lobby menu player spectator total)a
   @tick_period 9_000

--- a/lib/teiserver/tachyon/schema.ex
+++ b/lib/teiserver/tachyon/schema.ex
@@ -3,7 +3,6 @@ defmodule Teiserver.Tachyon.Schema do
   utilities to parse tachyon schemas
   """
   alias Teiserver.Helpers.CacheHelper
-  require Logger
 
   @type command_id :: String.t()
   @type message_id :: String.t()

--- a/lib/teiserver_web/live/account/party/index.ex
+++ b/lib/teiserver_web/live/account/party/index.ex
@@ -2,8 +2,8 @@ defmodule TeiserverWeb.Account.PartyLive.Index do
   alias Phoenix.PubSub
   alias Teiserver.Account
   alias Teiserver.Account.PartyLib
+
   use TeiserverWeb, :live_view
-  require Logger
 
   @impl Phoenix.LiveView
   def mount(params, session, socket) do

--- a/lib/teiserver_web/live/account/party/show.ex
+++ b/lib/teiserver_web/live/account/party/show.ex
@@ -3,8 +3,9 @@ defmodule TeiserverWeb.Account.PartyLive.Show do
   alias Teiserver.Account
   alias Teiserver.Account.PartyLib
   alias Teiserver.Battle
+
   use TeiserverWeb, :live_view
-  require Logger
+
   import Teiserver.Helper.NumberHelper, only: [int_parse: 1]
   import Teiserver.Helper.StringHelper, only: [possessive: 1]
 

--- a/lib/teiserver_web/live/battles/lobbies/show.ex
+++ b/lib/teiserver_web/live/battles/lobbies/show.ex
@@ -11,8 +11,9 @@ defmodule TeiserverWeb.Battle.LobbyLive.Show do
   alias Teiserver.Lobby
   alias Teiserver.ServerUserPlug
   alias Teiserver.Telemetry
+
   use TeiserverWeb, :live_view
-  require Logger
+
   import Teiserver.Helper.NumberHelper, only: [int_parse: 1]
 
   @extra_menu_content """

--- a/lib/teiserver_web/live/clients/show.ex
+++ b/lib/teiserver_web/live/clients/show.ex
@@ -5,8 +5,9 @@ defmodule TeiserverWeb.ClientLive.Show do
   alias Teiserver.Battle
   alias Teiserver.CacheUser
   alias Teiserver.Client
+
   use TeiserverWeb, :live_view
-  require Logger
+
   import Teiserver.Helper.NumberHelper, only: [int_parse: 1]
 
   @extra_menu_content """

--- a/lib/teiserver_web/templates/report/report/time_compare.html.heex
+++ b/lib/teiserver_web/templates/report/report/time_compare.html.heex
@@ -210,20 +210,6 @@
 
         <div class="old-help-box-large"></div>
 
-        <%= if @params["tabular"] != "true" do %>
-          <div id="chart" class="with-transitions mt-3" style="height: 400px;"></div>
-
-          <div class="row">
-            <div class="col">&nbsp;</div>
-            <div class="col">0 = Offline</div>
-            <div class="col">1 = Menu</div>
-            <div class="col">2 = Lobby</div>
-            <div class="col">3 = Spectator</div>
-            <div class="col">4 = Player</div>
-            <div class="col">&nbsp;</div>
-          </div>
-        <% end %>
-
         <%= if assigns[:stats] do %>
           <table class="table d-inline float-start">
             <thead>

--- a/lib/teiserver_web/views/general/general_view.ex
+++ b/lib/teiserver_web/views/general/general_view.ex
@@ -2,5 +2,5 @@ defmodule TeiserverWeb.General.GeneralView do
   use TeiserverWeb, :view
 
   def view_colour, do: :primary
-  def icon, do: StylingHelper.icon(:primary)
+  def icon, do: "fa-solid fa-robot"
 end

--- a/lib/teiserver_web/views/report/general_view.ex
+++ b/lib/teiserver_web/views/report/general_view.ex
@@ -11,7 +11,7 @@ defmodule TeiserverWeb.Report.GeneralView do
   def view_colour, do: :primary
 
   @spec icon() :: String.t()
-  def icon, do: StylingHelper.icon(:primary)
+  def icon, do: "fa-solid fa-clipboard"
 
   @spec view_colour(String.t()) :: atom
   def view_colour("client_events"), do: ComplexClientEventLib.colour()

--- a/lib/teiserver_web/views/telemetry/general_view.ex
+++ b/lib/teiserver_web/views/telemetry/general_view.ex
@@ -12,7 +12,7 @@ defmodule TeiserverWeb.Telemetry.GeneralView do
   def view_colour, do: :primary
 
   @spec icon() :: String.t()
-  def icon, do: StylingHelper.icon(:primary)
+  def icon, do: "fa-solid fa-binary"
 
   @spec view_colour(String.t()) :: atom
   def view_colour("infologs"), do: InfologLib.colours()

--- a/test/support/fixtures/asset.ex
+++ b/test/support/fixtures/asset.ex
@@ -4,7 +4,6 @@ defmodule Teiserver.AssetFixtures do
   alias Teiserver.Asset.Engine
   alias Teiserver.Asset.Game
   alias Teiserver.Repo
-  require Logger
 
   def create_map(attrs) do
     %Asset.Map{} |> Asset.Map.changeset(attrs) |> Repo.insert!()


### PR DESCRIPTION
Elixir 1.20 brings with it a number of typing system and compile time checks. I have upgraded to Elixir 1.20 locally and addressed some of these without actually upgrading the version in the repo.

This should make the upgrade to 1.20 smoother though it does not address all of them.