### PR TITLE
Structify autohost data

### DIFF
--- a/lib/teiserver/autohost.ex
+++ b/lib/teiserver/autohost.ex
@@ -4,12 +4,12 @@ defmodule Teiserver.Autohost do
   alias Teiserver.Autohost.Session
   alias Teiserver.Autohost.SessionRegistry
   alias Teiserver.Autohost.TachyonHandler
+  alias Teiserver.Autohost.Types, as: AT
   alias Teiserver.Bot.Bot
   alias Teiserver.BotQueries
   alias Teiserver.TachyonBattle
 
   @type id :: Teiserver.Bot.Bot.id()
-  @type reg_value :: SessionRegistry.reg_value()
 
   @type start_script :: %{
           required(:engine_version) => String.t(),
@@ -65,17 +65,17 @@ defmodule Teiserver.Autohost do
   @doc """
   Returns the data associated with an autohost session
   """
-  @spec lookup_autohost(Bot.id()) :: {pid(), reg_value()} | nil
+  @spec lookup_autohost(Bot.id()) :: {pid(), AT.Overview.t()} | nil
   def lookup_autohost(bot_id) do
     SessionRegistry.lookup(bot_id)
   end
 
-  @spec lookup_autohost(Bot.id()) :: {pid(), reg_value()} | nil
+  @spec lookup_autohost(Bot.id()) :: {pid(), AT.Overview.t()} | nil
   def lookup_autohost_connection(bot_id) do
     Teiserver.Autohost.Registry.lookup(bot_id)
   end
 
-  @spec list() :: [reg_value()]
+  @spec list() :: [AT.Overview.t()]
   defdelegate list(), to: SessionRegistry
 
   @doc """
@@ -86,9 +86,9 @@ defmodule Teiserver.Autohost do
   def find_autohost(_params \\ %{}) do
     autohost_val =
       SessionRegistry.list()
-      |> Enum.find(fn %{max_battles: m, current_battles: c} -> m > c end)
+      |> Enum.find(fn %AT.Overview{max_battles: m, current_battles: c} -> m > c end)
 
-    if autohost_val == nil, do: nil, else: autohost_val[:id]
+    if autohost_val == nil, do: nil, else: autohost_val.id
   end
 
   @spec start_battle(Bot.id(), TachyonBattle.id(), pid(), start_script()) ::

--- a/lib/teiserver/autohost.ex
+++ b/lib/teiserver/autohost.ex
@@ -1,6 +1,5 @@
 defmodule Teiserver.Autohost do
   @moduledoc false
-  alias Teiserver.Account.User
   alias Teiserver.Autohost.Session
   alias Teiserver.Autohost.SessionRegistry
   alias Teiserver.Autohost.TachyonHandler
@@ -11,38 +10,8 @@ defmodule Teiserver.Autohost do
 
   @type id :: Teiserver.Bot.Bot.id()
 
-  @type start_script :: %{
-          required(:engine_version) => String.t(),
-          required(:game_name) => String.t(),
-          required(:map_name) => String.t(),
-          required(:start_pos_type) => :fixed | :random | :ingame | :beforegame,
-          required(:ally_teams) => [ally_team(), ...],
-          optional(:game_options) => %{String.t() => String.t()},
-          optional(:spectators) => [player()],
-          optional(:bots) => [bot()]
-        }
-
-  @type ally_team :: %{
-          teams: [team(), ...]
-        }
-
-  @type team :: %{
-          players: [player()]
-        }
-
-  @type player :: %{
-          user_id: User.id(),
-          name: String.t(),
-          password: String.t()
-        }
-
-  @type bot :: %{
-          host_user_id: User.id(),
-          name: String.t(),
-          ai_short_name: String.t(),
-          ai_version: String.t(),
-          ai_options: %{String.t() => term()}
-        }
+  @type ally_team :: AT.StartScript.ally_team()
+  @type team :: AT.StartScript.team()
 
   @type start_response :: Session.start_response()
 
@@ -91,7 +60,7 @@ defmodule Teiserver.Autohost do
     if autohost_val == nil, do: nil, else: autohost_val.id
   end
 
-  @spec start_battle(Bot.id(), TachyonBattle.id(), pid(), start_script()) ::
+  @spec start_battle(Bot.id(), TachyonBattle.id(), pid(), AT.StartScript.t()) ::
           {:ok, autohost_pid :: pid(), start_response()} | {:error, term()}
   defdelegate start_battle(bot_id, battle_id, battle_pid, start_script),
     to: Session

--- a/lib/teiserver/autohost/registry.ex
+++ b/lib/teiserver/autohost/registry.ex
@@ -6,13 +6,8 @@ defmodule Teiserver.Autohost.Registry do
   and matchmaking
   """
 
+  alias Teiserver.Autohost.Types, as: AT
   alias Teiserver.Bot.Bot
-
-  @type reg_value :: %{
-          id: Bot.id(),
-          max_battles: non_neg_integer(),
-          current_battles: non_neg_integer()
-        }
 
   def start_link do
     Horde.Registry.start_link(keys: :unique, name: __MODULE__)
@@ -26,19 +21,7 @@ defmodule Teiserver.Autohost.Registry do
     {:via, Horde.Registry, {__MODULE__, autohost_id}}
   end
 
-  @spec register(reg_value) :: {:ok, pid()} | {:error, {:already_registered, pid()}}
-  def register(%{id: autohost_id} = val) do
-    # this is needed because the process that handle the ws connection is spawned
-    # by phoenix, so we can't spawn+register in the same step
-    Horde.Registry.register(__MODULE__, via_tuple(autohost_id), val)
-  end
-
-  @spec unregister(Bot.id()) :: :ok
-  def unregister(autohost_id) do
-    Horde.Registry.unregister(__MODULE__, via_tuple(autohost_id))
-  end
-
-  @spec lookup(Bot.id()) :: {pid(), reg_value()} | nil
+  @spec lookup(Bot.id()) :: {pid(), AT.Overview.t()} | nil
   def lookup(autohost_id) do
     case Horde.Registry.lookup(__MODULE__, via_tuple(autohost_id)) do
       [x] -> x
@@ -46,14 +29,10 @@ defmodule Teiserver.Autohost.Registry do
     end
   end
 
-  def update_value(autohost_id, callback) do
-    Horde.Registry.update_value(__MODULE__, via_tuple(autohost_id), callback)
-  end
-
   @doc """
   Returns all the currently registered autohosts
   """
-  @spec list() :: [reg_value()]
+  @spec list() :: [AT.Overview.t()]
   def list do
     Horde.Registry.select(__MODULE__, [{{:_, :_, :"$1"}, [], [:"$1"]}])
   end

--- a/lib/teiserver/autohost/session.ex
+++ b/lib/teiserver/autohost/session.ex
@@ -5,7 +5,6 @@ defmodule Teiserver.Autohost.Session do
   cleanly shutdown when required.
   """
 
-  alias Teiserver.Autohost
   alias Teiserver.Autohost.SessionRegistry
   alias Teiserver.Autohost.TachyonHandler
   alias Teiserver.Autohost.Types, as: AT
@@ -19,23 +18,14 @@ defmodule Teiserver.Autohost.Session do
 
   @default_call_timeout 5000
 
-  @typep battle_data :: %{
-           start_script: Autohost.start_script(),
-           ips: [String.t()],
-           port: non_neg_integer(),
-           # it is guaranteed that the event timestamp is unique per battle
-           pending_acks: :queue.queue(time: DateTime.t()),
-           last_acked_ts: DateTime.t() | nil
-         }
-
   @typep data :: %{
            autohost: Bot.t(),
            conn_pid: pid(),
            monitors: MC.t(),
            max_battles: non_neg_integer(),
            current_battles: non_neg_integer(),
-           pending_battles: %{TachyonBattle.id() => {GenServer.from(), Autohost.start_script()}},
-           active_battles: %{TachyonBattle.id() => battle_data()},
+           pending_battles: %{TachyonBattle.id() => {GenServer.from(), AT.StartScript.t()}},
+           active_battles: %{TachyonBattle.id() => AT.BattleData.t()},
            pending_replies: %{reference() => GenServer.from()}
          }
 
@@ -59,7 +49,7 @@ defmodule Teiserver.Autohost.Session do
   @type start_response :: %{ips: [String.t()], port: integer()}
 
   # TODO: there should be some kind of retry here
-  @spec start_battle(Bot.id(), TachyonBattle.id(), pid(), Autohost.start_script()) ::
+  @spec start_battle(Bot.id(), TachyonBattle.id(), pid(), AT.StartScript.t()) ::
           {:ok, autohost_pid :: pid(), start_response()} | {:error, term()}
   def start_battle(autohost_id, battle_id, battle_pid, start_script) do
     autohost_id
@@ -317,7 +307,13 @@ defmodule Teiserver.Autohost.Session do
 
   def handle_event(:info, {:update_capacity, max_battles, current_battles}, state, data) do
     data = %{data | max_battles: max_battles, current_battles: current_battles}
-    value = %AT.Overview{id: data.autohost.id, max_battles: max_battles, current_battles: current_battles}
+
+    value = %AT.Overview{
+      id: data.autohost.id,
+      max_battles: max_battles,
+      current_battles: current_battles
+    }
+
     SessionRegistry.set_value(value)
 
     case state do
@@ -338,12 +334,10 @@ defmodule Teiserver.Autohost.Session do
         {:keep_state, data}
 
       {:ok, start_response} ->
-        battle_data = %{
+        battle_data = %AT.BattleData{
           start_script: start_script,
           ips: start_response.ips,
-          port: start_response.port,
-          pending_acks: :queue.new(),
-          last_acked_ts: nil
+          port: start_response.port
         }
 
         data =
@@ -382,7 +376,10 @@ defmodule Teiserver.Autohost.Session do
 
     data =
       data
-      |> update_in([:active_battles, event.battle_id, :pending_acks], &:queue.in(event.time, &1))
+      |> update_in(
+        [:active_battles, event.battle_id, Access.key!(:pending_acks)],
+        &:queue.in(event.time, &1)
+      )
 
     {:keep_state, data}
   end
@@ -393,7 +390,7 @@ defmodule Teiserver.Autohost.Session do
 
   def handle_event(:info, {:ack_update_event, battle_id, timestamp}, _state, data) do
     data =
-      update_in(data, [:active_battles, battle_id], fn battle_data ->
+      update_in(data, [:active_battles, battle_id], fn %AT.BattleData{} = battle_data ->
         case :queue.out(battle_data.pending_acks) do
           {{:value, ^timestamp}, q2} ->
             %{battle_data | pending_acks: q2, last_acked_ts: timestamp}
@@ -418,7 +415,7 @@ defmodule Teiserver.Autohost.Session do
   # but it works just fine with negative number
   @dialyzer {:nowarn_function, get_subscription_start: 1}
   defp get_subscription_start(state) do
-    for {_battle_id, battle_data} <- state.active_battles do
+    for {_battle_id, %AT.BattleData{} = battle_data} <- state.active_battles do
       case {battle_data.last_acked_ts, :queue.peek(battle_data.pending_acks)} do
         {x, _pending} when not is_nil(x) ->
           x

--- a/lib/teiserver/autohost/session.ex
+++ b/lib/teiserver/autohost/session.ex
@@ -8,6 +8,7 @@ defmodule Teiserver.Autohost.Session do
   alias Teiserver.Autohost
   alias Teiserver.Autohost.SessionRegistry
   alias Teiserver.Autohost.TachyonHandler
+  alias Teiserver.Autohost.Types, as: AT
   alias Teiserver.Bot.Bot
   alias Teiserver.Helpers.MonitorCollection, as: MC
   alias Teiserver.TachyonBattle
@@ -165,7 +166,7 @@ defmodule Teiserver.Autohost.Session do
     Process.link(conn_pid)
     Process.flag(:trap_exit, true)
     Logger.info("session started")
-    SessionRegistry.set_value(autohost.id, 0, 0)
+    SessionRegistry.set_value(%AT.Overview{id: autohost.id, max_battles: 0, current_battles: 0})
 
     data = %{
       autohost: autohost,
@@ -316,7 +317,8 @@ defmodule Teiserver.Autohost.Session do
 
   def handle_event(:info, {:update_capacity, max_battles, current_battles}, state, data) do
     data = %{data | max_battles: max_battles, current_battles: current_battles}
-    SessionRegistry.set_value(data.autohost.id, max_battles, current_battles)
+    value = %AT.Overview{id: data.autohost.id, max_battles: max_battles, current_battles: current_battles}
+    SessionRegistry.set_value(value)
 
     case state do
       :handshaking -> {:next_state, :connected, data}

--- a/lib/teiserver/autohost/session.ex
+++ b/lib/teiserver/autohost/session.ex
@@ -18,17 +18,6 @@ defmodule Teiserver.Autohost.Session do
 
   @default_call_timeout 5000
 
-  @typep data :: %{
-           autohost: Bot.t(),
-           conn_pid: pid(),
-           monitors: MC.t(),
-           max_battles: non_neg_integer(),
-           current_battles: non_neg_integer(),
-           pending_battles: %{TachyonBattle.id() => {GenServer.from(), AT.StartScript.t()}},
-           active_battles: %{TachyonBattle.id() => AT.BattleData.t()},
-           pending_replies: %{reference() => GenServer.from()}
-         }
-
   @typep state :: :handshaking | :connected
 
   def child_spec({autohost, _conn_pid} = args) do
@@ -150,7 +139,7 @@ defmodule Teiserver.Autohost.Session do
   end
 
   @impl :gen_statem
-  @spec init({Bot.t(), pid()}) :: {:ok, state(), data(), term()}
+  @spec init({Bot.t(), pid()}) :: {:ok, state(), AT.SessionData.t(), term()}
   def init({autohost, conn_pid}) do
     Logger.metadata(actor_type: :autohost_session, actor_id: autohost.id)
     Process.link(conn_pid)
@@ -158,22 +147,13 @@ defmodule Teiserver.Autohost.Session do
     Logger.info("session started")
     SessionRegistry.set_value(%AT.Overview{id: autohost.id, max_battles: 0, current_battles: 0})
 
-    data = %{
-      autohost: autohost,
-      conn_pid: conn_pid,
-      monitors: MC.new(),
-      max_battles: 0,
-      current_battles: 0,
-      pending_battles: %{},
-      active_battles: %{},
-      pending_replies: %{}
-    }
+    data = %AT.SessionData{autohost: autohost, conn_pid: conn_pid}
 
     {:ok, :handshaking, data, [{:next_event, :internal, :subscribe_updates}]}
   end
 
   @impl :gen_statem
-  def handle_event(:internal, :subscribe_updates, _state, data) do
+  def handle_event(:internal, :subscribe_updates, _state, %AT.SessionData{} = data) do
     since = get_subscription_start(data)
 
     case TachyonHandler.subscribe_updates(data.conn_pid, since) do
@@ -182,7 +162,7 @@ defmodule Teiserver.Autohost.Session do
     end
   end
 
-  def handle_event({:call, _from}, _event, :handshaking, data) do
+  def handle_event({:call, _from}, _event, :handshaking, %AT.SessionData{} = data) do
     {:keep_state, data, [{:postpone, true}]}
   end
 
@@ -211,78 +191,93 @@ defmodule Teiserver.Autohost.Session do
     {:keep_state, data}
   end
 
-  def handle_event({:call, from}, {:send_message, _payload}, _state, data)
+  def handle_event({:call, from}, {:send_message, _payload}, _state, %AT.SessionData{} = data)
       when data.conn_pid == nil,
       do: {:keep_state, data, [{:reply, from, {:error, :no_autohost}}]}
 
-  def handle_event({:call, from}, {:send_message, %{battle_id: battle_id}}, _state, data)
+  def handle_event(
+        {:call, from},
+        {:send_message, %{battle_id: battle_id}},
+        _state,
+        %AT.SessionData{} = data
+      )
       when not is_map_key(data.active_battles, battle_id),
       do: {:keep_state, data, [{:reply, from, {:error, :invalid_battle}}]}
 
-  def handle_event({:call, from}, {:send_message, payload}, _state, data) do
+  def handle_event({:call, from}, {:send_message, payload}, _state, %AT.SessionData{} = data) do
     ref = make_ref()
     TachyonHandler.send_message(data.conn_pid, ref, payload)
     data = Map.update!(data, :pending_replies, &Map.put(&1, ref, from))
     {:keep_state, data}
   end
 
-  def handle_event({:call, from}, {:kill_battle, _battle_id}, _state, data)
+  def handle_event({:call, from}, {:kill_battle, _battle_id}, _state, %AT.SessionData{} = data)
       when data.conn_pid == nil,
       do: {:keep_state, data, [{:reply, from, {:error, :no_autohost}}]}
 
-  def handle_event({:call, from}, {:kill_battle, battle_id}, _state, data)
+  def handle_event({:call, from}, {:kill_battle, battle_id}, _state, %AT.SessionData{} = data)
       when not is_map_key(data.active_battles, battle_id),
       do: {:keep_state, data, [{:reply, from, {:error, :invalid_battle}}]}
 
-  def handle_event({:call, from}, {:kill_battle, battle_id}, _state, data) do
+  def handle_event({:call, from}, {:kill_battle, battle_id}, _state, %AT.SessionData{} = data) do
     ref = make_ref()
     TachyonHandler.kill_battle(data.conn_pid, ref, battle_id)
     data = Map.update!(data, :pending_replies, &Map.put(&1, ref, from))
     {:keep_state, data}
   end
 
-  def handle_event({:call, from}, {:add_player, _add_data}, _state, data)
+  def handle_event({:call, from}, {:add_player, _add_data}, _state, %AT.SessionData{} = data)
       when data.conn_pid == nil,
       do: {:keep_state, data, [{:reply, from, {:error, :no_autohost}}]}
 
-  def handle_event({:call, from}, {:add_player, add_data}, _state, data)
+  def handle_event({:call, from}, {:add_player, add_data}, _state, %AT.SessionData{} = data)
       when not is_map_key(data.active_battles, add_data.battle_id),
       do: {:keep_state, data, [{:reply, from, {:error, :invalid_battle}}]}
 
-  def handle_event({:call, from}, {:add_player, add_data}, _state, data) do
+  def handle_event({:call, from}, {:add_player, add_data}, _state, %AT.SessionData{} = data) do
     ref = make_ref()
     TachyonHandler.add_player(data.conn_pid, ref, add_data)
     data = Map.update!(data, :pending_replies, &Map.put(&1, ref, from))
     {:keep_state, data}
   end
 
-  def handle_event({:call, from}, :inspect_subscription_start, _state, data) do
+  def handle_event(
+        {:call, from},
+        :inspect_subscription_start,
+        _state,
+        %AT.SessionData{} = data
+      ) do
     {:keep_state, data, [{:reply, from, get_subscription_start(data)}]}
   end
 
-  def handle_event(:info, {:reply_kill_battle, ref, _resp}, _state, data)
+  def handle_event(:info, {:reply_kill_battle, ref, _resp}, _state, %AT.SessionData{} = data)
       when not is_map_key(data.pending_replies, ref),
       do: {:keep_state, data}
 
-  def handle_event(:info, {:reply_kill_battle, ref, resp}, _state, data) do
+  def handle_event(:info, {:reply_kill_battle, ref, resp}, _state, %AT.SessionData{} = data) do
     {from, pending_replies} = Map.pop!(data.pending_replies, ref)
     data = %{data | pending_replies: pending_replies}
     GenServer.reply(from, resp)
     {:keep_state, data}
   end
 
-  def handle_event(:info, {:reply_add_player, ref, _resp}, _state, data)
+  def handle_event(:info, {:reply_add_player, ref, _resp}, _state, %AT.SessionData{} = data)
       when not is_map_key(data.pending_replies, ref),
       do: {:keep_state, data}
 
-  def handle_event(:info, {:reply_add_player, ref, resp}, _state, data) do
+  def handle_event(:info, {:reply_add_player, ref, resp}, _state, %AT.SessionData{} = data) do
     {from, pending_replies} = Map.pop!(data.pending_replies, ref)
     data = %{data | pending_replies: pending_replies}
     GenServer.reply(from, resp)
     {:keep_state, data}
   end
 
-  def handle_event(:info, {:DOWN, ref, :process, _pid, _reason}, _state, data) do
+  def handle_event(
+        :info,
+        {:DOWN, ref, :process, _pid, _reason},
+        _state,
+        %AT.SessionData{} = data
+      ) do
     val = MC.get_val(data.monitors, ref)
     data = Map.update!(data, :monitors, &MC.demonitor_by_val(&1, val))
 
@@ -297,7 +292,7 @@ defmodule Teiserver.Autohost.Session do
     {:keep_state, data}
   end
 
-  def handle_event(:info, {:EXIT, from, reason}, _state, data) do
+  def handle_event(:info, {:EXIT, from, reason}, _state, %AT.SessionData{} = data) do
     Logger.info(
       "Exit sent from #{inspect(from)} because #{inspect(reason)}. Conn pid is #{inspect(data.conn_pid)}"
     )
@@ -305,7 +300,12 @@ defmodule Teiserver.Autohost.Session do
     {:stop, reason}
   end
 
-  def handle_event(:info, {:update_capacity, max_battles, current_battles}, state, data) do
+  def handle_event(
+        :info,
+        {:update_capacity, max_battles, current_battles},
+        state,
+        %AT.SessionData{} = data
+      ) do
     data = %{data | max_battles: max_battles, current_battles: current_battles}
 
     value = %AT.Overview{
@@ -322,10 +322,20 @@ defmodule Teiserver.Autohost.Session do
     end
   end
 
-  def handle_event(:info, {:reply_start_battle, battle_id, _resp}, _state, data)
+  def handle_event(
+        :info,
+        {:reply_start_battle, battle_id, _resp},
+        _state,
+        %AT.SessionData{} = data
+      )
       when not is_map_key(data.pending_battles, battle_id), do: {:keep_state, data}
 
-  def handle_event(:info, {:reply_start_battle, battle_id, resp}, _state, data) do
+  def handle_event(
+        :info,
+        {:reply_start_battle, battle_id, resp},
+        _state,
+        %AT.SessionData{} = data
+      ) do
     {{from, start_script}, pending_battles} = Map.pop!(data.pending_battles, battle_id)
 
     case resp do
@@ -351,12 +361,12 @@ defmodule Teiserver.Autohost.Session do
     end
   end
 
-  def handle_event(:info, {:reply_send_message, ref, _resp}, _state, data)
+  def handle_event(:info, {:reply_send_message, ref, _resp}, _state, %AT.SessionData{} = data)
       when not is_map_key(data.pending_replies, ref) do
     {:keep_state, data}
   end
 
-  def handle_event(:info, {:reply_send_message, ref, resp}, _state, data) do
+  def handle_event(:info, {:reply_send_message, ref, resp}, _state, %AT.SessionData{} = data) do
     {from, pending_replies} = Map.pop!(data.pending_replies, ref)
     data = %{data | pending_replies: pending_replies}
     GenServer.reply(from, resp)
@@ -367,30 +377,45 @@ defmodule Teiserver.Autohost.Session do
   # Because the autohost is the ultimate source of truth when it comes to running
   # battle, so if it tells teiserver that something is running, we need to
   # create a corresponding process. But for now, just drop the message
-  def handle_event(:info, {:update_event, %{battle_id: battle_id}}, _state, data)
+  def handle_event(
+        :info,
+        {:update_event, %{battle_id: battle_id}},
+        _state,
+        %AT.SessionData{} = data
+      )
       when not is_map_key(data.active_battles, battle_id),
       do: {:keep_state, data}
 
-  def handle_event(:info, {:update_event, event}, _state, data) do
+  def handle_event(:info, {:update_event, event}, _state, %AT.SessionData{} = data) do
     TachyonBattle.send_update_event(event)
 
     data =
       data
       |> update_in(
-        [:active_battles, event.battle_id, Access.key!(:pending_acks)],
+        [Access.key!(:active_battles), event.battle_id, Access.key!(:pending_acks)],
         &:queue.in(event.time, &1)
       )
 
     {:keep_state, data}
   end
 
-  def handle_event(:info, {:ack_update_event, battle_id, _timestamp}, _state, data)
+  def handle_event(
+        :info,
+        {:ack_update_event, battle_id, _timestamp},
+        _state,
+        %AT.SessionData{} = data
+      )
       when not is_map_key(data.active_battles, battle_id),
       do: {:keep_state, data}
 
-  def handle_event(:info, {:ack_update_event, battle_id, timestamp}, _state, data) do
+  def handle_event(
+        :info,
+        {:ack_update_event, battle_id, timestamp},
+        _state,
+        %AT.SessionData{} = data
+      ) do
     data =
-      update_in(data, [:active_battles, battle_id], fn %AT.BattleData{} = battle_data ->
+      update_in(data, [Access.key!(:active_battles), battle_id], fn %AT.BattleData{} = battle_data ->
         case :queue.out(battle_data.pending_acks) do
           {{:value, ^timestamp}, q2} ->
             %{battle_data | pending_acks: q2, last_acked_ts: timestamp}

--- a/lib/teiserver/autohost/session_registry.ex
+++ b/lib/teiserver/autohost/session_registry.ex
@@ -3,13 +3,8 @@ defmodule Teiserver.Autohost.SessionRegistry do
   Registry used to identify autohost sessions
   """
 
+  alias Teiserver.Autohost.Types, as: AT
   alias Teiserver.Bot.Bot
-
-  @type reg_value :: %{
-          id: Bot.id(),
-          max_battles: non_neg_integer(),
-          current_battles: non_neg_integer()
-        }
 
   def start_link do
     Registry.start_link(keys: :unique, name: __MODULE__)
@@ -23,13 +18,13 @@ defmodule Teiserver.Autohost.SessionRegistry do
     {:via, Registry, {__MODULE__, autohost_id}}
   end
 
-  @spec register(reg_value) :: {:ok, pid()} | {:error, {:already_registered, pid()}}
-  def register(%{id: autohost_id} = val) do
+  @spec register(AT.Overview.t()) :: {:ok, pid()} | {:error, {:already_registered, pid()}}
+  def register(%AT.Overview{id: autohost_id} = val) do
     # this is needed mostly for tests
     Registry.register(__MODULE__, autohost_id, val)
   end
 
-  @spec lookup(Bot.id()) :: {pid(), reg_value()} | nil
+  @spec lookup(Bot.id()) :: {pid(), AT.Overview.t()} | nil
   def lookup(autohost_id) do
     case Registry.lookup(__MODULE__, autohost_id) do
       [x] -> x
@@ -37,28 +32,18 @@ defmodule Teiserver.Autohost.SessionRegistry do
     end
   end
 
-  @spec set_value(
-          Bot.id(),
-          max_battles :: non_neg_integer(),
-          current_battles :: non_neg_integer()
-        ) :: reg_value()
-  def set_value(autohost_id, max_battles, current_battles) do
-    value = %{
-      id: autohost_id,
-      max_battles: max_battles,
-      current_battles: current_battles
-    }
-
-    result = Registry.update_value(__MODULE__, autohost_id, fn _old -> value end)
+  @spec set_value(AT.Overview.t()) :: AT.Overview.t()
+  def set_value(%AT.Overview{id: autohost_id} = overview) do
+    result = Registry.update_value(__MODULE__, autohost_id, fn _old -> overview end)
 
     if result == :error do
-      Registry.register(__MODULE__, autohost_id, value)
+      Registry.register(__MODULE__, autohost_id, overview)
     end
 
-    value
+    overview
   end
 
-  @spec get_value(Bot.id()) :: reg_value() | nil
+  @spec get_value(Bot.id()) :: AT.Overview.t() | nil
   def get_value(autohost_id) do
     case Registry.lookup(__MODULE__, autohost_id) do
       [{_pid, val}] -> val
@@ -80,7 +65,7 @@ defmodule Teiserver.Autohost.SessionRegistry do
   @doc """
   Returns all the currently registered autohosts sessions
   """
-  @spec list() :: [reg_value()]
+  @spec list() :: [AT.Overview.t()]
   def list do
     Registry.select(__MODULE__, [{{:_, :_, :"$1"}, [], [:"$1"]}])
   end

--- a/lib/teiserver/autohost/types/battle_data.ex
+++ b/lib/teiserver/autohost/types/battle_data.ex
@@ -1,0 +1,21 @@
+defmodule Teiserver.Autohost.Types.BattleData do
+  @moduledoc """
+  Whatever is required to track the state of a battle being run by a given
+  autohost.
+  Part of the autohost session state.
+  """
+
+  alias Teiserver.Autohost.Types, as: AT
+
+  @enforce_keys [:start_script, :ips, :port]
+  defstruct [:start_script, :ips, :port, pending_acks: :queue.new(), last_acked_ts: nil]
+
+  @type t() :: %__MODULE__{
+          start_script: AT.StartScript.t(),
+          ips: [String.t()],
+          port: non_neg_integer(),
+          # it is guaranteed that the event timestamp is unique per battle
+          pending_acks: :queue.queue(time: DateTime.t()),
+          last_acked_ts: DateTime.t() | nil
+        }
+end

--- a/lib/teiserver/autohost/types/bot.ex
+++ b/lib/teiserver/autohost/types/bot.ex
@@ -1,0 +1,17 @@
+defmodule Teiserver.Autohost.Types.Bot do
+  @moduledoc """
+  Representation of a bot for the start script given to autohost
+  """
+  alias Teiserver.Account.User
+
+  @enforce_keys [:host_user_id, :name, :ai_short_name, :ai_version]
+  defstruct [:host_user_id, :name, :ai_short_name, :ai_version, ai_options: %{}]
+
+  @type t() :: %__MODULE__{
+          host_user_id: User.id(),
+          name: String.t(),
+          ai_short_name: String.t(),
+          ai_version: String.t(),
+          ai_options: %{String.t() => term()}
+        }
+end

--- a/lib/teiserver/autohost/types/overview.ex
+++ b/lib/teiserver/autohost/types/overview.ex
@@ -1,0 +1,17 @@
+defmodule Teiserver.Autohost.Types.Overview do
+  @moduledoc """
+  Meant to be held in the registry for autohosts. To be used to find appropriate
+  autohost when starting a battle.
+  """
+
+  alias Teiserver.Bot.Bot
+
+  @enforce_keys [:id, :max_battles, :current_battles]
+  defstruct [:id, :max_battles, :current_battles]
+
+  @type t() :: %__MODULE__{
+          id: Bot.id(),
+          max_battles: non_neg_integer(),
+          current_battles: non_neg_integer()
+        }
+end

--- a/lib/teiserver/autohost/types/player.ex
+++ b/lib/teiserver/autohost/types/player.ex
@@ -1,0 +1,16 @@
+defmodule Teiserver.Autohost.Types.Player do
+  @moduledoc """
+  Representation of a player in the start script
+  """
+
+  alias Teiserver.Account.User
+
+  @enforce_keys [:user_id, :name, :password]
+  defstruct [:user_id, :name, :password]
+
+  @type t() :: %__MODULE__{
+          user_id: User.id(),
+          name: String.t(),
+          password: String.t()
+        }
+end

--- a/lib/teiserver/autohost/types/session_data.ex
+++ b/lib/teiserver/autohost/types/session_data.ex
@@ -1,0 +1,33 @@
+defmodule Teiserver.Autohost.Types.SessionData do
+  @moduledoc """
+  Data/state held by the process associated with a connected autohost
+  """
+
+  alias Teiserver.Autohost.Types, as: AT
+  alias Teiserver.Bot.Bot
+  alias Teiserver.Helpers.MonitorCollection, as: MC
+  alias Teiserver.TachyonBattle
+
+  @enforce_keys [:autohost, :conn_pid]
+  defstruct [
+    :autohost,
+    :conn_pid,
+    monitors: MC.new(),
+    max_battles: 0,
+    current_battles: 0,
+    pending_battles: %{},
+    active_battles: %{},
+    pending_replies: %{}
+  ]
+
+  @type t() :: %__MODULE__{
+          autohost: Bot.t(),
+          conn_pid: pid(),
+          monitors: MC.t(),
+          max_battles: non_neg_integer(),
+          current_battles: non_neg_integer(),
+          pending_battles: %{TachyonBattle.id() => {GenServer.from(), AT.StartScript.t()}},
+          active_battles: %{TachyonBattle.id() => AT.BattleData.t()},
+          pending_replies: %{reference() => GenServer.from()}
+        }
+end

--- a/lib/teiserver/autohost/types/start_script.ex
+++ b/lib/teiserver/autohost/types/start_script.ex
@@ -1,0 +1,39 @@
+defmodule Teiserver.Autohost.Types.StartScript do
+  @moduledoc """
+  Internal representation of the start script to be sent to autohost to
+  start a battle
+  """
+
+  alias Teiserver.Autohost.Types, as: AT
+
+  @enforce_keys [:engine_version, :game_name, :map_name, :start_pos_type, :ally_teams]
+  defstruct [
+    :engine_version,
+    :game_name,
+    :map_name,
+    :start_pos_type,
+    :ally_teams,
+    game_options: %{},
+    spectators: [],
+    bots: []
+  ]
+
+  @type t() :: %__MODULE__{
+          engine_version: String.t(),
+          game_name: String.t(),
+          map_name: String.t(),
+          start_pos_type: :fixed | :random | :ingame | :beforegame,
+          ally_teams: [ally_team(), ...],
+          game_options: %{String.t() => String.t()},
+          spectators: [AT.Player.t()],
+          bots: [AT.Bot.t()]
+        }
+
+  @type ally_team :: %{
+          teams: [team(), ...]
+        }
+
+  @type team :: %{
+          players: [AT.Player.t()]
+        }
+end

--- a/lib/teiserver/battle.ex
+++ b/lib/teiserver/battle.ex
@@ -7,6 +7,7 @@ defmodule Teiserver.Battle do
   alias Phoenix.PubSub
   alias Teiserver.Account
   alias Teiserver.Account.User
+  alias Teiserver.Autohost.Types, as: AT
   alias Teiserver.Battle.Match
   alias Teiserver.Battle.MatchLib
   alias Teiserver.Battle.MatchMembership
@@ -384,9 +385,9 @@ defmodule Teiserver.Battle do
     :ok
   end
 
-  @spec create_match_from_start_script(Teiserver.Autohost.start_script(), boolean()) ::
+  @spec create_match_from_start_script(AT.StartScript.t(), boolean()) ::
           {:ok, Match.t()} | {:error, Ecto.Changeset.t()}
-  def create_match_from_start_script(start_script, is_matchmaking) do
+  def create_match_from_start_script(%AT.StartScript{} = start_script, is_matchmaking) do
     ally_teams = start_script.ally_teams
 
     team_count = ally_teams |> Enum.count()

--- a/lib/teiserver/matchmaking/pairing_room.ex
+++ b/lib/teiserver/matchmaking/pairing_room.ex
@@ -9,6 +9,7 @@ defmodule Teiserver.Matchmaking.PairingRoom do
   alias Teiserver.Account.User
   alias Teiserver.Asset
   alias Teiserver.Autohost
+  alias Teiserver.Autohost.Types, as: AT
   alias Teiserver.Matchmaking.Member
   alias Teiserver.Matchmaking.QueueServer
   alias Teiserver.Matchmaking.QueueSupervisor
@@ -251,9 +252,9 @@ defmodule Teiserver.Matchmaking.PairingRoom do
   end
 
   @spec start_script(state(), %{version: String.t()}, String.t(), Asset.Map.t()) ::
-          Autohost.start_script()
+          AT.StartScript.t()
   defp start_script(state, engine, game, map) do
-    %{
+    %AT.StartScript{
       engine_version: engine.version,
       game_name: game,
       map_name: map.spring_name,

--- a/lib/teiserver/tachyon_battle.ex
+++ b/lib/teiserver/tachyon_battle.ex
@@ -10,6 +10,7 @@ defmodule Teiserver.TachyonBattle do
 
   alias Teiserver.Account.User
   alias Teiserver.Autohost
+  alias Teiserver.Autohost.Types, as: AT
   alias Teiserver.Battle
   alias Teiserver.Bot
   alias Teiserver.TachyonBattle
@@ -27,9 +28,9 @@ defmodule Teiserver.TachyonBattle do
   @doc """
   Start a battle process and connects it to the given autohost
   """
-  @spec start_battle(Bot.id(), Autohost.start_script(), boolean()) ::
+  @spec start_battle(Bot.id(), AT.StartScript.t(), boolean()) ::
           {:ok, {id(), pid()}, connection_info()} | {:error, term()}
-  def start_battle(autohost_id, start_script, is_matchmaking) do
+  def start_battle(autohost_id, %AT.StartScript{} = start_script, is_matchmaking) do
     with {:ok, match} <- Battle.create_match_from_start_script(start_script, is_matchmaking),
          {:ok, battle_id, pid} <- start_battle_process(autohost_id, match.id, start_script) do
       case TachyonBattle.Battle.get_connection_info(battle_id) do
@@ -39,9 +40,9 @@ defmodule Teiserver.TachyonBattle do
     end
   end
 
-  @spec start_battle_process(Autohost.id(), T.match_id(), Autohost.start_script()) ::
+  @spec start_battle_process(Autohost.id(), T.match_id(), AT.StartScript.t()) ::
           {:ok, T.id(), pid()} | {:error, term()}
-  def start_battle_process(autohost_id, match_id, start_script) do
+  def start_battle_process(autohost_id, match_id, %AT.StartScript{} = start_script) do
     battle_id = gen_id()
 
     # TODO: handle potential errors, like "already registered"

--- a/lib/teiserver/tachyon_battle/battle.ex
+++ b/lib/teiserver/tachyon_battle/battle.ex
@@ -2,6 +2,7 @@ defmodule Teiserver.TachyonBattle.Battle do
   @moduledoc false
   alias Teiserver.Account.User
   alias Teiserver.Autohost
+  alias Teiserver.Autohost.Types, as: AT
   alias Teiserver.Battle
   alias Teiserver.TachyonBattle.Registry
   alias Teiserver.TachyonBattle.Types, as: T
@@ -21,7 +22,7 @@ defmodule Teiserver.TachyonBattle.Battle do
           autohost_id: Autohost.id(),
           autohost_pid: pid(),
           autohost_timeout: timeout(),
-          start_script: Autohost.start_script(),
+          start_script: AT.StartScript.t(),
           # initialised: the battle is waiting for players to join and start the match
           # finished: the battle is over, but there are still some player in the match,
           # maybe looking at stats or whatever
@@ -111,7 +112,7 @@ defmodule Teiserver.TachyonBattle.Battle do
           battle_id: battle_id,
           match_id: match_id,
           autohost_id: autohost_id,
-          start_script: start_script
+          start_script: %AT.StartScript{} = start_script
         } = args
       ) do
     Logger.metadata(actor_type: :battle, actor_id: battle_id)

--- a/lib/teiserver/tachyon_battle/supervisor.ex
+++ b/lib/teiserver/tachyon_battle/supervisor.ex
@@ -1,6 +1,7 @@
 defmodule Teiserver.TachyonBattle.Supervisor do
   @moduledoc false
 
+  alias Teiserver.Autohost.Types, as: AT
   alias Teiserver.TachyonBattle.Battle
   alias Teiserver.TachyonBattle.Types, as: T
 
@@ -19,10 +20,10 @@ defmodule Teiserver.TachyonBattle.Supervisor do
           T.id(),
           T.match_id(),
           Teiserver.Autohost.id(),
-          Teiserver.Autohost.start_script()
+          AT.StartScript.t()
         ) ::
           DynamicSupervisor.on_start_child()
-  def start_battle(battle_id, match_id, autohost_id, start_script) do
+  def start_battle(battle_id, match_id, autohost_id, %AT.StartScript{} = start_script) do
     DynamicSupervisor.start_child(
       __MODULE__,
       {Battle,

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -26,6 +26,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
   alias Plug.Crypto
   alias Teiserver.Account.User
   alias Teiserver.Autohost
+  alias Teiserver.Autohost.Types, as: AT
   alias Teiserver.Helpers.Collections
   alias Teiserver.Helpers.MonitorCollection, as: MC
   alias Teiserver.Helpers.PubSubHelper
@@ -255,7 +256,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
   This should only be used for tests, because there is some gnarly logic in
   generating the start script and it's a bit hard to test end to end
   """
-  @spec get_start_script(LT.Types.id()) :: Autohost.start_script()
+  @spec get_start_script(LT.Types.id()) :: AT.StartScript.t()
   def get_start_script(lobby_id) do
     via_tuple(lobby_id) |> :gen_statem.call(:get_start_script, @default_call_timeout)
   end
@@ -2103,7 +2104,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
   defp bot_id?(id) when is_integer(id), do: false
   defp bot_id?(id), do: String.starts_with?(id, "bot")
 
-  @spec gen_start_script(LT.Data.t()) :: Autohost.start_script()
+  @spec gen_start_script(LT.Data.t()) :: AT.StartScript.t()
   defp gen_start_script(%LT.Data{} = state) do
     sorted =
       Map.values(state.players)
@@ -2123,7 +2124,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
             players =
               for player <- players do
-                %{
+                %AT.Player{
                   user_id: player.id,
                   name: player.name,
                   password: player.password
@@ -2132,15 +2133,13 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
             bots =
               for %LT.Bot{} = bot <- bots do
-                %{
+                %AT.Bot{
                   host_user_id: bot.host_user_id,
                   name: Map.get(bot, :name),
                   ai_short_name: bot.short_name,
                   ai_version: Map.get(bot, :version),
                   ai_options: bot.options
                 }
-                |> Enum.reject(fn {_key, v} -> v == nil || v == %{} end)
-                |> Map.new()
               end
 
             %{players: players, bots: bots}
@@ -2151,7 +2150,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
         %{teams: teams, startBox: at_config.start_box}
       end
 
-    %{
+    %AT.StartScript{
       engine_version: state.engine_version,
       game_name: state.game_version,
       map_name: state.map_name,
@@ -2160,9 +2159,9 @@ defmodule Teiserver.TachyonLobby.Lobby do
       spectators:
         Enum.map(state.spectators, fn {_s_id, s} ->
           %{user_id: s.id, name: s.name, password: s.password}
-        end)
+        end),
+      game_options: state.game_options
     }
-    |> Map.merge(Map.take(state, [:game_options]))
   end
 
   @spec update_property(atom(), term(), LT.Data.t(), User.id()) ::

--- a/test/support/fixtures/bot.ex
+++ b/test/support/fixtures/bot.ex
@@ -1,5 +1,6 @@
 defmodule Teiserver.BotFixtures do
   @moduledoc false
+  alias Teiserver.Autohost.Types, as: AT
   alias Teiserver.Bot
 
   def create_bot do
@@ -13,14 +14,14 @@ defmodule Teiserver.BotFixtures do
   end
 
   def start_script do
-    %{
+    %AT.StartScript{
       engine_version: "engineversion",
       game_name: "game name",
       map_name: "very map",
       start_pos_type: :fixed,
       ally_teams: [
         %{
-          teams: [%{players: [%{user_id: 123, name: "player name", password: "123"}]}]
+          teams: [%{players: [%AT.Player{user_id: 123, name: "player name", password: "123"}]}]
         }
       ]
     }

--- a/test/teiserver/autohost/autohost_test.exs
+++ b/test/teiserver/autohost/autohost_test.exs
@@ -4,6 +4,7 @@ defmodule Teiserver.Autohost.AutohostTest do
   alias Teiserver.Autohost.Session
   alias Teiserver.Autohost.SessionRegistry
   alias Teiserver.Autohost.TachyonHandler, as: TH
+  alias Teiserver.Autohost.Types, as: AT
   alias Teiserver.BotFixtures
 
   use Teiserver.DataCase, async: false
@@ -35,7 +36,8 @@ defmodule Teiserver.Autohost.AutohostTest do
   end
 
   defp register_autohost(id, max, current) do
-    SessionRegistry.register(%{id: id, max_battles: max, current_battles: current})
+    %AT.Overview{id: id, max_battles: max, current_battles: current}
+    |> SessionRegistry.register()
   end
 
   describe "autohost state" do

--- a/test/teiserver/autohost/session_registry_test.exs
+++ b/test/teiserver/autohost/session_registry_test.exs
@@ -1,27 +1,33 @@
 defmodule Teiserver.Autohost.SessionRegistryTest do
   alias Teiserver.Autohost.SessionRegistry
+  alias Teiserver.Autohost.Types, as: AT
 
   use Teiserver.DataCase, async: false
 
   @moduletag :tachyon
 
   test "set value also register" do
-    SessionRegistry.set_value(1, 20, 10)
-    assert SessionRegistry.get_value(1) == %{id: 1, max_battles: 20, current_battles: 10}
+    SessionRegistry.set_value(%AT.Overview{id: 1, max_battles: 20, current_battles: 10})
+
+    assert SessionRegistry.get_value(1) == %AT.Overview{
+             id: 1,
+             max_battles: 20,
+             current_battles: 10
+           }
   end
 
   test "can lookup" do
-    SessionRegistry.set_value(1, 20, 10)
-    {_pid, %{id: 1, max_battles: 20, current_battles: 10}} = SessionRegistry.lookup(1)
+    SessionRegistry.set_value(%AT.Overview{id: 1, max_battles: 20, current_battles: 10})
+    {_pid, %AT.Overview{id: 1, max_battles: 20, current_battles: 10}} = SessionRegistry.lookup(1)
   end
 
   test "list all registered sessions" do
-    SessionRegistry.set_value(1, 20, 10)
-    SessionRegistry.set_value(2, 1, 1)
+    SessionRegistry.set_value(%AT.Overview{id: 1, max_battles: 20, current_battles: 10})
+    SessionRegistry.set_value(%AT.Overview{id: 2, max_battles: 1, current_battles: 1})
 
     expected = [
-      %{id: 1, max_battles: 20, current_battles: 10},
-      %{id: 2, max_battles: 1, current_battles: 1}
+      %AT.Overview{id: 1, max_battles: 20, current_battles: 10},
+      %AT.Overview{id: 2, max_battles: 1, current_battles: 1}
     ]
 
     assert Enum.sort_by(SessionRegistry.list(), & &1.id) == expected

--- a/test/teiserver/battle/start_script_test.exs
+++ b/test/teiserver/battle/start_script_test.exs
@@ -1,4 +1,5 @@
 defmodule Teiserver.Battle.StartScriptTest do
+  alias Teiserver.Autohost.Types, as: AT
   alias Teiserver.Battle
   alias Teiserver.Helpers.GeneralTestLib
 
@@ -8,14 +9,14 @@ defmodule Teiserver.Battle.StartScriptTest do
     user1 = GeneralTestLib.make_user(%{"roles" => ["Verified"]})
     user2 = GeneralTestLib.make_user(%{"roles" => ["Verified"]})
 
-    start_script = %{
+    start_script = %AT.StartScript{
       game_name: "Beyond All Reason test-28379-33ba377",
       ally_teams: [
         %{
           teams: [
             %{
               players: [
-                %{
+                %AT.Player{
                   name: user1.name,
                   user_id: user1.id,
                   password: "AAAAAAA"
@@ -29,7 +30,7 @@ defmodule Teiserver.Battle.StartScriptTest do
           teams: [
             %{
               players: [
-                %{
+                %AT.Player{
                   name: user2.name,
                   user_id: user2.id,
                   password: "BBBBBBB"
@@ -61,14 +62,14 @@ defmodule Teiserver.Battle.StartScriptTest do
   test "test start script 1 vs bot" do
     user1 = GeneralTestLib.make_user(%{"roles" => ["Verified"]})
 
-    start_script = %{
+    start_script = %AT.StartScript{
       game_name: "Beyond All Reason test-28379-33ba377",
       ally_teams: [
         %{
           teams: [
             %{
               players: [
-                %{
+                %AT.Player{
                   name: user1.name,
                   user_id: user1.id,
                   password: "AAAAAAA"

--- a/test/teiserver/tachyon_lobby/lobby_test.exs
+++ b/test/teiserver/tachyon_lobby/lobby_test.exs
@@ -1,6 +1,7 @@
 defmodule Teiserver.TachyonLobby.LobbyTest do
   alias ExUnit.Callbacks
   alias Teiserver.AssetFixtures
+  alias Teiserver.Autohost.Types, as: AT
   alias Teiserver.KvStore
   alias Teiserver.Tachyon, as: TachyonLib
   alias Teiserver.TachyonLobby, as: Lobby
@@ -1890,7 +1891,10 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
         mk_start_params([2, 2]) |> Lobby.create()
 
       start_script = LobbyProcess.get_start_script(id)
-      %{ally_teams: [%{teams: [%{players: [%{user_id: @default_user_id}]}]}]} = start_script
+
+      %AT.StartScript{
+        ally_teams: [%{teams: [%{players: [%AT.Player{user_id: @default_user_id}]}]}]
+      } = start_script
     end
 
     test "with a spec" do

--- a/test/teiserver_web/tachyon/autohost_test.exs
+++ b/test/teiserver_web/tachyon/autohost_test.exs
@@ -1,5 +1,6 @@
 defmodule TeiserverWeb.Tachyon.Autohost do
   alias Teiserver.Autohost
+  alias Teiserver.Autohost.Types, as: AT
   alias Teiserver.BotFixtures
   alias Teiserver.Helpers.GeneralTestLib
   alias Teiserver.OAuthFixtures
@@ -103,8 +104,8 @@ defmodule TeiserverWeb.Tachyon.Autohost do
 
     expected =
       MapSet.new([
-        %{id: autohost.id, max_battles: 10, current_battles: 0},
-        %{id: other_autohost.id, max_battles: 15, current_battles: 1}
+        %AT.Overview{id: autohost.id, max_battles: 10, current_battles: 0},
+        %AT.Overview{id: other_autohost.id, max_battles: 15, current_battles: 1}
       ])
 
     poll_until(&Autohost.list/0, fn l ->


### PR DESCRIPTION
Similar to the [one for lobby](https://github.com/beyond-all-reason/teiserver/pull/1231), convert a few bare maps into structs in the autohost domain.