### PR TITLE
state may not have a userid

### DIFF
--- a/lib/teiserver/battle/servers/match_monitor_server.ex
+++ b/lib/teiserver/battle/servers/match_monitor_server.ex
@@ -553,7 +553,8 @@ defmodule Teiserver.Battle.MatchMonitorServer do
 
   @impl GenServer
   def terminate(_reason, state) do
-    Client.disconnect(state.userid, "match monitor terminate")
+    Map.get(state, :userid)
+    |> Client.disconnect("match monitor terminate")
   end
 
   @spec get_match_monitor_pid() :: pid() | nil

--- a/lib/teiserver/bridge/bridge_server.ex
+++ b/lib/teiserver/bridge/bridge_server.ex
@@ -498,7 +498,8 @@ defmodule Teiserver.Bridge.BridgeServer do
 
   @impl GenServer
   def terminate(_reason, state) do
-    Client.disconnect(state.userid, "bridge terminate")
+    Map.get(state, :userid)
+    |> Client.disconnect("bridge terminate")
   end
 
   @spec get_bridge_pid() :: pid | nil

--- a/lib/teiserver/coordinator/coordinator_server.ex
+++ b/lib/teiserver/coordinator/coordinator_server.ex
@@ -381,6 +381,7 @@ defmodule Teiserver.Coordinator.CoordinatorServer do
 
   @impl GenServer
   def terminate(_reason, state) do
-    Client.disconnect(state.userid, "coordinator terminate")
+    Map.get(state, :userid)
+    |> Client.disconnect("coordinator terminate")
   end
 end


### PR DESCRIPTION
not sure under what circumstance this happens, but it polutes the logs when attempting to disconnect a non-existent client.