### PR TITLE
spring: allow longer `!mode` commands in battle chat

### DIFF
--- a/lib/teiserver/protocols/spring/spring_in.ex
+++ b/lib/teiserver/protocols/spring/spring_in.ex
@@ -47,6 +47,10 @@ defmodule Teiserver.Protocols.SpringIn do
 
   @cluster_manager_regex ~r/^Host\[[A-Z]+\d+\]$/
 
+  # Battle chat commands that carry more data than a normal message (e.g. modoption
+  # key=value pairs) and so get a 1024-char allowance instead of the default 256.
+  @long_battle_command_prefixes ["$welcome-message", "!welcome-message", "!mode "]
+
   # Commands that don't require the user to be logged in
   @unauthenticated_commands ~w(
     PING STLS LOGIN REGISTER CONFIRMAGREEMENT RESETPASSWORDREQUEST EXIT CHANGEPASSWORD LISTCOMPFLAGS
@@ -1267,10 +1271,7 @@ defmodule Teiserver.Protocols.SpringIn do
               String.starts_with?(lowercase_msg, "!bset tweakunits") ->
             msg |> String.trim() |> String.slice(0..16_384)
 
-          String.starts_with?(lowercase_msg, ["$welcome-message", "!welcome-message"]) ->
-            msg |> String.trim() |> String.slice(0..1024)
-
-          String.starts_with?(lowercase_msg, "!mode ") ->
+          String.starts_with?(lowercase_msg, @long_battle_command_prefixes) ->
             msg |> String.trim() |> String.slice(0..1024)
 
           true ->
@@ -1296,10 +1297,7 @@ defmodule Teiserver.Protocols.SpringIn do
               String.starts_with?(lowercase_msg, "!bset tweakunits") ->
             msg |> String.trim() |> String.slice(0..16_384)
 
-          String.starts_with?(lowercase_msg, ["$welcome-message", "!welcome-message"]) ->
-            msg |> String.trim() |> String.slice(0..1024)
-
-          String.starts_with?(lowercase_msg, "!mode ") ->
+          String.starts_with?(lowercase_msg, @long_battle_command_prefixes) ->
             msg |> String.trim() |> String.slice(0..1024)
 
           true ->

--- a/lib/teiserver/protocols/spring/spring_in.ex
+++ b/lib/teiserver/protocols/spring/spring_in.ex
@@ -1270,6 +1270,9 @@ defmodule Teiserver.Protocols.SpringIn do
           String.starts_with?(lowercase_msg, ["$welcome-message", "!welcome-message"]) ->
             msg |> String.trim() |> String.slice(0..1024)
 
+          String.starts_with?(lowercase_msg, "!mode ") ->
+            msg |> String.trim() |> String.slice(0..1024)
+
           true ->
             msg |> String.trim() |> String.slice(0..256)
         end
@@ -1294,6 +1297,9 @@ defmodule Teiserver.Protocols.SpringIn do
             msg |> String.trim() |> String.slice(0..16_384)
 
           String.starts_with?(lowercase_msg, ["$welcome-message", "!welcome-message"]) ->
+            msg |> String.trim() |> String.slice(0..1024)
+
+          String.starts_with?(lowercase_msg, "!mode ") ->
             msg |> String.trim() |> String.slice(0..1024)
 
           true ->


### PR DESCRIPTION
## Problem

`SAYBATTLE`/`SAYBATTLEEX` slice normal battle-chat messages to 256 characters. The `!mode` autohost command (used by the sharing-mode preset system) carries a set of modoption `key=value` pairs and can exceed 256 chars. When it does, it's silently truncated mid-token into an invalid command, so the autohost rejects it (e.g. `Invalid parameter format "take_del"`) and no vote is started — with no feedback to the user.

## Change

Give `!mode`/`$mode` a 1024-character allowance in both `SAYBATTLE` and `SAYBATTLEEX`, the same tier already used for `welcome-message` commands (tweakdefs/tweakunits already get 16384). 1024 comfortably fits a mode name plus its full modoption set.

Part of: https://github.com/beyond-all-reason/BYAR-Chobby/issues/1040