### PR TITLE
open port for dev smtp server

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -98,6 +98,7 @@ services:
     volumes:
       - ./containers/mailpit-auth:/tmp/auth
     ports:
+      - "1025:1025"  # smtp port
       - "8025:8025"  # web UI
 
 volumes:


### PR DESCRIPTION
that was erroneously removed when [adding the devcontainer](https://github.com/beyond-all-reason/teiserver/pull/1248/) stuff