### PR TITLE
Add .dockerignore to trim the Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+_build
+deps
+node_modules
+.elixir_ls
+.lexical
+.formatter_exs_cache
+cover
+doc


### PR DESCRIPTION
Noticed that we were dumping our own .dockerignore into this repo from BAR-Devtools, which was dirtying the working tree and annoying me. Started to add it to gitignore over here (still an option), but this seemed like it would improve your docker build times, too, so may as well make it canonical.