### PR TITLE
Oauth authorization fixes

### DIFF
--- a/lib/teiserver_web/controllers/o_auth/authorize_controller.ex
+++ b/lib/teiserver_web/controllers/o_auth/authorize_controller.ex
@@ -11,6 +11,7 @@ defmodule TeiserverWeb.OAuth.AuthorizeController do
   def authorize(conn, %{"client_id" => client_id} = params) do
     with app when app != nil <- OAuth.get_application_by_uid(client_id),
          true <- OAuth.can_create_code?(app),
+         {:ok, _parsed_scopes} <- check_requested_scopes(app.scopes, params["scope"]),
          {:ok, redir_uri} <- OAuth.get_redirect_uri(app, Map.get(conn.params, "redirect_uri")) do
       reject_uri =
         error_redirect_uri(
@@ -38,6 +39,10 @@ defmodule TeiserverWeb.OAuth.AuthorizeController do
         |> render("bad_request.html",
           reason: "Cannot use this application to create auth token"
         )
+
+      {:error, {:invalid_scopes, scopes}} ->
+        scopes = Enum.join(scopes, ", ")
+        bad_request(conn, "Cannot request the following scopes: #{scopes}")
 
       {:error, err} ->
         bad_request(conn, "invalid redirection uri: #{inspect(err)}")
@@ -70,6 +75,8 @@ defmodule TeiserverWeb.OAuth.AuthorizeController do
   end
 
   defp do_generate_code(conn, app, redir_url, params) do
+    checked_scopes = check_requested_scopes(app.scopes, params["scope"])
+
     cond do
       Map.get(params, "response_type") != "code" ->
         error_redirect(conn, redir_url, "unsupported_response_type", "only code is supported")
@@ -77,11 +84,24 @@ defmodule TeiserverWeb.OAuth.AuthorizeController do
       Map.get(params, "code_challenge") == nil ->
         error_redirect(conn, redir_url, "invalid_request", "a code challenge must be provided")
 
+      elem(checked_scopes, 0) == :error ->
+        {:error, {:invalid_scopes, scopes}} = checked_scopes
+        scopes = Enum.join(scopes, ", ")
+
+        error_redirect(
+          conn,
+          redir_url,
+          "invalid_request",
+          "cannot request the following scopes #{scopes}"
+        )
+
       true ->
+        {:ok, scopes} = checked_scopes
+
         code_params = %{
           application: app,
           redirect_uri: URI.to_string(redir_url),
-          scopes: app.scopes,
+          scopes: scopes,
           challenge: Map.get(params, "code_challenge"),
           challenge_method: Map.get(params, "code_challenge_method")
         }
@@ -112,6 +132,7 @@ defmodule TeiserverWeb.OAuth.AuthorizeController do
                   st -> Map.put(query, "state", st)
                 end
               end)
+              |> Map.put(:scope, Enum.join(code.scopes, " "))
               |> URI.encode_query()
 
             conn |> redirect(external: URI.to_string(%{redir_url | query: query}))
@@ -127,6 +148,21 @@ defmodule TeiserverWeb.OAuth.AuthorizeController do
     conn
     |> put_status(400)
     |> render("bad_request.html", reason: reason)
+  end
+
+  defp check_requested_scopes(app_scopes, nil), do: {:ok, app_scopes}
+
+  defp check_requested_scopes(app_scopes, requested_scope_string) do
+    scopes = String.split(requested_scope_string)
+
+    invalid_scopes =
+      scopes
+      |> MapSet.new()
+      |> MapSet.difference(MapSet.new(app_scopes))
+
+    if MapSet.size(invalid_scopes) == 0,
+      do: {:ok, scopes},
+      else: {:error, {:invalid_scopes, invalid_scopes}}
   end
 
   defp error_redirect_uri(conn, %URI{} = redir_url, error, description) do

--- a/lib/teiserver_web/controllers/o_auth/authorize_controller.ex
+++ b/lib/teiserver_web/controllers/o_auth/authorize_controller.ex
@@ -9,41 +9,38 @@ defmodule TeiserverWeb.OAuth.AuthorizeController do
   end
 
   def authorize(conn, %{"client_id" => client_id} = params) do
-    case OAuth.get_application_by_uid(client_id) do
+    with app when app != nil <- OAuth.get_application_by_uid(client_id),
+         true <- OAuth.can_create_code?(app),
+         {:ok, redir_uri} <- OAuth.get_redirect_uri(app, Map.get(conn.params, "redirect_uri")) do
+      reject_uri =
+        error_redirect_uri(
+          conn,
+          redir_uri,
+          "access_denied",
+          "user refused to authorize application"
+        )
+
+      permissions = Enum.map(app.scopes, &OAuth.scope_description/1)
+
+      conn
+      |> render("authorize.html",
+        app_name: app.name,
+        permissions: permissions,
+        params: params,
+        reject_uri: reject_uri
+      )
+    else
       nil ->
         bad_request(conn, "invalid client_id")
 
-      app ->
-        if OAuth.can_create_code?(app) do
-          case OAuth.get_redirect_uri(app, Map.get(conn.params, "redirect_uri")) do
-            {:error, err} ->
-              bad_request(conn, "invalid redirection uri: #{inspect(err)}")
+      false ->
+        conn
+        |> render("bad_request.html",
+          reason: "Cannot use this application to create auth token"
+        )
 
-            {:ok, redir_uri} ->
-              reject_uri =
-                error_redirect_uri(
-                  conn,
-                  redir_uri,
-                  "access_denied",
-                  "user refused to authorize application"
-                )
-
-              permissions = Enum.map(app.scopes, &OAuth.scope_description/1)
-
-              conn
-              |> render("authorize.html",
-                app_name: app.name,
-                permissions: permissions,
-                params: params,
-                reject_uri: reject_uri
-              )
-          end
-        else
-          conn
-          |> render("bad_request.html",
-            reason: "Cannot use this application to create auth token"
-          )
-        end
+      {:error, err} ->
+        bad_request(conn, "invalid redirection uri: #{inspect(err)}")
     end
   end
 
@@ -60,15 +57,15 @@ defmodule TeiserverWeb.OAuth.AuthorizeController do
   end
 
   def generate_code(conn, %{"client_id" => client_id, "redirect_uri" => redirect_uri} = params) do
-    case OAuth.get_application_by_uid(client_id) do
+    with app when app != nil <- OAuth.get_application_by_uid(client_id),
+         {:ok, redir_url} <- OAuth.get_redirect_uri(app, redirect_uri) do
+      do_generate_code(conn, app, redir_url, params)
+    else
       nil ->
         bad_request(conn, "invalid client_id")
 
-      app ->
-        case OAuth.get_redirect_uri(app, redirect_uri) do
-          {:error, _reason} -> bad_request(conn, "invalid redirection url")
-          {:ok, redir_url} -> do_generate_code(conn, app, redir_url, params)
-        end
+      {:error, _reason} ->
+        bad_request(conn, "invalid redirection url")
     end
   end
 

--- a/lib/teiserver_web/controllers/o_auth/authorize_controller.ex
+++ b/lib/teiserver_web/controllers/o_auth/authorize_controller.ex
@@ -13,23 +13,30 @@ defmodule TeiserverWeb.OAuth.AuthorizeController do
          true <- OAuth.can_create_code?(app),
          {:ok, _parsed_scopes} <- check_requested_scopes(app.scopes, params["scope"]),
          {:ok, redir_uri} <- OAuth.get_redirect_uri(app, Map.get(conn.params, "redirect_uri")) do
-      reject_uri =
-        error_redirect_uri(
-          conn,
-          redir_uri,
-          "access_denied",
-          "user refused to authorize application"
+      authorized_apps = OAuth.list_authorized_applications(conn.assigns.current_user.id)
+
+      if Enum.find(authorized_apps, &(&1.id == app.id)) != nil do
+        params = Map.put(params, "response_type", "code")
+        do_generate_code(conn, app, redir_uri, params)
+      else
+        reject_uri =
+          error_redirect_uri(
+            conn,
+            redir_uri,
+            "access_denied",
+            "user refused to authorize application"
+          )
+
+        permissions = Enum.map(app.scopes, &OAuth.scope_description/1)
+
+        conn
+        |> render("authorize.html",
+          app_name: app.name,
+          permissions: permissions,
+          params: params,
+          reject_uri: reject_uri
         )
-
-      permissions = Enum.map(app.scopes, &OAuth.scope_description/1)
-
-      conn
-      |> render("authorize.html",
-        app_name: app.name,
-        permissions: permissions,
-        params: params,
-        reject_uri: reject_uri
-      )
+      end
     else
       nil ->
         bad_request(conn, "invalid client_id")

--- a/lib/teiserver_web/templates/o_auth/authorize/authorize.html.heex
+++ b/lib/teiserver_web/templates/o_auth/authorize/authorize.html.heex
@@ -23,8 +23,8 @@
         </ul>
 
         <% keys_to_copy =
-          ~w(client_id response_type code_challenge code_challenge_method redirect_uri state) %>
-        <form action={~p"/oauth/authorize"} method="post">
+          ~w(client_id response_type code_challenge code_challenge_method redirect_uri state scope) %>
+        <form action={~p"/oauth/authorize"} method="post" id="authorize">
           <input type="hidden" name="_csrf_token" value={get_csrf_token()} />
           <%= for key <- keys_to_copy do %>
             <input type="hidden" name={key} value={@params[key]} />

--- a/test/teiserver_web/controllers/o_auth/authorize_controller_test.exs
+++ b/test/teiserver_web/controllers/o_auth/authorize_controller_test.exs
@@ -18,7 +18,12 @@ defmodule TeiserverWeb.OAuth.AuthorizeControllerTest do
         redirect_uris: ["http://127.0.0.1:6789/oauth/callback"]
       })
 
-    {:ok, Keyword.put(data, :app, app)}
+    data =
+      data
+      |> Keyword.put(:app, app)
+      |> Keyword.put(:owner, data[:user])
+
+    {:ok, data}
   end
 
   describe "authorize" do
@@ -35,6 +40,33 @@ defmodule TeiserverWeb.OAuth.AuthorizeControllerTest do
       query = %{client_id: app.uid, redirect_uri: redir_uri}
       resp = get(conn, ~p"/oauth/authorize?#{query}")
       assert html_response(resp, 200) =~ app.name
+    end
+
+    test "can request scopes", %{conn: conn, owner: owner} do
+      {:ok, app} =
+        OAuth.create_application(%{
+          name: "testing app",
+          uid: "test_app_scopes",
+          owner_id: owner.id,
+          scopes: ["profile", "email", "groups"],
+          redirect_uris: ["http://127.0.0.1:6789/oauth/callback"]
+        })
+
+      redir_uri = "http://127.0.0.1/oauth/callback"
+      query = %{client_id: app.uid, redirect_uri: redir_uri, scope: "profile groups"}
+      resp = get(conn, ~p"/oauth/authorize?#{query}")
+      html_resp = assert html_response(resp, 200)
+      assert html_resp =~ app.name
+      {:ok, parsed} = Floki.parse_document(html_resp)
+      scope_element = Floki.find(parsed, "input[type=hidden][name=scope]")
+      assert Floki.attribute(scope_element, "value") == ["profile groups"]
+    end
+
+    test "must request scopes from the app", %{conn: conn, app: app} do
+      redir_uri = "http://127.0.0.1/oauth/callback"
+      query = %{client_id: app.uid, redirect_uri: redir_uri, scope: "tachyon.lobby profile"}
+      resp = get(conn, ~p"/oauth/authorize?#{query}")
+      assert resp.status == 400
     end
   end
 
@@ -135,6 +167,52 @@ defmodule TeiserverWeb.OAuth.AuthorizeControllerTest do
 
       assert %{"error" => "unsupported_response_type", "state" => "some random state"} =
                URI.decode_query(parsed)
+    end
+
+    test "code scopes based on request not app", %{conn: conn, owner: owner} do
+      {:ok, app} =
+        OAuth.create_application(%{
+          name: "testing app",
+          uid: "test_app_scopes",
+          owner_id: owner.id,
+          scopes: ["profile", "email", "groups"],
+          redirect_uris: ["http://127.0.0.1:6789/oauth/callback"]
+        })
+
+      data = %{
+        client_id: app.uid,
+        response_type: "code",
+        code_challenge: "blah",
+        code_challenge_method: "S256",
+        redirect_uri: hd(app.redirect_uris),
+        state: "some random state",
+        scope: "profile groups"
+      }
+
+      resp = post(conn, ~p"/oauth/authorize", data)
+      assert redired = redirected_to(resp, 302)
+      parsed = URI.parse(redired).query |> URI.decode_query()
+
+      assert parsed["scope"] == "profile groups"
+      {:ok, %OAuth.Code{} = db_code} = OAuth.get_valid_code(parsed["code"])
+      assert Enum.sort(db_code.scopes) == ["groups", "profile"]
+    end
+
+    test "request scopes must be subset of app scopes", %{conn: conn, app: app} do
+      data = %{
+        client_id: app.uid,
+        response_type: "code",
+        code_challenge: "blah",
+        code_challenge_method: "S256",
+        redirect_uri: hd(app.redirect_uris),
+        state: "some random state",
+        scope: "profile"
+      }
+
+      resp = post(conn, ~p"/oauth/authorize", data)
+      assert redired = redirected_to(resp, 302)
+      parsed = URI.parse(redired).query |> URI.decode_query()
+      assert %{"error" => "invalid_request"} = parsed
     end
   end
 end

--- a/test/teiserver_web/controllers/o_auth/authorize_controller_test.exs
+++ b/test/teiserver_web/controllers/o_auth/authorize_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule TeiserverWeb.OAuth.AuthorizeControllerTest do
   alias Teiserver.Helpers.GeneralTestLib
   alias Teiserver.OAuth
+  alias Teiserver.OAuthFixtures
   alias Teiserver.TeiserverTestLib
   use TeiserverWeb.ConnCase
 
@@ -67,6 +68,31 @@ defmodule TeiserverWeb.OAuth.AuthorizeControllerTest do
       query = %{client_id: app.uid, redirect_uri: redir_uri, scope: "tachyon.lobby profile"}
       resp = get(conn, ~p"/oauth/authorize?#{query}")
       assert resp.status == 400
+    end
+
+    test "automatically get code when app already authorized", %{
+      conn: conn,
+      app: app,
+      owner: owner
+    } do
+      # because we consider an app to be authorized when there is at least one code/token
+      # that'll likely change as it's not a great modelling.
+      OAuthFixtures.token_attrs(owner, app) |> OAuthFixtures.create_token()
+
+      redir_uri = "http://127.0.0.1/oauth/callback"
+
+      query = %{
+        client_id: app.uid,
+        redirect_uri: redir_uri,
+        code_challenge: "blah",
+        code_challenge_method: "S256",
+        state: "some random state"
+      }
+
+      resp = get(conn, ~p"/oauth/authorize?#{query}")
+      assert redired = redirected_to(resp, 302)
+      parsed = URI.parse(redired).query |> URI.decode_query()
+      {:ok, %OAuth.Code{}} = OAuth.get_valid_code(parsed["code"])
     end
   end
 


### PR DESCRIPTION
Two fixes there:

* when a user requests an authorization code, they can now specify which scopes they want and that will be honored. Instead of always putting the scopes of the application itself.

* when the application is already authorized, any new request for an authorization code will be automatically granted (when request is valid), skipping the authorization screen.