### PR TITLE
Disable $website command for MFA users

### DIFF
--- a/lib/teiserver/coordinator/coordinator_commands.ex
+++ b/lib/teiserver/coordinator/coordinator_commands.ex
@@ -4,6 +4,7 @@ defmodule Teiserver.Coordinator.CoordinatorCommands do
   alias Teiserver.Account
   alias Teiserver.Account.AccoladeLib
   alias Teiserver.Account.Auth
+  alias Teiserver.Account.AuthLib
   alias Teiserver.Account.CodeOfConductData
   alias Teiserver.CacheUser
   alias Teiserver.Client
@@ -525,23 +526,46 @@ defmodule Teiserver.Coordinator.CoordinatorCommands do
 
   defp do_handle(%{command: "website", senderid: senderid} = _cmd, state) do
     client = Client.get_client_by_id(senderid)
-
-    {:ok, code} =
-      Account.create_code(%{
-        value: ULID.generate(),
-        purpose: "one_time_login",
-        expires: DateTime.shift(DateTime.utc_now(), minute: 5),
-        user_id: senderid,
-        metadata: %{ip: client.ip}
-      })
+    sender = Account.get_user(senderid)
 
     host = Application.get_env(:teiserver, TeiserverWeb.Endpoint)[:url][:host]
-    url = "https://#{host}/one_time_login/#{code.value}"
 
-    Coordinator.send_to_user(
-      senderid,
-      "Your one-time login link is #{url} it will expire in 5 minutes and must be accessed from the same IP you are accessing the game."
-    )
+    {allowed?, reason} =
+      cond do
+        not AuthLib.mfa_required?() ->
+          {true, nil}
+
+        AuthLib.has_active_mfa?(senderid) ->
+          {false,
+           "You have MFA activated and cannot use one time links, please manually login to the site at https://#{host}"}
+
+        AuthLib.contains_mfa_role?(sender.roles) ->
+          {false,
+           "Your role contains one or more privileged roles, you will need to manually login to the site at https://#{host}"}
+
+        true ->
+          {true, nil}
+      end
+
+    if allowed? do
+      {:ok, code} =
+        Account.create_code(%{
+          value: ULID.generate(),
+          purpose: "one_time_login",
+          expires: DateTime.shift(DateTime.utc_now(), minute: 5),
+          user_id: senderid,
+          metadata: %{ip: client.ip}
+        })
+
+      url = "https://#{host}/one_time_login/#{code.value}"
+
+      Coordinator.send_to_user(
+        senderid,
+        "Your one-time login link is #{url} it will expire in 5 minutes and must be accessed from the same IP you are accessing the game."
+      )
+    else
+      Coordinator.send_to_user(senderid, reason)
+    end
 
     state
   end

--- a/test/teiserver/coordinator/coordinator_commands_async_test.exs
+++ b/test/teiserver/coordinator/coordinator_commands_async_test.exs
@@ -1,4 +1,4 @@
-defmodule Teiserver.Coordinator.CoordinatorCommandsTest do
+defmodule Teiserver.Coordinator.CoordinatorCommandsAsyncTest do
   alias Teiserver.Coordinator.CoordinatorCommands
 
   use ExUnit.Case, async: true

--- a/test/teiserver/coordinator/coordinator_commands_sync_test.exs
+++ b/test/teiserver/coordinator/coordinator_commands_sync_test.exs
@@ -1,0 +1,54 @@
+defmodule Teiserver.Coordinator.CoordinatorCommandsSyncTest do
+  alias Teiserver.Account
+  alias Teiserver.Account.UserLib
+  alias Teiserver.CacheUser
+
+  use Teiserver.ServerCase, async: false
+
+  import TeiserverTestLib,
+    only: [
+      auth_setup: 1,
+      _send_raw: 2,
+      _recv_raw: 1,
+      start_spring_server: 1
+    ]
+
+  setup :start_spring_server
+
+  setup(context) do
+    TeiserverTestLib.start_coordinator!()
+    %{socket: socket, user: user} = auth_setup(context)
+    {:ok, socket: socket, user: user}
+  end
+
+  describe "commands" do
+    test "$website - okay", %{socket: socket} do
+      _send_raw(socket, "SAYPRIVATE Coordinator $website\n")
+      reply = _recv_raw(socket)
+
+      assert reply =~
+               "SAYPRIVATE Coordinator $website\nSAIDPRIVATE Coordinator Your one-time login link is https://localhost/one_time_login"
+    end
+
+    test "$website - mfa role", %{socket: socket, user: user} do
+      # This only works if MFA is required, we will enable it for this test
+      config = Application.get_env(:teiserver, Teiserver)
+      new_config = Keyword.put(config, :require_mfa_for_privileged_roles, true)
+      Application.put_env(:teiserver, Teiserver, new_config)
+
+      user.id
+      |> Account.get_user!()
+      |> UserLib.script_update_user(%{roles: ["Admin"]})
+
+      CacheUser.recache_user(user.id)
+
+      _send_raw(socket, "SAYPRIVATE coordinator $website\n")
+      reply = _recv_raw(socket)
+
+      assert reply ==
+               "SAYPRIVATE Coordinator $website\nSAIDPRIVATE Coordinator Your role contains one or more privileged roles, you will need to manually login to the site at https://localhost\n"
+
+      Application.put_env(:teiserver, Teiserver, config)
+    end
+  end
+end


### PR DESCRIPTION
Users with MFA or any roles requiring MFA will no longer be able to get a one time link using the `$website` command as it would allow them to circumvent the MFA.