### PR TITLE
Fixed bad return from IP check api

### DIFF
--- a/lib/teiserver/ip_check/api.ex
+++ b/lib/teiserver/ip_check/api.ex
@@ -12,7 +12,7 @@ defmodule Teiserver.IpCheck.Api do
     with {:ok, endpoint} <- get_api_endpoint(),
          {:ok, key} <- get_api_key(),
          {:ok, %Response{body: body}} <- Req.get(endpoint, params: [q: ip, key: key]) do
-      %IpInfo{
+      result = %IpInfo{
         abuser?: body["is_abuser"],
         bogon?: body["is_bogon"],
         crawler?: body["is_crawler"],
@@ -21,6 +21,8 @@ defmodule Teiserver.IpCheck.Api do
         tor?: body["is_tor"],
         vpn?: body["is_vpn"]
       }
+
+      {:ok, result}
     end
   end
 


### PR DESCRIPTION
We were getting:
```ex
** (CaseClauseError) no case clause matching:

    %Teiserver.IpCheck.IpInfo{
      abuser?: nil,
      bogon?: nil,
      crawler?: nil,
      datacenter?: nil,
      proxy?: nil,
      tor?: nil,
      vpn?: nil
    }

    (teiserver 0.1.0) lib/teiserver/moderation/tasks/external_ip_check_task.ex:14: Teiserver.Moderation.Tasks.ExternalIPCheckTask.get_ban_reasons/1
```

This was caused by the IP check API used in prod not returning an OK'd pair.