### PR TITLE
Remove All Chat restriction from rename request button

### DIFF
--- a/lib/teiserver_web/templates/moderation/action/new_with_user.html.heex
+++ b/lib/teiserver_web/templates/moderation/action/new_with_user.html.heex
@@ -409,7 +409,6 @@ bsname = view_colour() %>
                     onclick={"
         $('#action_restriction_Warning_reminder').prop('checked', true);
         $('#action_restriction_All_lobbies').prop('checked', true);
-        $('#action_restriction_All_chat').prop('checked', true);
         $('#action_restriction_Room_chat').prop('checked', true);
         $('#action_restriction_Matchmaking').prop('checked', true);
         $('#action_restriction_Community').prop('checked', true);


### PR DESCRIPTION
To quote Stormfire as relayed by KayZee: With that restriction, players are unable to actually rename.

I suspect this old and misguided change of mine got in here during a recent merge.
