### PR TITLE
Follow-up #1160 - remove missed table columns

### DIFF
--- a/lib/teiserver_web/live/battles/match/show.html.heex
+++ b/lib/teiserver_web/live/battles/match/show.html.heex
@@ -138,14 +138,6 @@
                 <th>Play</th>
 
                 <th>Done</th>
-                <th>Taken</th>
-
-                <th>Prod</th>
-                <th>Used</th>
-
-                <th>Prod</th>
-                <th>Used</th>
-
                 <th colspan="1">&nbsp;</th>
               </tr>
             </thead>


### PR DESCRIPTION
5a47233b3e45390d6fbe76c935e36971801be501 left a couple of easy to miss column headers.
