### PR TITLE
Structify lobby data

### DIFF
--- a/lib/teiserver/helpers/collections.ex
+++ b/lib/teiserver/helpers/collections.ex
@@ -3,7 +3,7 @@ defmodule Teiserver.Helpers.Collections do
   @doc """
   Helper to recursively transform maps. Useful to parse incoming tachyon data
   into internal structure and vice versa
-  See tests in test/teiserver/tachyon/schema_test.exs for some examples.
+  See tests in Teiserver.Helpers.CollectionsTest for some examples.
   """
   def transform_map(nil, _mapping), do: nil
 
@@ -23,17 +23,30 @@ defmodule Teiserver.Helpers.Collections do
             f.(m, val)
 
           {dest_key, mapping} ->
-            cond do
-              is_function(mapping, 1) -> Map.put(m, dest_key, mapping.(val))
-              is_map(val) -> Map.put(m, dest_key, transform_map(val, mapping))
-              is_list(val) -> Map.put(m, dest_key, Enum.map(val, &transform_map(&1, mapping)))
-              true -> Map.put(m, dest_key, val)
-            end
+            transform_keyval(m, mapping, dest_key, val)
+
+          {dest_key, struct_module, mapping} ->
+            result = transform_keyval(m, mapping, dest_key, val)
+
+            Map.update!(result, dest_key, fn val ->
+              if is_list(val),
+                do: Enum.map(val, &struct(struct_module, &1)),
+                else: struct!(struct_module, val)
+            end)
         end
       else
         m
       end
     end)
+  end
+
+  defp transform_keyval(data, mapping, dest_key, val) do
+    cond do
+      is_function(mapping, 1) -> Map.put(data, dest_key, mapping.(val))
+      is_map(val) -> Map.put(data, dest_key, transform_map(val, mapping))
+      is_list(val) -> Map.put(data, dest_key, Enum.map(val, &transform_map(&1, mapping)))
+      true -> Map.put(data, dest_key, val)
+    end
   end
 
   @doc """

--- a/lib/teiserver/player/session.ex
+++ b/lib/teiserver/player/session.ex
@@ -23,6 +23,7 @@ defmodule Teiserver.Player.Session do
   alias Teiserver.Tachyon
   alias Teiserver.TachyonBattle
   alias Teiserver.TachyonLobby
+  alias Teiserver.TachyonLobby.Types, as: LT
 
   # For now, never restart a session. Until some form of state persistence is
   # implemented it's better to just remove the process completely than
@@ -489,13 +490,13 @@ defmodule Teiserver.Player.Session do
           optional(:tags) => %{String.t() => map()}
         }
   @spec create_lobby(T.userid(), lobby_start_params()) ::
-          {:ok, TachyonLobby.details()} | {:error, reason :: term()}
+          {:ok, LT.Details.t()} | {:error, reason :: term()}
   def create_lobby(user_id, start_params) do
     user_id |> via_tuple() |> GenServer.call({:lobby, {:create, start_params}})
   end
 
   @spec lobby_join(T.userid(), TachyonLobby.id()) ::
-          {:ok, TachyonLobby.details()} | {:error, reason :: term()}
+          {:ok, LT.Details.t()} | {:error, reason :: term()}
   def lobby_join(user_id, lobby_id) do
     user_id |> via_tuple() |> GenServer.call({:lobby, {:join, lobby_id}})
   end
@@ -693,7 +694,7 @@ defmodule Teiserver.Player.Session do
 
   defp rejoin_lobby(state, lobby_id) do
     case TachyonLobby.rejoin(lobby_id, state.user.id) do
-      {:ok, lobby_pid, details} ->
+      {:ok, lobby_pid, %LT.Details{} = details} ->
         state =
           state
           |> Map.update!(:monitors, &MC.monitor(&1, lobby_pid, {:lobby, details.id}))

--- a/lib/teiserver/player/session.ex
+++ b/lib/teiserver/player/session.ex
@@ -20,6 +20,7 @@ defmodule Teiserver.Player.Session do
   alias Teiserver.Party
   alias Teiserver.Player.SessionRegistry
   alias Teiserver.Player.SessionSupervisor
+  alias Teiserver.Player.Types, as: PT
   alias Teiserver.Tachyon
   alias Teiserver.TachyonBattle
   alias Teiserver.TachyonLobby
@@ -481,17 +482,10 @@ defmodule Teiserver.Player.Session do
   @typedoc """
   the same as Lobby.start_params, but without any creator data, these are filled by the session
   """
-  @type lobby_start_params :: %{
-          required(:name) => String.t(),
-          required(:map_name) => String.t(),
-          required(:ally_team_config) => TachyonLobby.ally_team_config(),
-          required(:boss_enabled?) => boolean(),
-          required(:game_options) => %{String.t() => String.t()},
-          optional(:tags) => %{String.t() => map()}
-        }
+  @type lobby_start_params :: PT.LobbyStartParams.t()
   @spec create_lobby(T.userid(), lobby_start_params()) ::
           {:ok, LT.Details.t()} | {:error, reason :: term()}
-  def create_lobby(user_id, start_params) do
+  def create_lobby(user_id, %PT.LobbyStartParams{} = start_params) do
     user_id |> via_tuple() |> GenServer.call({:lobby, {:create, start_params}})
   end
 
@@ -1111,12 +1105,19 @@ defmodule Teiserver.Player.Session do
   def handle_call({:lobby, {:create, _start_params}}, _from, state) when state.lobby != nil,
     do: {:reply, {:error, :already_in_lobby}, state}
 
-  def handle_call({:lobby, {:create, start_params}}, _from, state) do
-    data =
-      Map.merge(start_params, %{
-        creator_data: %{id: state.user.id, name: state.user.name},
-        creator_pid: self()
-      })
+  def handle_call({:lobby, {:create, %PT.LobbyStartParams{} = start_params}}, _from, state) do
+    data = %LT.StartParams{
+      creator_data: %LT.PlayerJoinData{id: state.user.id, name: state.user.name},
+      creator_pid: self(),
+      name: start_params.name,
+      map_name: start_params.map_name,
+      ally_team_config: start_params.ally_team_config,
+      game_version: start_params.game_version,
+      engine_version: start_params.engine_version,
+      boss_enabled?: start_params.boss_enabled? || false,
+      game_options: start_params.game_options,
+      tags: start_params.tags
+    }
 
     case TachyonLobby.create(data) do
       {:ok, pid, details} ->
@@ -1133,7 +1134,9 @@ defmodule Teiserver.Player.Session do
   end
 
   def handle_call({:lobby, {:join, lobby_id}}, _from, state) when state.lobby.id == lobby_id do
-    case TachyonLobby.join(lobby_id, %{id: state.user.id, name: state.user.name}, self()) do
+    join_data = %LT.PlayerJoinData{id: state.user.id, name: state.user.name}
+
+    case TachyonLobby.join(lobby_id, join_data, self()) do
       # no need to setup any monitors or update the state since we're already in the lobby
       {:ok, _pid, details} -> {:reply, {:ok, details}, state}
       {:error, reason} -> {:reply, {:error, reason}, state}
@@ -1144,7 +1147,9 @@ defmodule Teiserver.Player.Session do
     do: {:reply, {:error, :already_in_lobby}, state}
 
   def handle_call({:lobby, {:join, lobby_id}}, _from, state) do
-    case TachyonLobby.join(lobby_id, %{id: state.user.id, name: state.user.name}, self()) do
+    join_data = %LT.PlayerJoinData{id: state.user.id, name: state.user.name}
+
+    case TachyonLobby.join(lobby_id, join_data, self()) do
       {:ok, pid, details} ->
         state =
           state

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -245,7 +245,7 @@ defmodule Teiserver.Player.TachyonHandler do
     {:event, "lobby/left", %{id: lobby_id, reason: reason}, state}
   end
 
-  def handle_info({:lobby_list, {:add_lobby, lobby_id, overview}}, state) do
+  def handle_info({:lobby_list, {:add_lobby, lobby_id, %LT.ListOverview{} = overview}}, state) do
     data = %{lobbies: %{lobby_id => lobby_overview_to_tachyon(lobby_id, overview)}}
     {:event, "lobby/listUpdated", data, state}
   end

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -17,6 +17,7 @@ defmodule Teiserver.Player.TachyonHandler do
   alias Teiserver.Player.Session
   alias Teiserver.Player.SessionRegistry
   alias Teiserver.Player.SessionSupervisor
+  alias Teiserver.Player.Types, as: PT
   alias Teiserver.Tachyon.Handler
   alias Teiserver.Tachyon.Schema
   alias Teiserver.TachyonLobby.Types, as: LT
@@ -716,7 +717,7 @@ defmodule Teiserver.Player.TachyonHandler do
   def handle_command("lobby/create", "request", _msg_id, msg, state) do
     # TODO: the `lobby/update` has very similar logic. There should be a way
     # to combine the parsing
-    create_data = %{
+    create_data = %PT.LobbyStartParams{
       name: msg["data"]["name"],
       map_name: msg["data"]["mapName"],
       ally_team_config:
@@ -1207,7 +1208,7 @@ defmodule Teiserver.Player.TachyonHandler do
     |> Enum.reject(&is_nil/1)
   end
 
-  defp lobby_details_to_tachyon(details) do
+  defp lobby_details_to_tachyon(%LT.Details{} = details) do
     mappings = %{
       id: :id,
       players: {:players, &player_updates_to_tachyon/1},

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -19,6 +19,7 @@ defmodule Teiserver.Player.TachyonHandler do
   alias Teiserver.Player.SessionSupervisor
   alias Teiserver.Tachyon.Handler
   alias Teiserver.Tachyon.Schema
+  alias Teiserver.TachyonLobby.Types, as: LT
 
   require Logger
 
@@ -723,7 +724,7 @@ defmodule Teiserver.Player.TachyonHandler do
           sb = at["startBox"]
           teams = for t <- at["teams"], do: %{max_players: t["maxPlayers"]}
 
-          %{
+          %LT.AllyTeamConfig{
             max_teams: at["maxTeams"],
             start_box: %{
               top: sb["top"],
@@ -887,7 +888,7 @@ defmodule Teiserver.Player.TachyonHandler do
       "name" => :name,
       "mapName" => :map_name,
       "allyTeamConfig" =>
-        {:ally_team_config,
+        {:ally_team_config, LT.AllyTeamConfig,
          %{
            "maxTeams" => :max_teams,
            "startBox" =>

--- a/lib/teiserver/player/types/lobby_start_params.ex
+++ b/lib/teiserver/player/types/lobby_start_params.ex
@@ -1,0 +1,30 @@
+defmodule Teiserver.Player.Types.LobbyStartParams do
+  @moduledoc """
+  the same as TachyonLobby.Types.start_params,
+  but without any creator data, these are filled by the session
+  """
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  @enforce_keys [:name, :map_name, :ally_team_config]
+  defstruct [
+    :name,
+    :map_name,
+    :ally_team_config,
+    game_version: nil,
+    engine_version: nil,
+    boss_enabled?: false,
+    game_options: %{},
+    tags: %{}
+  ]
+
+  @type t() :: %__MODULE__{
+          name: String.t(),
+          map_name: String.t(),
+          ally_team_config: [LT.AllyTeamConfig.t()],
+          game_version: String.t() | nil,
+          engine_version: String.t() | nil,
+          boss_enabled?: boolean(),
+          game_options: %{String.t() => String.t()},
+          tags: %{String.t() => map()}
+        }
+end

--- a/lib/teiserver/tachyon_lobby.ex
+++ b/lib/teiserver/tachyon_lobby.ex
@@ -10,7 +10,7 @@ defmodule Teiserver.TachyonLobby do
   alias Teiserver.TachyonLobby.Types, as: LT
 
   @type id :: LT.Types.id()
-  @type overview :: TachyonLobby.List.overview()
+  @type overview :: LT.ListOverview.t()
   @type team :: LT.Types.team()
   @type ally_team_config :: [LT.AllyTeamConfig.t()]
 

--- a/lib/teiserver/tachyon_lobby.ex
+++ b/lib/teiserver/tachyon_lobby.ex
@@ -9,22 +9,21 @@ defmodule Teiserver.TachyonLobby do
   alias Teiserver.TachyonLobby.Lobby
   alias Teiserver.TachyonLobby.Types, as: LT
 
-  @type id :: Lobby.id()
-  @type details :: Lobby.details()
+  @type id :: LT.Types.id()
   @type overview :: TachyonLobby.List.overview()
   @type team :: LT.Types.team()
   @type ally_team_config :: [LT.AllyTeamConfig.t()]
 
-  @spec list() :: %{Lobby.id() => overview()}
+  @spec list() :: %{id() => overview()}
   defdelegate list(), to: TachyonLobby.List
 
-  @spec subscribe_updates() :: {non_neg_integer(), %{Lobby.id() => overview()}}
+  @spec subscribe_updates() :: {non_neg_integer(), %{id() => overview()}}
   defdelegate subscribe_updates(), to: TachyonLobby.List
   defdelegate unsubscribe_updates(), to: TachyonLobby.List
 
   @type start_params :: Lobby.start_params()
   @spec create(Lobby.start_params()) ::
-          {:ok, pid(), details()}
+          {:ok, pid(), LT.Details.t()}
           | {:error, {:already_started, pid()} | :max_children | term()}
   def create(start_params)
       when not is_map_key(start_params, :game_version) or start_params.game_version == nil do
@@ -47,17 +46,17 @@ defmodule Teiserver.TachyonLobby do
 
   def create(start_params) do
     with {:ok, %{pid: pid, id: id}} <- TachyonLobby.Supervisor.start_lobby(start_params),
-         {:ok, details} <- Lobby.get_details(id) do
+         {:ok, %LT.Details{} = details} <- Lobby.get_details(id) do
       {:ok, pid, details}
     end
   end
 
   @spec rejoin(id(), T.userid()) ::
-          {:ok, lobby_pid :: pid(), details()} | {:error, :invalid_lobby}
+          {:ok, lobby_pid :: pid(), LT.Details.t()} | {:error, :invalid_lobby}
   def rejoin(lobby_id, user_id), do: rejoin(lobby_id, user_id, self())
 
   @spec rejoin(id(), T.userid(), pid()) ::
-          {:ok, lobby_pid :: pid(), details()} | {:error, :invalid_lobby}
+          {:ok, lobby_pid :: pid(), LT.Details.t()} | {:error, :invalid_lobby}
   defdelegate rejoin(lobby_id, user_id, pid), to: Lobby
 
   @type client_status_update_data :: Lobby.client_status_update_data()
@@ -73,7 +72,7 @@ defmodule Teiserver.TachyonLobby do
     TachyonLobby.Supervisor.start_lobby_from_snapshot(id, serialized_state)
   end
 
-  @spec lookup(Lobby.id()) :: pid() | nil
+  @spec lookup(id()) :: pid() | nil
   defdelegate lookup(lobby_id), to: TachyonLobby.Registry
 
   @spec count() :: non_neg_integer()
@@ -81,7 +80,7 @@ defmodule Teiserver.TachyonLobby do
 
   @type player_join_data :: Lobby.player_join_data()
   @spec join(id(), player_join_data(), pid()) ::
-          {:ok, lobby_pid :: pid(), details()} | {:error, reason :: term()}
+          {:ok, lobby_pid :: pid(), LT.Details.t()} | {:error, reason :: term()}
   defdelegate join(lobby_id, join_data, pid \\ self()), to: Lobby
 
   @spec spectate(id(), T.userid()) :: :ok | {:error, :invalid_lobby | :not_in_lobby}
@@ -129,7 +128,7 @@ defmodule Teiserver.TachyonLobby do
   defdelegate leave(lobby_id, user_id), to: Lobby
 
   @spec join_ally_team(id(), T.userid(), allyTeam :: non_neg_integer()) ::
-          {:ok, details()}
+          {:ok, LT.Details.t()}
           | {:error,
              reason :: :invalid_lobby | :not_in_lobby | :invalid_ally_team | :ally_team_full}
   defdelegate join_ally_team(lobby_id, user_id, ally_team), to: Lobby

--- a/lib/teiserver/tachyon_lobby.ex
+++ b/lib/teiserver/tachyon_lobby.ex
@@ -138,7 +138,7 @@ defmodule Teiserver.TachyonLobby do
           :ok | {:error, reason :: :not_in_lobby | :battle_already_started | term()}
   defdelegate start_battle(lobby_id, user_id), to: Lobby
 
-  @type vote_ballot :: Lobby.vote_ballot()
+  @type vote_ballot :: LT.VoteState.vote_ballot()
   @spec vote_submit(id(), T.userid(), {String.t(), vote_ballot()}) ::
           :ok | {:error, :invalid_lobby | :invalid_vote}
   defdelegate vote_submit(lobby_id, user_id, ballot), to: Lobby

--- a/lib/teiserver/tachyon_lobby.ex
+++ b/lib/teiserver/tachyon_lobby.ex
@@ -21,12 +21,12 @@ defmodule Teiserver.TachyonLobby do
   defdelegate subscribe_updates(), to: TachyonLobby.List
   defdelegate unsubscribe_updates(), to: TachyonLobby.List
 
-  @type start_params :: Lobby.start_params()
-  @spec create(Lobby.start_params()) ::
+  @type start_params :: LT.StartParams.t()
+  @spec create(start_params()) ::
           {:ok, pid(), LT.Details.t()}
           | {:error, {:already_started, pid()} | :max_children | term()}
-  def create(start_params)
-      when not is_map_key(start_params, :game_version) or start_params.game_version == nil do
+  def create(%LT.StartParams{} = start_params)
+      when start_params.game_version == nil do
     # This is certainly not what we want to have long term, but for now it makes
     # it easier to change this parameter than having to redeploy
     case Asset.get_default_lobby_game() do
@@ -35,8 +35,8 @@ defmodule Teiserver.TachyonLobby do
     end
   end
 
-  def create(start_params)
-      when not is_map_key(start_params, :engine_version) or start_params.engine_version == nil do
+  def create(%LT.StartParams{} = start_params)
+      when start_params.engine_version == nil do
     # Same as above, it's unlikely we end up with that but it'll do for now
     case Asset.get_default_lobby_engine() do
       nil -> {:error, :no_engine_version_found}
@@ -44,7 +44,7 @@ defmodule Teiserver.TachyonLobby do
     end
   end
 
-  def create(start_params) do
+  def create(%LT.StartParams{} = start_params) do
     with {:ok, %{pid: pid, id: id}} <- TachyonLobby.Supervisor.start_lobby(start_params),
          {:ok, %LT.Details{} = details} <- Lobby.get_details(id) do
       {:ok, pid, details}
@@ -78,7 +78,7 @@ defmodule Teiserver.TachyonLobby do
   @spec count() :: non_neg_integer()
   defdelegate count(), to: TachyonLobby.Registry
 
-  @type player_join_data :: Lobby.player_join_data()
+  @type player_join_data :: LT.PlayerJoinData.t()
   @spec join(id(), player_join_data(), pid()) ::
           {:ok, lobby_pid :: pid(), LT.Details.t()} | {:error, reason :: term()}
   defdelegate join(lobby_id, join_data, pid \\ self()), to: Lobby

--- a/lib/teiserver/tachyon_lobby.ex
+++ b/lib/teiserver/tachyon_lobby.ex
@@ -13,7 +13,7 @@ defmodule Teiserver.TachyonLobby do
   @type details :: Lobby.details()
   @type overview :: TachyonLobby.List.overview()
   @type team :: LT.Types.team()
-  @type ally_team_config :: Lobby.ally_team_config()
+  @type ally_team_config :: [LT.AllyTeamConfig.t()]
 
   @spec list() :: %{Lobby.id() => overview()}
   defdelegate list(), to: TachyonLobby.List

--- a/lib/teiserver/tachyon_lobby.ex
+++ b/lib/teiserver/tachyon_lobby.ex
@@ -7,11 +7,12 @@ defmodule Teiserver.TachyonLobby do
   alias Teiserver.Data.Types, as: T
   alias Teiserver.TachyonLobby
   alias Teiserver.TachyonLobby.Lobby
+  alias Teiserver.TachyonLobby.Types, as: LT
 
   @type id :: Lobby.id()
   @type details :: Lobby.details()
   @type overview :: TachyonLobby.List.overview()
-  @type team :: Lobby.team()
+  @type team :: LT.Types.team()
   @type ally_team_config :: Lobby.ally_team_config()
 
   @spec list() :: %{Lobby.id() => overview()}

--- a/lib/teiserver/tachyon_lobby/list.ex
+++ b/lib/teiserver/tachyon_lobby/list.ex
@@ -15,6 +15,7 @@ defmodule Teiserver.TachyonLobby.List do
   alias Teiserver.Helpers.MonitorCollection, as: MC
   alias Teiserver.Helpers.PubSubHelper
   alias Teiserver.TachyonLobby.Lobby
+  alias Teiserver.TachyonLobby.Types, as: LT
 
   use GenServer
 
@@ -35,15 +36,15 @@ defmodule Teiserver.TachyonLobby.List do
   @typep state :: %{
            monitors: MC.t(),
            counter: non_neg_integer(),
-           lobbies: %{Lobby.id() => overview()},
+           lobbies: %{LT.Types.id() => overview()},
            # the map is a partial overview
-           changes: %{Lobby.id() => map()}
+           changes: %{LT.Types.id() => map()}
          }
 
   @doc """
   New lobby should call this function so that they get listed
   """
-  @spec register_lobby(pid(), Lobby.id(), overview()) :: :ok
+  @spec register_lobby(pid(), LT.Types.id(), overview()) :: :ok
   def register_lobby(lobby_pid, lobby_id, overview) do
     GenServer.cast(__MODULE__, {:register, {lobby_pid, lobby_id, overview}})
   end
@@ -55,7 +56,7 @@ defmodule Teiserver.TachyonLobby.List do
   # would need to measure.
   # one potential optimisation would be to store the list of lobbies in an
   # ets table that can be directly read from other processes
-  @spec list() :: %{Lobby.id() => overview()}
+  @spec list() :: %{LT.Types.id() => overview()}
   def list do
     {_counter, list} = GenServer.call(__MODULE__, :list)
     list
@@ -75,7 +76,7 @@ defmodule Teiserver.TachyonLobby.List do
   in the list call. It should be ignored
   """
   # similar comment regarding potential perf issue sending large messages
-  @spec subscribe_updates() :: {non_neg_integer(), %{Lobby.id() => overview()}}
+  @spec subscribe_updates() :: {non_neg_integer(), %{LT.Types.id() => overview()}}
   def subscribe_updates do
     PubSubHelper.subscribe(@update_topic)
     GenServer.call(__MODULE__, :list)
@@ -87,7 +88,7 @@ defmodule Teiserver.TachyonLobby.List do
     PubSubHelper.unsubscribe(@update_topic)
   end
 
-  @spec update_lobby(Lobby.id(), map()) :: :ok
+  @spec update_lobby(LT.Types.id(), map()) :: :ok
   def update_lobby(lobby_id, changes) do
     GenServer.cast(__MODULE__, {:update, lobby_id, changes})
   end

--- a/lib/teiserver/tachyon_lobby/list.ex
+++ b/lib/teiserver/tachyon_lobby/list.ex
@@ -21,31 +21,11 @@ defmodule Teiserver.TachyonLobby.List do
 
   @update_topic "teiserver_tachyonlobby_list"
 
-  @type overview :: %{
-          name: String.t(),
-          player_count: non_neg_integer(),
-          max_player_count: non_neg_integer(),
-          map_name: String.t(),
-          engine_version: String.t(),
-          game_version: String.t(),
-          boss_enabled?: boolean(),
-          current_battle: nil | %{started_at: DateTime.t()},
-          tags: %{String.t() => map()}
-        }
-
-  @typep state :: %{
-           monitors: MC.t(),
-           counter: non_neg_integer(),
-           lobbies: %{LT.Types.id() => overview()},
-           # the map is a partial overview
-           changes: %{LT.Types.id() => map()}
-         }
-
   @doc """
   New lobby should call this function so that they get listed
   """
-  @spec register_lobby(pid(), LT.Types.id(), overview()) :: :ok
-  def register_lobby(lobby_pid, lobby_id, overview) do
+  @spec register_lobby(pid(), LT.Types.id(), LT.ListOverview.t()) :: :ok
+  def register_lobby(lobby_pid, lobby_id, %LT.ListOverview{} = overview) do
     GenServer.cast(__MODULE__, {:register, {lobby_pid, lobby_id, overview}})
   end
 
@@ -56,7 +36,7 @@ defmodule Teiserver.TachyonLobby.List do
   # would need to measure.
   # one potential optimisation would be to store the list of lobbies in an
   # ets table that can be directly read from other processes
-  @spec list() :: %{LT.Types.id() => overview()}
+  @spec list() :: %{LT.Types.id() => LT.ListOverview.t()}
   def list do
     {_counter, list} = GenServer.call(__MODULE__, :list)
     list
@@ -76,7 +56,7 @@ defmodule Teiserver.TachyonLobby.List do
   in the list call. It should be ignored
   """
   # similar comment regarding potential perf issue sending large messages
-  @spec subscribe_updates() :: {non_neg_integer(), %{LT.Types.id() => overview()}}
+  @spec subscribe_updates() :: {non_neg_integer(), %{LT.Types.id() => LT.ListOverview.t()}}
   def subscribe_updates do
     PubSubHelper.subscribe(@update_topic)
     GenServer.call(__MODULE__, :list)
@@ -99,10 +79,10 @@ defmodule Teiserver.TachyonLobby.List do
   end
 
   @impl GenServer
-  @spec init(term()) :: {:ok, state(), {:continue, term()}}
+  @spec init(term()) :: {:ok, LT.ListState.t(), {:continue, term()}}
   def init(_arg) do
     :timer.send_interval(5_000, :broadcast_updates)
-    state = %{monitors: MC.new(), counter: 0, lobbies: %{}, changes: %{}}
+    state = %LT.ListState{}
     {:ok, state, {:continue, :bootstrap_state}}
   end
 
@@ -112,7 +92,7 @@ defmodule Teiserver.TachyonLobby.List do
   def broadcast_updates, do: Process.whereis(__MODULE__) |> send(:broadcast_updates)
 
   @impl GenServer
-  def handle_continue(:bootstrap_state, state) do
+  def handle_continue(:bootstrap_state, %LT.ListState{} = state) do
     {monitors, lobbies} =
       Teiserver.TachyonLobby.Registry.list_lobbies()
       |> Task.async_stream(
@@ -147,14 +127,17 @@ defmodule Teiserver.TachyonLobby.List do
   end
 
   @impl GenServer
-  def handle_call(:list, _from, state) do
+  def handle_call(:list, _from, %LT.ListState{} = state) do
     {:reply, {state.counter, state.lobbies}, state}
   end
 
   @impl GenServer
-  def handle_cast({:register, {lobby_pid, lobby_id, overview}}, state) do
+  def handle_cast(
+        {:register, {lobby_pid, lobby_id, %LT.ListOverview{} = overview}},
+        %LT.ListState{} = state
+      ) do
     state =
-      put_in(state, [:lobbies, lobby_id], overview)
+      put_in(state, [Access.key!(:lobbies), lobby_id], overview)
       |> Map.update!(:monitors, &MC.monitor(&1, lobby_pid, lobby_id))
       |> Map.update!(:counter, &(&1 + 1))
 
@@ -168,11 +151,13 @@ defmodule Teiserver.TachyonLobby.List do
     {:noreply, state}
   end
 
-  def handle_cast({:update, lobby_id, changes}, state) do
+  def handle_cast({:update, lobby_id, changes}, %LT.ListState{} = state) do
     state =
       state
       |> Map.update!(:counter, &(&1 + 1))
-      |> update_in([:lobbies, lobby_id], fn overview -> Map.merge(overview, changes) end)
+      |> update_in([Access.key!(:lobbies), lobby_id], fn %LT.ListOverview{} = overview ->
+        Map.merge(overview, changes)
+      end)
       |> Map.update!(:changes, fn chs ->
         Map.update(chs, lobby_id, changes, &Map.merge(&1, changes))
       end)
@@ -181,7 +166,7 @@ defmodule Teiserver.TachyonLobby.List do
   end
 
   @impl GenServer
-  def handle_info({:DOWN, ref, :process, _obj, _reason}, state) do
+  def handle_info({:DOWN, ref, :process, _obj, _reason}, %LT.ListState{} = state) do
     lobby_id = MC.get_val(state.monitors, ref)
 
     state =
@@ -199,7 +184,7 @@ defmodule Teiserver.TachyonLobby.List do
     {:noreply, state}
   end
 
-  def handle_info(:broadcast_updates, state) do
+  def handle_info(:broadcast_updates, %LT.ListState{} = state) do
     if state.changes != %{} do
       PubSubHelper.broadcast(@update_topic, %{
         event: :update_lobbies,

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -114,15 +114,11 @@ defmodule Teiserver.TachyonLobby.Lobby do
           ally_team_config: ally_team_config(),
           game_options: %{String.t() => String.t()},
           tags: %{String.t() => map()},
-          players: %{
-            T.userid() => %{
-              team: LT.Types.team(),
-              ready?: boolean(),
-              asset_status: asset_status()
-            }
-          },
+          players: %{T.userid() => LT.PlayerDetails.t()},
           spectators: %{
-            join_queue_position: number() | nil
+            T.userid() => %{
+              join_queue_position: number() | nil
+            }
           },
           bots: %{LT.Bot.id() => LT.Bot.t()},
           current_battle:
@@ -155,18 +151,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
   # represent the ID of a user or a bot slated to play in the game (no spec)
   @typep player_id :: T.userid() | String.t()
 
-  @typep player :: %{
-           id: T.userid(),
-           name: String.t(),
-           # used to generate the start script, and then will be sent to the
-           # player so they can join the battle
-           password: String.t(),
-           pid: pid(),
-           team: LT.Types.team(),
-           ready?: boolean(),
-           asset_status: asset_status()
-         }
-
   @typep spectator :: %{
            id: T.userid(),
            name: String.t(),
@@ -190,7 +174,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
            game_options: %{String.t() => String.t()},
            tags: %{String.t() => map()},
            # used to track the players in the lobby.
-           players: %{player_id() => player() | LT.Bot.t()},
+           players: %{player_id() => LT.Player.t() | LT.Bot.t()},
            spectators: %{T.userid() => spectator()},
            bot_idx_counter: non_neg_integer(),
            current_battle:
@@ -453,37 +437,38 @@ defmodule Teiserver.TachyonLobby.Lobby do
         do: MapSet.new([start_params.creator_data.id]),
         else: MapSet.new()
 
-    state = %{
-      id: id,
-      monitors: monitors,
-      name: start_params.name,
-      map_name: start_params.map_name,
-      game_version: start_params.game_version,
-      engine_version: start_params.engine_version,
-      boss_enabled?: boss_enabled?,
-      bosses: bosses,
-      ally_team_config: start_params.ally_team_config,
-      game_options: Map.get(start_params, :game_options, %{}),
-      tags: Map.get(start_params, :tags, %{}),
-      players: %{
-        start_params.creator_data.id => %{
-          id: start_params.creator_data.id,
-          name: start_params.creator_data.name,
-          password: gen_password(),
-          pid: start_params.creator_pid,
-          team: {0, 0, 0},
-          ready?: false,
-          asset_status: :complete
-        }
-      },
-      spectators: %{},
-      bot_idx_counter: 0,
-      current_battle: nil,
-      ids_to_rejoin: MapSet.new(),
-      vote_idx: 1,
-      current_vote: nil,
-      vote_history: %{}
-    }
+    state =
+      %{
+        id: id,
+        monitors: monitors,
+        name: start_params.name,
+        map_name: start_params.map_name,
+        game_version: start_params.game_version,
+        engine_version: start_params.engine_version,
+        boss_enabled?: boss_enabled?,
+        bosses: bosses,
+        ally_team_config: start_params.ally_team_config,
+        game_options: Map.get(start_params, :game_options, %{}),
+        tags: Map.get(start_params, :tags, %{}),
+        players: %{
+          start_params.creator_data.id => %LT.Player{
+            id: start_params.creator_data.id,
+            name: start_params.creator_data.name,
+            password: gen_password(),
+            pid: start_params.creator_pid,
+            team: {0, 0, 0},
+            ready?: false,
+            asset_status: :complete
+          }
+        },
+        spectators: %{},
+        bot_idx_counter: 0,
+        current_battle: nil,
+        ids_to_rejoin: MapSet.new(),
+        vote_idx: 1,
+        current_vote: nil,
+        vote_history: %{}
+      }
 
     TachyonLobby.List.register_lobby(self(), id, get_overview_from_state(state))
     Logger.info("Lobby created by user #{start_params.creator_data.id}")
@@ -534,9 +519,13 @@ defmodule Teiserver.TachyonLobby.Lobby do
       ids_left = MapSet.delete(data.ids_to_rejoin, user_id)
 
       players =
-        if is_map_key(data.players, user_id),
-          do: put_in(data.players, [user_id, :pid], user_pid),
-          else: data.players
+        if is_map_key(data.players, user_id) do
+          Map.update!(data.players, user_id, fn %LT.Player{} = p ->
+            %{p | pid: user_pid}
+          end)
+        else
+          data.players
+        end
 
       spectators =
         if is_map_key(data.spectators, user_id),
@@ -1157,7 +1146,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
         data
         |> Map.drop([:monitors])
         |> Map.update!(:players, fn ps ->
-          for {k, v} <- ps, into: %{}, do: {k, Map.delete(v, :pid)}
+          for {k, v} <- ps, into: %{}, do: {k, Map.replace(v, :pid, nil)}
         end)
         |> Map.update!(:spectators, fn ps ->
           for {k, v} <- ps, into: %{}, do: {k, Map.delete(v, :pid)}
@@ -1207,8 +1196,15 @@ defmodule Teiserver.TachyonLobby.Lobby do
     {players, bots} = Enum.split_with(state.players, fn {_id, p} -> is_map_key(p, :pid) end)
 
     players =
-      Enum.map(players, fn {p_id, p} ->
-        {p_id, Map.take(p, [:team, :ready?, :asset_status])}
+      Enum.map(players, fn {p_id, %LT.Player{} = p} ->
+        player = %LT.PlayerDetails{
+          id: p.id,
+          team: p.team,
+          ready?: p.ready?,
+          asset_status: p.asset_status
+        }
+
+        {p_id, player}
       end)
       |> Enum.into(%{})
 
@@ -1305,12 +1301,18 @@ defmodule Teiserver.TachyonLobby.Lobby do
     process_event({:update_boss, :remove, s_id}, aggregate)
   end
 
-  defp process_event({:move_spec_to_player, p_id, player_data} = ev, aggregate) do
-    player_data = Map.merge(%{ready?: false, asset_status: :complete}, player_data)
+  defp process_event({:move_spec_to_player, p_id, %{team: team}} = ev, aggregate) do
+    spec_data = aggregate.data.spectators[p_id]
 
-    player =
-      Map.merge(aggregate.data.spectators[p_id], player_data)
-      |> Map.delete(:join_queue_position)
+    player = %LT.Player{
+      id: spec_data.id,
+      name: spec_data.name,
+      password: spec_data.password,
+      pid: spec_data.pid,
+      team: team,
+      ready?: false,
+      asset_status: :complete
+    }
 
     aggregate
     |> update_in([:data, :spectators], &Map.delete(&1, p_id))
@@ -1753,7 +1755,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
   # find an empty slot for a player/bot to play
   # this function isn't too efficient, but it's never going to be run on
   # massive inputs since the engine cannot support more than 254 players anyway
-  @spec find_team(ally_team_config(), %{player_id() => player() | LT.Bot.t()}) ::
+  @spec find_team(ally_team_config(), %{player_id() => LT.Player.t() | LT.Bot.t()}) ::
           LT.Types.team() | nil
   defp find_team(ally_team_config, players) do
     # find the least full ally team

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -43,6 +43,14 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   @type asset_status :: :missing | :downloading | :complete
 
+  # Note[sparse_map_for_update]
+  # do not turn this into a struct!
+  # at time of writing this comment, none of the properties can be removed, but there is
+  # no guarantee that this will stay this way.
+  # There is a semantic difference between %{foo: nil} and %{} (foo is not present).
+  # `foo: nil` means that the property should be removed, but if the key is absent then
+  # nothing changes. If that becomes a struct, then all keys are present by default, and
+  # we lose the ability to tell the difference
   @typedoc """
   sparse map of everything that can be changed for a given bot
   """
@@ -211,6 +219,10 @@ defmodule Teiserver.TachyonLobby.Lobby do
     call_lobby(lobby_id, {:update_bot, update_data})
   end
 
+  # See Note[sparse_map_for_update]
+  @typedoc """
+  sparse map of everything that can be changed for a given bot
+  """
   @type lobby_update_data :: %{
           optional(:name) => String.t(),
           optional(:map_name) => String.t(),

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -41,33 +41,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   @behaviour :gen_statem
 
-  @typedoc """
-  Data required for a player to join a lobby. This allow lobbies to
-  be agnostic of how players are represented in the system
-  """
-  @type player_join_data :: %{
-          id: T.userid(),
-          name: String.t()
-        }
-
-  @typedoc """
-  the parameters required to create a new lobby.
-  It's enough data to generate the initial lobby internal state, which in
-  turn can be used to start a battle
-  """
-  @type start_params :: %{
-          required(:creator_data) => player_join_data(),
-          required(:creator_pid) => pid(),
-          required(:name) => String.t(),
-          required(:map_name) => String.t(),
-          required(:ally_team_config) => [LT.AllyTeamConfig.t()],
-          optional(:game_version) => String.t(),
-          optional(:engine_version) => String.t(),
-          optional(:boss_enabled?) => boolean(),
-          optional(:game_options) => %{String.t() => String.t()},
-          optional(:tags) => %{String.t() => map()}
-        }
-
   @type asset_status :: :missing | :downloading | :complete
 
   @typedoc """
@@ -136,14 +109,15 @@ defmodule Teiserver.TachyonLobby.Lobby do
     }
   end
 
-  @spec start_link({LT.Types.id(), start_params()}) :: GenServer.on_start()
-  def start_link({id, _start_params} = args) do
+  @spec start_link({LT.Types.id(), {:user, LT.StartParams.t()} | {:snapshot, binary()}}) ::
+          GenServer.on_start()
+  def start_link({id, _data} = args) do
     via_tuple(id) |> :gen_statem.start_link(__MODULE__, args, [])
   end
 
-  @spec join(LT.Types.id(), player_join_data(), pid()) ::
+  @spec join(LT.Types.id(), LT.PlayerJoinData.t(), pid()) ::
           {:ok, lobby_pid :: pid(), LT.Details.t()} | {:error, reason :: term()}
-  def join(lobby_id, join_data, pid \\ self()) do
+  def join(lobby_id, %LT.PlayerJoinData{} = join_data, pid \\ self()) do
     call_lobby(lobby_id, {:join, join_data, pid})
   end
 
@@ -309,19 +283,17 @@ defmodule Teiserver.TachyonLobby.Lobby do
   def callback_mode, do: :handle_event_function
 
   @impl :gen_statem
-  @spec init({LT.Types.id(), {:user, start_params()} | {:snapshot, binary()}}) ::
+  @spec init({LT.Types.id(), {:user, LT.StartParams.t()} | {:snapshot, binary()}}) ::
           {:ok, term(), LT.Data.t()}
-  def init({id, {:user, start_params}}) do
+  def init({id, {:user, %LT.StartParams{} = start_params}}) do
     Process.flag(:trap_exit, true)
     Logger.metadata(actor_type: :lobby, actor_id: id)
 
     monitors =
       MC.new() |> MC.monitor(start_params.creator_pid, {:user, start_params.creator_data.id})
 
-    boss_enabled? = Map.get(start_params, :boss_enabled?) || false
-
     bosses =
-      if boss_enabled?,
+      if start_params.boss_enabled?,
         do: MapSet.new([start_params.creator_data.id]),
         else: MapSet.new()
 
@@ -333,11 +305,11 @@ defmodule Teiserver.TachyonLobby.Lobby do
         map_name: start_params.map_name,
         game_version: start_params.game_version,
         engine_version: start_params.engine_version,
-        boss_enabled?: boss_enabled?,
+        boss_enabled?: start_params.boss_enabled?,
         bosses: bosses,
         ally_team_config: start_params.ally_team_config,
-        game_options: Map.get(start_params, :game_options, %{}),
-        tags: Map.get(start_params, :tags, %{}),
+        game_options: start_params.game_options,
+        tags: start_params.tags,
         players: %{
           start_params.creator_data.id => %LT.Player{
             id: start_params.creator_data.id,
@@ -468,7 +440,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   def handle_event(
         {:call, from},
-        {:join, join_data, _pid},
+        {:join, %LT.PlayerJoinData{} = join_data, _pid},
         _state,
         %LT.Data{} = data
       )
@@ -492,7 +464,12 @@ defmodule Teiserver.TachyonLobby.Lobby do
     {:keep_state, data, [{:reply, from, {:error, :lobby_full}}]}
   end
 
-  def handle_event({:call, from}, {:join, join_data, pid}, _state, %LT.Data{} = data) do
+  def handle_event(
+        {:call, from},
+        {:join, %LT.PlayerJoinData{} = join_data, pid},
+        _state,
+        %LT.Data{} = data
+      ) do
     user_id = join_data.id
 
     spec_data = %LT.Spectator{

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -72,20 +72,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   @type asset_status :: :missing | :downloading | :complete
 
-  @type vote_action :: {:change_map, String.t()} | {:appoint_boss, T.userid()} | :start
-  @type vote_ballot :: :yes | :no | :abstain
-  @type vote_state :: %{
-          id: String.t(),
-          action: vote_action,
-          initiator: T.userid(),
-          voters: %{T.userid() => :pending | vote_ballot()},
-          duration_s: non_neg_integer(),
-          until: DateTime.t(),
-          quorum: non_neg_integer(),
-          majority: non_neg_integer()
-        }
-  @type vote_outcome :: :passed | :failed | :cancelled | :timeout
-
   @typedoc """
   The public state of the lobby. Anything that clients need to know about
   when in a lobby should be exposed in the details object
@@ -105,12 +91,12 @@ defmodule Teiserver.TachyonLobby.Lobby do
           spectators: %{T.userid() => LT.SpectatorDetails.t()},
           bots: %{LT.Bot.id() => LT.Bot.t()},
           current_battle: LT.CurrentBattleDetails.t() | nil,
-          current_vote: nil | vote_state(),
+          current_vote: LT.VoteState.t() | nil,
           vote_history: %{
             String.t() => %{
-              vote: vote_state(),
+              vote: LT.VoteState.t(),
               finished_at: DateTime.t(),
-              outcome: vote_outcome()
+              outcome: LT.VoteState.vote_outcome()
             }
           }
         }
@@ -148,12 +134,12 @@ defmodule Teiserver.TachyonLobby.Lobby do
            current_battle: LT.CurrentBattle.t() | nil,
            ids_to_rejoin: MapSet.t(T.userid()),
            vote_idx: integer(),
-           current_vote: nil | vote_state(),
+           current_vote: LT.VoteState.t() | nil,
            vote_history: %{
              String.t() => %{
-               vote: vote_state(),
+               vote: LT.VoteState.t(),
                finished_at: DateTime.t(),
-               outcome: vote_outcome()
+               outcome: LT.VoteState.vote_outcome()
              }
            }
          }
@@ -177,9 +163,9 @@ defmodule Teiserver.TachyonLobby.Lobby do
               new_config :: [LT.AllyTeamConfig.t()]}
            | {:update_game_options, changes :: %{String.t() => String.t() | nil}}
            | {:update_tags, changes :: %{String.t() => map() | nil}}
-           | {:start_vote, vote_state()}
-           | {:cast_vote, T.userid(), vote_ballot()}
-           | {:vote_ended, DateTime.t(), vote_outcome()}
+           | {:start_vote, LT.VoteState.t()}
+           | {:cast_vote, T.userid(), LT.VoteState.vote_ballot()}
+           | {:vote_ended, DateTime.t(), LT.VoteState.vote_outcome()}
            | {:update_boss, :add | :remove, T.userid()}
 
   @spec gen_id() :: id()
@@ -329,7 +315,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
     call_lobby(lobby_id, {:update_properties, user_id, update_data})
   end
 
-  @spec vote_submit(id(), T.userid(), {String.t(), vote_ballot()}) ::
+  @spec vote_submit(id(), T.userid(), {String.t(), LT.VoteState.vote_ballot()}) ::
           :ok | {:error, :invalid_lobby | :invalid_vote}
   def vote_submit(lobby_id, user_id, ballot) do
     call_lobby(lobby_id, {:vote_submit, user_id, ballot})
@@ -1184,9 +1170,14 @@ defmodule Teiserver.TachyonLobby.Lobby do
       |> Enum.into(%{})
 
     vote_history =
-      Enum.map(state.vote_history, fn {id, record} ->
-        {id,
-         %{finished_at: record.finished_at, vote: record.vote.action, outcome: record.outcome}}
+      Enum.map(state.vote_history, fn {id, %LT.VoteRecord{} = record} ->
+        details = %LT.VoteDetails{
+          finished_at: record.finished_at,
+          vote: record.vote.action,
+          outcome: record.outcome
+        }
+
+        {id, details}
       end)
       |> Enum.into(%{})
 
@@ -1219,7 +1210,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
            updates: [event()],
            actions: [event_actions()]
          }
-  @typep event_actions :: {:vote_ended, final_vote :: vote_state(), outcome :: term()}
+  @typep event_actions :: {:vote_ended, final_vote :: LT.VoteState.t(), outcome :: term()}
   @spec process_events([event()], state()) :: aggregate()
   defp process_events(events, state),
     do:
@@ -1450,7 +1441,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
     |> Map.update!(:updates, &[ev | &1])
   end
 
-  defp process_event({:start_vote, vote_state} = ev, aggregate) do
+  defp process_event({:start_vote, %LT.VoteState{} = vote_state} = ev, aggregate) do
     aggregate
     |> put_in([:data, :current_vote], vote_state)
     |> update_in([:data, :vote_idx], &(&1 + 1))
@@ -1463,7 +1454,9 @@ defmodule Teiserver.TachyonLobby.Lobby do
        do: aggregate
 
   defp process_event({:cast_vote, user_id, ballot} = ev, aggregate) do
-    new_aggregate = aggregate |> put_in([:data, :current_vote, :voters, user_id], ballot)
+    new_aggregate =
+      aggregate
+      |> put_in([:data, :current_vote, Access.key!(:voters), user_id], ballot)
 
     case vote_result(new_aggregate.data.current_vote) do
       :undecided ->
@@ -1492,7 +1485,13 @@ defmodule Teiserver.TachyonLobby.Lobby do
   # and it allows us not to worry about storing the tref
   defp process_event({:vote_ended, ts, outcome}, aggregate) do
     vote_ev = {:vote_ended, aggregate.data.current_vote, outcome}
-    vote_record = %{vote: aggregate.data.current_vote, finished_at: ts, outcome: outcome}
+
+    vote_record = %LT.VoteRecord{
+      vote: aggregate.data.current_vote,
+      finished_at: ts,
+      outcome: outcome
+    }
+
     history = Map.put(aggregate.data.vote_history, aggregate.data.current_vote.id, vote_record)
 
     history =
@@ -2051,7 +2050,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
     # in a game
     quorum = (map_size(voters) * 0.501) |> :math.ceil() |> trunc()
 
-    %{
+    %LT.VoteState{
       id: "vote-#{state.vote_idx}",
       action: action,
       initiator: initiator_id,
@@ -2063,8 +2062,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
     }
   end
 
-  @spec vote_result(vote_state()) :: :undecided | {:ended, :passed | :failed}
-  defp vote_result(vote) do
+  @spec vote_result(LT.VoteState.t()) :: :undecided | {:ended, :passed | :failed}
+  defp vote_result(%LT.VoteState{} = vote) do
     votes = for {_user_id, v} <- vote.voters, do: v
 
     cond do

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -35,6 +35,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
   alias Teiserver.Tachyon
   alias Teiserver.TachyonBattle
   alias Teiserver.TachyonLobby
+  # lobby types
+  alias Teiserver.TachyonLobby.Types, as: LT
 
   require Logger
 
@@ -81,17 +83,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
           optional(:tags) => %{String.t() => map()}
         }
 
-  @typedoc """
-  These represent the indices respectively into
-  {ally team index, team index, player index}
-  since we don't really support "archon mode" though, the player index
-  is likely always going to be 0.
-  For example, a player in the first ally team, in the second spot
-  would have: {0, 1, 0}
-  """
-  @type team ::
-          {allyTeam :: non_neg_integer(), team :: non_neg_integer(), player :: non_neg_integer()}
-
   @type asset_status :: :missing | :downloading | :complete
 
   @type vote_action :: {:change_map, String.t()} | {:appoint_boss, T.userid()} | :start
@@ -124,21 +115,16 @@ defmodule Teiserver.TachyonLobby.Lobby do
           game_options: %{String.t() => String.t()},
           tags: %{String.t() => map()},
           players: %{
-            T.userid() => %{team: team(), ready?: boolean(), asset_status: asset_status()}
+            T.userid() => %{
+              team: LT.Types.team(),
+              ready?: boolean(),
+              asset_status: asset_status()
+            }
           },
           spectators: %{
             join_queue_position: number() | nil
           },
-          bots: %{
-            String.t() => %{
-              host_user_id: T.userid(),
-              team: team(),
-              name: String.t(),
-              short_name: String.t() | nil,
-              version: String.t() | nil,
-              options: %{String.t() => String.t()}
-            }
-          },
+          bots: %{LT.Bot.id() => LT.Bot.t()},
           current_battle:
             nil
             | %{
@@ -176,7 +162,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
            # player so they can join the battle
            password: String.t(),
            pid: pid(),
-           team: team(),
+           team: LT.Types.team(),
            ready?: boolean(),
            asset_status: asset_status()
          }
@@ -189,16 +175,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
            password: String.t(),
            pid: pid(),
            join_queue_position: number() | nil
-         }
-
-  @typep bot :: %{
-           id: String.t(),
-           team: team(),
-           host_user_id: T.userid(),
-           short_name: String.t(),
-           name: String.t() | nil,
-           version: String.t() | nil,
-           options: %{String.t() => String.t()}
          }
 
   @typep state :: %{
@@ -214,7 +190,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
            game_options: %{String.t() => String.t()},
            tags: %{String.t() => map()},
            # used to track the players in the lobby.
-           players: %{player_id() => player() | bot()},
+           players: %{player_id() => player() | LT.Bot.t()},
            spectators: %{T.userid() => spectator()},
            bot_idx_counter: non_neg_integer(),
            current_battle:
@@ -240,7 +216,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
   # for updates to broadcast to members
   # for more info on specific events, check how they are handled by `process_event/2`
   @typep event ::
-           {:move_player, player_id(), team()}
+           {:move_player, player_id(), LT.Types.team()}
            | {:add_spectator, spectator()}
            | {:remove_player_from_lobby, player_id()}
            | {:remove_spec_from_lobby, T.userid()}
@@ -823,7 +799,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
     else
       bot_id = "bot-#{data.bot_idx_counter}"
 
-      bot = %{
+      bot = %LT.Bot{
         id: bot_id,
         team: {ally_team, in_team_count, 0},
         host_user_id: user_id,
@@ -1777,7 +1753,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
   # find an empty slot for a player/bot to play
   # this function isn't too efficient, but it's never going to be run on
   # massive inputs since the engine cannot support more than 254 players anyway
-  @spec find_team(ally_team_config(), %{player_id() => player() | bot()}) :: team() | nil
+  @spec find_team(ally_team_config(), %{player_id() => player() | LT.Bot.t()}) ::
+          LT.Types.team() | nil
   defp find_team(ally_team_config, players) do
     # find the least full ally team
     ally_team =
@@ -1985,7 +1962,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
               end
 
             bots =
-              for bot <- bots do
+              for %LT.Bot{} = bot <- bots do
                 %{
                   host_user_id: bot.host_user_id,
                   name: Map.get(bot, :name),

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -115,11 +115,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
           game_options: %{String.t() => String.t()},
           tags: %{String.t() => map()},
           players: %{T.userid() => LT.PlayerDetails.t()},
-          spectators: %{
-            T.userid() => %{
-              join_queue_position: number() | nil
-            }
-          },
+          spectators: %{T.userid() => LT.SpectatorDetails.t()},
           bots: %{LT.Bot.id() => LT.Bot.t()},
           current_battle:
             nil
@@ -151,16 +147,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
   # represent the ID of a user or a bot slated to play in the game (no spec)
   @typep player_id :: T.userid() | String.t()
 
-  @typep spectator :: %{
-           id: T.userid(),
-           name: String.t(),
-           # used to generate the start script, and then will be sent to the
-           # player so they can join the battle
-           password: String.t(),
-           pid: pid(),
-           join_queue_position: number() | nil
-         }
-
   @typep state :: %{
            id: id(),
            monitors: MC.t(),
@@ -175,7 +161,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
            tags: %{String.t() => map()},
            # used to track the players in the lobby.
            players: %{player_id() => LT.Player.t() | LT.Bot.t()},
-           spectators: %{T.userid() => spectator()},
+           spectators: %{T.userid() => LT.Spectator.t()},
            bot_idx_counter: non_neg_integer(),
            current_battle:
              nil
@@ -201,7 +187,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
   # for more info on specific events, check how they are handled by `process_event/2`
   @typep event ::
            {:move_player, player_id(), LT.Types.team()}
-           | {:add_spectator, spectator()}
+           | {:add_spectator, LT.Spectator.t()}
            | {:remove_player_from_lobby, player_id()}
            | {:remove_spec_from_lobby, T.userid()}
            | {:move_spec_to_player, T.userid(), player_data :: map()}
@@ -528,9 +514,13 @@ defmodule Teiserver.TachyonLobby.Lobby do
         end
 
       spectators =
-        if is_map_key(data.spectators, user_id),
-          do: put_in(data.spectators, [user_id, :pid], user_pid),
-          else: data.spectators
+        if is_map_key(data.spectators, user_id) do
+          Map.update!(data.spectators, user_id, fn %LT.Spectator{} = s ->
+            %{s | pid: user_pid}
+          end)
+        else
+          data.spectators
+        end
 
       data =
         %{data | players: players, spectators: spectators, ids_to_rejoin: ids_left}
@@ -583,7 +573,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
   def handle_event({:call, from}, {:join, join_data, pid}, _state, data) do
     user_id = join_data.id
 
-    spec_data = %{
+    spec_data = %LT.Spectator{
       id: user_id,
       name: join_data.name,
       password: gen_password(),
@@ -1149,7 +1139,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
           for {k, v} <- ps, into: %{}, do: {k, Map.replace(v, :pid, nil)}
         end)
         |> Map.update!(:spectators, fn ps ->
-          for {k, v} <- ps, into: %{}, do: {k, Map.delete(v, :pid)}
+          for {k, v} <- ps, into: %{}, do: {k, Map.replace(v, :pid, nil)}
         end)
         |> :erlang.term_to_binary()
 
@@ -1209,8 +1199,9 @@ defmodule Teiserver.TachyonLobby.Lobby do
       |> Enum.into(%{})
 
     spectators =
-      Enum.map(state.spectators, fn {s_id, s} ->
-        {s_id, %{join_queue_position: s.join_queue_position}}
+      Enum.map(state.spectators, fn {s_id, %LT.Spectator{} = s} ->
+        spec = %LT.SpectatorDetails{id: s_id, join_queue_position: s.join_queue_position}
+        {s_id, spec}
       end)
       |> Enum.into(%{})
 
@@ -1321,9 +1312,15 @@ defmodule Teiserver.TachyonLobby.Lobby do
   end
 
   defp process_event({:move_player_to_spec, p_id, spec_data} = ev, aggregate) do
-    spec =
-      Map.merge(aggregate.data.players[p_id], spec_data)
-      |> Map.delete(:team)
+    %LT.Player{} = player = aggregate.data.players[p_id]
+
+    spec = %LT.Spectator{
+      id: player.id,
+      name: player.name,
+      password: player.password,
+      pid: player.pid,
+      join_queue_position: spec_data.join_queue_position
+    }
 
     aggregate
     |> update_in([:data, :players], &Map.delete(&1, p_id))
@@ -1838,7 +1835,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
   # what's the next index to use for join queue spec?
   defp find_spec_queue_pos(spectators) do
     max =
-      Enum.reduce(spectators, nil, fn {_id, s}, max_so_far ->
+      Enum.reduce(spectators, nil, fn {_id, %LT.Spectator{} = s}, max_so_far ->
         cond do
           s.join_queue_position == nil -> max_so_far
           max_so_far == nil -> s.join_queue_position
@@ -1851,7 +1848,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   # which player is next in the join queue?
   defp get_first_player_in_join_queue(spectators) do
-    Enum.reduce(spectators, {nil, nil}, fn {id, s}, {min_so_far, _prev_id} = acc ->
+    Enum.reduce(spectators, {nil, nil}, fn {id, %LT.Spectator{} = s},
+                                           {min_so_far, _prev_id} = acc ->
       cond do
         s.join_queue_position == nil ->
           acc

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -41,8 +41,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   @behaviour :gen_statem
 
-  @type id :: String.t()
-
   @typedoc """
   Data required for a player to join a lobby. This allow lobbies to
   be agnostic of how players are represented in the system
@@ -73,35 +71,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
   @type asset_status :: :missing | :downloading | :complete
 
   @typedoc """
-  The public state of the lobby. Anything that clients need to know about
-  when in a lobby should be exposed in the details object
-  """
-  @type details :: %{
-          id: id(),
-          name: String.t(),
-          map_name: String.t(),
-          game_version: String.t(),
-          engine_version: String.t(),
-          boss_enabled?: boolean(),
-          bosses: MapSet.t(T.userid()),
-          ally_team_config: [LT.AllyTeamConfig.t()],
-          game_options: %{String.t() => String.t()},
-          tags: %{String.t() => map()},
-          players: %{T.userid() => LT.PlayerDetails.t()},
-          spectators: %{T.userid() => LT.SpectatorDetails.t()},
-          bots: %{LT.Bot.id() => LT.Bot.t()},
-          current_battle: LT.CurrentBattleDetails.t() | nil,
-          current_vote: LT.VoteState.t() | nil,
-          vote_history: %{
-            String.t() => %{
-              vote: LT.VoteState.t(),
-              finished_at: DateTime.t(),
-              outcome: LT.VoteState.vote_outcome()
-            }
-          }
-        }
-
-  @typedoc """
   sparse map of everything that can be changed for a given bot
   """
   @type bot_update_data :: %{
@@ -112,45 +81,13 @@ defmodule Teiserver.TachyonLobby.Lobby do
           optional(:options) => %{String.t() => String.t()}
         }
 
-  # represent the ID of a user or a bot slated to play in the game (no spec)
-  @typep player_id :: T.userid() | String.t()
-
-  @typep state :: %{
-           id: id(),
-           monitors: MC.t(),
-           name: String.t(),
-           map_name: String.t(),
-           game_version: String.t(),
-           engine_version: String.t(),
-           boss_enabled?: boolean(),
-           bosses: MapSet.t(T.userid()),
-           ally_team_config: [LT.AllyTeamConfig.t()],
-           game_options: %{String.t() => String.t()},
-           tags: %{String.t() => map()},
-           # used to track the players in the lobby.
-           players: %{player_id() => LT.Player.t() | LT.Bot.t()},
-           spectators: %{T.userid() => LT.Spectator.t()},
-           bot_idx_counter: non_neg_integer(),
-           current_battle: LT.CurrentBattle.t() | nil,
-           ids_to_rejoin: MapSet.t(T.userid()),
-           vote_idx: integer(),
-           current_vote: LT.VoteState.t() | nil,
-           vote_history: %{
-             String.t() => %{
-               vote: LT.VoteState.t(),
-               finished_at: DateTime.t(),
-               outcome: LT.VoteState.vote_outcome()
-             }
-           }
-         }
-
   # the list of internal events used to manipulate the lobby data, but also
   # for updates to broadcast to members
   # for more info on specific events, check how they are handled by `process_event/2`
   @typep event ::
-           {:move_player, player_id(), LT.Types.team()}
+           {:move_player, LT.Types.player_id(), LT.Types.team()}
            | {:add_spectator, LT.Spectator.t()}
-           | {:remove_player_from_lobby, player_id()}
+           | {:remove_player_from_lobby, LT.Types.player_id()}
            | {:remove_spec_from_lobby, T.userid()}
            | {:move_spec_to_player, T.userid(), player_data :: map()}
            | {:move_player_to_spec, T.userid(), spec_data :: map()}
@@ -168,7 +105,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
            | {:vote_ended, DateTime.t(), LT.VoteState.vote_outcome()}
            | {:update_boss, :add | :remove, T.userid()}
 
-  @spec gen_id() :: id()
+  @spec gen_id() :: LT.Types.id()
   def gen_id, do: UUID.uuid4()
 
   @default_call_timeout 5000
@@ -186,7 +123,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
     :exit, {:noproc, _details} -> nil
   end
 
-  @spec get_details(id()) :: {:ok, details()} | {:error, reason :: term()}
+  @spec get_details(LT.Types.id()) :: {:ok, LT.Details.t()} | {:error, reason :: term()}
   def get_details(id) do
     call_lobby(id, :get_details)
   end
@@ -199,18 +136,18 @@ defmodule Teiserver.TachyonLobby.Lobby do
     }
   end
 
-  @spec start_link({id(), start_params()}) :: GenServer.on_start()
+  @spec start_link({LT.Types.id(), start_params()}) :: GenServer.on_start()
   def start_link({id, _start_params} = args) do
     via_tuple(id) |> :gen_statem.start_link(__MODULE__, args, [])
   end
 
-  @spec join(id(), player_join_data(), pid()) ::
-          {:ok, lobby_pid :: pid(), details()} | {:error, reason :: term()}
+  @spec join(LT.Types.id(), player_join_data(), pid()) ::
+          {:ok, lobby_pid :: pid(), LT.Details.t()} | {:error, reason :: term()}
   def join(lobby_id, join_data, pid \\ self()) do
     call_lobby(lobby_id, {:join, join_data, pid})
   end
 
-  @spec leave(id(), T.userid()) :: :ok | {:error, reason :: :lobby_full | term()}
+  @spec leave(LT.Types.id(), T.userid()) :: :ok | {:error, reason :: :lobby_full | term()}
   def leave(lobby_id, user_id) do
     via_tuple(lobby_id) |> :gen_statem.call({:leave, user_id}, @default_call_timeout)
   catch
@@ -219,15 +156,15 @@ defmodule Teiserver.TachyonLobby.Lobby do
     :exit, {:shutdown, _reason} -> :ok
   end
 
-  @spec join_ally_team(id(), T.userid(), allyTeam :: non_neg_integer()) ::
-          {:ok, details()}
+  @spec join_ally_team(LT.Types.id(), T.userid(), allyTeam :: non_neg_integer()) ::
+          {:ok, LT.Details.t()}
           | {:error,
              reason :: :invalid_lobby | :not_in_lobby | :invalid_ally_team | :ally_team_full}
   def join_ally_team(lobby_id, user_id, ally_team) do
     call_lobby(lobby_id, {:join_ally_team, user_id, ally_team})
   end
 
-  @spec spectate(id(), T.userid()) :: :ok | {:error, :invalid_lobby | :not_in_lobby}
+  @spec spectate(LT.Types.id(), T.userid()) :: :ok | {:error, :invalid_lobby | :not_in_lobby}
   def spectate(lobby_id, user_id) do
     call_lobby(lobby_id, {:spectate, user_id})
   end
@@ -235,14 +172,14 @@ defmodule Teiserver.TachyonLobby.Lobby do
   @doc """
   request to be added as a spectator to the battle being played
   """
-  @spec join_battle(id(), T.userid()) ::
+  @spec join_battle(LT.Types.id(), T.userid()) ::
           :ok | {:error, :invalid_lobby | :not_in_lobby | :invalid_battle | term()}
   def join_battle(lobby_id, user_id) do
     call_lobby(lobby_id, {:join_battle, user_id})
   end
 
-  @spec rejoin(id(), T.userid(), pid()) ::
-          {:ok, lobby_pid :: pid(), details()} | {:error, :invalid_lobby}
+  @spec rejoin(LT.Types.id(), T.userid(), pid()) ::
+          {:ok, lobby_pid :: pid(), LT.Details.t()} | {:error, :invalid_lobby}
   def rejoin(lobby_id, user_id, pid) do
     call_lobby(lobby_id, {:rejoin, user_id, pid})
   end
@@ -251,7 +188,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
           optional(:ready?) => boolean(),
           optional(:asset_status) => asset_status()
         }
-  @spec update_client_status(id(), T.userid(), client_status_update_data()) ::
+  @spec update_client_status(LT.Types.id(), T.userid(), client_status_update_data()) ::
           :ok | {:error, :invalid_lobby | :not_in_lobby | :not_a_player}
   def update_client_status(lobby_id, user_id, update_data) do
     call_lobby(lobby_id, {:update_client_status, user_id, update_data})
@@ -262,7 +199,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
   @type add_bot_opts :: [add_bot_opt]
 
   @spec add_bot(
-          id(),
+          LT.Types.id(),
           T.userid(),
           ally_team :: non_neg_integer(),
           short_name :: String.t(),
@@ -288,12 +225,14 @@ defmodule Teiserver.TachyonLobby.Lobby do
     )
   end
 
-  @spec remove_bot(id(), bot_id :: String.t()) :: :ok | {:error, :invalid_bot_id | term()}
+  @spec remove_bot(LT.Types.id(), bot_id :: String.t()) ::
+          :ok | {:error, :invalid_bot_id | term()}
   def remove_bot(lobby_id, bot_id) do
     call_lobby(lobby_id, {:remove_bot, bot_id})
   end
 
-  @spec update_bot(id(), bot_update_data()) :: :ok | {:error, reason :: :invalid_bot_id | term()}
+  @spec update_bot(LT.Types.id(), bot_update_data()) ::
+          :ok | {:error, reason :: :invalid_bot_id | term()}
   def update_bot(lobby_id, update_data) do
     call_lobby(lobby_id, {:update_bot, update_data})
   end
@@ -309,19 +248,19 @@ defmodule Teiserver.TachyonLobby.Lobby do
   @doc """
   Update lobby properties, like ally team config, names and whatnot
   """
-  @spec update_properties(id(), T.userid(), lobby_update_data()) ::
+  @spec update_properties(LT.Types.id(), T.userid(), lobby_update_data()) ::
           :ok | {:error, :invalid_lobby | term()}
   def update_properties(lobby_id, user_id, update_data) do
     call_lobby(lobby_id, {:update_properties, user_id, update_data})
   end
 
-  @spec vote_submit(id(), T.userid(), {String.t(), LT.VoteState.vote_ballot()}) ::
+  @spec vote_submit(LT.Types.id(), T.userid(), {String.t(), LT.VoteState.vote_ballot()}) ::
           :ok | {:error, :invalid_lobby | :invalid_vote}
   def vote_submit(lobby_id, user_id, ballot) do
     call_lobby(lobby_id, {:vote_submit, user_id, ballot})
   end
 
-  @spec send_message(id(), T.userid(), String.t()) ::
+  @spec send_message(LT.Types.id(), T.userid(), String.t()) ::
           :ok | {:error, :invalid_request, reason :: term()}
   def send_message(lobby_id, from_id, msg_content) do
     call_lobby(lobby_id, {:send_message, from_id, msg_content})
@@ -331,29 +270,29 @@ defmodule Teiserver.TachyonLobby.Lobby do
   This should only be used for tests, because there is some gnarly logic in
   generating the start script and it's a bit hard to test end to end
   """
-  @spec get_start_script(id()) :: Autohost.start_script()
+  @spec get_start_script(LT.Types.id()) :: Autohost.start_script()
   def get_start_script(lobby_id) do
     via_tuple(lobby_id) |> :gen_statem.call(:get_start_script, @default_call_timeout)
   end
 
-  @spec join_queue(id(), T.userid()) :: :ok | {:error, :invalid_lobby | :not_in_lobby}
+  @spec join_queue(LT.Types.id(), T.userid()) :: :ok | {:error, :invalid_lobby | :not_in_lobby}
   def join_queue(lobby_id, user_id) do
     call_lobby(lobby_id, {:join_queue, user_id})
   end
 
-  @spec appoint_boss(id(), T.userid(), appointee_id :: T.userid()) ::
+  @spec appoint_boss(LT.Types.id(), T.userid(), appointee_id :: T.userid()) ::
           :ok | {:error, :invalid_lobby | :not_in_lobby | :no_boss_allowed | :not_a_boss}
   def appoint_boss(lobby_id, user_id, appointee_id) do
     call_lobby(lobby_id, {:appoint_boss, user_id, appointee_id})
   end
 
-  @spec unboss(id(), T.userid(), boss_id :: T.userid()) ::
+  @spec unboss(LT.Types.id(), T.userid(), boss_id :: T.userid()) ::
           :ok | {:error, :invalid_lobby | :not_in_lobby | :no_boss_allowed | :not_a_boss}
   def unboss(lobby_id, user_id, boss_id) do
     call_lobby(lobby_id, {:unboss, user_id, boss_id})
   end
 
-  @spec start_battle(id(), T.userid()) ::
+  @spec start_battle(LT.Types.id(), T.userid()) ::
           :ok | {:error, reason :: :not_in_lobby | :battle_already_started | term()}
   def start_battle(lobby_id, user_id) do
     call_lobby(lobby_id, {:start_battle, user_id})
@@ -370,7 +309,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
   def callback_mode, do: :handle_event_function
 
   @impl :gen_statem
-  @spec init({id(), {:user, start_params()} | {:snapshot, binary()}}) :: {:ok, term(), state()}
+  @spec init({LT.Types.id(), {:user, start_params()} | {:snapshot, binary()}}) ::
+          {:ok, term(), LT.Data.t()}
   def init({id, {:user, start_params}}) do
     Process.flag(:trap_exit, true)
     Logger.metadata(actor_type: :lobby, actor_id: id)
@@ -386,7 +326,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
         else: MapSet.new()
 
     state =
-      %{
+      %LT.Data{
         id: id,
         monitors: monitors,
         name: start_params.name,
@@ -450,19 +390,29 @@ defmodule Teiserver.TachyonLobby.Lobby do
   end
 
   @impl :gen_statem
-  def handle_event({:call, from}, :get_details, _state, data) do
+  def handle_event({:call, from}, :get_details, _state, %LT.Data{} = data) do
     {:keep_state, data, [{:reply, from, {:ok, get_details_from_state(data)}}]}
   end
 
-  def handle_event({:call, from}, :get_overview, _state, data) do
+  def handle_event({:call, from}, :get_overview, _state, %LT.Data{} = data) do
     {:keep_state, data, [{:reply, from, get_overview_from_state(data)}]}
   end
 
-  def handle_event({:call, from}, {:rejoin, _user_id, _user_pid}, state, data)
+  def handle_event(
+        {:call, from},
+        {:rejoin, _user_id, _user_pid},
+        state,
+        %LT.Data{} = data
+      )
       when state != :starting_up,
       do: {:keep_state, data, [{:reply, from, {:error, :invalid_lobby}}]}
 
-  def handle_event({:call, from}, {:rejoin, user_id, user_pid}, :starting_up, data) do
+  def handle_event(
+        {:call, from},
+        {:rejoin, user_id, user_pid},
+        :starting_up,
+        %LT.Data{} = data
+      ) do
     if MapSet.member?(data.ids_to_rejoin, user_id) do
       ids_left = MapSet.delete(data.ids_to_rejoin, user_id)
 
@@ -508,15 +458,20 @@ defmodule Teiserver.TachyonLobby.Lobby do
     end
   end
 
-  def handle_event({:call, _from}, _request, :starting_up, data) do
+  def handle_event({:call, _from}, _request, :starting_up, %LT.Data{} = data) do
     {:keep_state, data, [{:postpone, true}]}
   end
 
-  def handle_event({:call, from}, _request, :shutting_down, data) do
+  def handle_event({:call, from}, _request, :shutting_down, %LT.Data{} = data) do
     {:keep_state, data, [{:reply, from, {:error, :shutting_down}}]}
   end
 
-  def handle_event({:call, from}, {:join, join_data, _pid}, _state, data)
+  def handle_event(
+        {:call, from},
+        {:join, join_data, _pid},
+        _state,
+        %LT.Data{} = data
+      )
       when is_map_key(data.players, join_data.id) or is_map_key(data.spectators, join_data.id) do
     {:keep_state, data, [{:reply, from, {:ok, self(), get_details_from_state(data)}}]}
   end
@@ -527,12 +482,17 @@ defmodule Teiserver.TachyonLobby.Lobby do
   # lobby members, but it would be rather awkward to only have a subset
   # then in the battle. It's overall simpler to also limit the lobby size
   # (though the members of the lobby may not be the one in the battle itself)
-  def handle_event({:call, from}, {:join, _join_data, _pid}, _state, data)
+  def handle_event(
+        {:call, from},
+        {:join, _join_data, _pid},
+        _state,
+        %LT.Data{} = data
+      )
       when map_size(data.spectators) + map_size(data.players) >= 251 do
     {:keep_state, data, [{:reply, from, {:error, :lobby_full}}]}
   end
 
-  def handle_event({:call, from}, {:join, join_data, pid}, _state, data) do
+  def handle_event({:call, from}, {:join, join_data, pid}, _state, %LT.Data{} = data) do
     user_id = join_data.id
 
     spec_data = %LT.Spectator{
@@ -548,7 +508,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
     {:keep_state, data, [{:reply, from, {:ok, self(), get_details_from_state(data)}}]}
   end
 
-  def handle_event({:call, from}, {:leave, user_id}, _state, data)
+  def handle_event({:call, from}, {:leave, user_id}, _state, %LT.Data{} = data)
       when is_map_key(data.players, user_id) do
     case remove_player_from_lobby(user_id, data) do
       data when map_size(data.players) > 0 or map_size(data.spectators) > 0 ->
@@ -559,7 +519,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
     end
   end
 
-  def handle_event({:call, from}, {:leave, user_id}, _state, data)
+  def handle_event({:call, from}, {:leave, user_id}, _state, %LT.Data{} = data)
       when is_map_key(data.spectators, user_id) do
     data = remove_spectator_from_lobby(user_id, data)
 
@@ -570,22 +530,42 @@ defmodule Teiserver.TachyonLobby.Lobby do
     end
   end
 
-  def handle_event({:call, from}, {:leave, _user_id}, _state, data),
+  def handle_event({:call, from}, {:leave, _user_id}, _state, %LT.Data{} = data),
     do: {:keep_state, data, [{:reply, from, {:error, :not_in_lobby}}]}
 
-  def handle_event({:call, from}, {:join_ally_team, user_id, _ally_team}, _state, data)
+  def handle_event(
+        {:call, from},
+        {:join_ally_team, user_id, _ally_team},
+        _state,
+        %LT.Data{} = data
+      )
       when not is_map_key(data.players, user_id) and not is_map_key(data.spectators, user_id),
       do: {:keep_state, data, [{:reply, from, {:error, :not_in_lobby}}]}
 
-  def handle_event({:call, from}, {:join_ally_team, user_id, _ally_team}, _state, data)
+  def handle_event(
+        {:call, from},
+        {:join_ally_team, user_id, _ally_team},
+        _state,
+        %LT.Data{} = data
+      )
       when not is_map_key(data.players, user_id) and not is_map_key(data.spectators, user_id),
       do: {:keep_state, data, [{:reply, from, {:error, :not_in_lobby}}]}
 
-  def handle_event({:call, from}, {:join_ally_team, _user_id, ally_team}, _state, data)
+  def handle_event(
+        {:call, from},
+        {:join_ally_team, _user_id, ally_team},
+        _state,
+        %LT.Data{} = data
+      )
       when ally_team >= length(data.ally_team_config) or ally_team < 0,
       do: {:keep_state, data, [{:reply, from, {:error, :invalid_ally_team}}]}
 
-  def handle_event({:call, from}, {:join_ally_team, user_id, ally_team}, _state, data) do
+  def handle_event(
+        {:call, from},
+        {:join_ally_team, user_id, ally_team},
+        _state,
+        %LT.Data{} = data
+      ) do
     ally_team_capacity = Enum.at(data.ally_team_config, ally_team).max_teams
 
     in_team_count = team_count(ally_team, data.players)
@@ -629,11 +609,11 @@ defmodule Teiserver.TachyonLobby.Lobby do
     end
   end
 
-  def handle_event({:call, from}, {:spectate, user_id}, _state, data)
+  def handle_event({:call, from}, {:spectate, user_id}, _state, %LT.Data{} = data)
       when not is_map_key(data.players, user_id) and not is_map_key(data.spectators, user_id),
       do: {:keep_state, data, [{:reply, from, {:error, :not_in_lobby}}]}
 
-  def handle_event({:call, from}, {:spectate, user_id}, _state, data)
+  def handle_event({:call, from}, {:spectate, user_id}, _state, %LT.Data{} = data)
       when is_map_key(data.spectators, user_id) do
     if data.spectators[user_id].join_queue_position == nil do
       {:keep_state, data, [{:reply, from, :ok}]}
@@ -645,7 +625,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
     end
   end
 
-  def handle_event({:call, from}, {:spectate, user_id}, _state, data)
+  def handle_event({:call, from}, {:spectate, user_id}, _state, %LT.Data{} = data)
       when is_map_key(data.players, user_id) do
     events = [
       {:move_player_to_spec, user_id, %{join_queue_position: nil}},
@@ -659,15 +639,15 @@ defmodule Teiserver.TachyonLobby.Lobby do
     {:keep_state, aggregate.data, [{:reply, from, :ok}]}
   end
 
-  def handle_event({:call, from}, {:join_battle, user_id}, _state, data)
+  def handle_event({:call, from}, {:join_battle, user_id}, _state, %LT.Data{} = data)
       when not is_map_key(data.players, user_id) and not is_map_key(data.spectators, user_id),
       do: {:keep_state, data, [{:reply, from, {:error, :not_in_lobby}}]}
 
-  def handle_event({:call, from}, {:join_battle, _user_id}, _state, data)
+  def handle_event({:call, from}, {:join_battle, _user_id}, _state, %LT.Data{} = data)
       when is_nil(data.current_battle),
       do: {:keep_state, data, [{:reply, from, {:error, :invalid_battle}}]}
 
-  def handle_event({:call, from}, {:join_battle, user_id}, _state, data) do
+  def handle_event({:call, from}, {:join_battle, user_id}, _state, %LT.Data{} = data) do
     %{name: name, password: password} =
       get_in(data.spectators[user_id]) || get_in(data.players[user_id])
 
@@ -704,32 +684,47 @@ defmodule Teiserver.TachyonLobby.Lobby do
     end
   end
 
-  def handle_event({:call, from}, {:update_client_status, user_id, _update_data}, _state, data)
+  def handle_event(
+        {:call, from},
+        {:update_client_status, user_id, _update_data},
+        _state,
+        %LT.Data{} = data
+      )
       when not is_map_key(data.players, user_id) and not is_map_key(data.spectators, user_id),
       do: {:keep_state, data, [{:reply, from, {:error, :not_in_lobby}}]}
 
   # maybe we'll want to keep track of client status when they move from player
   # to spec, but for now, just reject the request for non players.
-  def handle_event({:call, from}, {:update_client_status, user_id, _update_data}, _state, data)
+  def handle_event(
+        {:call, from},
+        {:update_client_status, user_id, _update_data},
+        _state,
+        %LT.Data{} = data
+      )
       when is_map_key(data.spectators, user_id),
       do: {:keep_state, data, [{:reply, from, {:error, :not_a_player}}]}
 
-  def handle_event({:call, from}, {:update_client_status, user_id, update_data}, _state, data) do
+  def handle_event(
+        {:call, from},
+        {:update_client_status, user_id, update_data},
+        _state,
+        %LT.Data{} = data
+      ) do
     supported_properties = [:ready?, :asset_status]
     event = {:update_client_status, user_id, Map.take(update_data, supported_properties)}
     data = process_events([event], data) |> broadcast_updates() |> Map.get(:data)
     {:keep_state, data, [{:reply, from, :ok}]}
   end
 
-  def handle_event({:call, from}, {:add_bot, user_id, _add_data}, _state, data)
+  def handle_event({:call, from}, {:add_bot, user_id, _add_data}, _state, %LT.Data{} = data)
       when not is_map_key(data.players, user_id) and not is_map_key(data.spectators, user_id),
       do: {:keep_state, data, [{:reply, from, {:error, :not_in_lobby}}]}
 
-  def handle_event({:call, from}, {:add_bot, _user_id, add_data}, _state, data)
+  def handle_event({:call, from}, {:add_bot, _user_id, add_data}, _state, %LT.Data{} = data)
       when add_data.ally_team >= length(data.ally_team_config) or add_data.ally_team < 0,
       do: {:keep_state, data, [{:reply, from, {:error, :invalid_ally_team}}]}
 
-  def handle_event({:call, from}, {:add_bot, user_id, add_data}, _state, data) do
+  def handle_event({:call, from}, {:add_bot, user_id, add_data}, _state, %LT.Data{} = data) do
     ally_team = add_data.ally_team
     ally_team_capacity = Enum.at(data.ally_team_config, ally_team).max_teams
 
@@ -760,11 +755,11 @@ defmodule Teiserver.TachyonLobby.Lobby do
     end
   end
 
-  def handle_event({:call, from}, {:remove_bot, bot_id}, _state, data)
+  def handle_event({:call, from}, {:remove_bot, bot_id}, _state, %LT.Data{} = data)
       when not is_map_key(data.players, bot_id),
       do: {:keep_state, data, [{:reply, from, {:error, :invalid_bot_id}}]}
 
-  def handle_event({:call, from}, {:remove_bot, bot_id}, _state, data) do
+  def handle_event({:call, from}, {:remove_bot, bot_id}, _state, %LT.Data{} = data) do
     events = [{:remove_player_from_lobby, bot_id}, :repack_players, :fill_from_join_queue]
     aggregate = process_events(events, data) |> broadcast_updates()
     process_event_actions(aggregate)
@@ -772,22 +767,37 @@ defmodule Teiserver.TachyonLobby.Lobby do
     {:keep_state, aggregate.data, [{:reply, from, :ok}]}
   end
 
-  def handle_event({:call, from}, {:update_bot, %{id: bot_id}}, _state, data)
+  def handle_event({:call, from}, {:update_bot, %{id: bot_id}}, _state, %LT.Data{} = data)
       when not is_map_key(data.players, bot_id),
       do: {:keep_state, data, [{:reply, from, {:error, :invalid_bot_id}}]}
 
-  def handle_event({:call, from}, {:update_bot, %{id: bot_id} = update_data}, _state, data) do
+  def handle_event(
+        {:call, from},
+        {:update_bot, %{id: bot_id} = update_data},
+        _state,
+        %LT.Data{} = data
+      ) do
     patch_merge(data.players[bot_id], update_data)
     data = update_in(data.players[bot_id], &patch_merge(&1, update_data))
     broadcast_update({:update, nil, %{players: %{bot_id => update_data}}}, data)
     {:keep_state, data, [{:reply, from, :ok}]}
   end
 
-  def handle_event({:call, from}, {:update_properties, _user_id, data}, _state, fsm_data)
+  def handle_event(
+        {:call, from},
+        {:update_properties, _user_id, data},
+        _state,
+        %LT.Data{} = fsm_data
+      )
       when map_size(data) == 0,
       do: {:keep_state, fsm_data, [{:reply, from, :ok}]}
 
-  def handle_event({:call, from}, {:update_properties, user_id, data}, _state, fsm_data) do
+  def handle_event(
+        {:call, from},
+        {:update_properties, user_id, data},
+        _state,
+        %LT.Data{} = fsm_data
+      ) do
     # for now, all properties can only be updated by bosses, so shortcut the reduce
     is_allowed? = not fsm_data.boss_enabled? or MapSet.member?(fsm_data.bosses, user_id)
 
@@ -817,11 +827,21 @@ defmodule Teiserver.TachyonLobby.Lobby do
     end
   end
 
-  def handle_event({:call, from}, {:vote_submit, _user_id, {vote_id, _ballot}}, _state, data)
+  def handle_event(
+        {:call, from},
+        {:vote_submit, _user_id, {vote_id, _ballot}},
+        _state,
+        %LT.Data{} = data
+      )
       when data.current_vote.id != vote_id,
       do: {:keep_state, data, [{:reply, from, {:error, :invalid_vote}}]}
 
-  def handle_event({:call, from}, {:vote_submit, user_id, {_vote_id, ballot}}, _state, data) do
+  def handle_event(
+        {:call, from},
+        {:vote_submit, user_id, {_vote_id, ballot}},
+        _state,
+        %LT.Data{} = data
+      ) do
     if is_map_key(data.current_vote.voters, user_id) do
       event = {:cast_vote, user_id, ballot}
       aggregate = process_events([event], data) |> broadcast_updates()
@@ -832,11 +852,21 @@ defmodule Teiserver.TachyonLobby.Lobby do
     end
   end
 
-  def handle_event({:call, from}, {:send_message, from_id, _msg_content}, _state, data)
+  def handle_event(
+        {:call, from},
+        {:send_message, from_id, _msg_content},
+        _state,
+        %LT.Data{} = data
+      )
       when not is_map_key(data.players, from_id) and not is_map_key(data.spectators, from_id),
       do: {:keep_state, data, [{:reply, from, {:error, :invalid_request, :not_in_lobby}}]}
 
-  def handle_event({:call, from}, {:send_message, from_id, msg_content}, _state, data) do
+  def handle_event(
+        {:call, from},
+        {:send_message, from_id, msg_content},
+        _state,
+        %LT.Data{} = data
+      ) do
     msg =
       Messaging.new(
         msg_content,
@@ -852,11 +882,11 @@ defmodule Teiserver.TachyonLobby.Lobby do
     {:keep_state, data, [{:reply, from, :ok}]}
   end
 
-  def handle_event({:call, from}, {:join_queue, user_id}, _state, data)
+  def handle_event({:call, from}, {:join_queue, user_id}, _state, %LT.Data{} = data)
       when not is_map_key(data.players, user_id) and not is_map_key(data.spectators, user_id),
       do: {:keep_state, data, [{:reply, from, {:error, :not_in_lobby}}]}
 
-  def handle_event({:call, from}, {:join_queue, user_id}, _state, data) do
+  def handle_event({:call, from}, {:join_queue, user_id}, _state, %LT.Data{} = data) do
     cond do
       # already in the join queue, do nothing. This avoid someone
       # losing their position if they fat-finger the button
@@ -909,16 +939,31 @@ defmodule Teiserver.TachyonLobby.Lobby do
     end
   end
 
-  def handle_event({:call, from}, {:appoint_boss, user_id, _appointee_id}, _state, data)
+  def handle_event(
+        {:call, from},
+        {:appoint_boss, user_id, _appointee_id},
+        _state,
+        %LT.Data{} = data
+      )
       when not is_map_key(data.players, user_id) and not is_map_key(data.spectators, user_id),
       do: {:keep_state, data, [{:reply, from, {:error, :not_in_lobby}}]}
 
-  def handle_event({:call, from}, {:appoint_boss, _user_id, appointee_id}, _state, data)
+  def handle_event(
+        {:call, from},
+        {:appoint_boss, _user_id, appointee_id},
+        _state,
+        %LT.Data{} = data
+      )
       when not is_map_key(data.players, appointee_id) and
              not is_map_key(data.spectators, appointee_id),
       do: {:keep_state, data, [{:reply, from, {:error, :not_in_lobby}}]}
 
-  def handle_event({:call, from}, {:appoint_boss, user_id, appointee_id}, _state, data) do
+  def handle_event(
+        {:call, from},
+        {:appoint_boss, user_id, appointee_id},
+        _state,
+        %LT.Data{} = data
+      ) do
     cond do
       not data.boss_enabled? ->
         {:keep_state, data, [{:reply, from, {:error, :no_boss_allowed}}]}
@@ -943,15 +988,15 @@ defmodule Teiserver.TachyonLobby.Lobby do
     end
   end
 
-  def handle_event({:call, from}, {:unboss, user_id, _boss_id}, _state, data)
+  def handle_event({:call, from}, {:unboss, user_id, _boss_id}, _state, %LT.Data{} = data)
       when not is_map_key(data.players, user_id) and not is_map_key(data.spectators, user_id),
       do: {:keep_state, data, [{:reply, from, {:error, :not_in_lobby}}]}
 
-  def handle_event({:call, from}, {:unboss, _user_id, boss_id}, _state, data)
+  def handle_event({:call, from}, {:unboss, _user_id, boss_id}, _state, %LT.Data{} = data)
       when not is_map_key(data.players, boss_id) and not is_map_key(data.spectators, boss_id),
       do: {:keep_state, data, [{:reply, from, {:error, :not_in_lobby}}]}
 
-  def handle_event({:call, from}, {:unboss, user_id, boss_id}, _state, data) do
+  def handle_event({:call, from}, {:unboss, user_id, boss_id}, _state, %LT.Data{} = data) do
     cond do
       not MapSet.member?(data.bosses, user_id) ->
         {:keep_state, data, [{:reply, from, {:error, :not_a_boss}}]}
@@ -966,15 +1011,15 @@ defmodule Teiserver.TachyonLobby.Lobby do
     end
   end
 
-  def handle_event({:call, from}, {:start_battle, user_id}, _state, data)
+  def handle_event({:call, from}, {:start_battle, user_id}, _state, %LT.Data{} = data)
       when not is_map_key(data.players, user_id) and not is_map_key(data.spectators, user_id),
       do: {:keep_state, data, [{:reply, from, {:error, :not_in_lobby}}]}
 
-  def handle_event({:call, from}, {:start_battle, _user_id}, _state, data)
+  def handle_event({:call, from}, {:start_battle, _user_id}, _state, %LT.Data{} = data)
       when data.current_battle != nil,
       do: {:keep_state, data, [{:reply, from, {:error, :battle_already_started}}]}
 
-  def handle_event({:call, from}, {:start_battle, _user_id}, _state, data) do
+  def handle_event({:call, from}, {:start_battle, _user_id}, _state, %LT.Data{} = data) do
     with autohost_id when autohost_id != nil <- Autohost.find_autohost(),
          {:ok, {battle_id, battle_pid} = battle_data, host_data} <-
            TachyonBattle.start_battle(
@@ -1017,10 +1062,10 @@ defmodule Teiserver.TachyonLobby.Lobby do
     end
   end
 
-  def handle_event({:call, from}, :get_start_script, _state, data),
+  def handle_event({:call, from}, :get_start_script, _state, %LT.Data{} = data),
     do: {:keep_state, data, [{:reply, from, gen_start_script(data)}]}
 
-  def handle_event(:info, {:DOWN, ref, :process, _pid, :shutdown}, state, data) do
+  def handle_event(:info, {:DOWN, ref, :process, _pid, :shutdown}, state, %LT.Data{} = data) do
     val = MC.get_val(data.monitors, ref)
     data = Map.update!(data, :monitors, &MC.demonitor_by_val(&1, val))
 
@@ -1031,11 +1076,11 @@ defmodule Teiserver.TachyonLobby.Lobby do
   end
 
   # only DOWN events matter when shutting down the lobby, everything else should be ignored
-  def handle_event(:info, _msg, :shutting_down, data) do
+  def handle_event(:info, _msg, :shutting_down, %LT.Data{} = data) do
     {:keep_state, data}
   end
 
-  def handle_event(:info, {:DOWN, ref, :process, _obj, reason}, _state, data) do
+  def handle_event(:info, {:DOWN, ref, :process, _obj, reason}, _state, %LT.Data{} = data) do
     val = MC.get_val(data.monitors, ref)
     data = Map.update!(data, :monitors, &MC.demonitor_by_val(&1, val))
 
@@ -1069,7 +1114,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
     end
   end
 
-  def handle_event(:info, {:vote_timeout, vote_id}, _state, data)
+  def handle_event(:info, {:vote_timeout, vote_id}, _state, %LT.Data{} = data)
       when data.current_vote.id == vote_id do
     event = {:vote_ended, DateTime.utc_now(), :timeout}
     aggregate = process_events([event], data) |> broadcast_updates()
@@ -1077,18 +1122,19 @@ defmodule Teiserver.TachyonLobby.Lobby do
     {:keep_state, aggregate.data}
   end
 
-  def handle_event(:info, {:vote_timeout, _vote_id}, _state, data), do: {:keep_state, data}
+  def handle_event(:info, {:vote_timeout, _vote_id}, _state, %LT.Data{} = data),
+    do: {:keep_state, data}
 
-  def handle_event(:info, {:EXIT, _pid, reason}, _state, _data) do
+  def handle_event(:info, {:EXIT, _pid, reason}, _state, %LT.Data{} = _data) do
     {:stop, reason}
   end
 
-  def handle_event(:internal, :empty, _state, data) do
+  def handle_event(:internal, :empty, _state, %LT.Data{} = data) do
     Logger.info("Lobby shutting down because empty")
     {:stop, {:shutdown, :empty}, data}
   end
 
-  def handle_event(:state_timeout, :snapshot_timeout, :starting_up, data) do
+  def handle_event(:state_timeout, :snapshot_timeout, :starting_up, %LT.Data{} = data) do
     Logger.warning("failed to recover before time out. Missing #{inspect(data.ids_to_rejoin)}")
     {:stop, :normal}
   end
@@ -1113,7 +1159,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   def terminate(_reason, _state, _data), do: nil
 
-  @spec via_tuple(id()) :: GenServer.name()
+  @spec via_tuple(LT.Types.id()) :: GenServer.name()
   defp via_tuple(lobby_id) do
     TachyonLobby.Registry.via_tuple(lobby_id)
   end
@@ -1125,8 +1171,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
     :exit, {:shutdown, _reason} -> {:error, :invalid_lobby}
   end
 
-  @spec get_overview_from_state(state :: state()) :: TachyonLobby.List.overview()
-  defp get_overview_from_state(state) do
+  @spec get_overview_from_state(state :: LT.Data.t()) :: TachyonLobby.List.overview()
+  defp get_overview_from_state(%LT.Data{} = state) do
     %{
       name: state.name,
       player_count: map_size(state.players),
@@ -1145,8 +1191,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
     }
   end
 
-  @spec get_details_from_state(state()) :: details()
-  defp get_details_from_state(state) do
+  @spec get_details_from_state(LT.Data.t()) :: LT.Details.t()
+  defp get_details_from_state(%LT.Data{} = state) do
     {players, bots} = Enum.split_with(state.players, fn {_id, p} -> is_map_key(p, :pid) end)
 
     players =
@@ -1181,38 +1227,38 @@ defmodule Teiserver.TachyonLobby.Lobby do
       end)
       |> Enum.into(%{})
 
-    Map.take(state, [
-      :id,
-      :name,
-      :map_name,
-      :game_version,
-      :engine_version,
-      :boss_enabled?,
-      :bosses,
-      :ally_team_config,
-      :current_battle,
-      :current_vote,
-      :game_options,
-      :tags
-    ])
-    |> Map.put(:players, players)
-    |> Map.put(:spectators, spectators)
-    |> Map.put(:bots, Map.new(bots))
-    |> Map.put(:vote_history, vote_history)
+    %LT.Details{
+      id: state.id,
+      name: state.name,
+      map_name: state.map_name,
+      game_version: state.game_version,
+      engine_version: state.engine_version,
+      boss_enabled?: state.boss_enabled?,
+      bosses: state.bosses,
+      ally_team_config: state.ally_team_config,
+      game_options: state.game_options,
+      tags: state.tags,
+      players: players,
+      bots: Map.new(bots),
+      spectators: spectators,
+      current_battle: state.current_battle,
+      current_vote: state.current_vote,
+      vote_history: vote_history
+    }
   end
 
   # Given a list of events to process (in the event sourcing way) and the initial
   # state to apply these events to, returns the final state alongside any
   # potential update events that should also be broadcasted to members
   @typep aggregate :: %{
-           initial_data: state(),
-           data: state(),
+           initial_data: LT.Data.t(),
+           data: LT.Data.t(),
            updates: [event()],
            actions: [event_actions()]
          }
   @typep event_actions :: {:vote_ended, final_vote :: LT.VoteState.t(), outcome :: term()}
-  @spec process_events([event()], state()) :: aggregate()
-  defp process_events(events, state),
+  @spec process_events([event()], LT.Data.t()) :: aggregate()
+  defp process_events(events, %LT.Data{} = state),
     do:
       Enum.reduce(
         events,
@@ -1220,13 +1266,13 @@ defmodule Teiserver.TachyonLobby.Lobby do
         &process_event/2
       )
 
-  @spec process_event(event(), %{data: state(), updates: [event()]}) :: %{
-          data: state(),
+  @spec process_event(event(), %{data: LT.Data.t(), updates: [event()]}) :: %{
+          data: LT.Data.t(),
           updates: [event()]
         }
   defp process_event({:move_player, p_id, team} = ev, aggregate) do
     aggregate
-    |> update_in([:data, :players, p_id], fn p ->
+    |> update_in([:data, Access.key!(:players), p_id], fn p ->
       Map.merge(p, %{team: team, ready?: false, asset_status: :complete})
     end)
     |> update_in([:updates], &[ev | &1])
@@ -1234,16 +1280,19 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   defp process_event({:add_spectator, spec_data} = ev, aggregate) do
     aggregate
-    |> put_in([:data, :spectators, spec_data.id], spec_data)
-    |> update_in([:data, :monitors], &MC.monitor(&1, spec_data.pid, {:user, spec_data.id}))
+    |> put_in([:data, Access.key!(:spectators), spec_data.id], spec_data)
+    |> update_in(
+      [:data, Access.key!(:monitors)],
+      &MC.monitor(&1, spec_data.pid, {:user, spec_data.id})
+    )
     |> update_in([:updates], &[ev | &1])
   end
 
   defp process_event({:remove_player_from_lobby, p_id} = ev, aggregate) do
     aggregate =
       aggregate
-      |> update_in([:data, :players], &Map.delete(&1, p_id))
-      |> update_in([:data, :monitors], &MC.demonitor_by_val(&1, {:user, p_id}))
+      |> update_in([:data, Access.key!(:players)], &Map.delete(&1, p_id))
+      |> update_in([:data, Access.key!(:monitors)], &MC.demonitor_by_val(&1, {:user, p_id}))
       |> update_in([:updates], &[ev | &1])
 
     aggregate = process_event({:cast_vote, p_id, :abstain}, aggregate)
@@ -1253,8 +1302,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
   defp process_event({:remove_spec_from_lobby, s_id} = ev, aggregate) do
     aggregate =
       aggregate
-      |> update_in([:data, :spectators], &Map.delete(&1, s_id))
-      |> update_in([:data, :monitors], &MC.demonitor_by_val(&1, {:user, s_id}))
+      |> update_in([:data, Access.key!(:spectators)], &Map.delete(&1, s_id))
+      |> update_in([:data, Access.key!(:monitors)], &MC.demonitor_by_val(&1, {:user, s_id}))
       |> update_in([:updates], &[ev | &1])
 
     aggregate = process_event({:cast_vote, s_id, :abstain}, aggregate)
@@ -1275,8 +1324,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
     }
 
     aggregate
-    |> update_in([:data, :spectators], &Map.delete(&1, p_id))
-    |> put_in([:data, :players, p_id], player)
+    |> update_in([:data, Access.key!(:spectators)], &Map.delete(&1, p_id))
+    |> put_in([:data, Access.key!(:players), p_id], player)
     |> update_in([:updates], &[ev | &1])
   end
 
@@ -1292,8 +1341,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
     }
 
     aggregate
-    |> update_in([:data, :players], &Map.delete(&1, p_id))
-    |> put_in([:data, :spectators, p_id], spec)
+    |> update_in([:data, Access.key!(:players)], &Map.delete(&1, p_id))
+    |> put_in([:data, Access.key!(:spectators), p_id], spec)
     |> update_in([:updates], &[ev | &1])
   end
 
@@ -1324,7 +1373,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
       |> Enum.reject(&is_nil/1)
 
     aggregate
-    |> put_in([:data, :players], repacked_players)
+    |> put_in([:data, Access.key!(:players)], repacked_players)
     |> update_in([:updates], &(events ++ &1))
   end
 
@@ -1341,19 +1390,19 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   defp process_event({:update_client_status, p_id, changes} = ev, aggregate) do
     aggregate
-    |> update_in([:data, :players, p_id], &Map.merge(&1, changes))
+    |> update_in([:data, Access.key!(:players), p_id], &Map.merge(&1, changes))
     |> update_in([:updates], &[ev | &1])
   end
 
   defp process_event({:update_lobby_name, new_name} = ev, aggregate) do
     aggregate
-    |> put_in([:data, :name], new_name)
+    |> put_in([:data, Access.key!(:name)], new_name)
     |> update_in([:updates], &[ev | &1])
   end
 
   defp process_event({:update_map_name, new_name} = ev, aggregate) do
     aggregate
-    |> put_in([:data, :map_name], new_name)
+    |> put_in([:data, Access.key!(:map_name)], new_name)
     |> update_in([:updates], &[ev | &1])
   end
 
@@ -1431,20 +1480,20 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   defp process_event({:update_game_options, changes} = ev, aggregate) do
     aggregate
-    |> update_in([:data, :game_options], &patch_merge(&1, changes))
+    |> update_in([:data, Access.key!(:game_options)], &patch_merge(&1, changes))
     |> Map.update!(:updates, &[ev | &1])
   end
 
   defp process_event({:update_tags, changes} = ev, aggregate) do
     aggregate
-    |> update_in([:data, :tags], &patch_merge(&1, changes))
+    |> update_in([:data, Access.key!(:tags)], &patch_merge(&1, changes))
     |> Map.update!(:updates, &[ev | &1])
   end
 
   defp process_event({:start_vote, %LT.VoteState{} = vote_state} = ev, aggregate) do
     aggregate
-    |> put_in([:data, :current_vote], vote_state)
-    |> update_in([:data, :vote_idx], &(&1 + 1))
+    |> put_in([:data, Access.key!(:current_vote)], vote_state)
+    |> update_in([:data, Access.key!(:vote_idx)], &(&1 + 1))
     |> Map.update!(:updates, &[ev | &1])
   end
 
@@ -1456,7 +1505,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
   defp process_event({:cast_vote, user_id, ballot} = ev, aggregate) do
     new_aggregate =
       aggregate
-      |> put_in([:data, :current_vote, Access.key!(:voters), user_id], ballot)
+      |> put_in([:data, Access.key!(:current_vote), Access.key!(:voters), user_id], ballot)
 
     case vote_result(new_aggregate.data.current_vote) do
       :undecided ->
@@ -1509,8 +1558,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
       end
 
     aggregate
-    |> put_in([:data, :current_vote], nil)
-    |> put_in([:data, :vote_history], history)
+    |> put_in([:data, Access.key!(:current_vote)], nil)
+    |> put_in([:data, Access.key!(:vote_history)], history)
     |> Map.update!(:updates, &[{:vote_ended, vote_record} | &1])
     |> Map.update!(:actions, &[vote_ev | &1])
   end
@@ -1520,7 +1569,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
       aggregate
     else
       aggregate
-      |> update_in([:data, :bosses], &MapSet.put(&1, appointee_id))
+      |> update_in([:data, Access.key!(:bosses)], &MapSet.put(&1, appointee_id))
       |> Map.update!(:updates, &[ev | &1])
     end
   end
@@ -1528,7 +1577,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
   defp process_event({:update_boss, :remove, boss_id} = ev, aggregate) do
     if MapSet.member?(aggregate.data.bosses, boss_id) do
       aggregate
-      |> update_in([:data, :bosses], &MapSet.delete(&1, boss_id))
+      |> update_in([:data, Access.key!(:bosses)], &MapSet.delete(&1, boss_id))
       |> Map.update!(:updates, &[ev | &1])
     else
       aggregate
@@ -1733,7 +1782,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
   # find an empty slot for a player/bot to play
   # this function isn't too efficient, but it's never going to be run on
   # massive inputs since the engine cannot support more than 254 players anyway
-  @spec find_team([LT.AllyTeamConfig.t()], %{player_id() => LT.Player.t() | LT.Bot.t()}) ::
+  @spec find_team([LT.AllyTeamConfig.t()], %{LT.Types.player_id() => LT.Player.t() | LT.Bot.t()}) ::
           LT.Types.team() | nil
   defp find_team(ally_team_config, players) do
     # find the least full ally team
@@ -1845,8 +1894,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
     |> elem(1)
   end
 
-  @spec remove_player_from_lobby(T.userid(), state()) :: state()
-  defp remove_player_from_lobby(user_id, state) do
+  @spec remove_player_from_lobby(T.userid(), LT.Data.t()) :: LT.Data.t()
+  defp remove_player_from_lobby(user_id, %LT.Data{} = state) do
     # if the user leaving is associated with any bot, we need to remove all of
     # them as well.
     bot_ids_to_remove =
@@ -1865,8 +1914,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
     aggregate.data
   end
 
-  @spec remove_spectator_from_lobby(T.userid(), state()) :: state()
-  defp remove_spectator_from_lobby(user_id, state) do
+  @spec remove_spectator_from_lobby(T.userid(), LT.Data.t()) :: LT.Data.t()
+  defp remove_spectator_from_lobby(user_id, %LT.Data{} = state) do
     bot_ids_to_remove =
       Enum.filter(state.players, fn {_bot_id, b} -> Map.get(b, :host_user_id) == user_id end)
       |> Enum.map(&elem(&1, 0))
@@ -1882,9 +1931,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   # Add the first player from the join queue to the player list and returns the
   # updated state alongside the player id that was added
-  # {state(), T.userid() | nil}
-  @spec add_player_from_join_queue(state()) :: event() | nil
-  defp add_player_from_join_queue(state) do
+  @spec add_player_from_join_queue(LT.Data.t()) :: event() | nil
+  defp add_player_from_join_queue(%LT.Data{} = state) do
     player_to_add =
       case get_first_player_in_join_queue(state.spectators) do
         nil ->
@@ -1915,8 +1963,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
   defp bot_id?(id) when is_integer(id), do: false
   defp bot_id?(id), do: String.starts_with?(id, "bot")
 
-  @spec gen_start_script(state()) :: Autohost.start_script()
-  defp gen_start_script(state) do
+  @spec gen_start_script(LT.Data.t()) :: Autohost.start_script()
+  defp gen_start_script(%LT.Data{} = state) do
     sorted =
       Map.values(state.players)
       |> Enum.sort_by(& &1.team)
@@ -1977,7 +2025,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
     |> Map.merge(Map.take(state, [:game_options]))
   end
 
-  @spec update_property(atom(), term(), state(), T.userid()) ::
+  @spec update_property(atom(), term(), LT.Data.t(), T.userid()) ::
           {:ok, [event()]} | {:error, String.t()}
   defp update_property(:name, new_name, _state, _user_id) do
     # we can expand lobby name validation later
@@ -1988,7 +2036,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
     {:ok, [{:update_lobby_name, new_name}]}
   end
 
-  defp update_property(:map_name, new_name, state, user_id) do
+  defp update_property(:map_name, new_name, %LT.Data{} = state, user_id) do
     cond do
       not is_map_key(state.players, user_id) ->
         {:error, "Only players can change the map"}

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -24,7 +24,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
   # case basis.
 
   alias Plug.Crypto
-  alias Teiserver.Asset
   alias Teiserver.Autohost
   alias Teiserver.Data.Types, as: T
   alias Teiserver.Helpers.Collections
@@ -43,18 +42,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
   @behaviour :gen_statem
 
   @type id :: String.t()
-
-  @type ally_team_config :: [
-          %{
-            max_teams: pos_integer(),
-            start_box: Asset.startbox(),
-            teams: [
-              %{
-                max_players: pos_integer()
-              }
-            ]
-          }
-        ]
 
   @typedoc """
   Data required for a player to join a lobby. This allow lobbies to
@@ -75,7 +62,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
           required(:creator_pid) => pid(),
           required(:name) => String.t(),
           required(:map_name) => String.t(),
-          required(:ally_team_config) => ally_team_config(),
+          required(:ally_team_config) => [LT.AllyTeamConfig.t()],
           optional(:game_version) => String.t(),
           optional(:engine_version) => String.t(),
           optional(:boss_enabled?) => boolean(),
@@ -111,7 +98,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
           engine_version: String.t(),
           boss_enabled?: boolean(),
           bosses: MapSet.t(T.userid()),
-          ally_team_config: ally_team_config(),
+          ally_team_config: [LT.AllyTeamConfig.t()],
           game_options: %{String.t() => String.t()},
           tags: %{String.t() => map()},
           players: %{T.userid() => LT.PlayerDetails.t()},
@@ -151,7 +138,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
            engine_version: String.t(),
            boss_enabled?: boolean(),
            bosses: MapSet.t(T.userid()),
-           ally_team_config: ally_team_config(),
+           ally_team_config: [LT.AllyTeamConfig.t()],
            game_options: %{String.t() => String.t()},
            tags: %{String.t() => map()},
            # used to track the players in the lobby.
@@ -186,8 +173,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
            | {:update_client_status, T.userid(), client_status :: map()}
            | {:update_lobby_name, new_name :: String.t()}
            | {:update_map_name, new_name :: String.t()}
-           | {:update_ally_team_config, old_config :: ally_team_config(),
-              new_config :: ally_team_config()}
+           | {:update_ally_team_config, old_config :: [LT.AllyTeamConfig.t()],
+              new_config :: [LT.AllyTeamConfig.t()]}
            | {:update_game_options, changes :: %{String.t() => String.t() | nil}}
            | {:update_tags, changes :: %{String.t() => map() | nil}}
            | {:start_vote, vote_state()}
@@ -328,7 +315,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
   @type lobby_update_data :: %{
           optional(:name) => String.t(),
           optional(:map_name) => String.t(),
-          optional(:ally_team_config) => ally_team_config(),
+          optional(:ally_team_config) => [LT.AllyTeamConfig.t()],
           optional(:game_options) => %{String.t() => String.t() | nil},
           optional(:tags) => %{String.t() => map() | nil}
         }
@@ -1327,7 +1314,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
     data = aggregate.data
 
     repacked_players =
-      for {_at, at_idx} <- Enum.with_index(data.ally_team_config) do
+      for {%LT.AllyTeamConfig{} = _at, at_idx} <- Enum.with_index(data.ally_team_config) do
         Enum.filter(data.players, fn {_id, %{team: {p_at, _team, _player}}} -> at_idx == p_at end)
         |> Enum.map(fn {_id, p} -> p end)
         |> Enum.sort_by(& &1.team)
@@ -1384,7 +1371,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
     spec_ids =
       Enum.map(state.players, fn {p_id, %{team: {x, y, z}}} ->
-        with at_config when not is_nil(at_config) <- Enum.at(new_config, x),
+        with at_config = %LT.AllyTeamConfig{} when not is_nil(at_config) <- Enum.at(new_config, x),
              team_config when not is_nil(team_config) <- Enum.at(at_config.teams, y) do
           if y < at_config.max_teams && z < team_config.max_players,
             do: nil,
@@ -1641,7 +1628,11 @@ defmodule Teiserver.TachyonLobby.Lobby do
         {nil, new_at} ->
           new_at
 
-        {old_at, new_at} ->
+        {%LT.AllyTeamConfig{} = old_at, %LT.AllyTeamConfig{} = new_at} ->
+          # we are broadcasting patch updates, so structs are meaningless
+          # in this context
+          new_at = Map.from_struct(new_at)
+
           Map.update!(new_at, :teams, fn new_teams ->
             Collections.zip_with_padding(old_at.teams, new_teams, nil)
             |> Enum.map(fn {_old_team, new_team} -> new_team end)
@@ -1743,12 +1734,12 @@ defmodule Teiserver.TachyonLobby.Lobby do
   # find an empty slot for a player/bot to play
   # this function isn't too efficient, but it's never going to be run on
   # massive inputs since the engine cannot support more than 254 players anyway
-  @spec find_team(ally_team_config(), %{player_id() => LT.Player.t() | LT.Bot.t()}) ::
+  @spec find_team([LT.AllyTeamConfig.t()], %{player_id() => LT.Player.t() | LT.Bot.t()}) ::
           LT.Types.team() | nil
   defp find_team(ally_team_config, players) do
     # find the least full ally team
     ally_team =
-      for {at, at_idx} <- Enum.with_index(ally_team_config) do
+      for {%LT.AllyTeamConfig{} = at, at_idx} <- Enum.with_index(ally_team_config) do
         total_capacity = Enum.sum_by(at.teams, fn t -> t.max_players end)
 
         capacity = total_capacity - team_count(at_idx, players)
@@ -1934,7 +1925,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
       |> Map.values()
 
     ally_teams =
-      for {at, at_config} <- Enum.zip(sorted, state.ally_team_config) do
+      for {at, %LT.AllyTeamConfig{} = at_config} <- Enum.zip(sorted, state.ally_team_config) do
         teams =
           Enum.group_by(at, &elem(&1.team, 1))
           |> Map.values()

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -97,7 +97,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
   # it has the pid (from the registry).
   # but if the needs arise, this could be overloaded to use a lobby id
   # and the usual via_tuple mechanism
-  @spec get_overview(pid()) :: TachyonLobby.List.overview() | nil
+  @spec get_overview(pid()) :: LT.ListOverview.t() | nil
   def get_overview(lobby_pid) do
     :gen_statem.call(lobby_pid, :get_overview, @default_call_timeout)
   catch
@@ -1160,9 +1160,9 @@ defmodule Teiserver.TachyonLobby.Lobby do
     :exit, {:shutdown, _reason} -> {:error, :invalid_lobby}
   end
 
-  @spec get_overview_from_state(state :: LT.Data.t()) :: TachyonLobby.List.overview()
+  @spec get_overview_from_state(state :: LT.Data.t()) :: LT.ListOverview.t()
   defp get_overview_from_state(%LT.Data{} = state) do
-    %{
+    %LT.ListOverview{
       name: state.name,
       player_count: map_size(state.players),
       max_player_count:

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -117,12 +117,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
           players: %{T.userid() => LT.PlayerDetails.t()},
           spectators: %{T.userid() => LT.SpectatorDetails.t()},
           bots: %{LT.Bot.id() => LT.Bot.t()},
-          current_battle:
-            nil
-            | %{
-                id: TachyonBattle.id(),
-                started_at: DateTime.t()
-              },
+          current_battle: LT.CurrentBattleDetails.t() | nil,
           current_vote: nil | vote_state(),
           vote_history: %{
             String.t() => %{
@@ -163,13 +158,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
            players: %{player_id() => LT.Player.t() | LT.Bot.t()},
            spectators: %{T.userid() => LT.Spectator.t()},
            bot_idx_counter: non_neg_integer(),
-           current_battle:
-             nil
-             | %{
-                 id: Teiserver.TachyonBattle.id(),
-                 pid: pid(),
-                 started_at: DateTime.t()
-               },
+           current_battle: LT.CurrentBattle.t() | nil,
            ids_to_rejoin: MapSet.t(T.userid()),
            vote_idx: integer(),
            current_vote: nil | vote_state(),
@@ -1034,8 +1023,10 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
       now = DateTime.utc_now()
 
+      battle = %LT.CurrentBattle{id: battle_id, pid: battle_pid, started_at: now}
+
       data =
-        %{data | current_battle: %{id: battle_id, pid: battle_pid, started_at: now}}
+        %{data | current_battle: battle}
         |> Map.update!(:monitors, &MC.monitor(&1, battle_pid, :current_battle))
 
       broadcast_update({:update, nil, %{current_battle: data.current_battle}}, data)

--- a/lib/teiserver/tachyon_lobby/registry.ex
+++ b/lib/teiserver/tachyon_lobby/registry.ex
@@ -1,6 +1,6 @@
 defmodule Teiserver.TachyonLobby.Registry do
   @moduledoc false
-  alias Teiserver.TachyonLobby.Lobby
+  alias Teiserver.TachyonLobby.Types, as: LT
 
   def child_spec(_arg) do
     Supervisor.child_spec(Registry,
@@ -16,12 +16,12 @@ defmodule Teiserver.TachyonLobby.Registry do
   @doc """
   How to reach a given lobby from its ID
   """
-  @spec via_tuple(Lobby.id()) :: GenServer.name()
+  @spec via_tuple(LT.Types.id()) :: GenServer.name()
   def via_tuple(lobby_id) do
     {:via, Registry, {__MODULE__, lobby_id}}
   end
 
-  @spec lookup(Lobby.id()) :: pid() | nil
+  @spec lookup(LT.Types.id()) :: pid() | nil
   def lookup(lobby_id) do
     case Registry.lookup(__MODULE__, lobby_id) do
       [{pid, _value}] -> pid
@@ -37,7 +37,7 @@ defmodule Teiserver.TachyonLobby.Registry do
     _e in ArgumentError -> 0
   end
 
-  @spec list_lobbies() :: [{Lobby.id(), pid()}]
+  @spec list_lobbies() :: [{LT.Types.id(), pid()}]
   def list_lobbies do
     Registry.select(__MODULE__, [{{:"$1", :"$2", :_}, [], [{{:"$1", :"$2"}}]}])
   end

--- a/lib/teiserver/tachyon_lobby/supervisor.ex
+++ b/lib/teiserver/tachyon_lobby/supervisor.ex
@@ -2,11 +2,12 @@ defmodule Teiserver.TachyonLobby.Supervisor do
   @moduledoc false
   alias Horde.DynamicSupervisor, as: HordeSupervisor
   alias Teiserver.TachyonLobby.Lobby
+  alias Teiserver.TachyonLobby.Types, as: LT
 
   use Horde.DynamicSupervisor
 
   @spec start_lobby(Lobby.start_params()) ::
-          {:ok, %{pid: pid(), id: Lobby.id()}}
+          {:ok, %{pid: pid(), id: LT.Types.id()}}
           | {:error, {:already_started, pid()} | :max_children | term()}
   def start_lobby(start_params) do
     id = Lobby.gen_id()

--- a/lib/teiserver/tachyon_lobby/supervisor.ex
+++ b/lib/teiserver/tachyon_lobby/supervisor.ex
@@ -6,10 +6,10 @@ defmodule Teiserver.TachyonLobby.Supervisor do
 
   use Horde.DynamicSupervisor
 
-  @spec start_lobby(Lobby.start_params()) ::
+  @spec start_lobby(LT.StartParams.t()) ::
           {:ok, %{pid: pid(), id: LT.Types.id()}}
           | {:error, {:already_started, pid()} | :max_children | term()}
-  def start_lobby(start_params) do
+  def start_lobby(%LT.StartParams{} = start_params) do
     id = Lobby.gen_id()
 
     case HordeSupervisor.start_child(__MODULE__, {Lobby, {id, {:user, start_params}}}) do

--- a/lib/teiserver/tachyon_lobby/types/ally_team_config.ex
+++ b/lib/teiserver/tachyon_lobby/types/ally_team_config.ex
@@ -1,0 +1,19 @@
+defmodule Teiserver.TachyonLobby.Types.AllyTeamConfig do
+  @moduledoc """
+  Ally team configuration for tachyon lobbies
+  """
+
+  alias Teiserver.Asset
+
+  # start box are optional, if none given, engine allow spawing anywhere on
+  # the map. It can also be controlled game side through modoption, that's
+  # how polygon start boxes work
+  @enforce_keys [:max_teams, :teams]
+  defstruct [:max_teams, :teams, :start_box]
+
+  @type t() :: %__MODULE__{
+          max_teams: pos_integer(),
+          teams: [%{max_players: pos_integer()}],
+          start_box: Asset.startbox()
+        }
+end

--- a/lib/teiserver/tachyon_lobby/types/bot.ex
+++ b/lib/teiserver/tachyon_lobby/types/bot.ex
@@ -1,0 +1,22 @@
+defmodule Teiserver.TachyonLobby.Types.Bot do
+  @moduledoc """
+  A bot in a lobby. It always has a team (a bot cannot be a spectator)
+  and is also tied to a player: their machine is used to run the AI
+  """
+
+  alias Teiserver.TachyonLobby.Types.Types, as: LT
+
+  @enforce_keys [:id, :host_user_id, :team, :name]
+  defstruct [:id, :host_user_id, :team, :name, :short_name, :version, :options]
+
+  @type id() :: String.t()
+  @type t() :: %__MODULE__{
+          id: id(),
+          host_user_id: Teiserver.Account.User.id(),
+          team: LT.team(),
+          name: String.t(),
+          short_name: String.t() | nil,
+          version: String.t() | nil,
+          options: %{String.t() => String.t()}
+        }
+end

--- a/lib/teiserver/tachyon_lobby/types/current_battle.ex
+++ b/lib/teiserver/tachyon_lobby/types/current_battle.ex
@@ -1,0 +1,16 @@
+defmodule Teiserver.TachyonLobby.Types.CurrentBattle do
+  @moduledoc """
+  Internal representation of a battle attached to a lobby
+  """
+
+  alias Teiserver.TachyonBattle
+
+  @enforce_keys [:id, :pid, :started_at]
+  defstruct [:id, :pid, :started_at]
+
+  @type t() :: %__MODULE__{
+          id: TachyonBattle.id(),
+          pid: pid(),
+          started_at: DateTime.t()
+        }
+end

--- a/lib/teiserver/tachyon_lobby/types/current_battle_details.ex
+++ b/lib/teiserver/tachyon_lobby/types/current_battle_details.ex
@@ -1,0 +1,15 @@
+defmodule Teiserver.TachyonLobby.Types.CurrentBattleDetails do
+  @moduledoc """
+  Public version of CurrentBattle
+  """
+
+  alias Teiserver.TachyonBattle
+
+  @enforce_keys [:id, :started_at]
+  defstruct [:id, :started_at]
+
+  @type t() :: %__MODULE__{
+          id: TachyonBattle.id(),
+          started_at: DateTime.t()
+        }
+end

--- a/lib/teiserver/tachyon_lobby/types/data.ex
+++ b/lib/teiserver/tachyon_lobby/types/data.ex
@@ -1,0 +1,64 @@
+defmodule Teiserver.TachyonLobby.Types.Data do
+  @moduledoc """
+  Internal data for a lobby. Everything that's required for a lobby to run
+  """
+
+  alias Teiserver.Account.User
+  alias Teiserver.Helpers.MonitorCollection, as: MC
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  @enforce_keys [
+    :id,
+    :monitors,
+    :name,
+    :map_name,
+    :game_version,
+    :engine_version,
+    :boss_enabled?,
+    :ally_team_config
+  ]
+  defstruct [
+    :id,
+    :monitors,
+    :name,
+    :map_name,
+    :game_version,
+    :engine_version,
+    :boss_enabled?,
+    :ally_team_config,
+    bosses: MapSet.new(),
+    game_options: %{},
+    tags: %{},
+    players: %{},
+    spectators: %{},
+    bots: %{},
+    bot_idx_counter: 0,
+    current_battle: nil,
+    ids_to_rejoin: MapSet.new(),
+    vote_idx: 1,
+    current_vote: nil,
+    vote_history: %{}
+  ]
+
+  @type t() :: %__MODULE__{
+          id: LT.Types.id(),
+          monitors: MC.t(),
+          name: String.t(),
+          game_version: String.t(),
+          engine_version: String.t(),
+          boss_enabled?: boolean(),
+          bosses: MapSet.t(User.id()),
+          ally_team_config: [LT.AllyTeamConfig.t()],
+          game_options: %{String.t() => String.t()},
+          tags: %{String.t() => map()},
+          players: %{LT.Types.player_id() => LT.PlayerDetails.t()},
+          spectators: %{User.id() => LT.SpectatorDetails.t()},
+          bots: %{LT.Bot.id() => LT.Bot.t()},
+          bot_idx_counter: integer(),
+          current_battle: LT.CurrentBattleDetails.t() | nil,
+          ids_to_rejoin: MapSet.t(),
+          vote_idx: integer(),
+          current_vote: LT.VoteState.t() | nil,
+          vote_history: %{String.t() => LT.VoteRecord.t()}
+        }
+end

--- a/lib/teiserver/tachyon_lobby/types/details.ex
+++ b/lib/teiserver/tachyon_lobby/types/details.ex
@@ -1,0 +1,56 @@
+defmodule Teiserver.TachyonLobby.Types.Details do
+  @moduledoc """
+  Public, detailed data of a lobby. This is derived from the internal data
+  and contains everything that's required for player/specs in the lobby.
+  """
+
+  alias Teiserver.Account.User
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  @enforce_keys [
+    :id,
+    :name,
+    :map_name,
+    :game_version,
+    :engine_version,
+    :boss_enabled?,
+    :ally_team_config
+  ]
+  defstruct [
+    :id,
+    :name,
+    :map_name,
+    :game_version,
+    :engine_version,
+    :boss_enabled?,
+    :ally_team_config,
+    bosses: MapSet.new(),
+    game_options: %{},
+    tags: %{},
+    players: %{},
+    spectators: %{},
+    bots: %{},
+    current_battle: nil,
+    current_vote: nil,
+    vote_history: %{}
+  ]
+
+  @type t() :: %__MODULE__{
+          id: LT.Types.id(),
+          name: String.t(),
+          map_name: String.t(),
+          game_version: String.t(),
+          engine_version: String.t(),
+          boss_enabled?: boolean(),
+          bosses: MapSet.t(User.id()),
+          ally_team_config: [LT.AllyTeamConfig.t()],
+          game_options: %{String.t() => String.t()},
+          tags: %{String.t() => map()},
+          players: %{LT.Types.player_id() => LT.PlayerDetails.t()},
+          spectators: %{User.id() => LT.SpectatorDetails.t()},
+          bots: %{LT.Bot.id() => LT.Bot.t()},
+          current_battle: LT.CurrentBattleDetails.t() | nil,
+          current_vote: LT.VoteState.t() | nil,
+          vote_history: %{String.t() => LT.VoteDetails.t()}
+        }
+end

--- a/lib/teiserver/tachyon_lobby/types/list_overview.ex
+++ b/lib/teiserver/tachyon_lobby/types/list_overview.ex
@@ -1,0 +1,41 @@
+defmodule Teiserver.TachyonLobby.Types.ListOverview do
+  @moduledoc """
+  Subset of a lobby overview used for listing.
+  This data is sent to any client that subscribe to lobby updates so it's
+  important to keep it as lean as possible.
+  Any property there should be directly used by clients and otherwise culled
+  """
+
+  @enforce_keys [
+    :name,
+    :player_count,
+    :max_player_count,
+    :map_name,
+    :engine_version,
+    :game_version,
+    :boss_enabled?
+  ]
+  defstruct [
+    :name,
+    :player_count,
+    :max_player_count,
+    :map_name,
+    :engine_version,
+    :game_version,
+    :boss_enabled?,
+    current_battle: nil,
+    tags: %{}
+  ]
+
+  @type t() :: %__MODULE__{
+          name: String.t(),
+          player_count: non_neg_integer(),
+          max_player_count: non_neg_integer(),
+          map_name: String.t(),
+          engine_version: String.t(),
+          game_version: String.t(),
+          boss_enabled?: boolean(),
+          current_battle: %{started_at: DateTime.t()} | nil,
+          tags: %{String.t() => map()}
+        }
+end

--- a/lib/teiserver/tachyon_lobby/types/list_state.ex
+++ b/lib/teiserver/tachyon_lobby/types/list_state.ex
@@ -1,0 +1,21 @@
+defmodule Teiserver.TachyonLobby.Types.ListState do
+  @moduledoc """
+  Internal state for the processes holding list of lobbies
+  """
+
+  alias Teiserver.Helpers.MonitorCollection, as: MC
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  defstruct monitors: MC.new(),
+            counter: 0,
+            lobbies: %{},
+            changes: %{}
+
+  @type t() :: %__MODULE__{
+          monitors: MC.t(),
+          counter: non_neg_integer(),
+          lobbies: %{LT.Types.id() => LT.ListOverview.t()},
+          # the map is a partial overview
+          changes: %{LT.Types.id() => map()}
+        }
+end

--- a/lib/teiserver/tachyon_lobby/types/player.ex
+++ b/lib/teiserver/tachyon_lobby/types/player.ex
@@ -1,0 +1,24 @@
+defmodule Teiserver.TachyonLobby.Types.Player do
+  @moduledoc """
+  Internal representation of a player in a lobby.
+  Holds all data required to start a game
+  """
+  alias Teiserver.TachyonLobby.Types.Types, as: LT
+
+  @enforce_keys [:id, :name, :password, :team, :ready?, :asset_status]
+  defstruct [:id, :name, :password, :pid, :team, :ready?, :asset_status]
+
+  @type t() :: %__MODULE__{
+          id: Teiserver.Account.User.id(),
+          name: String.t(),
+          # used to generate the start script, and then will be sent to the
+          # player so they can join the battle
+          password: String.t(),
+          # pid can be nil when restoring state from snapshot until
+          # the session rejoins the lobby
+          pid: pid() | nil,
+          team: LT.team(),
+          ready?: boolean(),
+          asset_status: LT.asset_status()
+        }
+end

--- a/lib/teiserver/tachyon_lobby/types/player_details.ex
+++ b/lib/teiserver/tachyon_lobby/types/player_details.ex
@@ -1,0 +1,16 @@
+defmodule Teiserver.TachyonLobby.Types.PlayerDetails do
+  @moduledoc """
+  Public version of a player in a lobby. Subset of Types.Player
+  """
+  alias Teiserver.TachyonLobby.Types.Types, as: LT
+
+  @enforce_keys [:id, :team, :ready?, :asset_status]
+  defstruct [:id, :team, :ready?, :asset_status]
+
+  @type t() :: %__MODULE__{
+          id: Teiserver.Account.User.id(),
+          team: LT.team(),
+          ready?: boolean(),
+          asset_status: LT.asset_status()
+        }
+end

--- a/lib/teiserver/tachyon_lobby/types/player_join_data.ex
+++ b/lib/teiserver/tachyon_lobby/types/player_join_data.ex
@@ -1,0 +1,14 @@
+defmodule Teiserver.TachyonLobby.Types.PlayerJoinData do
+  @moduledoc """
+  Data required for a player to join a lobby. This allow lobbies to
+  be agnostic of how players are represented in the system
+  """
+
+  @enforce_keys [:id, :name]
+  defstruct [:id, :name]
+
+  @type t() :: %__MODULE__{
+          id: Teiserver.Account.User.id(),
+          name: String.t()
+        }
+end

--- a/lib/teiserver/tachyon_lobby/types/spectator.ex
+++ b/lib/teiserver/tachyon_lobby/types/spectator.ex
@@ -1,0 +1,18 @@
+defmodule Teiserver.TachyonLobby.Types.Spectator do
+  @moduledoc """
+  Internal representation of a spectator in a lobby
+  """
+
+  @enforce_keys [:id]
+  defstruct [:id, :name, :password, :pid, :join_queue_position]
+
+  @type t() :: %__MODULE__{
+          id: Teiserver.Account.User.id(),
+          name: String.t(),
+          # pid can be nil when restoring state from snapshot until
+          # the session rejoins the lobby
+          password: String.t(),
+          pid: pid(),
+          join_queue_position: number() | nil
+        }
+end

--- a/lib/teiserver/tachyon_lobby/types/spectator_details.ex
+++ b/lib/teiserver/tachyon_lobby/types/spectator_details.ex
@@ -1,0 +1,13 @@
+defmodule Teiserver.TachyonLobby.Types.SpectatorDetails do
+  @moduledoc """
+  Public version of a spectator in a lobby.
+  """
+
+  @enforce_keys [:id]
+  defstruct [:id, :join_queue_position]
+
+  @type t() :: %__MODULE__{
+          id: Teiserver.Account.User.id(),
+          join_queue_position: number() | nil
+        }
+end

--- a/lib/teiserver/tachyon_lobby/types/start_params.ex
+++ b/lib/teiserver/tachyon_lobby/types/start_params.ex
@@ -1,0 +1,36 @@
+defmodule Teiserver.TachyonLobby.Types.StartParams do
+  @moduledoc """
+  the parameters required to create a new lobby.
+  It's enough data to generate the initial lobby internal state, which in
+  turn can be used to start a battle
+  """
+
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  @enforce_keys [:creator_data, :creator_pid, :name, :map_name, :ally_team_config]
+  defstruct [
+    :creator_data,
+    :creator_pid,
+    :name,
+    :map_name,
+    :ally_team_config,
+    game_version: nil,
+    engine_version: nil,
+    boss_enabled?: false,
+    game_options: %{},
+    tags: %{}
+  ]
+
+  @type t() :: %__MODULE__{
+          creator_data: LT.PlayerJoinData.t(),
+          creator_pid: pid(),
+          name: String.t(),
+          map_name: String.t(),
+          ally_team_config: [LT.AllyTeamConfig.t()],
+          game_version: String.t() | nil,
+          engine_version: String.t() | nil,
+          boss_enabled?: boolean(),
+          game_options: %{String.t() => String.t()},
+          tags: %{String.t() => map()}
+        }
+end

--- a/lib/teiserver/tachyon_lobby/types/types.ex
+++ b/lib/teiserver/tachyon_lobby/types/types.ex
@@ -1,0 +1,16 @@
+defmodule Teiserver.TachyonLobby.Types.Types do
+  @moduledoc """
+  central location for lobby related types that aren't really suited to be structs
+  """
+
+  @typedoc """
+  These represent the indices respectively into
+  {ally team index, team index, player index}
+  since we don't really support "archon mode" though, the player index
+  is likely always going to be 0.
+  For example, a player in the first ally team, in the second spot
+  would have: {0, 1, 0}
+  """
+  @type team ::
+          {allyTeam :: non_neg_integer(), team :: non_neg_integer(), player :: non_neg_integer()}
+end

--- a/lib/teiserver/tachyon_lobby/types/types.ex
+++ b/lib/teiserver/tachyon_lobby/types/types.ex
@@ -13,4 +13,6 @@ defmodule Teiserver.TachyonLobby.Types.Types do
   """
   @type team ::
           {allyTeam :: non_neg_integer(), team :: non_neg_integer(), player :: non_neg_integer()}
+
+  @type asset_status :: :missing | :downloading | :complete
 end

--- a/lib/teiserver/tachyon_lobby/types/types.ex
+++ b/lib/teiserver/tachyon_lobby/types/types.ex
@@ -3,6 +3,11 @@ defmodule Teiserver.TachyonLobby.Types.Types do
   central location for lobby related types that aren't really suited to be structs
   """
 
+  @type id() :: String.t()
+
+  # represent the ID of a user or a bot slated to play in the game (no spec)
+  @type player_id :: Teiserver.Account.User.id() | String.t()
+
   @typedoc """
   These represent the indices respectively into
   {ally team index, team index, player index}

--- a/lib/teiserver/tachyon_lobby/types/vote_details.ex
+++ b/lib/teiserver/tachyon_lobby/types/vote_details.ex
@@ -1,0 +1,15 @@
+defmodule Teiserver.TachyonLobby.Types.VoteDetails do
+  @moduledoc """
+  Public version of a vote record to be used with the lobby details
+  """
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  @enforce_keys [:vote, :finished_at, :outcome]
+  defstruct [:vote, :finished_at, :outcome]
+
+  @type t() :: %__MODULE__{
+          vote: LT.VoteState.vote_outcome(),
+          finished_at: DateTime.t(),
+          outcome: LT.VoteState.vote_outcome()
+        }
+end

--- a/lib/teiserver/tachyon_lobby/types/vote_record.ex
+++ b/lib/teiserver/tachyon_lobby/types/vote_record.ex
@@ -1,0 +1,15 @@
+defmodule Teiserver.TachyonLobby.Types.VoteRecord do
+  @moduledoc """
+  Used for the vote history of a lobby
+  """
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  @enforce_keys [:vote, :finished_at, :outcome]
+  defstruct [:vote, :finished_at, :outcome]
+
+  @type t() :: %__MODULE__{
+          vote: LT.VoteState.t(),
+          finished_at: DateTime.t(),
+          outcome: LT.VoteState.vote_outcome()
+        }
+end

--- a/lib/teiserver/tachyon_lobby/types/vote_state.ex
+++ b/lib/teiserver/tachyon_lobby/types/vote_state.ex
@@ -1,0 +1,22 @@
+defmodule Teiserver.TachyonLobby.Types.VoteState do
+  @moduledoc """
+  Data about the current active vote in the lobby
+  """
+  alias Teiserver.Account.User
+  defstruct [:id, :action, :initiator, :voters, :duration_s, :until, :quorum, :majority]
+
+  @type vote_action :: {:change_map, String.t()} | {:appoint_boss, User.id()} | :start
+  @type vote_ballot :: :yes | :no | :abstain
+  @type vote_outcome :: :passed | :failed | :cancelled | :timeout
+
+  @type t() :: %__MODULE__{
+          id: String.t(),
+          action: vote_action,
+          initiator: Teiserver.Account.User.id(),
+          voters: %{Teiserver.Account.User.id() => :pending | vote_ballot()},
+          duration_s: non_neg_integer(),
+          until: DateTime.t(),
+          quorum: non_neg_integer(),
+          majority: non_neg_integer()
+        }
+end

--- a/test/teiserver/helpers/collections_test.exs
+++ b/test/teiserver/helpers/collections_test.exs
@@ -1,4 +1,9 @@
+defmodule Teiserver.Helpers.CollectionsTest.TestStruct do
+  defstruct [:foo, :bar]
+end
+
 defmodule Teiserver.Helpers.CollectionsTest do
+  alias Teiserver.Helpers.CollectionsTest.TestStruct
   use ExUnit.Case
 
   import Teiserver.Helpers.Collections, only: [transform_map: 2]
@@ -93,6 +98,28 @@ defmodule Teiserver.Helpers.CollectionsTest do
       spec = %{foo: fn m, _k -> Map.put(m, :key, "nope") end}
       data = %{foo: nil}
       expected = %{key: "nope"}
+      assert transform_map(data, spec) == expected
+    end
+
+    test "can create structs" do
+      spec = %{"data" => {:data, TestStruct, %{"foo" => :foo, "bar" => :bar}}}
+      data = %{"data" => %{"foo" => "fooval", "bar" => "barval"}}
+
+      expected = %{
+        data: %TestStruct{foo: "fooval", bar: "barval"}
+      }
+
+      assert transform_map(data, spec) == expected
+    end
+
+    test "can create structs in lists" do
+      spec = %{"data" => {:data, TestStruct, %{"foo" => :foo, "bar" => :bar}}}
+      data = %{"data" => [%{"foo" => "fooval", "bar" => "barval"}]}
+
+      expected = %{
+        data: [%TestStruct{foo: "fooval", bar: "barval"}]
+      }
+
       assert transform_map(data, spec) == expected
     end
   end

--- a/test/teiserver/tachyon_lobby/list_test.exs
+++ b/test/teiserver/tachyon_lobby/list_test.exs
@@ -62,7 +62,10 @@ defmodule Teiserver.TachyonLobby.ListTest do
     {sink_pid, id, _pid} = mk_lobby()
 
     assert {_initial_counter, %{^id => _overview}} = Lobby.subscribe_updates()
-    {:ok, _lobby_pid, _details} = Lobby.join(id, %{id: "user2", name: "name-user2"}, sink_pid)
+
+    {:ok, _lobby_pid, _details} =
+      Lobby.join(id, %LT.PlayerJoinData{id: "user2", name: "name-user2"}, sink_pid)
+
     {:ok, _details} = Lobby.join_ally_team(id, "user2", 1)
     Lobby.List.broadcast_updates()
     assert_receive %{event: :update_lobbies, changes: %{^id => %{player_count: 2}}}
@@ -85,9 +88,15 @@ defmodule Teiserver.TachyonLobby.ListTest do
     {sink_pid, id, _pid} = mk_lobby([3, 3])
 
     assert {_initial_counter, %{^id => _overview}} = Lobby.subscribe_updates()
-    {:ok, _lobby_pid1, _details1} = Lobby.join(id, %{id: "user2", name: "name-user2"}, sink_pid)
+
+    {:ok, _lobby_pid1, _details1} =
+      Lobby.join(id, %LT.PlayerJoinData{id: "user2", name: "name-user2"}, sink_pid)
+
     {:ok, _details} = Lobby.join_ally_team(id, "user2", 1)
-    {:ok, _lobby_pid2, _details2} = Lobby.join(id, %{id: "user3", name: "name-user3"}, sink_pid)
+
+    {:ok, _lobby_pid2, _details2} =
+      Lobby.join(id, %LT.PlayerJoinData{id: "user3", name: "name-user3"}, sink_pid)
+
     {:ok, _details} = Lobby.join_ally_team(id, "user3", 1)
     Lobby.List.broadcast_updates()
     assert_receive %{event: :update_lobbies, changes: %{^id => %{player_count: 3}}}
@@ -98,9 +107,14 @@ defmodule Teiserver.TachyonLobby.ListTest do
     {_sink_pid2, id2, _pid2} = mk_lobby()
     assert {_initial_counter, _lobbies} = Lobby.subscribe_updates()
 
-    {:ok, _lobby_pid1, _details1} = Lobby.join(id1, %{id: "user2", name: "name-user2"}, sink_pid)
+    {:ok, _lobby_pid1, _details1} =
+      Lobby.join(id1, %LT.PlayerJoinData{id: "user2", name: "name-user2"}, sink_pid)
+
     {:ok, _details} = Lobby.join_ally_team(id1, "user2", 1)
-    {:ok, _lobby_pid2, _details2} = Lobby.join(id2, %{id: "user3", name: "name-user3"}, sink_pid)
+
+    {:ok, _lobby_pid2, _details2} =
+      Lobby.join(id2, %LT.PlayerJoinData{id: "user3", name: "name-user3"}, sink_pid)
+
     {:ok, _details} = Lobby.join_ally_team(id2, "user3", 1)
 
     Lobby.List.broadcast_updates()
@@ -121,7 +135,10 @@ defmodule Teiserver.TachyonLobby.ListTest do
     {sink_pid, id, _pid} = mk_lobby()
 
     assert {_initial_counter, %{^id => _overview}} = Lobby.subscribe_updates()
-    {:ok, _lobby_pid, _details} = Lobby.join(id, %{id: "user2", name: "name-user2"}, sink_pid)
+
+    {:ok, _lobby_pid, _details} =
+      Lobby.join(id, %LT.PlayerJoinData{id: "user2", name: "name-user2"}, sink_pid)
+
     :ok = Lobby.join_queue(id, "user2")
     Lobby.List.broadcast_updates()
     assert_receive %{event: :update_lobbies, changes: %{^id => %{player_count: 2}}}
@@ -132,7 +149,10 @@ defmodule Teiserver.TachyonLobby.ListTest do
 
     assert {_initial_counter, %{^id => _overview}} = Lobby.subscribe_updates()
     {:ok, _bot_id1} = Lobby.add_bot(id, "1234", 1, "bot")
-    {:ok, _lobby_pid, _details} = Lobby.join(id, %{id: "user2", name: "name-user2"}, sink_pid)
+
+    {:ok, _lobby_pid, _details} =
+      Lobby.join(id, %LT.PlayerJoinData{id: "user2", name: "name-user2"}, sink_pid)
+
     {:ok, _details} = Lobby.join_ally_team(id, "user2", 1)
     Lobby.List.broadcast_updates()
 
@@ -143,7 +163,10 @@ defmodule Teiserver.TachyonLobby.ListTest do
     {sink_pid, id, _pid} = mk_lobby()
 
     assert {_initial_counter, %{^id => _overview}} = Lobby.subscribe_updates()
-    {:ok, _lobby_pid, _details} = Lobby.join(id, %{id: "user2", name: "name-user2"}, sink_pid)
+
+    {:ok, _lobby_pid, _details} =
+      Lobby.join(id, %LT.PlayerJoinData{id: "user2", name: "name-user2"}, sink_pid)
+
     {:ok, _details} = Lobby.join_ally_team(id, "user2", 1)
     Lobby.List.broadcast_updates()
     assert_receive %{event: :update_lobbies, changes: %{^id => %{player_count: 2}}}
@@ -169,7 +192,7 @@ defmodule Teiserver.TachyonLobby.ListTest do
       Enum.map([2, 3, 4, 5], fn i ->
         {:ok, sink_pid} = Task.start_link(:timer, :sleep, [:infinity])
         player_id = to_string(i)
-        player = %{id: player_id, name: "name-#{player_id}"}
+        player = %LT.PlayerJoinData{id: player_id, name: "name-#{player_id}"}
         {:ok, _lobby_pid, _details} = Lobby.join(id, player, sink_pid)
         {to_string(i), Map.put(player, :pid, sink_pid)}
       end)
@@ -276,7 +299,10 @@ defmodule Teiserver.TachyonLobby.ListTest do
     test "ally team config change triggers player count change" do
       {sink_pid, id, _pid} = mk_lobby([1, 1])
       assert {_initial_counter, %{}} = Lobby.subscribe_updates()
-      {:ok, _lobby_pid, _details} = Lobby.join(id, %{id: "user2", name: "name-user2"}, sink_pid)
+
+      {:ok, _lobby_pid, _details} =
+        Lobby.join(id, %LT.PlayerJoinData{id: "user2", name: "name-user2"}, sink_pid)
+
       {:ok, _join_details} = Lobby.join_ally_team(id, "user2", 1)
       Lobby.List.broadcast_updates()
       assert_receive %{event: :update_lobbies, changes: %{^id => %{player_count: 2}}}
@@ -301,7 +327,7 @@ defmodule Teiserver.TachyonLobby.ListTest do
   end
 
   defp mk_start_params(teams) do
-    %{
+    %LT.StartParams{
       creator_data: %{id: "1234", name: "name-1234"},
       creator_pid: self(),
       name: "test create lobby",

--- a/test/teiserver/tachyon_lobby/list_test.exs
+++ b/test/teiserver/tachyon_lobby/list_test.exs
@@ -1,5 +1,6 @@
 defmodule Teiserver.TachyonLobby.ListTest do
   alias Teiserver.TachyonLobby, as: Lobby
+  alias Teiserver.TachyonLobby.Types, as: LT
   use Teiserver.DataCase
   import Teiserver.Support.Polling, only: [poll_until: 2]
 
@@ -311,7 +312,7 @@ defmodule Teiserver.TachyonLobby.ListTest do
         Enum.map(teams, fn max_team ->
           x = for _i <- 1..max_team, do: %{max_players: 1}
 
-          %{
+          %LT.AllyTeamConfig{
             max_teams: max_team,
             start_box: %{top: 0, left: 0, bottom: 1, right: 0.2},
             teams: x

--- a/test/teiserver/tachyon_lobby/list_test.exs
+++ b/test/teiserver/tachyon_lobby/list_test.exs
@@ -315,7 +315,7 @@ defmodule Teiserver.TachyonLobby.ListTest do
   end
 
   defp overview_fixture do
-    %{
+    %LT.ListOverview{
       name: "lobby name",
       player_count: 1,
       max_player_count: 2,

--- a/test/teiserver/tachyon_lobby/lobby_test.exs
+++ b/test/teiserver/tachyon_lobby/lobby_test.exs
@@ -121,7 +121,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "as a spectator" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([1, 1]) |> Lobby.create()
 
       {:ok, sink_pid} = Task.start_link(:timer, :sleep, [:infinity])
@@ -133,7 +133,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "is idempotent" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 1]) |> Lobby.create()
 
       {:ok, _lobby_pid, details} = Lobby.join(id, mk_player("other-user-id"), self())
@@ -144,7 +144,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     test "participants get updated events on join" do
       {:ok, sink_pid} = Task.start_link(:timer, :sleep, [:infinity])
 
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:ok, _lobby_pid, _details} = Lobby.join(id, mk_player("user2"), sink_pid)
@@ -154,7 +154,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
 
       {:ok, sink_pid} = Task.start_link(:timer, :sleep, [:infinity])
 
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:ok, _lobby_pid2, _details2} = Lobby.join(id, mk_player("user2"), sink_pid)
@@ -167,7 +167,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     test "lobby full" do
       {:ok, sink_pid} = Task.start_link(:timer, :sleep, [:infinity])
 
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       for i <- 1..250 do
@@ -188,14 +188,14 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "must be in lobby" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([1, 1]) |> Lobby.create()
 
       {:error, :not_in_lobby} = Lobby.leave(id, "not here")
     end
 
     test "must target valid ally team" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([1, 1]) |> Lobby.create()
 
       {:ok, _pid, _details} = Lobby.join(id, mk_player("user2"))
@@ -203,7 +203,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "ally team must have empty space" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([1, 1]) |> Lobby.create()
 
       {:ok, _pid, _details} = Lobby.join(id, mk_player("user2"))
@@ -213,7 +213,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     test "works" do
       {:ok, sink_pid} = Task.start_link(:timer, :sleep, [:infinity])
 
-      {:ok, _pid, %{id: id} = create_details} =
+      {:ok, _pid, %LT.Details{id: id} = create_details} =
         mk_start_params([1, 1]) |> Lobby.create()
 
       assert %{ready?: false, asset_status: :complete} = create_details.players[@default_user_id]
@@ -230,7 +230,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     test "player moving also get updates" do
       {:ok, sink_pid} = Task.start_link(:timer, :sleep, [:infinity])
 
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([1, 1]) |> Map.put(:creator_pid, sink_pid) |> Lobby.create()
 
       {:ok, _lobby_pid, _join_details} = Lobby.join(id, mk_player("user2"))
@@ -247,7 +247,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     test "can change ally team" do
       {:ok, sink_pid} = Task.start_link(:timer, :sleep, [:infinity])
 
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:ok, _lobby_pid, _join_details} = Lobby.join(id, mk_player("user2"), sink_pid)
@@ -261,7 +261,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     test "changing ally team updates" do
       {:ok, sink_pid} = Task.start_link(:timer, :sleep, [:infinity])
 
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:ok, _lobby_pid, _join_details} = Lobby.join(id, mk_player("user2"), sink_pid)
@@ -279,7 +279,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     test "other players are reshuffled" do
       {:ok, sink_pid} = Task.start_link(:timer, :sleep, [:infinity])
 
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:ok, _lobby_pid, _join_details} = Lobby.join(id, mk_player("user2"), sink_pid)
@@ -304,14 +304,14 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
 
   describe "leaving" do
     test "cannot leave lobby if not in the lobby" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 1]) |> Lobby.create()
 
       {:error, :not_in_lobby} = Lobby.leave(id, "not here")
     end
 
     test "cannot leave lobby if already left" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 1]) |> Lobby.create()
 
       {:ok, _pid, _details} = Lobby.join(id, mk_player("user2"), self())
@@ -320,7 +320,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "can leave lobby" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:ok, _pid, _details} = Lobby.join(id, mk_player("user2"), self())
@@ -343,7 +343,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "can leave lobby and rejoin" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       player = mk_player("user2")
@@ -355,7 +355,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     test "leaving lobby send updates to remaining members" do
       {:ok, sink_pid} = Task.start_link(:timer, :sleep, [:infinity])
 
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:ok, _pid, _details} = Lobby.join(id, mk_player("user2"), sink_pid)
@@ -369,7 +369,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     test "reshuffling player on leave sends updates" do
       {:ok, sink_pid} = Task.start_link(:timer, :sleep, [:infinity])
 
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:ok, _pid, _details} = Lobby.join(id, mk_player("user2"), sink_pid)
@@ -401,7 +401,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     test "player pid dying means player is removed from lobby" do
       {:ok, sink_pid} = Task.start(:timer, :sleep, [:infinity])
 
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Map.put(:creator_pid, sink_pid) |> Lobby.create()
 
       {:ok, _pid, _details} = Lobby.join(id, mk_player("user2"), self())
@@ -413,7 +413,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     test "spectator pid dying means is removed from lobby" do
       {:ok, sink_pid} = Task.start(:timer, :sleep, [:infinity])
 
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:ok, _pid, _details} = Lobby.join(id, mk_player("user2"), sink_pid)
@@ -427,7 +427,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     test "spec leaving removes monitors" do
       {:ok, sink_pid} = Task.start(:timer, :sleep, [:infinity])
 
-      {:ok, lobby_pid, %{id: id}} =
+      {:ok, lobby_pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:ok, _pid, _details} = Lobby.join(id, mk_player("user2"), sink_pid)
@@ -443,7 +443,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     test "player leaving removes monitors" do
       {:ok, sink_pid} = Task.start(:timer, :sleep, [:infinity])
 
-      {:ok, lobby_pid, %{id: id}} =
+      {:ok, lobby_pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:ok, _pid, _details} = Lobby.join(id, mk_player("user2"), sink_pid)
@@ -465,14 +465,14 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "must be in lobby" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:error, :not_in_lobby} = Lobby.spectate(id, "not in lobby")
     end
 
     test "works" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       :ok = Lobby.spectate(id, @default_user_id)
@@ -486,7 +486,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "is idempotent" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       :ok = Lobby.spectate(id, @default_user_id)
@@ -502,7 +502,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "not in lobby" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:error, :not_in_lobby} = Lobby.join_queue(id, "not in lobby")
@@ -678,14 +678,14 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "must be in lobby" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:error, :not_in_lobby} = Lobby.add_bot(id, "random-user-id", 0, "bot short name")
     end
 
     test "must specify valid ally team" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:error, :invalid_ally_team} = Lobby.add_bot(id, @default_user_id, 10, "bot short name")
@@ -693,14 +693,14 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "must have space in ally team" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([1, 1]) |> Lobby.create()
 
       {:error, :ally_team_full} = Lobby.add_bot(id, @default_user_id, 0, "bot short name")
     end
 
     test "add_bot works" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([1, 1]) |> Lobby.create()
 
       {:ok, bot_id} = Lobby.add_bot(id, @default_user_id, 1, "bot short name")
@@ -719,7 +719,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "lobby details has the bots" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([1, 1]) |> Lobby.create()
 
       {:ok, bot_id} =
@@ -746,7 +746,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "bots correctly put in teams" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([3, 3]) |> Lobby.create()
 
       {:ok, bot_id1} = Lobby.add_bot(id, @default_user_id, 0, "bot short name")
@@ -759,7 +759,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "bots are taken into account for team capacity" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([1, 1]) |> Lobby.create()
 
       {:ok, _bot_id} = Lobby.add_bot(id, @default_user_id, 1, "bot short name")
@@ -767,7 +767,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "creator leaving also removes bots" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:ok, sink_pid} = Task.start(:timer, :sleep, [:infinity])
@@ -820,14 +820,14 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "correct id required to remove bot" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:error, :invalid_bot_id} = Lobby.remove_bot(id, "lolnope")
     end
 
     test "remove_bot works" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:ok, bot_id} = Lobby.add_bot(id, @default_user_id, 1, "bot short name")
@@ -838,7 +838,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "removing a bot reshuffle the teams" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:ok, bot_id1} = Lobby.add_bot(id, @default_user_id, 1, "bot short name")
@@ -853,7 +853,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
 
     test "removing bot allow specs in join queue to get the spot" do
       # Setup
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([1, 1]) |> Lobby.create()
 
       {:ok, bot_id} = Lobby.add_bot(id, @default_user_id, 1, "bot short name")
@@ -894,14 +894,14 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "update needs correct id" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:error, :invalid_bot_id} = Lobby.update_bot(id, %{id: "lolnope"})
     end
 
     test "can update some properties" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:ok, bot_id} = Lobby.add_bot(id, @default_user_id, 1, "bot")
@@ -925,7 +925,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "only supported properties" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:error, _reason} =
@@ -933,7 +933,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "name work" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       :ok = Lobby.update_properties(id, @default_user_id, %{name: "new name"})
@@ -943,7 +943,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "map name" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       :ok = Lobby.update_properties(id, @default_user_id, %{map_name: "new map"})
@@ -1260,7 +1260,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
 
   describe "update ally team" do
     test "work" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       new_ally_team_config = mk_start_params([1, 1]).ally_team_config
@@ -1287,7 +1287,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "ally team config diff with less ally team teams" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([1, 1, 1]) |> Lobby.create()
 
       new_ally_team_config = mk_start_params([1, 1]).ally_team_config
@@ -1301,7 +1301,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "ally team config diff with less teams" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([3]) |> Lobby.create()
 
       new_ally_team_config = mk_start_params([2]).ally_team_config
@@ -1443,7 +1443,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     test "no snapshot when normal exit" do
       sink_pid = mk_sink()
 
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([1, 1]) |> Map.put(:creator_pid, sink_pid) |> Lobby.create()
 
       TachyonLib.restart_system()
@@ -1453,7 +1453,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     test "can rejoin lobby from snapshot" do
       sink_pid = mk_sink()
 
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([1, 1]) |> Map.put(:creator_pid, sink_pid) |> Lobby.create()
 
       Process.exit(sink_pid, :shutdown)
@@ -1467,7 +1467,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     test "must rejoin first before being able to leave" do
       sink_pid = mk_sink()
 
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([1, 1]) |> Map.put(:creator_pid, sink_pid) |> Lobby.create()
 
       Process.exit(sink_pid, :shutdown)
@@ -1495,7 +1495,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
       assert {_initial_counter, %{}} = Lobby.subscribe_updates()
       sink_pid = mk_sink()
 
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([1, 1]) |> Map.put(:creator_pid, sink_pid) |> Lobby.create()
 
       drain_msg_queue()
@@ -1519,14 +1519,14 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "must be in lobby" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:error, :not_in_lobby} = Lobby.update_client_status(id, "user1", %{ready?: true})
     end
 
     test "can update properties one by one" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       :ok = Lobby.update_client_status(id, @default_user_id, %{ready?: true})
@@ -1539,7 +1539,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "can update multiple properties at once" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       :ok =
@@ -1557,7 +1557,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     # could also be handled by client. For now, keep implementation simple
     # and always process the request
     test "send event if no changes" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       :ok = Lobby.update_client_status(id, @default_user_id, %{ready?: false})
@@ -1566,7 +1566,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "only player can update status" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([1, 1]) |> Lobby.create()
 
       {:ok, sink_pid} = Task.start_link(:timer, :sleep, [:infinity])
@@ -1578,7 +1578,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
 
   describe "update game options" do
     test "can add an option" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       :ok = Lobby.update_properties(id, @default_user_id, %{game_options: %{"foo" => "bar"}})
@@ -1588,7 +1588,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "can update option" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2])
         |> Map.put(:game_options, %{"foo" => "bar"})
         |> Lobby.create()
@@ -1602,7 +1602,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "can remove an option" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2])
         |> Map.put(:game_options, %{"foo" => "bar"})
         |> Lobby.create()
@@ -1614,7 +1614,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "can add remove and update in one request" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2])
         |> Map.put(:game_options, %{"foo" => "bar", "ranked" => "true"})
         |> Lobby.create()
@@ -1651,7 +1651,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "can add a tag" do
-      {:ok, _pid, %{id: id}} = mk_start_params([2, 2]) |> Lobby.create()
+      {:ok, _pid, %LT.Details{id: id}} = mk_start_params([2, 2]) |> Lobby.create()
 
       :ok = Lobby.update_properties(id, @default_user_id, %{tags: %{"competitive" => %{}}})
       {:ok, details} = LobbyProcess.get_details(id)
@@ -1660,7 +1660,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "can remove a tag" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2])
         |> Map.put(:tags, %{"competitive" => %{}, "no_rush" => %{}})
         |> Lobby.create()
@@ -1672,7 +1672,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "existing tags survive partial update" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2])
         |> Map.put(:tags, %{"competitive" => %{}, "no_rush" => %{}})
         |> Lobby.create()
@@ -1683,7 +1683,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "can add remove and update in one request" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2])
         |> Map.put(:tags, %{"competitive" => %{}, "no_rush" => %{}})
         |> Lobby.create()
@@ -1711,7 +1711,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "must be in lobby" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:error, :not_in_lobby} = Lobby.start_battle(id, "not in lobby")
@@ -1725,7 +1725,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "must be in lobby" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:error, :not_in_lobby} = Lobby.join_battle(id, "not in lobby")
@@ -1734,7 +1734,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
 
   describe "start script" do
     test "with 1 player" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       start_script = LobbyProcess.get_start_script(id)
@@ -1742,7 +1742,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "with a spec" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:ok, _lobby_pid, _details} = Lobby.join(id, mk_player("other-user-id"))
@@ -1752,7 +1752,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "with 2 players in the same team" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:ok, _lobby_pid, _details} = Lobby.join(id, mk_player("other-user-id"))
@@ -1765,7 +1765,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "1 ally team with a player leaving then joining" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:ok, _lobby_pid, _details} = Lobby.join(id, mk_player("other-user-id"))
@@ -1780,7 +1780,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "2 ally teams" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:ok, _lobby_pid, _details} = Lobby.join(id, mk_player("other-user-id"))
@@ -1793,7 +1793,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
     end
 
     test "with a bot" do
-      {:ok, _pid, %{id: id}} =
+      {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([2, 2]) |> Lobby.create()
 
       {:ok, _bot_id} = Lobby.add_bot(id, @default_user_id, 1, "bot short name")

--- a/test/teiserver/tachyon_lobby/lobby_test.exs
+++ b/test/teiserver/tachyon_lobby/lobby_test.exs
@@ -1086,10 +1086,12 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
       {:ok, details} = LobbyProcess.get_details(id)
       assert map_size(details.vote_history) == 2
       assert vote_id < vote_id2
-      assert details.vote_history[vote_id].outcome == :passed
-      assert details.vote_history[vote_id].vote == {:change_map, "new map"}
-      assert details.vote_history[vote_id2].outcome == :failed
-      assert details.vote_history[vote_id2].vote == {:change_map, "new map2"}
+      record1 = %LT.VoteDetails{} = details.vote_history[vote_id]
+      record2 = %LT.VoteDetails{} = details.vote_history[vote_id2]
+      assert record1.outcome == :passed
+      assert record1.vote == {:change_map, "new map"}
+      assert record2.outcome == :failed
+      assert record2.vote == {:change_map, "new map2"}
     end
 
     test "map stays when vote fails" do

--- a/test/teiserver/tachyon_lobby/lobby_test.exs
+++ b/test/teiserver/tachyon_lobby/lobby_test.exs
@@ -5,6 +5,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
   alias Teiserver.Tachyon, as: TachyonLib
   alias Teiserver.TachyonLobby, as: Lobby
   alias Teiserver.TachyonLobby.Lobby, as: LobbyProcess
+  alias Teiserver.TachyonLobby.Types, as: LT
 
   use Teiserver.DataCase
 
@@ -1849,7 +1850,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
         Enum.map(teams, fn max_team ->
           x = for _i <- 1..max_team, do: %{max_players: 1}
 
-          %{
+          %LT.AllyTeamConfig{
             max_teams: max_team,
             start_box: %{top: 0, left: 0, bottom: 1, right: 0.2},
             teams: x

--- a/test/teiserver/tachyon_lobby/lobby_test.exs
+++ b/test/teiserver/tachyon_lobby/lobby_test.exs
@@ -27,7 +27,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
   test "must have a game in db" do
     result =
       mk_start_params([1, 1])
-      |> Map.drop([:game_version])
+      |> Map.replace!(:game_version, nil)
       |> Lobby.create()
 
     assert result == {:error, :no_game_version_found}
@@ -38,7 +38,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
 
     {:ok, _pid, details} =
       mk_start_params([1, 1])
-      |> Map.drop([:game_version])
+      |> Map.replace!(:game_version, nil)
       |> Lobby.create()
 
     assert details.game_version == game.name
@@ -47,7 +47,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
   test "must have engine in db" do
     result =
       mk_start_params([1, 1])
-      |> Map.drop([:engine_version])
+      |> Map.replace!(:engine_version, nil)
       |> Lobby.create()
 
     assert result == {:error, :no_engine_version_found}
@@ -58,7 +58,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
 
     {:ok, _pid, details} =
       mk_start_params([1, 1])
-      |> Map.drop([:engine_version])
+      |> Map.replace!(:engine_version, nil)
       |> Lobby.create()
 
     assert details.engine_version == engine.name
@@ -1841,7 +1841,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
   end
 
   defp mk_start_params(teams) do
-    %{
+    %LT.StartParams{
       creator_data: %{id: @default_user_id, name: "name-#{@default_user_id}"},
       creator_pid: self(),
       name: "test create lobby",
@@ -1862,7 +1862,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
   end
 
   defp mk_player(user_id) do
-    %{id: user_id, name: "name-#{user_id}"}
+    %LT.PlayerJoinData{id: user_id, name: "name-#{user_id}"}
   end
 
   # create a lobby with a few specs already in. Simplify the logic when


### PR DESCRIPTION
This adds proper structs for almost all types defined for tachyon lobbies. Almost all `@type ...` have been moved to structs.
I've also done a smoke test with the new client and it still works.
There is no business logic change on this PR.