### PR TITLE
Updading banned item now re-caches them

### DIFF
--- a/lib/teiserver/moderation.ex
+++ b/lib/teiserver/moderation.ex
@@ -925,7 +925,7 @@ defmodule Teiserver.Moderation do
     %BannedDomain{}
     |> BannedDomain.changeset(attrs)
     |> Repo.insert()
-    |> LoadBannedDomainsTask.maybe_recache()
+    |> LoadBannedDomainsTask.cache_if_ok()
   end
 
   @doc """
@@ -944,7 +944,7 @@ defmodule Teiserver.Moderation do
     banned_domain
     |> BannedDomain.changeset(attrs)
     |> Repo.update()
-    |> LoadBannedDomainsTask.maybe_recache()
+    |> LoadBannedDomainsTask.cache_if_ok()
   end
 
   @doc """
@@ -961,7 +961,7 @@ defmodule Teiserver.Moderation do
   """
   def delete_banned_domain(%BannedDomain{} = banned_domain) do
     Repo.delete(banned_domain)
-    |> LoadBannedDomainsTask.maybe_recache()
+    |> LoadBannedDomainsTask.cache_if_ok()
   end
 
   @doc """
@@ -1044,7 +1044,7 @@ defmodule Teiserver.Moderation do
     %BannedIP{}
     |> BannedIP.changeset(attrs)
     |> Repo.insert()
-    |> LoadBannedIPsTask.maybe_recache()
+    |> LoadBannedIPsTask.cache_if_ok()
   end
 
   @doc """
@@ -1063,7 +1063,7 @@ defmodule Teiserver.Moderation do
     banned_ip
     |> BannedIP.changeset(attrs)
     |> Repo.update()
-    |> LoadBannedIPsTask.maybe_recache()
+    |> LoadBannedIPsTask.cache_if_ok()
   end
 
   @doc """
@@ -1080,7 +1080,7 @@ defmodule Teiserver.Moderation do
   """
   def delete_banned_ip(%BannedIP{} = banned_ip) do
     Repo.delete(banned_ip)
-    |> LoadBannedIPsTask.maybe_recache()
+    |> LoadBannedIPsTask.cache_if_ok()
   end
 
   @doc """
@@ -1159,7 +1159,7 @@ defmodule Teiserver.Moderation do
     %BannedPhrase{}
     |> BannedPhrase.changeset(attrs)
     |> Repo.insert()
-    |> LoadBannedPhrasesTask.maybe_recache()
+    |> LoadBannedPhrasesTask.cache_if_ok()
   end
 
   @doc """
@@ -1178,7 +1178,7 @@ defmodule Teiserver.Moderation do
     banned_phrase
     |> BannedPhrase.changeset(attrs)
     |> Repo.update()
-    |> LoadBannedPhrasesTask.maybe_recache()
+    |> LoadBannedPhrasesTask.cache_if_ok()
   end
 
   @doc """
@@ -1195,7 +1195,7 @@ defmodule Teiserver.Moderation do
   """
   def delete_banned_phrase(%BannedPhrase{} = banned_phrase) do
     Repo.delete(banned_phrase)
-    |> LoadBannedPhrasesTask.maybe_recache()
+    |> LoadBannedPhrasesTask.cache_if_ok()
   end
 
   @doc """

--- a/lib/teiserver/moderation.ex
+++ b/lib/teiserver/moderation.ex
@@ -925,14 +925,7 @@ defmodule Teiserver.Moderation do
     %BannedDomain{}
     |> BannedDomain.changeset(attrs)
     |> Repo.insert()
-    |> then(fn
-      {:ok, _struct} = result ->
-        LoadBannedDomainsTask.perform()
-        result
-
-      result ->
-        result
-    end)
+    |> LoadBannedDomainsTask.maybe_recache()
   end
 
   @doc """
@@ -951,14 +944,7 @@ defmodule Teiserver.Moderation do
     banned_domain
     |> BannedDomain.changeset(attrs)
     |> Repo.update()
-    |> then(fn
-      {:ok, _struct} = result ->
-        LoadBannedDomainsTask.perform()
-        result
-
-      result ->
-        result
-    end)
+    |> LoadBannedDomainsTask.maybe_recache()
   end
 
   @doc """
@@ -975,14 +961,7 @@ defmodule Teiserver.Moderation do
   """
   def delete_banned_domain(%BannedDomain{} = banned_domain) do
     Repo.delete(banned_domain)
-    |> then(fn
-      {:ok, _struct} = result ->
-        LoadBannedDomainsTask.perform()
-        result
-
-      result ->
-        result
-    end)
+    |> LoadBannedDomainsTask.maybe_recache()
   end
 
   @doc """
@@ -1065,14 +1044,7 @@ defmodule Teiserver.Moderation do
     %BannedIP{}
     |> BannedIP.changeset(attrs)
     |> Repo.insert()
-    |> then(fn
-      {:ok, _struct} = result ->
-        LoadBannedIPsTask.perform()
-        result
-
-      result ->
-        result
-    end)
+    |> LoadBannedIPsTask.maybe_recache()
   end
 
   @doc """
@@ -1091,14 +1063,7 @@ defmodule Teiserver.Moderation do
     banned_ip
     |> BannedIP.changeset(attrs)
     |> Repo.update()
-    |> then(fn
-      {:ok, _struct} = result ->
-        LoadBannedIPsTask.perform()
-        result
-
-      result ->
-        result
-    end)
+    |> LoadBannedIPsTask.maybe_recache()
   end
 
   @doc """
@@ -1115,14 +1080,7 @@ defmodule Teiserver.Moderation do
   """
   def delete_banned_ip(%BannedIP{} = banned_ip) do
     Repo.delete(banned_ip)
-    |> then(fn
-      {:ok, _struct} = result ->
-        LoadBannedIPsTask.perform()
-        result
-
-      result ->
-        result
-    end)
+    |> LoadBannedIPsTask.maybe_recache()
   end
 
   @doc """
@@ -1201,14 +1159,7 @@ defmodule Teiserver.Moderation do
     %BannedPhrase{}
     |> BannedPhrase.changeset(attrs)
     |> Repo.insert()
-    |> then(fn
-      {:ok, _struct} = result ->
-        LoadBannedPhrasesTask.perform()
-        result
-
-      result ->
-        result
-    end)
+    |> LoadBannedPhrasesTask.maybe_recache()
   end
 
   @doc """
@@ -1227,14 +1178,7 @@ defmodule Teiserver.Moderation do
     banned_phrase
     |> BannedPhrase.changeset(attrs)
     |> Repo.update()
-    |> then(fn
-      {:ok, _struct} = result ->
-        LoadBannedPhrasesTask.perform()
-        result
-
-      result ->
-        result
-    end)
+    |> LoadBannedPhrasesTask.maybe_recache()
   end
 
   @doc """
@@ -1251,14 +1195,7 @@ defmodule Teiserver.Moderation do
   """
   def delete_banned_phrase(%BannedPhrase{} = banned_phrase) do
     Repo.delete(banned_phrase)
-    |> then(fn
-      {:ok, _struct} = result ->
-        LoadBannedPhrasesTask.perform()
-        result
-
-      result ->
-        result
-    end)
+    |> LoadBannedPhrasesTask.maybe_recache()
   end
 
   @doc """

--- a/lib/teiserver/moderation.ex
+++ b/lib/teiserver/moderation.ex
@@ -14,6 +14,9 @@ defmodule Teiserver.Moderation do
   alias Teiserver.Moderation.BannedDomain
   alias Teiserver.Moderation.BannedIP
   alias Teiserver.Moderation.BannedPhrase
+  alias Teiserver.Moderation.LoadBannedDomainsTask
+  alias Teiserver.Moderation.LoadBannedIPsTask
+  alias Teiserver.Moderation.LoadBannedPhrasesTask
   alias Teiserver.Moderation.RefreshUserRestrictionsTask
   alias Teiserver.Moderation.Report
   alias Teiserver.Moderation.ReportLib
@@ -922,6 +925,14 @@ defmodule Teiserver.Moderation do
     %BannedDomain{}
     |> BannedDomain.changeset(attrs)
     |> Repo.insert()
+    |> then(fn
+      {:ok, _struct} = result ->
+        LoadBannedDomainsTask.perform()
+        result
+
+      result ->
+        result
+    end)
   end
 
   @doc """
@@ -940,6 +951,14 @@ defmodule Teiserver.Moderation do
     banned_domain
     |> BannedDomain.changeset(attrs)
     |> Repo.update()
+    |> then(fn
+      {:ok, _struct} = result ->
+        LoadBannedDomainsTask.perform()
+        result
+
+      result ->
+        result
+    end)
   end
 
   @doc """
@@ -956,6 +975,14 @@ defmodule Teiserver.Moderation do
   """
   def delete_banned_domain(%BannedDomain{} = banned_domain) do
     Repo.delete(banned_domain)
+    |> then(fn
+      {:ok, _struct} = result ->
+        LoadBannedDomainsTask.perform()
+        result
+
+      result ->
+        result
+    end)
   end
 
   @doc """
@@ -1038,6 +1065,14 @@ defmodule Teiserver.Moderation do
     %BannedIP{}
     |> BannedIP.changeset(attrs)
     |> Repo.insert()
+    |> then(fn
+      {:ok, _struct} = result ->
+        LoadBannedIPsTask.perform()
+        result
+
+      result ->
+        result
+    end)
   end
 
   @doc """
@@ -1056,6 +1091,14 @@ defmodule Teiserver.Moderation do
     banned_ip
     |> BannedIP.changeset(attrs)
     |> Repo.update()
+    |> then(fn
+      {:ok, _struct} = result ->
+        LoadBannedIPsTask.perform()
+        result
+
+      result ->
+        result
+    end)
   end
 
   @doc """
@@ -1072,6 +1115,14 @@ defmodule Teiserver.Moderation do
   """
   def delete_banned_ip(%BannedIP{} = banned_ip) do
     Repo.delete(banned_ip)
+    |> then(fn
+      {:ok, _struct} = result ->
+        LoadBannedIPsTask.perform()
+        result
+
+      result ->
+        result
+    end)
   end
 
   @doc """
@@ -1150,6 +1201,14 @@ defmodule Teiserver.Moderation do
     %BannedPhrase{}
     |> BannedPhrase.changeset(attrs)
     |> Repo.insert()
+    |> then(fn
+      {:ok, _struct} = result ->
+        LoadBannedPhrasesTask.perform()
+        result
+
+      result ->
+        result
+    end)
   end
 
   @doc """
@@ -1168,6 +1227,14 @@ defmodule Teiserver.Moderation do
     banned_phrase
     |> BannedPhrase.changeset(attrs)
     |> Repo.update()
+    |> then(fn
+      {:ok, _struct} = result ->
+        LoadBannedPhrasesTask.perform()
+        result
+
+      result ->
+        result
+    end)
   end
 
   @doc """
@@ -1184,6 +1251,14 @@ defmodule Teiserver.Moderation do
   """
   def delete_banned_phrase(%BannedPhrase{} = banned_phrase) do
     Repo.delete(banned_phrase)
+    |> then(fn
+      {:ok, _struct} = result ->
+        LoadBannedPhrasesTask.perform()
+        result
+
+      result ->
+        result
+    end)
   end
 
   @doc """

--- a/lib/teiserver/moderation/tasks/load_banned_domains_task.ex
+++ b/lib/teiserver/moderation/tasks/load_banned_domains_task.ex
@@ -17,4 +17,11 @@ defmodule Teiserver.Moderation.LoadBannedDomainsTask do
       banned_domains
     )
   end
+
+  def maybe_recache({:ok, struct}) do
+    perform()
+    {:ok, struct}
+  end
+
+  def maybe_recache(result), do: result
 end

--- a/lib/teiserver/moderation/tasks/load_banned_domains_task.ex
+++ b/lib/teiserver/moderation/tasks/load_banned_domains_task.ex
@@ -18,10 +18,10 @@ defmodule Teiserver.Moderation.LoadBannedDomainsTask do
     )
   end
 
-  def maybe_recache({:ok, struct}) do
+  def cache_if_ok({:ok, struct}) do
     perform()
     {:ok, struct}
   end
 
-  def maybe_recache(result), do: result
+  def cache_if_ok(result), do: result
 end

--- a/lib/teiserver/moderation/tasks/load_banned_ips_task.ex
+++ b/lib/teiserver/moderation/tasks/load_banned_ips_task.ex
@@ -20,4 +20,11 @@ defmodule Teiserver.Moderation.LoadBannedIPsTask do
       blocked_ip_ranges
     )
   end
+
+  def maybe_recache({:ok, struct}) do
+    perform()
+    {:ok, struct}
+  end
+
+  def maybe_recache(result), do: result
 end

--- a/lib/teiserver/moderation/tasks/load_banned_ips_task.ex
+++ b/lib/teiserver/moderation/tasks/load_banned_ips_task.ex
@@ -21,10 +21,10 @@ defmodule Teiserver.Moderation.LoadBannedIPsTask do
     )
   end
 
-  def maybe_recache({:ok, struct}) do
+  def cache_if_ok({:ok, struct}) do
     perform()
     {:ok, struct}
   end
 
-  def maybe_recache(result), do: result
+  def cache_if_ok(result), do: result
 end

--- a/lib/teiserver/moderation/tasks/load_banned_phrases_task.ex
+++ b/lib/teiserver/moderation/tasks/load_banned_phrases_task.ex
@@ -21,10 +21,10 @@ defmodule Teiserver.Moderation.LoadBannedPhrasesTask do
     )
   end
 
-  def maybe_recache({:ok, struct}) do
+  def cache_if_ok({:ok, struct}) do
     perform()
     {:ok, struct}
   end
 
-  def maybe_recache(result), do: result
+  def cache_if_ok(result), do: result
 end

--- a/lib/teiserver/moderation/tasks/load_banned_phrases_task.ex
+++ b/lib/teiserver/moderation/tasks/load_banned_phrases_task.ex
@@ -20,4 +20,11 @@ defmodule Teiserver.Moderation.LoadBannedPhrasesTask do
       banned_phrases
     )
   end
+
+  def maybe_recache({:ok, struct}) do
+    perform()
+    {:ok, struct}
+  end
+
+  def maybe_recache(result), do: result
 end


### PR DESCRIPTION
Currently creating, updating or deleting a banned item (IP, Domain or Phrase) would leave you with a stale cache. This solves that and will update the cache on a successful change.