### PR TITLE
Documented and tested external IP check task

### DIFF
--- a/lib/teiserver/moderation/tasks/external_ip_check_task.ex
+++ b/lib/teiserver/moderation/tasks/external_ip_check_task.ex
@@ -1,35 +1,67 @@
 defmodule Teiserver.Moderation.Tasks.ExternalIPCheckTask do
   @moduledoc """
-  Downloads the IP API data
+  Downloads the IP API data.
+
+  Data is expected to arrive in JSON format with keys in the body
+  for things like "is_proxy". Any missing will just be ignored.
+
+  If the check is not enabled/configured you will receive a list with
+  one atom saying why the check did not take place. This is intended
+  to help with debugging on a production system if the checks
+  are not coming back with valid data.
   """
   alias Req.Response
   alias Teiserver.Config
+  alias Teiserver.Plugins
+
+  use Plugins
 
   require Logger
 
+  @spec query_ip(String.t()) :: [atom()]
   def query_ip(ip) do
+    enabled? = Config.get_site_config_cache("teiserver.External IP check enabled")
+
+    if enabled? do
+      do_query(ip)
+    else
+      [:not_enabled]
+    end
+  end
+
+  defp do_query(ip) do
     key = Config.get_site_config_cache("teiserver.External IP check key")
     endpoint = Config.get_site_config_cache("teiserver.External IP check endpoint")
 
-    case Req.get(endpoint, params: [q: ip, key: key]) do
-      {:ok, %Response{body: body}} ->
-        [
-          {:is_abuser, "teiserver.external_ip_ban_is_abuser"},
-          {:is_bogon, "teiserver.external_ip_ban_is_bogon"},
-          {:is_crawler, "teiserver.external_ip_ban_is_crawler"},
-          {:is_datacenter, "teiserver.external_ip_ban_is_datacenter"},
-          {:is_proxy, "teiserver.external_ip_ban_is_proxy"},
-          {:is_tor, "teiserver.external_ip_ban_is_tor"},
-          {:is_vpn, "teiserver.external_ip_ban_is_vpn"}
-        ]
-        |> Enum.filter(fn {k, v} ->
-          Config.get_site_config_cache(v) and body[to_string(k)]
-        end)
-        |> Enum.map(fn {k, _v} -> k end)
+    if key != "" and endpoint != "" do
+      case Req.get(endpoint, params: [q: ip, key: key]) do
+        {:ok, %Response{body: body}} ->
+          parse_body(body)
 
-      {:error, error} ->
-        Logger.error("Failed to lookup ip #{ip} - #{inspect(error)}")
-        []
+        {:error, error} ->
+          Logger.error("Failed to lookup ip #{ip} - #{inspect(error)}")
+          []
+      end
+    else
+      [:not_configured]
     end
+  end
+
+  @decorate Plugins.plugin(:parse_external_ip_response)
+  @spec parse_body(%{String.t() => any()}) :: [atom()]
+  def parse_body(body) do
+    [
+      {:is_abuser, "teiserver.external_ip_ban_is_abuser"},
+      {:is_bogon, "teiserver.external_ip_ban_is_bogon"},
+      {:is_crawler, "teiserver.external_ip_ban_is_crawler"},
+      {:is_datacenter, "teiserver.external_ip_ban_is_datacenter"},
+      {:is_proxy, "teiserver.external_ip_ban_is_proxy"},
+      {:is_tor, "teiserver.external_ip_ban_is_tor"},
+      {:is_vpn, "teiserver.external_ip_ban_is_vpn"}
+    ]
+    |> Enum.filter(fn {k, v} ->
+      Config.get_site_config_cache(v) and body[to_string(k)] == true
+    end)
+    |> Enum.map(fn {k, _v} -> k end)
   end
 end

--- a/test/teiserver/moderation/tasks/external_ip_check_task_test.exs
+++ b/test/teiserver/moderation/tasks/external_ip_check_task_test.exs
@@ -1,0 +1,80 @@
+defmodule Teiserver.Moderation.Tasks.ExternalIpCheckTaskTest do
+  alias Req.Response
+  alias Teiserver.Config
+  alias Teiserver.Moderation.Tasks.ExternalIPCheckTask
+
+  use Teiserver.DataCase, async: false
+
+  import ExUnit.CaptureLog
+  import Mock
+
+  describe "external IP check query" do
+    setup [:setup_for_mock]
+
+    test "calls when enabled" do
+      with_mock(Req,
+        get: fn "endpoint", [params: [q: q, key: _key]] ->
+          case q do
+            "happy" ->
+              {:ok, %Response{body: %{"is_vpn" => false}}}
+
+            "unhappy" ->
+              {:ok, %Response{body: %{"is_vpn" => true}}}
+
+            "wrong_type" ->
+              {:ok, %Response{body: %{"is_vpn" => 3}}}
+
+            "empty" ->
+              {:ok, %Response{body: %{}}}
+
+            "error" ->
+              {:error, "Some error"}
+          end
+        end
+      ) do
+        assert ExternalIPCheckTask.query_ip("happy") == []
+        assert ExternalIPCheckTask.query_ip("unhappy") == [:is_vpn]
+
+        # When the wrong type we skip the value because we test for
+        # `true` rather than truthy
+        assert ExternalIPCheckTask.query_ip("wrong_type") == []
+        assert ExternalIPCheckTask.query_ip("empty") == []
+
+        # We expect this to generate an error log and return an empty list
+        {result, log} =
+          with_log(fn ->
+            ExternalIPCheckTask.query_ip("error")
+          end)
+
+        assert result == []
+        assert log =~ "[error] Failed to lookup ip error - \"Some error\""
+      end
+    end
+
+    test "does not call when disabled" do
+      Config.update_site_config("teiserver.External IP check enabled", false)
+      assert ExternalIPCheckTask.query_ip("192.0.1.168") == [:not_enabled]
+    end
+
+    test "does not call when key or endpoint are missing" do
+      # Enable the check itself
+      Config.update_site_config("teiserver.External IP check enabled", true)
+
+      # Endpoint but no key
+      Config.delete_site_config("teiserver.External IP check key")
+      Config.update_site_config("teiserver.External IP check endpoint", "123")
+      assert ExternalIPCheckTask.query_ip("192.0.1.168") == [:not_configured]
+
+      # Key but no endpoint
+      Config.update_site_config("teiserver.External IP check endpoint", "123")
+      Config.delete_site_config("teiserver.External IP check key")
+      assert ExternalIPCheckTask.query_ip("192.0.1.168") == [:not_configured]
+    end
+  end
+
+  defp setup_for_mock(_state) do
+    Config.update_site_config("teiserver.External IP check enabled", true)
+    Config.update_site_config("teiserver.External IP check key", "key")
+    Config.update_site_config("teiserver.External IP check endpoint", "endpoint")
+  end
+end


### PR DESCRIPTION
In preparation for making use of the external IP check task I wanted to ensure it was correctly tested as well as allowing for different response formats via the plugin system.