### PR TITLE
Fix Internal Server Error on retention report

### DIFF
--- a/lib/teiserver/account/reports/retention_report.ex
+++ b/lib/teiserver/account/reports/retention_report.ex
@@ -74,9 +74,10 @@ defmodule Teiserver.Account.RetentionReport do
 
         if last_played != nil and last_login != nil do
           inserted_date = NaiveDateTime.to_date(user.inserted_at)
+          last_login_date = DateTime.to_date(last_login)
 
           %{
-            last_login: Date.diff(inserted_date, DateTime.to_date(last_login)) |> abs(),
+            last_login: Date.diff(inserted_date, last_login_date) |> abs(),
             last_played: Date.diff(inserted_date, last_played) |> abs()
           }
         end

--- a/lib/teiserver/account/reports/retention_report.ex
+++ b/lib/teiserver/account/reports/retention_report.ex
@@ -73,9 +73,11 @@ defmodule Teiserver.Account.RetentionReport do
           end)
 
         if last_played != nil and last_login != nil do
+          inserted_date = NaiveDateTime.to_date(user.inserted_at)
+
           %{
-            last_login: DateTime.diff(user.inserted_at, last_login, :day) |> abs(),
-            last_played: DateTime.diff(user.inserted_at, last_played, :day) |> abs()
+            last_login: Date.diff(inserted_date, DateTime.to_date(last_login)) |> abs(),
+            last_played: Date.diff(inserted_date, last_played) |> abs()
           }
         end
       end)

--- a/test/teiserver/account/retention_report_test.exs
+++ b/test/teiserver/account/retention_report_test.exs
@@ -1,8 +1,8 @@
 defmodule Teiserver.Account.RetentionReportTest do
   @moduledoc false
   alias Teiserver.Account.RetentionReport
-  alias Teiserver.Logging
   alias Teiserver.Helpers.GeneralTestLib
+  alias Teiserver.Logging
 
   use Teiserver.DataCase, async: false
 
@@ -20,7 +20,7 @@ defmodule Teiserver.Account.RetentionReportTest do
       # a 500 for the page.
       {:ok, user} =
         user
-        |> change(last_login: DateTime.utc_now() |> DateTime.truncate(:second))
+        |> change(last_login: DateTime.utc_now(:second))
         |> Repo.update()
 
       {:ok, _log} =
@@ -32,14 +32,14 @@ defmodule Teiserver.Account.RetentionReportTest do
       result = RetentionReport.run(nil, %{})
 
       assert result.user_count == 1
-      assert is_list(result.graph_data)
+      assert [["Login" | _], ["Play" | _]] = result.graph_data
     end
 
     test "runs with no matching players" do
       result = RetentionReport.run(nil, %{})
 
       assert result.user_count == 0
-      assert is_list(result.graph_data)
+      assert [["Login" | _], ["Play" | _]] = result.graph_data
     end
   end
 end

--- a/test/teiserver/account/retention_report_test.exs
+++ b/test/teiserver/account/retention_report_test.exs
@@ -32,14 +32,14 @@ defmodule Teiserver.Account.RetentionReportTest do
       result = RetentionReport.run(nil, %{})
 
       assert result.user_count == 1
-      assert [["Login" | _], ["Play" | _]] = result.graph_data
+      assert [["Login" | _login], ["Play" | _play]] = result.graph_data
     end
 
     test "runs with no matching players" do
       result = RetentionReport.run(nil, %{})
 
       assert result.user_count == 0
-      assert [["Login" | _], ["Play" | _]] = result.graph_data
+      assert [["Login" | _login], ["Play" | _play]] = result.graph_data
     end
   end
 end

--- a/test/teiserver/account/retention_report_test.exs
+++ b/test/teiserver/account/retention_report_test.exs
@@ -1,0 +1,45 @@
+defmodule Teiserver.Account.RetentionReportTest do
+  @moduledoc false
+  alias Teiserver.Account.RetentionReport
+  alias Teiserver.Logging
+  alias Teiserver.Helpers.GeneralTestLib
+
+  use Teiserver.DataCase, async: false
+
+  describe "run/2" do
+    test "does not raise for verified players with recorded activity" do
+      user =
+        GeneralTestLib.make_user(%{
+          "roles" => ["Verified"],
+          "data" => %{"last_login_mins" => 60}
+        })
+
+      # last_login is a DateTime while inserted_at is a NaiveDateTime; the report
+      # has to reconcile these types when computing day offsets. Previously this
+      # combination raised a FunctionClauseError in DateTime.diff/3 and returned
+      # a 500 for the page.
+      {:ok, user} =
+        user
+        |> change(last_login: DateTime.utc_now() |> DateTime.truncate(:second))
+        |> Repo.update()
+
+      {:ok, _log} =
+        Logging.create_user_activity_day_log(%{
+          date: Date.utc_today(),
+          data: %{"player" => %{to_string(user.id) => 30}}
+        })
+
+      result = RetentionReport.run(nil, %{})
+
+      assert result.user_count == 1
+      assert is_list(result.graph_data)
+    end
+
+    test "runs with no matching players" do
+      result = RetentionReport.run(nil, %{})
+
+      assert result.user_count == 0
+      assert is_list(result.graph_data)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Visiting `/teiserver/reports/show/retention` (as a moderator/admin) returned an Internal Server Error.

## Cause

`Teiserver.Account.RetentionReport.run/2` computed day offsets with `DateTime.diff/3`:

    last_login: DateTime.diff(user.inserted_at, last_login, :day) |> abs(),
    last_played: DateTime.diff(user.inserted_at, last_played, :day) |> abs()

`DateTime.diff/3` only accepts `%DateTime{}` structs, but:
- `user.inserted_at` is a `NaiveDateTime` (default `timestamps()`)
- `last_played` comes from `log.date`, which is a `Date`

This raised a `FunctionClauseError`, producing the 500.

## Fix

Normalize all values to `Date` and use `Date.diff/2` (whole-day difference, matching the original `:day` intent):

    inserted_date = NaiveDateTime.to_date(user.inserted_at)

    %{
      last_login: Date.diff(inserted_date, DateTime.to_date(last_login)) |> abs(),
      last_played: Date.diff(inserted_date, last_played) |> abs()
    }

This mirrors the date-normalization already used in `Teiserver.Account.RetentionRateExport`.

## Testing

Added `test/teiserver/account/retention_report_test.exs`. One test reproduces the original crash - a Verified user with a `DateTime` `last_login` and a matching `user_activity_day_log` - and asserts the report now returns a result instead of raising. A second test covers the empty case.

Run with `mix test test/teiserver/account/retention_report_test.exs`.

## AI usage disclosure

This contribution was AI-assisted using GitHub Copilot/Claude Sonnet 4.6. 