### PR TITLE
Add telemetry span around message_severity function

### DIFF
--- a/lib/teiserver/moderation/schemas/banned_phrase.ex
+++ b/lib/teiserver/moderation/schemas/banned_phrase.ex
@@ -118,15 +118,24 @@ defmodule Teiserver.Moderation.BannedPhrase do
   @spec message_severity(String.t(), severity(), [search_type()]) :: nil | BannedPhrase.severity()
   def message_severity(message, min_severity \\ :high, types \\ [:raw, :fuzzy, :regex]) do
     found_phrase =
-      Moderation.list_banned_phrases_cache()
-      |> Enum.filter(fn %BannedPhrase{type: type, severity: severity} ->
-        severity_is_at_least(severity, min_severity) and Enum.member?(types, type)
-      end)
-      |> Enum.find(fn %BannedPhrase{type: type, severity: severity} = banned_phrase ->
-        severity_is_at_least(severity, min_severity) and
-          Enum.member?(types, type) and
-          phrase_match?(banned_phrase, message)
-      end)
+      :telemetry.span(
+        [:teiserver, :moderation, :message_severity],
+        %{min_severity: min_severity},
+        fn ->
+          found_phrase =
+            Moderation.list_banned_phrases_cache()
+            |> Enum.filter(fn %BannedPhrase{type: type, severity: severity} ->
+              severity_is_at_least(severity, min_severity) and Enum.member?(types, type)
+            end)
+            |> Enum.find(fn %BannedPhrase{type: type, severity: severity} = banned_phrase ->
+              severity_is_at_least(severity, min_severity) and
+                Enum.member?(types, type) and
+                phrase_match?(banned_phrase, message)
+            end)
+
+          {found_phrase, %{min_severity: min_severity, matched: found_phrase != nil}}
+        end
+      )
 
     if found_phrase do
       found_phrase.severity

--- a/lib/teiserver/monitoring/internal.ex
+++ b/lib/teiserver/monitoring/internal.ex
@@ -1,0 +1,51 @@
+defmodule Teiserver.Monitoring.Internal do
+  @moduledoc false
+  use PromEx.Plugin
+
+  @impl PromEx.Plugin
+  def event_metrics(_opts) do
+    Event.build(
+      :teiserver_internal_event_metrics,
+      [
+        distribution(
+          [:teiserver, :moderation, :message_severity, :stop],
+          event_name: [:moderation, :message_severity],
+          measurement: :duration,
+          reporter_options: [
+            buckets: [
+              1,
+              2,
+              3,
+              5,
+              8,
+              13,
+              21,
+              34,
+              55,
+              89,
+              144,
+              233,
+              377,
+              610,
+              987,
+              1597,
+              2584,
+              4181
+            ]
+          ],
+          tags: [:matched]
+        ),
+        counter(
+          [:teiserver, :moderation, :message_severity, :stop],
+          event_name: [:moderation, :message_severity],
+          measurement: :count
+        )
+      ]
+    )
+  end
+
+  @impl PromEx.Plugin
+  def polling_metrics(_opts) do
+    []
+  end
+end

--- a/lib/teiserver/prom_ex.ex
+++ b/lib/teiserver/prom_ex.ex
@@ -70,6 +70,7 @@ defmodule Teiserver.PromEx do
       # Plugins.Broadway,
 
       # Add your own PromEx metrics plugins
+      Teiserver.Monitoring.Internal,
       Teiserver.Monitoring.Tachyon,
       Teiserver.Monitoring.Spring
     ]

--- a/lib/teiserver_web/telemetry.ex
+++ b/lib/teiserver_web/telemetry.ex
@@ -48,7 +48,18 @@ defmodule TeiserverWeb.Telemetry do
       summary("vm.memory.total", unit: {:byte, :kilobyte}),
       summary("vm.total_run_queue_lengths.total"),
       summary("vm.total_run_queue_lengths.cpu"),
-      summary("vm.total_run_queue_lengths.io")
+      summary("vm.total_run_queue_lengths.io"),
+
+      # Moderation
+      distribution(
+        [:moderation, :message_severity],
+        event_name: [:teiserver, :moderation, :message_severity, :stop],
+        measurement: :duration,
+        reporter_options: [
+          buckets: [1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987, 1597, 2584, 4181]
+        ],
+        tags: [:matched]
+      )
     ] ++
       TeiserverTelemetry.metrics()
 


### PR DESCRIPTION
This is a function potentially being called a lot of times with an expensive cost, this would give us an idea of how much and at what processing cost we are looking at.

I thought about wrapping the `phrase_match?` function to get a per phrase metric too but wanted to keep it light and limited for now.