### PR TITLE
Rework metadata cache

### DIFF
--- a/lib/teiserver/logging/lib/audit_log_lib.ex
+++ b/lib/teiserver/logging/lib/audit_log_lib.ex
@@ -2,8 +2,10 @@ defmodule Teiserver.Logging.AuditLogLib do
   @moduledoc false
 
   alias Teiserver.Logging.AuditLog
+  alias Teiserver.Repo
 
   use TeiserverWeb, :library
+  use TeiserverWeb, :queries
 
   @spec colours() :: atom
   def colours, do: :danger2
@@ -11,15 +13,12 @@ defmodule Teiserver.Logging.AuditLogLib do
   @spec icon() :: String.t()
   def icon, do: "fa-solid fa-archive"
 
-  @spec add_audit_types([String.t()]) :: :ok
-  def add_audit_types(types) do
-    new_types = list_audit_types() ++ types
-    Teiserver.store_put(:application_metadata_cache, "audit_types", new_types)
-  end
-
   @spec list_audit_types :: [String.t()]
   def list_audit_types do
-    Teiserver.cache_get(:application_metadata_cache, "audit_types") || []
+    query = from logs in AuditLog, as: :audit_log, distinct: :action, select: [:action]
+
+    Repo.all(query)
+    |> Enum.map(& &1.action)
   end
 
   # Queries

--- a/lib/teiserver/metadata_cache.ex
+++ b/lib/teiserver/metadata_cache.ex
@@ -4,6 +4,10 @@ defmodule Teiserver.MetadataCache do
   """
 
   alias Teiserver.Helpers.CacheHelper
+  alias Teiserver.Moderation.LoadBannedDomainsTask
+  alias Teiserver.Moderation.LoadBannedIPsTask
+  alias Teiserver.Moderation.LoadBannedPhrasesTask
+  alias Teiserver.Moderation.Tasks.LoadVPNsTask
 
   use Supervisor
 
@@ -14,9 +18,17 @@ defmodule Teiserver.MetadataCache do
   @impl Supervisor
   def init(_arg) do
     children = [
-      CacheHelper.concache_perm_sup(:application_metadata_cache)
+      CacheHelper.concache_perm_sup(:application_metadata_cache),
+      {Task,
+       fn ->
+         LoadVPNsTask.perform()
+         LoadBannedIPsTask.perform()
+         LoadBannedPhrasesTask.perform()
+         LoadBannedDomainsTask.perform()
+       end}
+      |> Supervisor.child_spec(restart: :transient)
     ]
 
-    Supervisor.init(children, strategy: :one_for_one)
+    Supervisor.init(children, strategy: :rest_for_one)
   end
 end

--- a/lib/teiserver/metadata_cache.ex
+++ b/lib/teiserver/metadata_cache.ex
@@ -7,44 +7,16 @@ defmodule Teiserver.MetadataCache do
 
   use Supervisor
 
-  def start_link(opts) do
-    with {:ok, sup} <- Supervisor.start_link(__MODULE__, :ok, opts),
-         :ok <- random_names() do
-      {:ok, sup}
-    end
+  def start_link(init_arg) do
+    Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
   end
 
   @impl Supervisor
-  def init(:ok) do
+  def init(_arg) do
     children = [
       CacheHelper.concache_perm_sup(:application_metadata_cache)
     ]
 
     Supervisor.init(children, strategy: :one_for_one)
-  end
-
-  defp random_names do
-    Teiserver.store_put(
-      :application_metadata_cache,
-      "random_names_1",
-      ~w(serene energised humble auspicious decisive exemplary cheerful determined playful spry springy)
-    )
-
-    Teiserver.store_put(:application_metadata_cache, "random_names_2", ~w(
-      maroon cherry rose ruby
-      amber carrot
-      lemon beige
-      mint lime cadmium
-      aqua cerulean
-      lavender indigo
-      magenta amethyst
-    ))
-
-    Teiserver.store_put(
-      :application_metadata_cache,
-      "random_names_3",
-      ~w(tick pawn lazarus rocketeer crossbow mace centurion tumbleweed smuggler compass ghost sprinter butler webber platypus hound welder recluse archangel gunslinger sharpshooter umbrella fatboy marauder vanguard razorback titan) ++
-        ~w(grunt graverobber aggravator trasher thug bedbug deceiver augur spectre fiend twitcher duck skuttle sumo arbiter manticore termite commando mammoth shiva karganeth catapult behemoth juggernaught)
-    )
   end
 end

--- a/lib/teiserver/metadata_cache.ex
+++ b/lib/teiserver/metadata_cache.ex
@@ -4,14 +4,12 @@ defmodule Teiserver.MetadataCache do
   """
 
   alias Teiserver.Helpers.CacheHelper
-  alias Teiserver.Logging.AuditLogLib
 
   use Supervisor
 
   def start_link(opts) do
     with {:ok, sup} <- Supervisor.start_link(__MODULE__, :ok, opts),
-         :ok <- random_names(),
-         :ok <- audit() do
+         :ok <- random_names() do
       {:ok, sup}
     end
   end
@@ -48,37 +46,5 @@ defmodule Teiserver.MetadataCache do
       ~w(tick pawn lazarus rocketeer crossbow mace centurion tumbleweed smuggler compass ghost sprinter butler webber platypus hound welder recluse archangel gunslinger sharpshooter umbrella fatboy marauder vanguard razorback titan) ++
         ~w(grunt graverobber aggravator trasher thug bedbug deceiver augur spectre fiend twitcher duck skuttle sumo arbiter manticore termite commando mammoth shiva karganeth catapult behemoth juggernaught)
     )
-  end
-
-  defp audit do
-    AuditLogLib.add_audit_types([
-      "Account:User password reset",
-      "Account:Failed login",
-      "Account:Created user",
-      "Account:Updated user",
-      "Account:Updated user permissions",
-      "Account:User registration",
-      "Account:Updated report",
-      "Site config:Update value",
-      "Moderation:Ban enabled",
-      "Moderation:Ban disabled",
-      "Moderation:Ban updated",
-      "Moderation:Ban enacted",
-      "Moderation:Action deleted",
-      "Moderation:Action halted",
-      "Moderation:Action re_posted",
-      "Moderation:Action updated",
-      "Moderation:Action created",
-      "Moderation:De-bridged user",
-      "Moderation:Mark as smurf",
-      "Teiserver:Updated automod action",
-      "Teiserver:Automod action enacted",
-      "Teiserver:De-bridged user",
-      "Teiserver:Changed user rating",
-      "Teiserver:Changed user name",
-      "Teiserver:Smurf merge",
-      "Microblog.delete_post",
-      "Discord.text_callback"
-    ])
   end
 end

--- a/lib/teiserver/mix_tasks/fake_data.ex
+++ b/lib/teiserver/mix_tasks/fake_data.ex
@@ -88,13 +88,26 @@ defmodule Mix.Tasks.Teiserver.Fakedata do
   """
   @spec generate_throwaway_name() :: String.t()
   def generate_throwaway_name do
-    [
-      Teiserver.store_get(:application_metadata_cache, "random_names_1"),
-      Teiserver.store_get(:application_metadata_cache, "random_names_2"),
-      Teiserver.store_get(:application_metadata_cache, "random_names_3")
-    ]
-    |> Enum.filter(fn l -> l != [] end)
-    |> Enum.map_join(" ", fn l -> Enum.random(l) |> String.capitalize() end)
+    names1 =
+      ~w(serene energised humble auspicious decisive exemplary cheerful
+        determined playful spry springy)
+
+    names2 =
+      ~w(maroon cherry rose ruby amber carrot lemon beige mint lime cadmium
+        aqua cerulean lavender indigo magenta amethyst)
+
+    names3 =
+      ~w(tick pawn lazarus rocketeer crossbow mace centurion tumbleweed smuggler compass
+        ghost sprinter butler webber platypus hound welder recluse archangel
+        gunslinger sharpshooter umbrella fatboy
+        marauder vanguard razorback titan
+        grunt graverobber aggravator trasher thug bedbug
+        deceiver augur spectre fiend twitcher duck skuttle sumo arbiter manticore
+        termite commando mammoth shiva karganeth catapult behemoth juggernaught
+      )
+
+    [names1, names2, names3]
+    |> Enum.map_join("", fn l -> Enum.random(l) |> String.capitalize() end)
   end
 
   defp make_accounts do
@@ -106,7 +119,7 @@ defmodule Mix.Tasks.Teiserver.Fakedata do
         Range.new(0, users_per_day())
         |> ParallelStream.map(fn _index ->
           minutes = :rand.uniform(24 * 60)
-          name = generate_throwaway_name() |> String.replace(" ", "")
+          name = generate_throwaway_name()
 
           %{
             name: name,

--- a/lib/teiserver/startup.ex
+++ b/lib/teiserver/startup.ex
@@ -6,10 +6,6 @@ defmodule Teiserver.Startup do
   alias Teiserver.Coordinator
   alias Teiserver.Coordinator.AutomodServer
   alias Teiserver.LobbyIdServer
-  alias Teiserver.Moderation.LoadBannedDomainsTask
-  alias Teiserver.Moderation.LoadBannedIPsTask
-  alias Teiserver.Moderation.LoadBannedPhrasesTask
-  alias Teiserver.Moderation.Tasks.LoadVPNsTask
   alias Teiserver.Telemetry
 
   use TeiserverWeb, :startup
@@ -34,19 +30,6 @@ defmodule Teiserver.Startup do
         :timer.sleep(200)
         Coordinator.start_coordinator()
         AutomodServer.start_automod_server()
-      end)
-    end
-
-    # If test mode we don't want to load this up for every test as we will generate
-    # a lot of errors related to the SQL sandbox. We have specific unit tests for
-    # these elsewhere in the codebase
-    if not Application.get_env(:teiserver, Teiserver)[:test_mode] do
-      spawn(fn ->
-        :timer.sleep(200)
-        LoadVPNsTask.perform()
-        LoadBannedIPsTask.perform()
-        LoadBannedPhrasesTask.perform()
-        LoadBannedDomainsTask.perform()
       end)
     end
 

--- a/lib/teiserver_web.ex
+++ b/lib/teiserver_web.ex
@@ -224,7 +224,6 @@ defmodule TeiserverWeb do
       import Teiserver.Account.AuthLib, only: [add_permission_set: 3]
 
       import Teiserver.Config, only: [add_site_config_type: 1]
-      import Teiserver.Logging.AuditLogLib, only: [add_audit_types: 1]
     end
   end
 

--- a/test/teiserver/logging/audit_log_test.exs
+++ b/test/teiserver/logging/audit_log_test.exs
@@ -1,0 +1,35 @@
+defmodule Teiserver.Logging.AuditLogTests do
+  alias Teiserver.Logging
+  alias Teiserver.Logging.AuditLog
+  alias Teiserver.Logging.AuditLogLib
+
+  use Teiserver.DataCase, async: false
+
+  test "add audit log" do
+    {:ok, %AuditLog{}} =
+      Logging.create_audit_log(%{
+        action: "test-action",
+        user_id: nil,
+        details: %{foo: "test details"},
+        ip: "123.123.123.123"
+      })
+  end
+
+  test "list distinct action types" do
+    actions = ["test-action1", "test-action2"]
+
+    Enum.with_index(actions ++ actions)
+    |> Enum.each(fn {action, idx} ->
+      {:ok, _log} =
+        Logging.create_audit_log(%{
+          action: action,
+          user_id: nil,
+          details: %{idx: idx},
+          ip: "123.123.123.123"
+        })
+    end)
+
+    got = AuditLogLib.list_audit_types() |> Enum.sort()
+    assert got == actions
+  end
+end


### PR DESCRIPTION
This rework the application metadata cache warmup logic.
The main issue is `startup.ex`, that file should not exist at all and everything should be under the main supervision tree.
This deals with the app metadata cache.