### PR TITLE
Ban search uses User table rather than CacheUser lookup

### DIFF
--- a/lib/teiserver_web/controllers/moderation/ban_controller.ex
+++ b/lib/teiserver_web/controllers/moderation/ban_controller.ex
@@ -137,7 +137,7 @@ defmodule TeiserverWeb.Moderation.BanController do
           |> List.flatten()
           |> Enum.map(fn %{user: user} -> user.id end)
           |> Enum.uniq()
-          |> Enum.map(fn userid -> Account.get_user_by_id(userid) end)
+          |> Enum.map(&Account.get_user!/1)
           |> Enum.reject(fn user ->
             Account.restricted?(user, ["Login", "All lobbies", "All chat"])
           end)


### PR DESCRIPTION
In certain situations a CacheUser will be passed through and cause an error. This pulls out an actual user and will error the entire request if they do not exist (which they should given we just got their ID from a list).