### PR TITLE
allow parens in lobby name

### DIFF
--- a/lib/teiserver/lobby/libs/lobby_lib.ex
+++ b/lib/teiserver/lobby/libs/lobby_lib.ex
@@ -605,7 +605,7 @@ defmodule Teiserver.Lobby.LobbyLib do
 
   @spec name_chars_valid?(String.t()) :: boolean
   def name_chars_valid?(name) do
-    case Regex.run(~r/^[a-zA-Z0-9_\-\[\] \<\>\+\|:]+$/, name) do
+    case Regex.run(~r/^[a-zA-Z0-9_\-\[\] \<\>\+\|:()]+$/, name) do
       [_match] -> true
       _no_match -> false
     end


### PR DESCRIPTION
No reason to disallow them, and by default, local spads use them in lobby name: `SPADS (default settings)` so allowing them make that work out of the box.