### PR TITLE
Rework ban reasons based on IP address

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -292,6 +292,8 @@ config :teiserver, Teiserver.PromEx,
   ets_flush_interval: 20_000,
   metrics_server: :disabled
 
+config :teiserver, Teiserver.IpCheck, client_module: Teiserver.IpCheck.Api
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -89,6 +89,8 @@ config :teiserver, Teiserver.PromEx,
     annotate_app_lifecycle: true
   ]
 
+config :teiserver, Teiserver.IpCheck, client_module: Teiserver.IpCheck.Stub
+
 try do
   import_config "dev.secret.exs"
 rescue

--- a/config/test.exs
+++ b/config/test.exs
@@ -71,6 +71,8 @@ config :teiserver, Oban,
 
 config :teiserver, Teiserver.PromEx, disabled: true
 
+config :teiserver, Teiserver.IpCheck, client_module: Teiserver.IpCheck.Stub
+
 config :teiserver, Teiserver.Mailer,
   adapter: Bamboo.TestAdapter,
   noreply_address: "noreply@testsite.co.uk",

--- a/lib/teiserver/ip_check.ex
+++ b/lib/teiserver/ip_check.ex
@@ -1,0 +1,12 @@
+defmodule Teiserver.IpCheck do
+  @moduledoc """
+  When you need to get some properties about a given IP
+  """
+  alias Teiserver.IpCheck.IpInfo
+
+  @spec query_ip(ip :: String.t()) :: {:ok, IpInfo.t()} | {:error, term()}
+  def query_ip(ip) do
+    module = Application.get_env(:teiserver, Teiserver.IpCheck)[:client_module]
+    apply(module, :query_ip, [ip])
+  end
+end

--- a/lib/teiserver/ip_check/api.ex
+++ b/lib/teiserver/ip_check/api.ex
@@ -1,0 +1,39 @@
+defmodule Teiserver.IpCheck.Api do
+  @moduledoc """
+  get data about IP address from 3rd party service
+  """
+
+  alias Req.Response
+  alias Teiserver.Config
+  alias Teiserver.IpCheck.IpInfo
+
+  @spec query_ip(ip :: String.t()) :: {:ok, IpInfo.t()} | {:error, term()}
+  def query_ip(ip) do
+    with {:ok, endpoint} <- get_api_endpoint(),
+         {:ok, key} <- get_api_key(),
+         {:ok, %Response{body: body}} <- Req.get(endpoint, params: [q: ip, key: key]) do
+      %IpInfo{
+        abuser?: body["is_abuser"],
+        bogon?: body["is_bogon"],
+        crawler?: body["is_crawler"],
+        datacenter?: body["is_datacenter"],
+        proxy?: body["is_proxy"],
+        tor?: body["is_tor"],
+        vpn?: body["is_vpn"]
+      }
+    end
+  end
+
+  defp get_api_endpoint do
+    endpoint = Config.get_site_config_cache("teiserver.External IP check key")
+
+    if endpoint != nil || endpoint != "",
+      do: {:ok, endpoint},
+      else: {:error, :missing_api_endpoint}
+  end
+
+  defp get_api_key do
+    key = Config.get_site_config_cache("teiserver.External IP check key")
+    if key != nil, do: {:ok, key}, else: {:error, :missing_ipapi_key}
+  end
+end

--- a/lib/teiserver/ip_check/ip_info.ex
+++ b/lib/teiserver/ip_check/ip_info.ex
@@ -1,0 +1,23 @@
+defmodule Teiserver.IpCheck.IpInfo do
+  @moduledoc """
+  Various data about IP, obtained through 3rd party API
+  """
+
+  defstruct abuser?: false,
+            bogon?: false,
+            crawler?: false,
+            datacenter?: false,
+            proxy?: false,
+            tor?: false,
+            vpn?: false
+
+  @type t() :: %__MODULE__{
+          abuser?: boolean(),
+          bogon?: boolean(),
+          crawler?: boolean(),
+          datacenter?: boolean(),
+          proxy?: boolean(),
+          tor?: boolean(),
+          vpn?: boolean()
+        }
+end

--- a/lib/teiserver/ip_check/stub.ex
+++ b/lib/teiserver/ip_check/stub.ex
@@ -1,0 +1,30 @@
+defmodule Teiserver.IpCheck.Stub do
+  @moduledoc """
+  A stub client to return IP info based on hardcoded responses
+  """
+  alias Teiserver.IpCheck.IpInfo
+
+  def query_ip(ip) do
+    cond do
+      ip == abuser_ip() -> {:ok, %IpInfo{abuser?: true}}
+      ip == bogon_ip() -> {:ok, %IpInfo{bogon?: true}}
+      ip == crawler_ip() -> {:ok, %IpInfo{crawler?: true}}
+      ip == datacenter_ip() -> {:ok, %IpInfo{datacenter?: true}}
+      ip == proxy_ip() -> {:ok, %IpInfo{proxy?: true}}
+      ip == tor_ip() -> {:ok, %IpInfo{tor?: true}}
+      ip == vpn_ip() -> {:ok, %IpInfo{vpn?: true}}
+      ip == error_ip() -> {:error, "boom for error ip"}
+      true -> {:ok, %IpInfo{}}
+    end
+  end
+
+  # bunch of methods to yield magic IP that would return the value you want
+  def abuser_ip, do: "142.251.30.1"
+  def bogon_ip, do: "142.251.30.2"
+  def crawler_ip, do: "142.251.30.3"
+  def datacenter_ip, do: "142.251.30.4"
+  def proxy_ip, do: "142.251.30.5"
+  def tor_ip, do: "142.251.30.6"
+  def vpn_ip, do: "142.251.30.7"
+  def error_ip, do: "142.251.30.254"
+end

--- a/lib/teiserver/moderation/tasks/external_ip_check_task.ex
+++ b/lib/teiserver/moderation/tasks/external_ip_check_task.ex
@@ -2,33 +2,34 @@ defmodule Teiserver.Moderation.Tasks.ExternalIPCheckTask do
   @moduledoc """
   Downloads the IP API data
   """
-  alias Req.Response
   alias Teiserver.Config
+  alias Teiserver.IpCheck
+  alias Teiserver.IpCheck.IpInfo
 
   require Logger
 
-  def query_ip(ip) do
-    key = Config.get_site_config_cache("teiserver.External IP check key")
-    endpoint = Config.get_site_config_cache("teiserver.External IP check endpoint")
-
-    case Req.get(endpoint, params: [q: ip, key: key]) do
-      {:ok, %Response{body: body}} ->
+  @spec get_ban_reasons(ip :: String.t()) :: [atom()]
+  def get_ban_reasons(ip) do
+    case IpCheck.query_ip(ip) do
+      {:ok, %IpInfo{} = result} ->
         [
-          {:is_abuser, "teiserver.external_ip_ban_is_abuser"},
-          {:is_bogon, "teiserver.external_ip_ban_is_bogon"},
-          {:is_crawler, "teiserver.external_ip_ban_is_crawler"},
-          {:is_datacenter, "teiserver.external_ip_ban_is_datacenter"},
-          {:is_proxy, "teiserver.external_ip_ban_is_proxy"},
-          {:is_tor, "teiserver.external_ip_ban_is_tor"},
-          {:is_vpn, "teiserver.external_ip_ban_is_vpn"}
+          {:is_abuser, :abuser?, "teiserver.external_ip_ban_is_abuser"},
+          {:is_bogon, :bogon?, "teiserver.external_ip_ban_is_bogon"},
+          {:is_crawler, :crawler?, "teiserver.external_ip_ban_is_crawler"},
+          {:is_datacenter, :datacenter?, "teiserver.external_ip_ban_is_datacenter"},
+          {:is_proxy, :proxy?, "teiserver.external_ip_ban_is_proxy"},
+          {:is_tor, :tor?, "teiserver.external_ip_ban_is_tor"},
+          {:is_vpn, :vpn?, "teiserver.external_ip_ban_is_vpn"}
         ]
-        |> Enum.filter(fn {k, v} ->
-          Config.get_site_config_cache(v) and body[to_string(k)]
+        |> Enum.map(fn {reason, result_key, reason_enabled_key} ->
+          if Config.get_site_config_cache(reason_enabled_key) and Map.get(result, result_key),
+            do: reason,
+            else: nil
         end)
-        |> Enum.map(fn {k, _v} -> k end)
+        |> Enum.reject(&is_nil/1)
 
-      {:error, error} ->
-        Logger.error("Failed to lookup ip #{ip} - #{inspect(error)}")
+      {:error, reason} ->
+        Logger.error("Failed to get ban reasons for ip #{ip} - #{inspect(reason)}")
         []
     end
   end

--- a/test/teiserver/moderation/tasks/external_ip_check_task_test.exs
+++ b/test/teiserver/moderation/tasks/external_ip_check_task_test.exs
@@ -1,0 +1,61 @@
+defmodule Teiserver.Moderation.Tasks.ExternalIpCheckTaskTest do
+  alias ExUnit.Callbacks
+
+  alias Teiserver.Config
+  alias Teiserver.IpCheck.Stub
+  alias Teiserver.Moderation.Tasks.ExternalIPCheckTask
+
+  use Teiserver.DataCase, async: false
+
+  describe "return ban reason when config enabled" do
+    test "abuser" do
+      setup_config("teiserver.external_ip_ban_is_abuser", true)
+      assert ExternalIPCheckTask.get_ban_reasons(Stub.abuser_ip()) == [:is_abuser]
+    end
+
+    test "bogon" do
+      setup_config("teiserver.external_ip_ban_is_bogon", true)
+      assert ExternalIPCheckTask.get_ban_reasons(Stub.bogon_ip()) == [:is_bogon]
+    end
+
+    test "crawler" do
+      setup_config("teiserver.external_ip_ban_is_crawler", true)
+      assert ExternalIPCheckTask.get_ban_reasons(Stub.crawler_ip()) == [:is_crawler]
+    end
+
+    test "datacenter" do
+      setup_config("teiserver.external_ip_ban_is_datacenter", true)
+      assert ExternalIPCheckTask.get_ban_reasons(Stub.datacenter_ip()) == [:is_datacenter]
+    end
+
+    test "proxy" do
+      setup_config("teiserver.external_ip_ban_is_proxy", true)
+      assert ExternalIPCheckTask.get_ban_reasons(Stub.proxy_ip()) == [:is_proxy]
+    end
+
+    test "tor" do
+      setup_config("teiserver.external_ip_ban_is_tor", true)
+      assert ExternalIPCheckTask.get_ban_reasons(Stub.tor_ip()) == [:is_tor]
+    end
+
+    test "vpn" do
+      setup_config("teiserver.external_ip_ban_is_vpn", true)
+      assert ExternalIPCheckTask.get_ban_reasons(Stub.vpn_ip()) == [:is_vpn]
+    end
+  end
+
+  test "ignore result if config disabled" do
+    setup_config("teiserver.external_ip_ban_is_vpn", false)
+    assert ExternalIPCheckTask.get_ban_reasons(Stub.vpn_ip()) == []
+  end
+
+  test "doesn't raise on error" do
+    assert ExternalIPCheckTask.get_ban_reasons(Stub.error_ip()) == []
+  end
+
+  defp setup_config(key, value) do
+    original_value = Config.get_site_config_cache(key)
+    Config.update_site_config(key, value)
+    Callbacks.on_exit(fn -> Config.update_site_config(key, original_value) end)
+  end
+end


### PR DESCRIPTION
* Split the logic about getting info about a given IP address from the moderation related logic.

* Run a stub client in dev and test. This allow the server to run out of the box and still give some useful results locally.

The `IpApi` module isn't tested there. It's probably a good place to use a mock. An alternative would be to have a real http server as stub, but that feels way too much.