### PR TITLE
Added some uses of moderation automation

### DIFF
--- a/lib/teiserver/chat/libs/word_lib.ex
+++ b/lib/teiserver/chat/libs/word_lib.ex
@@ -2,6 +2,7 @@ defmodule Teiserver.Chat.WordLib do
   @moduledoc false
   alias Teiserver.Config
   alias Teiserver.Helper.StringHelper
+  alias Teiserver.Moderation.BannedPhrase
   alias Teiserver.Plugins
 
   use Plugins
@@ -9,10 +10,6 @@ defmodule Teiserver.Chat.WordLib do
   require Logger
 
   @flagged_regex ~r/(n[i1l]gg(:?[e3]r|a)|cun[t7][s5]?|\b(r[e3])?[t7]ards?\b|卐)/iu
-  @blacklisted_regexs [
-    ~r(superinnapropriateword),
-    ~r(anotherreallybadword)
-  ]
 
   @doc """
   Given a text message it will look for a set of flagged words.
@@ -93,22 +90,12 @@ defmodule Teiserver.Chat.WordLib do
     end
   end
 
-  # TODO: Replace all calls to this with BannedPhrase.message_severity
   @spec blacklisted_phrase?(String.t()) :: boolean()
   @decorate Plugins.plugin(:blacklisted_phrase?)
   def blacklisted_phrase?(text) do
     text = StringHelper.leet_replace(text)
 
-    result =
-      @blacklisted_regexs
-      |> Enum.reduce(false, fn
-        _regex, true ->
-          true
-
-        r, false ->
-          Regex.match?(r, text)
-      end)
-
-    result
+    # If it's a high severity match then yes it is blacklisted
+    BannedPhrase.message_severity(text, :high) == :high
   end
 end

--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -7,6 +7,7 @@ defmodule Teiserver.CacheUser do
   alias Phoenix.PubSub
   alias Teiserver.Account
   alias Teiserver.Account.Auth
+  alias Teiserver.Account.CalculateSmurfKeyTask
   alias Teiserver.Account.Guardian
   alias Teiserver.Account.LoginThrottleServer
   alias Teiserver.Account.User
@@ -20,6 +21,8 @@ defmodule Teiserver.CacheUser do
   alias Teiserver.Data.Types, as: T
   alias Teiserver.EmailHelper
   alias Teiserver.Geoip
+  alias Teiserver.Moderation
+  alias Teiserver.Moderation.Tasks.ExternalIPCheckTask
   alias Teiserver.Plugins
   alias Teiserver.Telemetry
 
@@ -228,6 +231,21 @@ defmodule Teiserver.CacheUser do
       "country" => Geoip.get_flag(ip),
       "verification_code" => (:rand.uniform(899_999) + 100_000) |> to_string()
     })
+
+    ip_check_results = ExternalIPCheckTask.get_ban_reasons(ip)
+
+    unless Enum.empty?(ip_check_results) do
+      Account.update_user_stat(user.id, %{
+        "ip_check_results" => Enum.join(ip_check_results, ", "),
+        "ip_check_bad?" => true
+      })
+    end
+
+    if Moderation.banned_ip?(ip) do
+      Account.update_user_stat(user.id, %{
+        "banned_ip?" => true
+      })
+    end
 
     # Now add them to the cache
     user
@@ -691,14 +709,6 @@ defmodule Teiserver.CacheUser do
       {:ok, db_user, _claims} ->
         user = get_user_by_id(db_user.id)
 
-        # # If they're a smurf, log them in as the smurf!
-        # user =
-        #   if user.smurf_of_id != nil do
-        #     get_user_by_id(user.smurf_of_id)
-        #   else
-        #     user
-        #   end
-
         cond do
           user.smurf_of_id != nil ->
             Telemetry.log_complex_server_event(db_user.id, "Banned login", %{
@@ -733,6 +743,16 @@ defmodule Teiserver.CacheUser do
               lobby_hash: lobby_hash,
               last_ip: ip
             })
+
+            # One way hash of the creation IP. If enabled during testing we
+            # will get foreign key errors as the test shuts down
+            if not Application.get_env(:teiserver, Teiserver)[:test_mode] do
+              Account.create_smurf_key(
+                user.id,
+                "ip",
+                CalculateSmurfKeyTask.calculate_string_fingerprint(ip)
+              )
+            end
 
             {:error, "Unverified", user.id}
 
@@ -985,6 +1005,12 @@ defmodule Teiserver.CacheUser do
       Telemetry.log_simple_server_event(user.id, "account.user_login")
 
       if not bot? do
+        Account.create_smurf_key(
+          user.id,
+          "ip",
+          CalculateSmurfKeyTask.calculate_string_fingerprint(ip)
+        )
+
         Account.create_smurf_key(user.id, "client_app_hash", lobby_hash)
       end
     end
@@ -1170,6 +1196,9 @@ defmodule Teiserver.CacheUser do
       # (and also redundant)
       Account.query_users(search: [email_lower: email], select: [:email]) != [] ->
         {:error, "Email already attached to a user"}
+
+      Moderation.banned_domain?(email) ->
+        {:error, "Due to frequent abuse, that email provider is not allowed."}
 
       true ->
         :ok

--- a/lib/teiserver/data/client.ex
+++ b/lib/teiserver/data/client.ex
@@ -1,24 +1,17 @@
-# defmodule Teiserver.Data.ClientStruct do
-#   @enforce_keys [:in_game, :away, :rank, :moderator, :bot]
-#   defstruct [
-#     :id, :name, :team_size, :icon, :colour, :settings, :conditions, :map_list,
-#     current_search_time: 0, current_size: 0, contents: [], pid: nil
-#   ]
-# end
-
 defmodule Teiserver.Client do
   @moduledoc false
 
-  # alias Teiserver.Helper.DateHelper
   alias Phoenix.PubSub
   alias Teiserver.Account
   alias Teiserver.Account.Auth
+  alias Teiserver.Account.CalculateSmurfKeyTask
   alias Teiserver.Account.ClientLib
   alias Teiserver.CacheUser
   alias Teiserver.Coordinator
   alias Teiserver.Data.Types, as: T
   alias Teiserver.Lobby
   alias Teiserver.Telemetry
+
   require Logger
 
   @spec create(map()) :: map()
@@ -118,6 +111,15 @@ defmodule Teiserver.Client do
         protocol: protocol
       })
 
+    # If enabled during testing we will get foreign key errors as the test shuts down
+    if not Application.get_env(:teiserver, Teiserver)[:test_mode] do
+      Account.create_smurf_key(
+        user.id,
+        "ip",
+        CalculateSmurfKeyTask.calculate_string_fingerprint(ip)
+      )
+    end
+
     ClientLib.start_client_server(client)
 
     PubSub.broadcast(
@@ -177,32 +179,32 @@ defmodule Teiserver.Client do
   defdelegate get_client_by_name(name), to: ClientLib
 
   @spec get_client_by_id(nil) :: nil
-  @spec get_client_by_id(T.userid()) :: nil | T.client()
+  @spec get_client_by_id(User.id()) :: nil | T.client()
   defdelegate get_client_by_id(userid), to: ClientLib
 
-  @spec get_clients([T.userid()]) :: List.t()
+  @spec get_clients([User.id()]) :: List.t()
   defdelegate get_clients(id_list), to: ClientLib
 
-  @spec list_client_ids() :: [T.userid()]
+  @spec list_client_ids() :: [User.id()]
   defdelegate list_client_ids(), to: ClientLib
 
   @spec list_clients() :: [T.client()]
   defdelegate list_clients(), to: ClientLib
 
-  @spec list_clients([T.userid()]) :: [T.client()]
+  @spec list_clients([User.id()]) :: [T.client()]
   defdelegate list_clients(id_list), to: ClientLib
 
   @spec update(map(), :silent | :client_updated_status | :client_updated_battlestatus) ::
           T.client()
   def update(client, reason), do: ClientLib.replace_update_client(client, reason)
 
-  @spec get_client_pid(T.userid()) :: pid() | nil
+  @spec get_client_pid(User.id()) :: pid() | nil
   defdelegate get_client_pid(userid), to: ClientLib
 
-  @spec cast_client(T.userid(), any) :: any
+  @spec cast_client(User.id(), any) :: any
   defdelegate cast_client(userid, msg), to: ClientLib
 
-  @spec call_client(T.userid(), any) :: any | nil
+  @spec call_client(User.id(), any) :: any | nil
   defdelegate call_client(userid, msg), to: ClientLib
 
   @spec join_battle(T.client_id(), Integer.t(), boolean()) :: nil | T.client()
@@ -237,7 +239,7 @@ defmodule Teiserver.Client do
     end
   end
 
-  @spec disconnect(T.userid(), nil | String.t()) :: nil | :ok | {:error, any}
+  @spec disconnect(User.id(), nil | String.t()) :: nil | :ok | {:error, any}
   def disconnect(userid, reason \\ nil) do
     case get_client_by_id(userid) do
       nil -> nil
@@ -245,7 +247,7 @@ defmodule Teiserver.Client do
     end
   end
 
-  @spec kick_disconnect(T.userid(), nil | String.t()) :: nil | :ok | {:error, any}
+  @spec kick_disconnect(User.id(), nil | String.t()) :: nil | :ok | {:error, any}
   def kick_disconnect(userid, reason \\ nil) do
     case get_client_by_id(userid) do
       nil -> nil
@@ -312,7 +314,7 @@ defmodule Teiserver.Client do
     )
   end
 
-  @spec set_awaiting_warn_ack(T.userid()) :: :ok
+  @spec set_awaiting_warn_ack(User.id()) :: :ok
   def set_awaiting_warn_ack(userid) do
     case get_client_by_id(userid) do
       nil ->
@@ -325,14 +327,14 @@ defmodule Teiserver.Client do
     :ok
   end
 
-  @spec clear_awaiting_warn_ack(T.userid()) :: :ok
+  @spec clear_awaiting_warn_ack(User.id()) :: :ok
   def clear_awaiting_warn_ack(userid) do
     client = get_client_by_id(userid)
     update(%{client | awaiting_warn_ack: false}, :silent)
     :ok
   end
 
-  @spec enable_client_message_print(T.userid()) :: :ok
+  @spec enable_client_message_print(User.id()) :: :ok
   def enable_client_message_print(userid) do
     case get_client_by_id(userid) do
       nil ->
@@ -344,7 +346,7 @@ defmodule Teiserver.Client do
     end
   end
 
-  @spec disable_client_message_print(T.userid()) :: :ok
+  @spec disable_client_message_print(User.id()) :: :ok
   def disable_client_message_print(userid) do
     case get_client_by_id(userid) do
       nil ->
@@ -356,7 +358,7 @@ defmodule Teiserver.Client do
     end
   end
 
-  @spec enable_server_message_print(T.userid()) :: :ok
+  @spec enable_server_message_print(User.id()) :: :ok
   def enable_server_message_print(userid) do
     case get_client_by_id(userid) do
       nil ->
@@ -368,7 +370,7 @@ defmodule Teiserver.Client do
     end
   end
 
-  @spec disable_server_message_print(T.userid()) :: :ok
+  @spec disable_server_message_print(User.id()) :: :ok
   def disable_server_message_print(userid) do
     case get_client_by_id(userid) do
       nil ->

--- a/test/teiserver/moderation/tasks/external_ip_check_task_test.exs
+++ b/test/teiserver/moderation/tasks/external_ip_check_task_test.exs
@@ -7,6 +7,8 @@ defmodule Teiserver.Moderation.Tasks.ExternalIpCheckTaskTest do
 
   use Teiserver.DataCase, async: false
 
+  import ExUnit.CaptureLog
+
   describe "return ban reason when config enabled" do
     test "abuser" do
       setup_config("teiserver.external_ip_ban_is_abuser", true)
@@ -50,7 +52,12 @@ defmodule Teiserver.Moderation.Tasks.ExternalIpCheckTaskTest do
   end
 
   test "doesn't raise on error" do
-    assert ExternalIPCheckTask.get_ban_reasons(Stub.error_ip()) == []
+    {result, _log} =
+      with_log(fn ->
+        ExternalIPCheckTask.get_ban_reasons(Stub.error_ip())
+      end)
+
+    assert result == []
   end
 
   defp setup_config(key, value) do


### PR DESCRIPTION
- WordLib blacklisted phrases now uses BannedPhrases so can be configured at runtime
- User registration makes use of external IP check functionality
- Fixed noisy log with external IP check test