### PR TITLE
Simpler tachyon envelope validation

### DIFF
--- a/lib/teiserver/tachyon/schema.ex
+++ b/lib/teiserver/tachyon/schema.ex
@@ -20,32 +20,35 @@ defmodule Teiserver.Tachyon.Schema do
   @spec parse_envelope(any()) ::
           {:ok, command_id(), message_type(), message_id()} | {:error, term()}
   def parse_envelope(raw_json) do
-    schema =
-      Teiserver.cache_get_or_store(@cache_name, :envelope, fn ->
-        """
-        {
-          "title": "tachyon envelope",
-          "type": "object",
-          "properties": {
-            "type": {"type": "string"},
-            "messageId": {"type": "string"},
-            "commandId": {"type": "string"},
-            "data": {"type": "object"}
-          },
-          "required": ["type", "messageId", "commandId"]
-        }
-        """
-        |> Jason.decode!()
-        |> JsonXema.new()
-      end)
+    with :ok <- check_map(raw_json),
+         :ok <- check_str_key(raw_json, "messageId"),
+         :ok <- check_str_key(raw_json, "type"),
+         :ok <- check_str_key(raw_json, "commandId"),
+         :ok <- check_data(raw_json) do
+      {:ok, raw_json["commandId"], raw_json["type"], raw_json["messageId"]}
+    else
+      {:error, err} -> {:error, "Invalid tachyon message: #{err}"}
+    end
+  end
 
-    case JsonXema.validate(schema, raw_json) do
-      :ok ->
-        {:ok, Map.get(raw_json, "commandId"), Map.get(raw_json, "type"),
-         Map.get(raw_json, "messageId")}
+  def check_map(obj) when is_map(obj), do: :ok
+  def check_map(_obj), do: {:error, "invalid type, expected object"}
 
-      {:error, err} ->
-        {:error, "Invalid tachyon message: #{inspect(err)}"}
+  defp check_str_key(obj, k) do
+    cond do
+      not is_map_key(obj, k) -> {:error, "missing key #{k}"}
+      not is_binary(obj[k]) -> {:error, "invalid type for key #{k}"}
+      true -> :ok
+    end
+  end
+
+  defp check_data(obj) do
+    data = obj["data"]
+
+    if data != nil and not is_map(data) do
+      {:error, "data must be an object"}
+    else
+      :ok
     end
   end
 

--- a/lib/teiserver/tachyon/schema.ex
+++ b/lib/teiserver/tachyon/schema.ex
@@ -22,10 +22,10 @@ defmodule Teiserver.Tachyon.Schema do
   def parse_envelope(raw_json) do
     with :ok <- check_map(raw_json),
          :ok <- check_str_key(raw_json, "messageId"),
-         :ok <- check_str_key(raw_json, "type"),
+         {:ok, typ} <- check_type(raw_json),
          :ok <- check_str_key(raw_json, "commandId"),
          :ok <- check_data(raw_json) do
-      {:ok, raw_json["commandId"], raw_json["type"], raw_json["messageId"]}
+      {:ok, raw_json["commandId"], typ, raw_json["messageId"]}
     else
       {:error, err} -> {:error, "Invalid tachyon message: #{err}"}
     end
@@ -39,6 +39,18 @@ defmodule Teiserver.Tachyon.Schema do
       not is_map_key(obj, k) -> {:error, "missing key #{k}"}
       not is_binary(obj[k]) -> {:error, "invalid type for key #{k}"}
       true -> :ok
+    end
+  end
+
+  defp check_type(obj) do
+    with :ok <- check_str_key(obj, "type") do
+      typ = obj["type"]
+
+      if typ in ["request", "response", "event"] do
+        {:ok, typ}
+      else
+        {:error, "type must be one of request, response, event but got #{typ}"}
+      end
     end
   end
 

--- a/test/teiserver/tachyon/schema_test.exs
+++ b/test/teiserver/tachyon/schema_test.exs
@@ -50,6 +50,11 @@ defmodule Teiserver.Tachyon.SchemaTest do
       {:error, _msg} = Schema.parse_envelope(obj)
     end
 
+    test "type must be one of event/request/response" do
+      obj = %{"type" => "wat?", "commandId" => "ns/cmd", "messageId" => "123"}
+      {:error, _msg} = Schema.parse_envelope(obj)
+    end
+
     test "commandId required" do
       obj = %{"type" => "request", "messageId" => "123"}
       {:error, _msg} = Schema.parse_envelope(obj)

--- a/test/teiserver/tachyon/schema_test.exs
+++ b/test/teiserver/tachyon/schema_test.exs
@@ -1,0 +1,63 @@
+defmodule Teiserver.Tachyon.SchemaTest do
+  alias Teiserver.Tachyon.Schema
+  use ExUnit.Case
+
+  describe "parse_envelope" do
+    test "correct object" do
+      obj = %{
+        "messageId" => "123",
+        "type" => "request",
+        "commandId" => "ns/cmd"
+      }
+
+      {:ok, "ns/cmd", "request", "123"} = Schema.parse_envelope(obj)
+    end
+
+    test "correct object with data" do
+      obj = %{
+        "messageId" => "123",
+        "type" => "request",
+        "commandId" => "ns/cmd",
+        "data" => %{"foo" => "bar"}
+      }
+
+      {:ok, "ns/cmd", "request", "123"} = Schema.parse_envelope(obj)
+    end
+
+    test "must pass an object" do
+      {:error, _msg} = Schema.parse_envelope("not an object")
+      {:error, _msg} = Schema.parse_envelope(["also", "not", "an", "object"])
+      {:error, _msg} = Schema.parse_envelope(2)
+    end
+
+    test "messageId required" do
+      obj = %{"type" => "request", "commandId" => "ns/cmd"}
+      {:error, _msg} = Schema.parse_envelope(obj)
+    end
+
+    test "messageId must be a string" do
+      obj = %{"type" => "request", "commandId" => "ns/cmd", "messageId" => 2}
+      {:error, _msg} = Schema.parse_envelope(obj)
+    end
+
+    test "type required" do
+      obj = %{"commandId" => "ns/cmd", "messageId" => "123"}
+      {:error, _msg} = Schema.parse_envelope(obj)
+    end
+
+    test "type must be a string" do
+      obj = %{"type" => 123, "commandId" => "ns/cmd", "messageId" => "123"}
+      {:error, _msg} = Schema.parse_envelope(obj)
+    end
+
+    test "commandId required" do
+      obj = %{"type" => "request", "messageId" => "123"}
+      {:error, _msg} = Schema.parse_envelope(obj)
+    end
+
+    test "commandId must be a string" do
+      obj = %{"type" => "request", "commandId" => 123, "messageId" => "123"}
+      {:error, _msg} = Schema.parse_envelope(obj)
+    end
+  end
+end


### PR DESCRIPTION
Instead of using json schema to parse the outer layer of a tachyon message, manually verify it. The schema is super simple and well known, and it is much faster without json schema.

before:
<img width="996" height="393" alt="2026-06-11-996x393-scrot" src="https://github.com/user-attachments/assets/4fc9cf3b-33dd-49d5-aa24-97e764fcbc7b" />

after:
<img width="996" height="360" alt="2026-06-11-996x360-scrot" src="https://github.com/user-attachments/assets/b867501a-0871-4181-9b86-aca3966b94d5" />

