### PR TITLE
Fixed auth check for overwatch users, added overwatch link to main page

### DIFF
--- a/lib/teiserver_web/live/general/home/index.html.heex
+++ b/lib/teiserver_web/live/general/home/index.html.heex
@@ -19,12 +19,12 @@
   </.menu_card>
 
   <.menu_card
-    :if={false and allow?(@current_user, "Moderator")}
-    icon="question"
+    :if={allow?(@current_user, "Overwatch") and not allow?(@current_user, "Contributor")}
+    icon="fa-eye"
     icon_class="fa-solid"
-    url={~p"/teiserver/admin"}
+    url={~p"/moderation"}
   >
-    Appeals
+    Overwatch
   </.menu_card>
 
   <.menu_card

--- a/lib/teiserver_web/templates/moderation/general/index.html.heex
+++ b/lib/teiserver_web/templates/moderation/general/index.html.heex
@@ -24,7 +24,7 @@
   )}
 
   <.menu_card
-    :if={allow?(@socket, "Moderator")}
+    :if={allow?(@conn, "Moderator")}
     icon="text-slash"
     url={~p"/moderation/banned_phrases"}
   >
@@ -32,7 +32,7 @@
   </.menu_card>
 
   <.menu_card
-    :if={allow?(@socket, "Moderator")}
+    :if={allow?(@conn, "Moderator")}
     icon="globe"
     url={~p"/moderation/banned_domains"}
   >
@@ -40,7 +40,7 @@
   </.menu_card>
 
   <.menu_card
-    :if={allow?(@socket, "Moderator")}
+    :if={allow?(@conn, "Moderator")}
     icon="location-dot"
     url={~p"/moderation/banned_ips"}
   >


### PR DESCRIPTION
Overwatch (but not moderators or above) will see the following new link on their homepage:
<img width="714" height="426" alt="image" src="https://github.com/user-attachments/assets/daf34c70-6c12-4173-a9c9-83ee41c664ee" />

