### PR TITLE
Fix test SAYPRIVATE with special characters

### DIFF
--- a/test/support/teiserver_test_lib.ex
+++ b/test/support/teiserver_test_lib.ex
@@ -160,7 +160,7 @@ defmodule Teiserver.TeiserverTestLib do
 
   def _recv_raw({:sslsocket, _tcp, _tls} = socket) do
     case :ssl.recv(socket, 0, 500) do
-      {:ok, reply} -> reply |> to_string()
+      {:ok, reply} -> IO.iodata_to_binary(reply)
       {:error, :timeout} -> :timeout
       {:error, :closed} -> :closed
     end
@@ -168,7 +168,7 @@ defmodule Teiserver.TeiserverTestLib do
 
   def _recv_raw(socket) do
     case :gen_tcp.recv(socket, 0, 500) do
-      {:ok, reply} -> reply |> to_string()
+      {:ok, reply} -> IO.iodata_to_binary(reply)
       {:error, :timeout} -> :timeout
       {:error, :closed} -> :closed
     end
@@ -187,7 +187,7 @@ defmodule Teiserver.TeiserverTestLib do
   def _recv_until({:sslsocket, _tcp, _tls} = socket, acc) do
     case :ssl.recv(socket, 0, 1000) do
       {:ok, reply} ->
-        _recv_until(socket, acc <> to_string(reply))
+        _recv_until(socket, acc <> IO.iodata_to_binary(reply))
 
       {:error, :timeout} ->
         acc
@@ -197,7 +197,7 @@ defmodule Teiserver.TeiserverTestLib do
   def _recv_until(socket, acc) do
     case :gen_tcp.recv(socket, 0, 1000) do
       {:ok, reply} ->
-        _recv_until(socket, acc <> to_string(reply))
+        _recv_until(socket, acc <> IO.iodata_to_binary(reply))
 
       {:error, :timeout} ->
         acc

--- a/test/teiserver/protocols/spring/spring_auth_test.exs
+++ b/test/teiserver/protocols/spring/spring_auth_test.exs
@@ -138,18 +138,17 @@ IGNORELISTEND\n"
     assert reply == "SAIDPRIVATE #{user2.name} What about now?\n"
   end
 
-  # TODO: Make this work
-  # test "SAYPRIVATE with special characters", %{socket: socket1, user: user} = context do
-  #   user2 = new_user()
-  #   %{socket: socket2} = auth_setup(context, user2)
-  #   reply = _recv_raw(socket1)
-  #   assert reply =~ "ADDUSER #{user2.name} ?? #{user2.id} LuaLobby Chobby\n"
-  #   assert reply =~ " LuaLobby Chobby\n"
+  test "SAYPRIVATE with special characters", %{socket: socket1, user: user} = context do
+    user2 = new_user()
+    %{socket: socket2} = auth_setup(context, user2)
+    reply = _recv_raw(socket1)
+    assert reply =~ "ADDUSER #{user2.name} ?? #{user2.id} LuaLobby Chobby\n"
+    assert reply =~ " LuaLobby Chobby\n"
 
-  #   _send_raw(socket2, "SAYPRIVATE #{user.name} тест!\n")
-  #   reply = _recv_raw(socket1)
-  #   assert reply == "SAIDPRIVATE #{user2.name} тест!\n"
-  # end
+    _send_raw(socket2, "SAYPRIVATE #{user.name} тест!\n")
+    reply = _recv_raw(socket1)
+    assert reply == "SAIDPRIVATE #{user2.name} тест!\n"
+  end
 
   test "FRIENDLIST, ADDFRIEND, REMOVEFRIEIND, ACCEPTFRIENDREQUEST, DECLINEFRIENDREQUEST",
        %{


### PR DESCRIPTION
Fix `_recv_raw` and `_recv_until` to correctly handle non-ASCII data.