### PR TITLE
Struct for lobby events

### DIFF
--- a/lib/teiserver/tachyon_lobby/event.ex
+++ b/lib/teiserver/tachyon_lobby/event.ex
@@ -1,0 +1,13 @@
+defprotocol Teiserver.TachyonLobby.Event do
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  @doc """
+  Given an event and an aggregate, returns the new aggregate.
+
+  This function must be side-effect free, because many events may be folded
+  together or rolled back before arriving to the final aggregate to be used
+  by the lobby.
+  """
+  @spec apply_event(term(), LT.Aggregate.t()) :: LT.Aggregate.t()
+  def apply_event(event, data)
+end

--- a/lib/teiserver/tachyon_lobby/events/add_spectator.ex
+++ b/lib/teiserver/tachyon_lobby/events/add_spectator.ex
@@ -1,0 +1,34 @@
+defmodule Teiserver.TachyonLobby.Events.AddSpectator do
+  @moduledoc """
+  Adding a brand new player to the lobby, as a spectator
+  """
+
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  @enforce_keys [:spec]
+  defstruct [:spec]
+
+  @type t() :: %__MODULE__{
+          spec: LT.Spectator.t()
+        }
+end
+
+defimpl Teiserver.TachyonLobby.Event, for: Teiserver.TachyonLobby.Events.AddSpectator do
+  alias Teiserver.Helpers.MonitorCollection, as: MC
+  alias Teiserver.TachyonLobby.Events.AddSpectator
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  def apply_event(%AddSpectator{} = ev, %LT.Aggregate{} = agg) do
+    data =
+      agg.data
+      |> put_in([Access.key!(:spectators), ev.spec.id], ev.spec)
+      |> update_in([Access.key!(:monitors)], &MC.monitor(&1, ev.spec.pid, {:user, ev.spec.id}))
+
+    changes =
+      agg.changes
+      |> Map.put_new(:spectators, %{})
+      |> put_in([:spectators, ev.spec.id], Map.take(ev.spec, [:join_queue_position]))
+
+    %{agg | data: data, changes: changes}
+  end
+end

--- a/lib/teiserver/tachyon_lobby/events/cancel_kick_vote.ex
+++ b/lib/teiserver/tachyon_lobby/events/cancel_kick_vote.ex
@@ -1,0 +1,36 @@
+defmodule Teiserver.TachyonLobby.Events.CancelKickVote do
+  @moduledoc """
+  Take care of cancelling a potential kickban vote when a player/spec
+  leaves the lobby.
+  """
+  alias Teiserver.Account.User
+
+  @enforce_keys [:user_id]
+  defstruct [:user_id]
+
+  @type t() :: %__MODULE__{
+          user_id: User.id()
+        }
+end
+
+defimpl Teiserver.TachyonLobby.Event, for: Teiserver.TachyonLobby.Events.CancelKickVote do
+  alias Teiserver.TachyonLobby.Events
+  alias Teiserver.TachyonLobby.Events.CancelKickVote
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  def apply_event(%CancelKickVote{} = ev, %LT.Aggregate{} = agg) do
+    case agg.data.current_vote do
+      %{action: {:kickban, user_id, nil}} when user_id == ev.user_id ->
+        end_event = %Events.VoteEnded{
+          finished_at: DateTime.utc_now(),
+          vote: agg.data.current_vote,
+          outcome: :cancelled
+        }
+
+        Teiserver.TachyonLobby.Event.apply_event(end_event, agg)
+
+      _other ->
+        agg
+    end
+  end
+end

--- a/lib/teiserver/tachyon_lobby/events/cast_vote.ex
+++ b/lib/teiserver/tachyon_lobby/events/cast_vote.ex
@@ -1,0 +1,131 @@
+defmodule Teiserver.TachyonLobby.Events.CastVote do
+  @moduledoc """
+  To change the tags for a lobby
+  """
+
+  alias Teiserver.Account.User
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  @enforce_keys [:user_id, :vote, :ballot]
+  defstruct [:user_id, :vote, :ballot]
+
+  @type t() :: %__MODULE__{
+          user_id: User.id(),
+          vote: LT.VoteState.t(),
+          ballot: LT.VoteState.vote_ballot()
+        }
+end
+
+defimpl Teiserver.TachyonLobby.Event, for: Teiserver.TachyonLobby.Events.CastVote do
+  alias Teiserver.TachyonLobby.Event
+  alias Teiserver.TachyonLobby.Events
+  alias Teiserver.TachyonLobby.Events.CastVote
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  def apply_event(%CastVote{} = ev, %LT.Aggregate{} = agg)
+      when agg.data.current_vote == nil or
+             agg.data.current_vote.id != ev.vote.id or
+             not is_map_key(agg.data.current_vote.voters, ev.user_id) do
+    agg
+  end
+
+  def apply_event(%CastVote{} = ev, %LT.Aggregate{} = agg) do
+    data =
+      put_in(agg.data, [Access.key!(:current_vote), Access.key!(:voters), ev.user_id], ev.ballot)
+
+    agg = %{agg | data: data}
+
+    case vote_result(agg.data.current_vote) do
+      :undecided ->
+        changes =
+          agg.changes
+          |> Map.put_new(:current_vote, %{})
+          |> Map.update!(:current_vote, &Map.put_new(&1, :voters, %{}))
+          |> put_in([:current_vote, :voters, ev.user_id], ev.ballot)
+
+        %{agg | changes: changes}
+
+      {:ended, result} ->
+        new_aggregate =
+          Event.apply_event(
+            %Events.VoteEnded{
+              vote: data.current_vote,
+              finished_at: DateTime.utc_now(),
+              outcome: result
+            },
+            agg
+          )
+
+        case {result, ev.vote.action} do
+          {:failed, _action} ->
+            new_aggregate
+
+          {:passed, {:change_map, new_map}} ->
+            Event.apply_event(%Events.UpdateMapName{new_map: new_map}, new_aggregate)
+
+          {:passed, {:appoint_boss, boss_id}} ->
+            Event.apply_event(
+              %Events.UpdateBoss{action: :add, appointee_id: boss_id},
+              new_aggregate
+            )
+
+          {:passed, {:kickban, target_id, ban_until}} ->
+            data = new_aggregate.data
+
+            target_in_lobby? =
+              is_map_key(data.players, target_id) or
+                is_map_key(data.spectators, target_id)
+
+            cond do
+              target_in_lobby? ->
+                Event.apply_event(
+                  %Events.Kickban{user_id: target_id, ban_until: ban_until},
+                  new_aggregate
+                )
+
+              ban_until != nil ->
+                effective_ban_until =
+                  if DateTime.compare(ban_until, DateTime.utc_now()) == :gt,
+                    do: ban_until,
+                    else: nil
+
+                case effective_ban_until do
+                  nil ->
+                    new_aggregate
+
+                  dt ->
+                    ms = DateTime.diff(dt, DateTime.utc_now(), :millisecond)
+
+                    side_effects =
+                      if ms > 0,
+                        do: [
+                          {:send_after, ms, {:ban_expired, target_id}}
+                          | new_aggregate.side_effects
+                        ],
+                        else: new_aggregate.side_effects
+
+                    new_data = put_in(data.banned_users[target_id], dt)
+                    %{new_aggregate | data: new_data, side_effects: side_effects}
+                end
+
+              true ->
+                new_aggregate
+            end
+
+            # just let the thing crash if a new vote action shows up. It'll be easy
+            # to spot and fix/add support. :start isn't yet supported
+        end
+    end
+  end
+
+  @spec vote_result(LT.VoteState.t()) :: :undecided | {:ended, :passed | :failed}
+  defp vote_result(%LT.VoteState{} = vote) do
+    votes = for {_user_id, v} <- vote.voters, do: v
+
+    cond do
+      Enum.count(votes, &(&1 != :pending)) < vote.quorum -> :undecided
+      Enum.count(votes, &(&1 == :yes)) >= vote.majority -> {:ended, :passed}
+      true -> {:ended, :failed}
+    end
+  end
+end

--- a/lib/teiserver/tachyon_lobby/events/fill_from_join_queue.ex
+++ b/lib/teiserver/tachyon_lobby/events/fill_from_join_queue.ex
@@ -1,0 +1,47 @@
+defmodule Teiserver.TachyonLobby.Events.FillFromJoinQueue do
+  @moduledoc """
+  Add any player from the join queue to the list of active players whereverer
+  there is space, attempting to fill the least full teams first
+  """
+
+  defstruct []
+end
+
+defimpl Teiserver.TachyonLobby.Event, for: Teiserver.TachyonLobby.Events.FillFromJoinQueue do
+  alias Teiserver.Account.User
+  alias Teiserver.TachyonLobby.Events
+  alias Teiserver.TachyonLobby.Events.FillFromJoinQueue
+  alias Teiserver.TachyonLobby.Lobby
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  def apply_event(%FillFromJoinQueue{}, %LT.Aggregate{} = agg) do
+    case add_player_from_join_queue(agg.data) do
+      nil ->
+        agg
+
+      {id, player_data} ->
+        ev = %Events.MoveSpecToPlayer{user_id: id, player_data: player_data}
+        new_aggregate = Teiserver.TachyonLobby.Event.apply_event(ev, agg)
+        apply_event(%FillFromJoinQueue{}, new_aggregate)
+    end
+  end
+
+  # Add the first player from the join queue to the player list and returns the
+  # updated state alongside the player id that was added
+  @spec add_player_from_join_queue(LT.Data.t()) :: {User.id(), map()} | nil
+  defp add_player_from_join_queue(%LT.Data{} = state) do
+    case Lobby.get_first_player_in_join_queue(state.spectators) do
+      nil ->
+        nil
+
+      id ->
+        case Lobby.find_team(state.ally_team_config, state.players) do
+          nil ->
+            nil
+
+          team ->
+            {id, %{team: team, ready?: false, asset_status: :complete}}
+        end
+    end
+  end
+end

--- a/lib/teiserver/tachyon_lobby/events/kickban.ex
+++ b/lib/teiserver/tachyon_lobby/events/kickban.ex
@@ -1,0 +1,70 @@
+defmodule Teiserver.TachyonLobby.Events.Kickban do
+  @moduledoc """
+  Kick a player from the lobby. May also add a ban duration.
+  This also remove all the bots associated with the player
+  """
+
+  alias Teiserver.Account.User
+
+  @enforce_keys [:user_id, :ban_until]
+  defstruct [:user_id, :ban_until]
+
+  @type t() :: %__MODULE__{
+          user_id: User.id(),
+          ban_until: DateTime.t()
+        }
+end
+
+defimpl Teiserver.TachyonLobby.Event, for: Teiserver.TachyonLobby.Events.Kickban do
+  alias Teiserver.TachyonLobby.Event
+  alias Teiserver.TachyonLobby.Events
+  alias Teiserver.TachyonLobby.Events.Kickban
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  def apply_event(%Kickban{} = ev, %LT.Aggregate{} = agg) do
+    effective_ban_until =
+      case ev.ban_until do
+        nil -> nil
+        dt -> if DateTime.compare(dt, DateTime.utc_now()) == :gt, do: dt, else: nil
+      end
+
+    target_pid =
+      get_in(agg.data.players[ev.user_id].pid) || get_in(agg.data.spectators[ev.user_id].pid)
+
+    agg =
+      case effective_ban_until do
+        nil ->
+          agg
+
+        dt ->
+          ms = DateTime.diff(dt, DateTime.utc_now(), :millisecond)
+          data = put_in(agg.data, [Access.key!(:banned_users), ev.user_id], dt)
+
+          effects =
+            if ms > 0,
+              do: [{:send_after, ms, {:ban_expired, ev.user_id}} | agg.side_effects],
+              else: []
+
+          %{agg | data: data, side_effects: effects}
+      end
+
+    agg =
+      if is_map_key(agg.data.players, ev.user_id) do
+        Event.apply_event(%Events.RemovePlayerFromLobby{player_id: ev.user_id}, agg)
+      else
+        Event.apply_event(%Events.RemoveSpecFromLobby{user_id: ev.user_id}, agg)
+      end
+
+    effects =
+      if target_pid do
+        reason = if effective_ban_until != nil, do: "banned", else: "kicked"
+        message = {:lobby, agg.data.id, {:left, reason, effective_ban_until}}
+        effect = {:send_to_user, target_pid, message}
+        [effect | agg.side_effects]
+      else
+        agg.side_effects
+      end
+
+    %{agg | side_effects: effects}
+  end
+end

--- a/lib/teiserver/tachyon_lobby/events/move_player.ex
+++ b/lib/teiserver/tachyon_lobby/events/move_player.ex
@@ -1,0 +1,40 @@
+defmodule Teiserver.TachyonLobby.Events.MovePlayer do
+  @moduledoc """
+  Move a player from one team to another
+  """
+
+  alias Teiserver.Account.User
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  @enforce_keys [:player_id, :team]
+  defstruct [:player_id, :team]
+
+  @type t() :: %__MODULE__{
+          player_id: User.id(),
+          team: LT.Types.team()
+        }
+end
+
+defimpl Teiserver.TachyonLobby.Event, for: Teiserver.TachyonLobby.Events.MovePlayer do
+  alias Teiserver.TachyonLobby.Events
+  alias Teiserver.TachyonLobby.Events.MovePlayer
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  def apply_event(%MovePlayer{} = ev, %LT.Aggregate{} = agg) do
+    data = put_in(agg.data, [Access.key!(:players), ev.player_id, Access.key!(:team)], ev.team)
+
+    changes =
+      agg.changes
+      |> Map.put_new(:players, %{})
+      |> Map.update!(:players, fn players ->
+        players
+        |> Map.put_new(ev.player_id, %{})
+        |> update_in([ev.player_id], fn p ->
+          Map.merge(%{team: ev.team, ready?: false, asset_status: :complete}, p)
+        end)
+      end)
+
+    new_aggregate = %{agg | data: data, changes: changes}
+    Teiserver.TachyonLobby.Event.apply_event(%Events.RepackPlayers{}, new_aggregate)
+  end
+end

--- a/lib/teiserver/tachyon_lobby/events/move_player_to_spec.ex
+++ b/lib/teiserver/tachyon_lobby/events/move_player_to_spec.ex
@@ -1,0 +1,54 @@
+defmodule Teiserver.TachyonLobby.Events.MovePlayerToSpec do
+  @moduledoc """
+  When a player becomes a spectator. This cannot be applied to a bot
+  """
+  alias Teiserver.Account.User
+
+  @enforce_keys [:user_id, :spec_data]
+  defstruct [:user_id, :spec_data]
+
+  @type t() :: %__MODULE__{
+          user_id: User.id(),
+          spec_data: map()
+        }
+end
+
+defimpl Teiserver.TachyonLobby.Event, for: Teiserver.TachyonLobby.Events.MovePlayerToSpec do
+  alias Teiserver.TachyonLobby.Events
+  alias Teiserver.TachyonLobby.Events.MovePlayerToSpec
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  def apply_event(%MovePlayerToSpec{} = ev, %LT.Aggregate{} = agg) do
+    %LT.Player{} = player = agg.data.players[ev.user_id]
+
+    spec = %LT.Spectator{
+      id: player.id,
+      name: player.name,
+      password: player.password,
+      pid: player.pid,
+      join_queue_position: ev.spec_data.join_queue_position
+    }
+
+    data =
+      agg.data
+      |> update_in([Access.key!(:players)], &Map.delete(&1, ev.user_id))
+      |> put_in([Access.key!(:spectators), ev.user_id], spec)
+
+    changes =
+      agg.changes
+      |> Map.put_new(:players, %{})
+      |> put_in([:players, ev.user_id], nil)
+      |> Map.put_new(:spectators, %{})
+      |> put_in([:spectators, ev.user_id], ev.spec_data)
+
+    overview_changes = Map.put(agg.overview_changes, :player_count, map_size(data.players))
+
+    new_aggregate = %{agg | data: data, changes: changes, overview_changes: overview_changes}
+
+    Enum.reduce(
+      [%Events.RepackPlayers{}, %Events.FillFromJoinQueue{}],
+      new_aggregate,
+      &Teiserver.TachyonLobby.Event.apply_event/2
+    )
+  end
+end

--- a/lib/teiserver/tachyon_lobby/events/move_spec_to_player.ex
+++ b/lib/teiserver/tachyon_lobby/events/move_spec_to_player.ex
@@ -1,0 +1,52 @@
+defmodule Teiserver.TachyonLobby.Events.MoveSpecToPlayer do
+  @moduledoc """
+  Move a spectator into an ally team
+  """
+
+  alias Teiserver.Account.User
+
+  @enforce_keys [:user_id, :player_data]
+  defstruct [:user_id, :player_data]
+
+  @type t() :: %__MODULE__{
+          user_id: User.id(),
+          player_data: map()
+        }
+end
+
+defimpl Teiserver.TachyonLobby.Event, for: Teiserver.TachyonLobby.Events.MoveSpecToPlayer do
+  alias Teiserver.TachyonLobby.Events.MoveSpecToPlayer
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  def apply_event(%MoveSpecToPlayer{} = ev, %LT.Aggregate{} = agg) do
+    spec_data = agg.data.spectators[ev.user_id]
+
+    player = %LT.Player{
+      id: spec_data.id,
+      name: spec_data.name,
+      password: spec_data.password,
+      pid: spec_data.pid,
+      team: ev.player_data.team,
+      ready?: false,
+      asset_status: :complete
+    }
+
+    data =
+      agg.data
+      |> update_in([Access.key!(:spectators)], &Map.delete(&1, ev.user_id))
+      |> put_in([Access.key!(:players), ev.user_id], player)
+
+    player_data = Map.merge(%{ready?: false, asset_status: :complete}, ev.player_data)
+
+    changes =
+      agg.changes
+      |> Map.put_new(:players, %{})
+      |> put_in([:players, ev.user_id], player_data)
+      |> Map.put_new(:spectators, %{})
+      |> put_in([:spectators, ev.user_id], nil)
+
+    overview_changes = Map.put(agg.overview_changes, :player_count, map_size(data.players))
+
+    %{agg | data: data, changes: changes, overview_changes: overview_changes}
+  end
+end

--- a/lib/teiserver/tachyon_lobby/events/remove_player_from_lobby.ex
+++ b/lib/teiserver/tachyon_lobby/events/remove_player_from_lobby.ex
@@ -14,11 +14,23 @@ end
 
 defimpl Teiserver.TachyonLobby.Event, for: Teiserver.TachyonLobby.Events.RemovePlayerFromLobby do
   alias Teiserver.Helpers.MonitorCollection, as: MC
+  alias Teiserver.TachyonLobby.Event
   alias Teiserver.TachyonLobby.Events
   alias Teiserver.TachyonLobby.Events.RemovePlayerFromLobby
   alias Teiserver.TachyonLobby.Types, as: LT
 
   def apply_event(%RemovePlayerFromLobby{} = ev, %LT.Aggregate{} = agg) do
+    agg =
+      Enum.reduce(
+        [
+          %Events.CancelKickVote{user_id: ev.player_id},
+          %Events.CastVote{user_id: ev.player_id, vote: agg.data.current_vote, ballot: :abstain},
+          %Events.UpdateBoss{action: :remove, appointee_id: ev.player_id}
+        ],
+        agg,
+        &Event.apply_event/2
+      )
+
     # if the user leaving is associated with any bot, we need to remove all of
     # them as well.
     ids_to_remove =
@@ -44,17 +56,8 @@ defimpl Teiserver.TachyonLobby.Event, for: Teiserver.TachyonLobby.Events.RemoveP
       |> update_in([:players], &Map.merge(&1, removed_changes))
 
     overview_changes = Map.put(agg.overview_changes, :player_count, map_size(data.players))
+    agg = %{agg | data: data, changes: changes, overview_changes: overview_changes}
 
-    # TODO This should handle voting and boss updates once these are converted to structs
-    # aggregate = process_event({:cast_vote, p_id, :abstain}, aggregate)
-    # process_event({:update_boss, :remove, p_id}, aggregate)
-    # TODO: this should handle cancelling kickban vote as well
-    new_aggregate = %{agg | data: data, changes: changes, overview_changes: overview_changes}
-
-    Enum.reduce(
-      [%Events.RepackPlayers{}, %Events.FillFromJoinQueue{}],
-      new_aggregate,
-      &Teiserver.TachyonLobby.Event.apply_event/2
-    )
+    Enum.reduce([%Events.RepackPlayers{}, %Events.FillFromJoinQueue{}], agg, &Event.apply_event/2)
   end
 end

--- a/lib/teiserver/tachyon_lobby/events/remove_player_from_lobby.ex
+++ b/lib/teiserver/tachyon_lobby/events/remove_player_from_lobby.ex
@@ -1,0 +1,60 @@
+defmodule Teiserver.TachyonLobby.Events.RemovePlayerFromLobby do
+  @moduledoc """
+  Removing a player or a bot from the lobby
+  """
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  @enforce_keys [:player_id]
+  defstruct [:player_id]
+
+  @type t() :: %__MODULE__{
+          player_id: LT.Types.player_id()
+        }
+end
+
+defimpl Teiserver.TachyonLobby.Event, for: Teiserver.TachyonLobby.Events.RemovePlayerFromLobby do
+  alias Teiserver.Helpers.MonitorCollection, as: MC
+  alias Teiserver.TachyonLobby.Events
+  alias Teiserver.TachyonLobby.Events.RemovePlayerFromLobby
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  def apply_event(%RemovePlayerFromLobby{} = ev, %LT.Aggregate{} = agg) do
+    # if the user leaving is associated with any bot, we need to remove all of
+    # them as well.
+    ids_to_remove =
+      Enum.filter(agg.data.players, fn {_bot_id, b} ->
+        Map.get(b, :host_user_id) == ev.player_id
+      end)
+      |> Enum.map(&elem(&1, 0))
+      |> Enum.into(MapSet.new([ev.player_id]))
+
+    data =
+      agg.data
+      |> update_in([Access.key!(:players)], fn players ->
+        Enum.reject(players, fn {p_id, _data} -> MapSet.member?(ids_to_remove, p_id) end)
+        |> Enum.into(%{})
+      end)
+      |> update_in([Access.key!(:monitors)], &MC.demonitor_by_val(&1, {:user, ev.player_id}))
+
+    removed_changes = Enum.map(ids_to_remove, fn id -> {id, nil} end) |> Enum.into(%{})
+
+    changes =
+      agg.changes
+      |> Map.put_new(:players, %{})
+      |> update_in([:players], &Map.merge(&1, removed_changes))
+
+    overview_changes = Map.put(agg.overview_changes, :player_count, map_size(data.players))
+
+    # TODO This should handle voting and boss updates once these are converted to structs
+    # aggregate = process_event({:cast_vote, p_id, :abstain}, aggregate)
+    # process_event({:update_boss, :remove, p_id}, aggregate)
+    # TODO: this should handle cancelling kickban vote as well
+    new_aggregate = %{agg | data: data, changes: changes, overview_changes: overview_changes}
+
+    Enum.reduce(
+      [%Events.RepackPlayers{}, %Events.FillFromJoinQueue{}],
+      new_aggregate,
+      &Teiserver.TachyonLobby.Event.apply_event/2
+    )
+  end
+end

--- a/lib/teiserver/tachyon_lobby/events/remove_spec_from_lobby.ex
+++ b/lib/teiserver/tachyon_lobby/events/remove_spec_from_lobby.ex
@@ -14,11 +14,23 @@ end
 
 defimpl Teiserver.TachyonLobby.Event, for: Teiserver.TachyonLobby.Events.RemoveSpecFromLobby do
   alias Teiserver.Helpers.MonitorCollection, as: MC
+  alias Teiserver.TachyonLobby.Event
   alias Teiserver.TachyonLobby.Events
   alias Teiserver.TachyonLobby.Events.RemoveSpecFromLobby
   alias Teiserver.TachyonLobby.Types, as: LT
 
   def apply_event(%RemoveSpecFromLobby{} = ev, %LT.Aggregate{} = agg) do
+    agg =
+      Enum.reduce(
+        [
+          %Events.CancelKickVote{user_id: ev.user_id},
+          %Events.CastVote{user_id: ev.user_id, vote: agg.data.current_vote, ballot: :abstain},
+          %Events.UpdateBoss{action: :remove, appointee_id: ev.user_id}
+        ],
+        agg,
+        &Event.apply_event/2
+      )
+
     # if the user leaving is associated with any bot, we need to remove all of
     # them as well.
     bot_ids_to_remove =
@@ -47,16 +59,8 @@ defimpl Teiserver.TachyonLobby.Event, for: Teiserver.TachyonLobby.Events.RemoveS
       |> put_in([:spectators, ev.user_id], nil)
 
     overview_changes = Map.put(agg.overview_changes, :player_count, map_size(data.players))
+    agg = %{agg | data: data, changes: changes, overview_changes: overview_changes}
 
-    # TODO This should handle voting and boss updates once these are converted to structs
-    # aggregate = process_event({:cast_vote, p_id, :abstain}, aggregate)
-    # process_event({:update_boss, :remove, p_id}, aggregate)
-    new_aggregate = %{agg | data: data, changes: changes, overview_changes: overview_changes}
-
-    Enum.reduce(
-      [%Events.RepackPlayers{}, %Events.FillFromJoinQueue{}],
-      new_aggregate,
-      &Teiserver.TachyonLobby.Event.apply_event/2
-    )
+    Enum.reduce([%Events.RepackPlayers{}, %Events.FillFromJoinQueue{}], agg, &Event.apply_event/2)
   end
 end

--- a/lib/teiserver/tachyon_lobby/events/remove_spec_from_lobby.ex
+++ b/lib/teiserver/tachyon_lobby/events/remove_spec_from_lobby.ex
@@ -1,0 +1,62 @@
+defmodule Teiserver.TachyonLobby.Events.RemoveSpecFromLobby do
+  @moduledoc """
+  Removing a spectator from the lobby
+  """
+  alias Teiserver.Account.User
+
+  @enforce_keys [:user_id]
+  defstruct [:user_id]
+
+  @type t() :: %__MODULE__{
+          user_id: User.id()
+        }
+end
+
+defimpl Teiserver.TachyonLobby.Event, for: Teiserver.TachyonLobby.Events.RemoveSpecFromLobby do
+  alias Teiserver.Helpers.MonitorCollection, as: MC
+  alias Teiserver.TachyonLobby.Events
+  alias Teiserver.TachyonLobby.Events.RemoveSpecFromLobby
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  def apply_event(%RemoveSpecFromLobby{} = ev, %LT.Aggregate{} = agg) do
+    # if the user leaving is associated with any bot, we need to remove all of
+    # them as well.
+    bot_ids_to_remove =
+      Enum.filter(agg.data.players, fn {_bot_id, b} ->
+        Map.get(b, :host_user_id) == ev.user_id
+      end)
+      |> Enum.map(&elem(&1, 0))
+      |> Enum.into(MapSet.new())
+
+    data =
+      agg.data
+      |> update_in([Access.key!(:players)], fn players ->
+        Enum.reject(players, fn {p_id, _data} -> MapSet.member?(bot_ids_to_remove, p_id) end)
+        |> Enum.into(%{})
+      end)
+      |> update_in([Access.key!(:spectators)], &Map.delete(&1, ev.user_id))
+      |> update_in([Access.key!(:monitors)], &MC.demonitor_by_val(&1, {:user, ev.user_id}))
+
+    bot_changes = Enum.map(bot_ids_to_remove, fn id -> {id, nil} end) |> Enum.into(%{})
+
+    changes =
+      agg.changes
+      |> Map.put_new(:players, %{})
+      |> Map.update!(:players, &Map.merge(&1, bot_changes))
+      |> Map.put_new(:spectators, %{})
+      |> put_in([:spectators, ev.user_id], nil)
+
+    overview_changes = Map.put(agg.overview_changes, :player_count, map_size(data.players))
+
+    # TODO This should handle voting and boss updates once these are converted to structs
+    # aggregate = process_event({:cast_vote, p_id, :abstain}, aggregate)
+    # process_event({:update_boss, :remove, p_id}, aggregate)
+    new_aggregate = %{agg | data: data, changes: changes, overview_changes: overview_changes}
+
+    Enum.reduce(
+      [%Events.RepackPlayers{}, %Events.FillFromJoinQueue{}],
+      new_aggregate,
+      &Teiserver.TachyonLobby.Event.apply_event/2
+    )
+  end
+end

--- a/lib/teiserver/tachyon_lobby/events/repack_players.ex
+++ b/lib/teiserver/tachyon_lobby/events/repack_players.ex
@@ -1,0 +1,39 @@
+defmodule Teiserver.TachyonLobby.Events.RepackPlayers do
+  @moduledoc """
+  Reshuffle every player/bot team so that each stay in the same allyteam, but
+  their team is now consecutive (without gap) and starts at 0.
+  So that for example, [{0, 0, 0}, {0, 2, 0}] represent an ally team with 2 players
+  but their team's index is not consecutive. After processing this event, it
+  should be [{0, 0, 0}, {0, 1, 0}]
+  """
+
+  defstruct []
+end
+
+defimpl Teiserver.TachyonLobby.Event, for: Teiserver.TachyonLobby.Events.RepackPlayers do
+  alias Teiserver.TachyonLobby.Events.MovePlayer
+  alias Teiserver.TachyonLobby.Events.RepackPlayers
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  def apply_event(%RepackPlayers{}, %LT.Aggregate{} = agg) do
+    data = agg.data
+
+    move_events =
+      for {%LT.AllyTeamConfig{} = _at, at_idx} <- Enum.with_index(data.ally_team_config) do
+        Enum.filter(data.players, fn {_id, %{team: {p_at, _team, _player}}} -> at_idx == p_at end)
+        |> Enum.map(fn {_id, p} -> p end)
+        |> Enum.sort_by(& &1.team)
+        |> Enum.with_index()
+        |> Enum.map(fn {p, idx} -> {p.id, put_elem(p.team, 1, idx)} end)
+      end
+      |> List.flatten()
+      |> Enum.map(fn {p_id, team} ->
+        if data.players[p_id].team != team do
+          %MovePlayer{player_id: p_id, team: team}
+        end
+      end)
+      |> Enum.reject(&is_nil/1)
+
+    Enum.reduce(move_events, agg, &Teiserver.TachyonLobby.Event.apply_event/2)
+  end
+end

--- a/lib/teiserver/tachyon_lobby/events/start_vote.ex
+++ b/lib/teiserver/tachyon_lobby/events/start_vote.ex
@@ -1,0 +1,31 @@
+defmodule Teiserver.TachyonLobby.Events.StartVote do
+  @moduledoc """
+  To change the tags for a lobby
+  """
+
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  @enforce_keys [:vote_state]
+  defstruct [:vote_state]
+
+  @type t() :: %__MODULE__{
+          vote_state: LT.VoteState.t()
+        }
+end
+
+defimpl Teiserver.TachyonLobby.Event, for: Teiserver.TachyonLobby.Events.StartVote do
+  alias Teiserver.TachyonLobby.Events.StartVote
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  def apply_event(%StartVote{} = ev, %LT.Aggregate{} = agg) do
+    data = %{agg.data | current_vote: ev.vote_state, vote_idx: agg.data.vote_idx + 1}
+    changes = Map.put(agg.changes, :current_vote, Map.from_struct(ev.vote_state))
+    vote = ev.vote_state
+
+    side_effects = [
+      {:send_after, :timer.seconds(vote.duration_s), {:vote_timeout, vote.id}} | agg.side_effects
+    ]
+
+    %{agg | data: data, changes: changes, side_effects: side_effects}
+  end
+end

--- a/lib/teiserver/tachyon_lobby/events/update_ally_team_config.ex
+++ b/lib/teiserver/tachyon_lobby/events/update_ally_team_config.ex
@@ -1,0 +1,122 @@
+defmodule Teiserver.TachyonLobby.Events.UpdateAllyTeamConfig do
+  @moduledoc """
+  Modify ally team configuration. This may end up in a lot of player movements.
+  Players should stay as players whenever possible, but may have to be moved
+  from one team to another. If the new ally team configuration is too small then
+  some players will be put at the beginning of the join queue
+  """
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  @enforce_keys [:old_config, :new_config]
+  defstruct [:old_config, :new_config]
+
+  @type t() :: %__MODULE__{
+          old_config: LT.AllyTeamConfig.t(),
+          new_config: LT.AllyTeamConfig.t()
+        }
+end
+
+defimpl Teiserver.TachyonLobby.Event, for: Teiserver.TachyonLobby.Events.UpdateAllyTeamConfig do
+  alias Teiserver.Helpers.Collections
+  alias Teiserver.TachyonLobby.Events
+  alias Teiserver.TachyonLobby.Events.UpdateAllyTeamConfig
+  alias Teiserver.TachyonLobby.Lobby
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  def apply_event(%UpdateAllyTeamConfig{} = ev, %LT.Aggregate{} = agg) do
+    spec_ids =
+      Enum.map(agg.data.players, fn {p_id, %{team: {x, y, z}}} ->
+        with at_config = %LT.AllyTeamConfig{} when not is_nil(at_config) <-
+               Enum.at(ev.new_config, x),
+             team_config when not is_nil(team_config) <- Enum.at(at_config.teams, y) do
+          if y < at_config.max_teams && z < team_config.max_players,
+            do: nil,
+            else: p_id
+        else
+          nil -> p_id
+        end
+      end)
+      |> Enum.reject(&is_nil/1)
+
+    {bot_ids, player_ids} = Enum.split_with(spec_ids, &Lobby.bot_id?/1)
+
+    position_offset =
+      case Lobby.get_first_player_in_join_queue(agg.data.spectators) do
+        nil -> 0
+        spec_id -> agg.data.spectators[spec_id].join_queue_position - Enum.count(player_ids) - 1
+      end
+
+    spec_events =
+      Enum.with_index(player_ids, position_offset)
+      |> Enum.map(fn {p_id, pos} ->
+        %Events.MovePlayerToSpec{user_id: p_id, spec_data: %{join_queue_position: pos}}
+      end)
+
+    bot_events = Enum.map(bot_ids, fn b_id -> %Events.RemovePlayerFromLobby{player_id: b_id} end)
+
+    events = spec_events ++ bot_events ++ [%Events.RepackPlayers{}, %Events.FillFromJoinQueue{}]
+
+    new_aggregate =
+      Enum.reduce(
+        events,
+        %{agg | data: Map.replace!(agg.data, :ally_team_config, ev.new_config)},
+        &Teiserver.TachyonLobby.Event.apply_event/2
+      )
+
+    # We put players in join queue, and then fill the teams with
+    # the join queue, which means we can have events like
+    # MovePlayerToSpec and later MoveSpecToPlayer
+    # which would generate an update with %{spectators: %{x => nil}}
+    # So we need to detect these and remove such updates
+    changes =
+      case Map.get(new_aggregate.changes, :spectators) do
+        nil ->
+          new_aggregate.changes
+
+        spec_changes ->
+          spec_changes =
+            Enum.filter(spec_changes, fn {s_id, changes} ->
+              changes != nil || is_map_key(agg.data.spectators, s_id)
+            end)
+            |> Enum.into(%{})
+
+          if spec_changes == %{},
+            do: Map.delete(new_aggregate.changes, :spectators),
+            else: Map.put(new_aggregate.changes, :spectators, spec_changes)
+      end
+
+    at_changes =
+      Collections.zip_with_padding(ev.old_config, ev.new_config, nil)
+      |> Enum.map(fn
+        {_old_at, nil} ->
+          nil
+
+        {nil, new_at} ->
+          new_at
+
+        {%LT.AllyTeamConfig{} = old_at, %LT.AllyTeamConfig{} = new_at} ->
+          # we are broadcasting patch updates, so structs are meaningless
+          # in this context
+          new_at = Map.from_struct(new_at)
+
+          Map.update!(new_at, :teams, fn new_teams ->
+            Collections.zip_with_padding(old_at.teams, new_teams, nil)
+            |> Enum.map(fn {_old_team, new_team} -> new_team end)
+          end)
+      end)
+
+    changes = Map.put(changes, :ally_team_config, at_changes)
+
+    new_max_player_count =
+      Enum.sum(
+        for at <- ev.new_config, team <- at.teams do
+          team.max_players
+        end
+      )
+
+    overview_changes =
+      Map.put(new_aggregate.overview_changes, :max_player_count, new_max_player_count)
+
+    %{new_aggregate | changes: changes, overview_changes: overview_changes}
+  end
+end

--- a/lib/teiserver/tachyon_lobby/events/update_boss.ex
+++ b/lib/teiserver/tachyon_lobby/events/update_boss.ex
@@ -1,0 +1,51 @@
+defmodule Teiserver.TachyonLobby.Events.UpdateBoss do
+  @moduledoc """
+  Add or remove boss
+  """
+
+  alias Teiserver.Account.User
+
+  @enforce_keys [:action, :appointee_id]
+  defstruct [:action, :appointee_id]
+
+  @type t() :: %__MODULE__{
+          action: :add | :remove,
+          appointee_id: User.id()
+        }
+end
+
+defimpl Teiserver.TachyonLobby.Event, for: Teiserver.TachyonLobby.Events.UpdateBoss do
+  alias Teiserver.TachyonLobby.Events.UpdateBoss
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  def apply_event(%UpdateBoss{} = ev, %LT.Aggregate{} = agg) do
+    boss? = MapSet.member?(agg.data.bosses, ev.appointee_id)
+
+    cond do
+      ev.action == :add and boss? -> agg
+      ev.action == :remove and not boss? -> agg
+      true -> do_apply_event(ev, agg)
+    end
+  end
+
+  defp do_apply_event(%UpdateBoss{} = ev, %LT.Aggregate{} = agg) do
+    data =
+      case ev.action do
+        :add ->
+          %{agg.data | bosses: MapSet.put(agg.data.bosses, ev.appointee_id)}
+
+        :remove ->
+          %{agg.data | bosses: MapSet.delete(agg.data.bosses, ev.appointee_id)}
+      end
+
+    changes = agg.changes |> Map.put_new(:bosses, %{})
+
+    changes =
+      case ev.action do
+        :add -> put_in(changes.bosses[ev.appointee_id], %{})
+        :remove -> put_in(changes.bosses[ev.appointee_id], nil)
+      end
+
+    %{agg | data: data, changes: changes}
+  end
+end

--- a/lib/teiserver/tachyon_lobby/events/update_client_status.ex
+++ b/lib/teiserver/tachyon_lobby/events/update_client_status.ex
@@ -1,0 +1,41 @@
+defmodule Teiserver.TachyonLobby.Events.UpdateClientStatus do
+  @moduledoc """
+  Updating client status, like ready/not ready and asset status
+  """
+
+  alias Teiserver.Account.User
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  @enforce_keys [:user_id, :client_status_updates]
+  defstruct [:user_id, :client_status_updates]
+
+  @type client_status_update_data :: %{
+          optional(:ready?) => boolean(),
+          optional(:asset_status) => LT.Types.asset_status()
+        }
+  @type t() :: %__MODULE__{
+          user_id: User.id(),
+          client_status_updates: client_status_update_data()
+        }
+end
+
+defimpl Teiserver.TachyonLobby.Event, for: Teiserver.TachyonLobby.Events.UpdateClientStatus do
+  alias Teiserver.TachyonLobby.Events.UpdateClientStatus
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  def apply_event(%UpdateClientStatus{} = ev, %LT.Aggregate{} = agg) do
+    data =
+      update_in(
+        agg.data,
+        [Access.key!(:players), ev.user_id],
+        &Map.merge(&1, ev.client_status_updates)
+      )
+
+    changes =
+      agg.changes
+      |> Map.put_new(:players, %{})
+      |> put_in([:players, ev.user_id], ev.client_status_updates)
+
+    %{agg | data: data, changes: changes}
+  end
+end

--- a/lib/teiserver/tachyon_lobby/events/update_game_options.ex
+++ b/lib/teiserver/tachyon_lobby/events/update_game_options.ex
@@ -1,0 +1,26 @@
+defmodule Teiserver.TachyonLobby.Events.UpdateGameOptions do
+  @moduledoc """
+  To change the game options
+  """
+
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  @enforce_keys [:changes]
+  defstruct [:changes]
+
+  @type t() :: %__MODULE__{
+          changes: %{String.t() => String.t() | nil}
+        }
+end
+
+defimpl Teiserver.TachyonLobby.Event, for: Teiserver.TachyonLobby.Events.UpdateGameOptions do
+  alias Teiserver.Helpers.Collections
+  alias Teiserver.TachyonLobby.Events.UpdateGameOptions
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  def apply_event(%UpdateGameOptions{} = ev, %LT.Aggregate{} = agg) do
+    data = %{agg.data | game_options: Collections.patch_merge(agg.data.game_options, ev.changes)}
+    changes = Map.put(agg.changes, :game_options, ev.changes)
+    %{agg | data: data, changes: changes}
+  end
+end

--- a/lib/teiserver/tachyon_lobby/events/update_lobby_name.ex
+++ b/lib/teiserver/tachyon_lobby/events/update_lobby_name.ex
@@ -1,0 +1,26 @@
+defmodule Teiserver.TachyonLobby.Events.UpdateLobbyName do
+  @moduledoc """
+  To change the name of the lobby
+  """
+
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  @enforce_keys [:new_name]
+  defstruct [:new_name]
+
+  @type t() :: %__MODULE__{
+          new_name: String.t()
+        }
+end
+
+defimpl Teiserver.TachyonLobby.Event, for: Teiserver.TachyonLobby.Events.UpdateLobbyName do
+  alias Teiserver.TachyonLobby.Events.UpdateLobbyName
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  def apply_event(%UpdateLobbyName{} = ev, %LT.Aggregate{} = agg) do
+    data = Map.put(agg.data, :name, ev.new_name)
+    changes = Map.put(agg.changes, :name, ev.new_name)
+    overview_changes = Map.put(agg.overview_changes, :name, ev.new_name)
+    %{agg | data: data, changes: changes, overview_changes: overview_changes}
+  end
+end

--- a/lib/teiserver/tachyon_lobby/events/update_map_name.ex
+++ b/lib/teiserver/tachyon_lobby/events/update_map_name.ex
@@ -1,0 +1,26 @@
+defmodule Teiserver.TachyonLobby.Events.UpdateMapName do
+  @moduledoc """
+  To change the tags for a lobby
+  """
+
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  @enforce_keys [:new_map]
+  defstruct [:new_map]
+
+  @type t() :: %__MODULE__{
+          new_map: String.t()
+        }
+end
+
+defimpl Teiserver.TachyonLobby.Event, for: Teiserver.TachyonLobby.Events.UpdateMapName do
+  alias Teiserver.TachyonLobby.Events.UpdateMapName
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  def apply_event(%UpdateMapName{} = ev, %LT.Aggregate{} = agg) do
+    data = %{agg.data | map_name: ev.new_map}
+    changes = Map.put(agg.changes, :map_name, ev.new_map)
+    overview_changes = Map.put(agg.overview_changes, :map_name, ev.new_map)
+    %{agg | data: data, changes: changes, overview_changes: overview_changes}
+  end
+end

--- a/lib/teiserver/tachyon_lobby/events/update_tags.ex
+++ b/lib/teiserver/tachyon_lobby/events/update_tags.ex
@@ -1,0 +1,26 @@
+defmodule Teiserver.TachyonLobby.Events.UpdateTags do
+  @moduledoc """
+  To change the tags for a lobby
+  """
+
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  @enforce_keys [:changes]
+  defstruct [:changes]
+
+  @type t() :: %__MODULE__{
+          changes: %{String.t() => map() | nil}
+        }
+end
+
+defimpl Teiserver.TachyonLobby.Event, for: Teiserver.TachyonLobby.Events.UpdateTags do
+  alias Teiserver.Helpers.Collections
+  alias Teiserver.TachyonLobby.Events.UpdateTags
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  def apply_event(%UpdateTags{} = ev, %LT.Aggregate{} = agg) do
+    data = %{agg.data | tags: Collections.patch_merge(agg.data.tags, ev.changes)}
+    changes = Map.put(agg.changes, :tags, ev.changes)
+    %{agg | data: data, changes: changes}
+  end
+end

--- a/lib/teiserver/tachyon_lobby/events/vote_ended.ex
+++ b/lib/teiserver/tachyon_lobby/events/vote_ended.ex
@@ -1,0 +1,64 @@
+defmodule Teiserver.TachyonLobby.Events.VoteEnded do
+  @moduledoc """
+  Marks the end of the current vote
+  """
+
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  @enforce_keys [:finished_at, :vote, :outcome]
+  defstruct [:finished_at, :vote, :outcome]
+
+  @type t() :: %__MODULE__{
+          finished_at: DateTime.t(),
+          vote: LT.VoteState.t(),
+          outcome: LT.VoteState.vote_outcome()
+        }
+end
+
+defimpl Teiserver.TachyonLobby.Event, for: Teiserver.TachyonLobby.Events.VoteEnded do
+  alias Teiserver.TachyonLobby.Events.VoteEnded
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  # don't bother cancelling the vote timeout timer. The event handler checks the vote id
+  # and it allows us not to worry about storing the tref
+  def apply_event(%VoteEnded{} = ev, %LT.Aggregate{} = agg) do
+    vote_record = %LT.VoteRecord{
+      vote: ev.vote,
+      finished_at: ev.finished_at,
+      outcome: ev.outcome
+    }
+
+    history = Map.put(agg.data.vote_history, agg.data.current_vote.id, vote_record)
+
+    max_vote_history_size = 10
+
+    history =
+      if map_size(history) > max_vote_history_size do
+        dates =
+          Enum.map(history, fn {_id, record} -> record.finished_at end)
+          |> Enum.sort()
+
+        cutoff = Enum.at(dates, 4)
+
+        Enum.filter(history, fn {_id, record} -> record.finished_at >= cutoff end)
+        |> Enum.into(%{})
+      else
+        history
+      end
+
+    data = %{agg.data | current_vote: nil, vote_history: history}
+
+    changes =
+      agg.changes
+      |> Map.put(:current_vote, nil)
+      |> Map.put_new(:vote_history, %{})
+      |> put_in([:vote_history, ev.vote.id], %{
+        vote: ev.vote.action,
+        finished_at: ev.finished_at,
+        outcome: ev.outcome
+      })
+
+    side_effects = [{:vote_ended, ev.vote, ev.outcome} | agg.side_effects]
+    %{agg | data: data, changes: changes, side_effects: side_effects}
+  end
+end

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -512,7 +512,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
     }
 
     events = [{:add_spectator, spec_data}]
-    data = process_events(events, data) |> broadcast_updates(user_id) |> Map.get(:data)
+    data = process_events(data, events, sender_id: user_id)
     {:keep_state, data, [{:reply, from, {:ok, self(), get_details_from_state(data)}}]}
   end
 
@@ -600,7 +600,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
           {true, nil} ->
             # we're moving a player from a different ally team
             events = [{:move_player, user_id, team}, :repack_players]
-            data = process_events(events, data) |> broadcast_updates() |> Map.get(:data)
+            data = process_events(data, events)
 
             {:keep_state, data, [{:reply, from, {:ok, get_details_from_state(data)}}]}
 
@@ -608,9 +608,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
             # Adding a spec into an ally team. The way we construct the team
             # means it doesn't require any reshuffling of existing players
             events = [{:move_spec_to_player, user_id, %{team: team}}]
-            aggregate = process_events(events, data) |> broadcast_updates()
-            process_event_actions(aggregate)
-            data = aggregate.data
+            data = process_events(data, events)
 
             {:keep_state, data, [{:reply, from, {:ok, get_details_from_state(data)}}]}
         end
@@ -641,10 +639,9 @@ defmodule Teiserver.TachyonLobby.Lobby do
       :fill_from_join_queue
     ]
 
-    aggregate = process_events(events, data) |> broadcast_updates()
-    process_event_actions(aggregate)
+    data = process_events(data, events)
 
-    {:keep_state, aggregate.data, [{:reply, from, :ok}]}
+    {:keep_state, data, [{:reply, from, :ok}]}
   end
 
   def handle_event({:call, from}, {:join_battle, user_id}, _state, %LT.Data{} = data)
@@ -720,7 +717,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
       ) do
     supported_properties = [:ready?, :asset_status]
     event = {:update_client_status, user_id, Map.take(update_data, supported_properties)}
-    data = process_events([event], data) |> broadcast_updates() |> Map.get(:data)
+    data = process_events(data, [event])
     {:keep_state, data, [{:reply, from, :ok}]}
   end
 
@@ -769,10 +766,9 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   def handle_event({:call, from}, {:remove_bot, bot_id}, _state, %LT.Data{} = data) do
     events = [{:remove_player_from_lobby, bot_id}, :repack_players, :fill_from_join_queue]
-    aggregate = process_events(events, data) |> broadcast_updates()
-    process_event_actions(aggregate)
+    data = process_events(data, events)
 
-    {:keep_state, aggregate.data, [{:reply, from, :ok}]}
+    {:keep_state, data, [{:reply, from, :ok}]}
   end
 
   def handle_event({:call, from}, {:update_bot, %{id: bot_id}}, _state, %LT.Data{} = data)
@@ -821,8 +817,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
         end)
 
       if Enum.empty?(errors) do
-        final_data = process_events(events, fsm_data) |> broadcast_updates() |> Map.get(:data)
-        # broadcast_list_updates(events, fsm_data, final_data)
+        final_data = process_events(fsm_data, events)
         {:keep_state, final_data, [{:reply, from, :ok}]}
       else
         message = Enum.join(errors, ", ")
@@ -851,9 +846,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
       ) do
     if is_map_key(data.current_vote.voters, user_id) do
       event = {:cast_vote, user_id, ballot}
-      aggregate = process_events([event], data) |> broadcast_updates()
-      process_event_actions(aggregate)
-      {:keep_state, aggregate.data, [{:reply, from, :ok}]}
+      data = process_events(data, [event])
+      {:keep_state, data, [{:reply, from, :ok}]}
     else
       {:keep_state, data, [{:reply, from, {:error, :invalid_vote}}]}
     end
@@ -918,7 +912,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
           {:move_player_to_spec, user_id, %{join_queue_position: pos}}
         ]
 
-        data = process_events(events, data) |> broadcast_updates() |> Map.get(:data)
+        data = process_events(data, events)
 
         {:keep_state, data, [{:reply, from, :ok}]}
 
@@ -939,7 +933,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
             team ->
               events = [{:move_spec_to_player, user_id, %{team: team}}]
-              process_events(events, data) |> broadcast_updates() |> Map.get(:data)
+              process_events(data, events)
           end
 
         {:keep_state, data, [{:reply, from, :ok}]}
@@ -982,10 +976,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
         events = [{:start_vote, vote}]
 
-        data =
-          process_events(events, data)
-          |> broadcast_updates()
-          |> Map.get(:data)
+        data = process_events(data, events)
 
         {:keep_state, data, [{:reply, from, :ok}]}
 
@@ -1034,12 +1025,12 @@ defmodule Teiserver.TachyonLobby.Lobby do
         |> :timer.send_after({:vote_timeout, vote.id})
 
         events = [{:start_vote, vote}]
-        data = process_events(events, data) |> broadcast_updates() |> Map.get(:data)
+        data = process_events(data, events)
         {:keep_state, data, [{:reply, from, :ok}]}
 
       true ->
         events = [{:update_boss, :add, appointee_id}]
-        data = process_events(events, data) |> broadcast_updates() |> Map.get(:data)
+        data = process_events(data, events)
         {:keep_state, data, [{:reply, from, :ok}]}
     end
   end
@@ -1062,7 +1053,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
       true ->
         events = [{:update_boss, :remove, boss_id}]
-        data = process_events(events, data) |> broadcast_updates() |> Map.get(:data)
+        data = process_events(data, events)
         {:keep_state, data, [{:reply, from, :ok}]}
     end
   end
@@ -1177,9 +1168,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
   def handle_event(:info, {:vote_timeout, vote_id}, _state, %LT.Data{} = data)
       when data.current_vote.id == vote_id do
     event = {:vote_ended, DateTime.utc_now(), :timeout}
-    aggregate = process_events([event], data) |> broadcast_updates()
-    process_event_actions(aggregate)
-    {:keep_state, aggregate.data}
+    data = process_events(data, [event])
+    {:keep_state, data}
   end
 
   def handle_event(:info, {:vote_timeout, _vote_id}, _state, %LT.Data{} = data),
@@ -1329,34 +1319,58 @@ defmodule Teiserver.TachyonLobby.Lobby do
     PubSubHelper.broadcast(list_topic(), message)
   end
 
-  # Given a list of events to process (in the event sourcing way) and the initial
-  # state to apply these events to, returns the final state alongside any
-  # potential update events that should also be broadcasted to members
-  @typep aggregate :: %{
-           initial_data: LT.Data.t(),
-           data: LT.Data.t(),
-           updates: [event()],
-           actions: [event_actions()]
-         }
-  @typep event_actions :: {:vote_ended, final_vote :: LT.VoteState.t(), outcome :: term()}
+  defp process_events(%LT.Data{} = data, events, opts \\ []) do
+    final_aggregate = compute_aggregate(data, events)
+    sender_id = opts[:sender_id]
 
-  @spec process_events([event()], LT.Data.t()) :: aggregate()
-  defp process_events(events, %LT.Data{} = state) do
-    final_aggregate =
-      Enum.reduce(
-        events,
-        %{initial_data: state, data: state, updates: [], actions: []},
-        &process_event/2
-      )
+    if final_aggregate.changes != %{},
+      do: broadcast_update({:update, sender_id, final_aggregate.changes}, final_aggregate.data)
 
-    if final_aggregate.data != state do
-      update_in(final_aggregate, [:data, Access.key!(:counter)], &(&1 + 1))
-    else
-      final_aggregate
-    end
+    broadcast_list_updates(final_aggregate)
+    Enum.each(final_aggregate.side_effects, &process_event_action(&1, final_aggregate.data))
+    final_aggregate.data
   end
 
-  @spec process_event(event(), %{data: LT.Data.t(), updates: [event()]}) :: %{
+  defp compute_aggregate(%LT.Data{} = data, events) do
+    aggregate = %LT.Aggregate{data: data}
+
+    final_aggregate = Enum.reduce(events, aggregate, &apply_event/2)
+
+    initial_player_count = Enum.count(data.players, fn {_id, p} -> not bot_id?(p.id) end)
+
+    final_player_count =
+      Enum.count(final_aggregate.data.players, fn {_id, p} -> not bot_id?(p.id) end)
+
+    update_in(final_aggregate, [Access.key!(:overview_changes)], fn changes ->
+      if final_player_count != initial_player_count do
+        Map.put(changes, :player_count, final_player_count)
+      else
+        changes
+      end
+    end)
+    |> update_in([Access.key!(:data), Access.key!(:counter)], fn c ->
+      if final_aggregate.data != data,
+        do: c + 1,
+        else: c
+    end)
+  end
+
+  defp apply_event(event, %LT.Aggregate{} = agg) do
+    result = process_event(event, %{data: agg.data, updates: [], actions: []})
+    new_changes = Enum.reduce(result.updates, agg.changes, &update_change_from_event/2)
+
+    overview_changes =
+      Map.merge(agg.overview_changes, overview_changes_from_events(result.updates))
+
+    %LT.Aggregate{
+      data: result.data,
+      changes: new_changes,
+      overview_changes: overview_changes,
+      side_effects: Map.get(result, :actions, []) ++ agg.side_effects
+    }
+  end
+
+  @spec process_event(event(), %{data: LT.Data.t(), updates: [event()], actions: list()}) :: %{
           data: LT.Data.t(),
           updates: [event()]
         }
@@ -1530,7 +1544,17 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
     events = spec_events ++ bot_events ++ [:repack_players, :fill_from_join_queue]
 
-    new_aggregate = process_events(events, Map.replace!(state, :ally_team_config, new_config))
+    new_aggregate =
+      Enum.reduce(
+        events,
+        %{
+          initial_data: state,
+          data: Map.replace!(state, :ally_team_config, new_config),
+          updates: [],
+          actions: []
+        },
+        &process_event/2
+      )
 
     # We put players in join queue, and then fill the teams with
     # the join queue, which means we can have events like
@@ -1720,26 +1744,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
     end
   end
 
-  # avoid sending a useless lobby list update when the last member of the lobby
-  # just left. The caller of this function will detect the lobby is empty and
-  # terminate the process, which will trigger the final lobby list update for
-  # this lobby
-  @spec broadcast_updates(aggregate()) :: aggregate()
-  defp broadcast_updates(%{data: data} = aggregate)
-       when map_size(data.players) == 0 and map_size(data.spectators) == 0,
-       do: aggregate
-
-  defp broadcast_updates(aggregate, sender_id \\ nil) do
-    change_map = Enum.reduce(aggregate.updates, %{}, &update_change_from_event/2)
-
-    if change_map != %{} do
-      broadcast_update({:update, sender_id, change_map}, aggregate.data)
-      broadcast_list_updates(aggregate)
-    end
-
-    aggregate
-  end
-
   defp update_change_from_event({:move_player, p_id, team}, change_map) do
     change_map
     |> Map.put_new(:players, %{})
@@ -1865,43 +1869,23 @@ defmodule Teiserver.TachyonLobby.Lobby do
     |> put_in([:bosses, boss_id], nil)
   end
 
-  defp broadcast_list_updates(%{data: final_state})
-       when map_size(final_state.players) == 0 and map_size(final_state.spectators) == 0,
-       do: final_state
+  defp broadcast_list_updates(%LT.Aggregate{} = agg)
+       when map_size(agg.data.players) == 0 and map_size(agg.data.spectators) == 0,
+       do: :ok
 
-  # events, starting_state, final_state) do
-  defp broadcast_list_updates(%{updates: events, data: data} = aggregate) do
-    initial_player_count =
-      Enum.count(aggregate.initial_data.players, fn {_id, p} -> not bot_id?(p.id) end)
+  defp broadcast_list_updates(%LT.Aggregate{} = agg) when agg.overview_changes == %{}, do: :ok
 
-    final_player_count = Enum.count(aggregate.data.players, fn {_id, p} -> not bot_id?(p.id) end)
+  defp broadcast_list_updates(%LT.Aggregate{} = aggregate) do
+    message = %{
+      counter: aggregate.data.counter,
+      event: :update_lobby,
+      lobby_id: aggregate.data.id,
+      changes: aggregate.overview_changes
+    }
 
-    change_map = overview_changes_from_events(events)
-
-    change_map =
-      if final_player_count != initial_player_count do
-        Map.put(change_map, :player_count, final_player_count)
-      else
-        change_map
-      end
-
-    if change_map != %{} do
-      # # although the player count may not have changed, for simplicity sake
-      # # just include it. We're already sending a message anyway
-      change_map = Map.put(change_map, :player_count, final_player_count)
-      LobbyRegistry.put_overview(data.id, get_overview_from_state(data))
-
-      message = %{
-        counter: data.counter,
-        event: :update_lobby,
-        lobby_id: data.id,
-        changes: change_map
-      }
-
-      PubSubHelper.broadcast(list_topic(), message)
-    end
-
-    aggregate
+    LobbyRegistry.put_overview(aggregate.data.id, get_overview_from_state(aggregate.data))
+    PubSubHelper.broadcast(list_topic(), message)
+    :ok
   end
 
   defp overview_changes_from_events(events) do
@@ -2060,9 +2044,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
           :fill_from_join_queue
         ]
 
-    aggregate = process_events(events, state) |> broadcast_updates()
-    process_event_actions(aggregate)
-    aggregate.data
+    process_events(state, events)
   end
 
   @spec remove_spectator_from_lobby(User.id(), LT.Data.t()) :: LT.Data.t()
@@ -2075,9 +2057,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
       Enum.map(bot_ids_to_remove, fn id -> {:remove_player_from_lobby, id} end) ++
         [{:remove_spec_from_lobby, user_id}, :repack_players, :fill_from_join_queue]
 
-    aggregate = process_events(events, state) |> broadcast_updates()
-    process_event_actions(aggregate)
-    aggregate.data
+    process_events(state, events)
   end
 
   # Add the first player from the join queue to the player list and returns the
@@ -2271,9 +2251,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   defp update_property(prop, _value, _state, _user_id),
     do: {:error, "update #{prop} is not supported"}
-
-  defp process_event_actions(aggregate),
-    do: Enum.each(aggregate.actions, &process_event_action(&1, aggregate.data))
 
   defp process_event_action({:vote_ended, vote, outcome}, fsm_data) do
     broadcast_to_members(fsm_data, nil, {:lobby, fsm_data.id, {:vote_ended, vote.id, outcome}})

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -70,17 +70,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
   # for updates to broadcast to members
   # for more info on specific events, check how they are handled by `process_event/2`
   @typep event ::
-           {:move_player, LT.Types.player_id(), LT.Types.team()}
-           | {:add_spectator, LT.Spectator.t()}
-           | {:remove_player_from_lobby, LT.Types.player_id()}
-           | {:remove_spec_from_lobby, User.id()}
-           | {:move_spec_to_player, User.id(), player_data :: map()}
-           | {:move_player_to_spec, User.id(), spec_data :: map()}
-           | :repack_players
-           | :fill_from_join_queue
-           | {:update_ally_team_config, old_config :: [LT.AllyTeamConfig.t()],
-              new_config :: [LT.AllyTeamConfig.t()]}
-           | {:start_vote, LT.VoteState.t()}
+            {:start_vote, LT.VoteState.t()}
            | {:cast_vote, User.id(), LT.VoteState.vote_ballot()}
            | {:vote_ended, DateTime.t(), LT.VoteState.vote_outcome()}
            | {:update_boss, :add | :remove, User.id()}
@@ -506,7 +496,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
       join_queue_position: nil
     }
 
-    events = [{:add_spectator, spec_data}]
+    events = [%Events.AddSpectator{spec: spec_data}]
     data = process_events(data, events, sender_id: user_id)
     {:keep_state, data, [{:reply, from, {:ok, self(), get_details_from_state(data)}}]}
   end
@@ -594,7 +584,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
         case {is_map_key(data.players, user_id), data.spectators[user_id]} do
           {true, nil} ->
             # we're moving a player from a different ally team
-            events = [{:move_player, user_id, team}, :repack_players]
+            events = [%Events.MovePlayer{player_id: user_id, team: team}]
             data = process_events(data, events)
 
             {:keep_state, data, [{:reply, from, {:ok, get_details_from_state(data)}}]}
@@ -602,7 +592,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
           {false, _s} ->
             # Adding a spec into an ally team. The way we construct the team
             # means it doesn't require any reshuffling of existing players
-            events = [{:move_spec_to_player, user_id, %{team: team}}]
+            events = [%Events.MoveSpecToPlayer{user_id: user_id, player_data: %{team: team}}]
             data = process_events(data, events)
 
             {:keep_state, data, [{:reply, from, {:ok, get_details_from_state(data)}}]}
@@ -628,14 +618,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   def handle_event({:call, from}, {:spectate, user_id}, _state, %LT.Data{} = data)
       when is_map_key(data.players, user_id) do
-    events = [
-      {:move_player_to_spec, user_id, %{join_queue_position: nil}},
-      :repack_players,
-      :fill_from_join_queue
-    ]
-
+    events = [%Events.MovePlayerToSpec{user_id: user_id, spec_data: %{join_queue_position: nil}}]
     data = process_events(data, events)
-
     {:keep_state, data, [{:reply, from, :ok}]}
   end
 
@@ -765,7 +749,12 @@ defmodule Teiserver.TachyonLobby.Lobby do
       do: {:keep_state, data, [{:reply, from, {:error, :invalid_bot_id}}]}
 
   def handle_event({:call, from}, {:remove_bot, bot_id}, _state, %LT.Data{} = data) do
-    events = [{:remove_player_from_lobby, bot_id}, :repack_players, :fill_from_join_queue]
+    events = [
+      %Events.RemovePlayerFromLobby{player_id: bot_id},
+      %Events.RepackPlayers{},
+      %Events.FillFromJoinQueue{}
+    ]
+
     data = process_events(data, events)
 
     {:keep_state, data, [{:reply, from, :ok}]}
@@ -908,8 +897,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
         pos = find_spec_queue_pos(data.spectators)
 
         events = [
-          {:move_spec_to_player, s_id, %{team: player.team}},
-          {:move_player_to_spec, user_id, %{join_queue_position: pos}}
+          %Events.MoveSpecToPlayer{user_id: s_id, player_data: %{team: player.team}},
+          %Events.MovePlayerToSpec{user_id: user_id, spec_data: %{join_queue_position: pos}}
         ]
 
         data = process_events(data, events)
@@ -932,7 +921,10 @@ defmodule Teiserver.TachyonLobby.Lobby do
               broadcast_update({:update, nil, update}, data)
 
             team ->
-              events = [{:move_spec_to_player, user_id, %{team: team}}]
+              events = [
+                %Events.MoveSpecToPlayer{user_id: user_id, player_data: %{team: team}}
+              ]
+
               process_events(data, events)
           end
 
@@ -1360,7 +1352,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   # TODO: this should be a temporary function until all events are converted to
   # structs which implement the Event protocol
-  defp apply_event(event, %LT.Aggregate{} = agg) do
+  def apply_event(event, %LT.Aggregate{} = agg) do
     if Event.impl_for(event) != nil do
       Event.apply_event(event, agg)
     else
@@ -1377,208 +1369,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
           data: LT.Data.t(),
           updates: [event()]
         }
-  defp process_event({:move_player, p_id, team} = ev, aggregate) do
-    aggregate
-    |> update_in([:data, Access.key!(:players), p_id], fn p ->
-      Map.merge(p, %{team: team, ready?: false, asset_status: :complete})
-    end)
-    |> update_in([:updates], &[ev | &1])
-  end
-
-  defp process_event({:add_spectator, spec_data} = ev, aggregate) do
-    aggregate
-    |> put_in([:data, Access.key!(:spectators), spec_data.id], spec_data)
-    |> update_in(
-      [:data, Access.key!(:monitors)],
-      &MC.monitor(&1, spec_data.pid, {:user, spec_data.id})
-    )
-    |> update_in([:updates], &[ev | &1])
-  end
-
-  defp process_event({:remove_player_from_lobby, p_id} = ev, aggregate) do
-    aggregate =
-      aggregate
-      |> update_in([:data, Access.key!(:players)], &Map.delete(&1, p_id))
-      |> update_in([:data, Access.key!(:monitors)], &MC.demonitor_by_val(&1, {:user, p_id}))
-      |> update_in([:updates], &[ev | &1])
-
-    aggregate = maybe_cancel_kick_vote(p_id, aggregate)
-    aggregate = process_event({:cast_vote, p_id, :abstain}, aggregate)
-    process_event({:update_boss, :remove, p_id}, aggregate)
-  end
-
-  defp process_event({:remove_spec_from_lobby, s_id} = ev, aggregate) do
-    aggregate =
-      aggregate
-      |> update_in([:data, Access.key!(:spectators)], &Map.delete(&1, s_id))
-      |> update_in([:data, Access.key!(:monitors)], &MC.demonitor_by_val(&1, {:user, s_id}))
-      |> update_in([:updates], &[ev | &1])
-
-    aggregate = maybe_cancel_kick_vote(s_id, aggregate)
-    aggregate = process_event({:cast_vote, s_id, :abstain}, aggregate)
-    process_event({:update_boss, :remove, s_id}, aggregate)
-  end
-
-  defp process_event({:move_spec_to_player, p_id, %{team: team}} = ev, aggregate) do
-    spec_data = aggregate.data.spectators[p_id]
-
-    player = %LT.Player{
-      id: spec_data.id,
-      name: spec_data.name,
-      password: spec_data.password,
-      pid: spec_data.pid,
-      team: team,
-      ready?: false,
-      asset_status: :complete
-    }
-
-    aggregate
-    |> update_in([:data, Access.key!(:spectators)], &Map.delete(&1, p_id))
-    |> put_in([:data, Access.key!(:players), p_id], player)
-    |> update_in([:updates], &[ev | &1])
-  end
-
-  defp process_event({:move_player_to_spec, p_id, spec_data} = ev, aggregate) do
-    %LT.Player{} = player = aggregate.data.players[p_id]
-
-    spec = %LT.Spectator{
-      id: player.id,
-      name: player.name,
-      password: player.password,
-      pid: player.pid,
-      join_queue_position: spec_data.join_queue_position
-    }
-
-    aggregate
-    |> update_in([:data, Access.key!(:players)], &Map.delete(&1, p_id))
-    |> put_in([:data, Access.key!(:spectators), p_id], spec)
-    |> update_in([:updates], &[ev | &1])
-  end
-
-  # given a state where the players may not be all on consecutive ally team and
-  # teams, re-assign all required player.team so that they are all consecutive
-  # player should never change ally team when doing so, only teams
-  # and since archon isn't really supported, this ends up only repacking the teams
-  defp process_event(:repack_players, aggregate) do
-    data = aggregate.data
-
-    repacked_players =
-      for {%LT.AllyTeamConfig{} = _at, at_idx} <- Enum.with_index(data.ally_team_config) do
-        Enum.filter(data.players, fn {_id, %{team: {p_at, _team, _player}}} -> at_idx == p_at end)
-        |> Enum.map(fn {_id, p} -> p end)
-        |> Enum.sort_by(& &1.team)
-        |> Enum.with_index()
-        |> Enum.map(fn {p, idx} -> {p.id, Map.update!(p, :team, &put_elem(&1, 1, idx))} end)
-      end
-      |> List.flatten()
-      |> Enum.into(%{})
-
-    events =
-      Enum.map(repacked_players, fn {p_id, p} ->
-        if data.players[p_id].team != p.team do
-          {:move_player, p_id, p.team}
-        end
-      end)
-      |> Enum.reject(&is_nil/1)
-
-    aggregate
-    |> put_in([:data, Access.key!(:players)], repacked_players)
-    |> update_in([:updates], &(events ++ &1))
-  end
-
-  defp process_event(:fill_from_join_queue, aggregate) do
-    case add_player_from_join_queue(aggregate.data) do
-      nil ->
-        aggregate
-
-      ev ->
-        new_aggregate = process_event(ev, aggregate)
-        process_event(:fill_from_join_queue, new_aggregate)
-    end
-  end
-
-  defp process_event({:update_ally_team_config, _old_config, new_config} = ev, aggregate) do
-    state = aggregate.data
-
-    spec_ids =
-      Enum.map(state.players, fn {p_id, %{team: {x, y, z}}} ->
-        with at_config = %LT.AllyTeamConfig{} when not is_nil(at_config) <- Enum.at(new_config, x),
-             team_config when not is_nil(team_config) <- Enum.at(at_config.teams, y) do
-          if y < at_config.max_teams && z < team_config.max_players,
-            do: nil,
-            else: p_id
-        else
-          nil -> p_id
-        end
-      end)
-      |> Enum.reject(&is_nil/1)
-
-    {bot_ids, player_ids} = Enum.split_with(spec_ids, &bot_id?/1)
-
-    position_offset =
-      case get_first_player_in_join_queue(state.spectators) do
-        nil -> 0
-        spec_id -> state.spectators[spec_id].join_queue_position - Enum.count(player_ids) - 1
-      end
-
-    spec_events =
-      Enum.with_index(player_ids, position_offset)
-      |> Enum.map(fn {p_id, pos} -> {:move_player_to_spec, p_id, %{join_queue_position: pos}} end)
-
-    bot_events = Enum.map(bot_ids, fn b_id -> {:remove_player_from_lobby, b_id} end)
-
-    events = spec_events ++ bot_events ++ [:repack_players, :fill_from_join_queue]
-
-    new_aggregate =
-      Enum.reduce(
-        events,
-        %{
-          initial_data: state,
-          data: Map.replace!(state, :ally_team_config, new_config),
-          updates: [],
-          actions: []
-        },
-        &process_event/2
-      )
-
-    # We put players in join queue, and then fill the teams with
-    # the join queue, which means we can have events like
-    # :move_player_to_spec and later :move_spec_to_player
-    # which would generate an update with %{spectators: %{x => nil}}
-    # where x was never a spectator to beging with.
-    # So we need to detect these events and replace the pair with a :move_player
-    # event instead.
-    added_ids =
-      Enum.map(new_aggregate.updates, fn
-        {:move_spec_to_player, id, _data} -> id
-        _other -> nil
-      end)
-      |> Enum.reject(&is_nil/1)
-
-    ids_to_fix = player_ids |> MapSet.new() |> MapSet.intersection(MapSet.new(added_ids))
-
-    final_events =
-      Enum.map(new_aggregate.updates, fn ev ->
-        case ev do
-          {:move_player_to_spec, x, _spec_data} ->
-            if MapSet.member?(ids_to_fix, x),
-              do: nil,
-              else: ev
-
-          {:move_spec_to_player, x, data} ->
-            if MapSet.member?(ids_to_fix, x),
-              do: {:move_player, x, data.team},
-              else: ev
-
-          _other ->
-            ev
-        end
-      end)
-      |> Enum.reject(&is_nil/1)
-
-    new_aggregate |> put_in([:updates], [ev | final_events] ++ aggregate.updates)
-  end
-
   defp process_event({:start_vote, %LT.VoteState{} = vote_state} = ev, aggregate) do
     aggregate
     |> put_in([:data, Access.key!(:current_vote)], vote_state)
@@ -1611,7 +1401,12 @@ defmodule Teiserver.TachyonLobby.Lobby do
           {:passed, {:change_map, new_map}} ->
             # until all events have been converted to structs, and we don't carry around
             # the non-struct aggregate, need some transformation there
-            agg = merge_map_aggregate_to_struct(%LT.Aggregate{data: new_aggregate.data}, new_aggregate)
+            agg =
+              merge_map_aggregate_to_struct(
+                %LT.Aggregate{data: new_aggregate.data},
+                new_aggregate
+              )
+
             apply_event(%Events.UpdateMapName{new_map: new_map}, agg)
 
           {:passed, {:appoint_boss, boss_id}} ->
@@ -1710,90 +1505,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
     end
   end
 
-  defp maybe_cancel_kick_vote(leaving_user_id, aggregate) do
-    case aggregate.data.current_vote do
-      %{action: {:kickban, ^leaving_user_id, nil}} ->
-        process_event({:vote_ended, DateTime.utc_now(), :cancelled}, aggregate)
-
-      _other ->
-        aggregate
-    end
-  end
-
-  defp update_change_from_event({:move_player, p_id, team}, change_map) do
-    change_map
-    |> Map.put_new(:players, %{})
-    |> Map.update!(:players, fn players ->
-      players
-      |> Map.put_new(p_id, %{})
-      |> update_in([p_id], fn p ->
-        Map.merge(%{team: team, ready?: false, asset_status: :complete}, p)
-      end)
-    end)
-  end
-
-  defp update_change_from_event({:add_spectator, spec_data}, change_map) do
-    change_map
-    |> Map.put_new(:spectators, %{})
-    |> put_in([:spectators, spec_data.id], Map.take(spec_data, [:join_queue_position]))
-  end
-
-  defp update_change_from_event({:remove_player_from_lobby, p_id}, change_map) do
-    change_map
-    |> Map.put_new(:players, %{})
-    |> put_in([:players, p_id], nil)
-  end
-
-  defp update_change_from_event({:remove_spec_from_lobby, s_id}, change_map) do
-    change_map
-    |> Map.put_new(:spectators, %{})
-    |> put_in([:spectators, s_id], nil)
-  end
-
-  defp update_change_from_event({:move_spec_to_player, p_id, player_data}, change_map) do
-    player_data = Map.merge(%{ready?: false, asset_status: :complete}, player_data)
-
-    change_map
-    |> Map.put_new(:players, %{})
-    |> put_in([:players, p_id], player_data)
-    |> Map.put_new(:spectators, %{})
-    |> put_in([:spectators, p_id], nil)
-  end
-
-  defp update_change_from_event({:move_player_to_spec, p_id, spec_data}, change_map) do
-    change_map
-    |> Map.put_new(:players, %{})
-    |> put_in([:players, p_id], nil)
-    |> Map.put_new(:spectators, %{})
-    |> put_in([:spectators, p_id], spec_data)
-  end
-
-  defp update_change_from_event(:repack_players, change_map), do: change_map
-
-  defp update_change_from_event({:update_ally_team_config, old_config, new_config}, change_map) do
-    changes =
-      Collections.zip_with_padding(old_config, new_config, nil)
-      |> Enum.map(fn
-        {_old_at, nil} ->
-          nil
-
-        {nil, new_at} ->
-          new_at
-
-        {%LT.AllyTeamConfig{} = old_at, %LT.AllyTeamConfig{} = new_at} ->
-          # we are broadcasting patch updates, so structs are meaningless
-          # in this context
-          new_at = Map.from_struct(new_at)
-
-          Map.update!(new_at, :teams, fn new_teams ->
-            Collections.zip_with_padding(old_at.teams, new_teams, nil)
-            |> Enum.map(fn {_old_team, new_team} -> new_team end)
-          end)
-      end)
-
-    Map.put(change_map, :ally_team_config, changes)
-  end
-
   defp update_change_from_event({:start_vote, vote}, change_map),
     do: Map.put(change_map, :current_vote, vote)
 
@@ -1846,32 +1557,12 @@ defmodule Teiserver.TachyonLobby.Lobby do
     :ok
   end
 
-  defp overview_changes_from_events(events) do
-    Enum.reduce(events, %{}, fn ev, change_map ->
-      case ev do
-        {:update_ally_team_config, _old_config, new_config} ->
-          change_map
-          |> Map.put(
-            :max_player_count,
-            Enum.sum(
-              for at <- new_config, team <- at.teams do
-                team.max_players
-              end
-            )
-          )
-
-        _other ->
-          change_map
-      end
-    end)
-  end
-
   # find an empty slot for a player/bot to play
   # this function isn't too efficient, but it's never going to be run on
   # massive inputs since the engine cannot support more than 254 players anyway
   @spec find_team([LT.AllyTeamConfig.t()], %{LT.Types.player_id() => LT.Player.t() | LT.Bot.t()}) ::
           LT.Types.team() | nil
-  defp find_team(ally_team_config, players) do
+  def find_team(ally_team_config, players) do
     # find the least full ally team
     ally_team =
       for {%LT.AllyTeamConfig{} = at, at_idx} <- Enum.with_index(ally_team_config) do
@@ -1964,7 +1655,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
   end
 
   # which player is next in the join queue?
-  defp get_first_player_in_join_queue(spectators) do
+  def get_first_player_in_join_queue(spectators) do
     Enum.reduce(spectators, {nil, nil}, fn {id, %LT.Spectator{} = s},
                                            {min_so_far, _prev_id} = acc ->
       cond do
@@ -1982,62 +1673,13 @@ defmodule Teiserver.TachyonLobby.Lobby do
   end
 
   @spec remove_player_from_lobby(User.id(), LT.Data.t()) :: LT.Data.t()
-  defp remove_player_from_lobby(user_id, %LT.Data{} = state) do
-    # if the user leaving is associated with any bot, we need to remove all of
-    # them as well.
-    bot_ids_to_remove =
-      Enum.filter(state.players, fn {_bot_id, b} -> Map.get(b, :host_user_id) == user_id end)
-      |> Enum.map(&elem(&1, 0))
-
-    events =
-      Enum.map([user_id | bot_ids_to_remove], fn id -> {:remove_player_from_lobby, id} end) ++
-        [
-          :repack_players,
-          :fill_from_join_queue
-        ]
-
-    process_events(state, events)
+  defp remove_player_from_lobby(user_id, %LT.Data{} = data) do
+    process_events(data, [%Events.RemovePlayerFromLobby{player_id: user_id}])
   end
 
   @spec remove_spectator_from_lobby(User.id(), LT.Data.t()) :: LT.Data.t()
-  defp remove_spectator_from_lobby(user_id, %LT.Data{} = state) do
-    bot_ids_to_remove =
-      Enum.filter(state.players, fn {_bot_id, b} -> Map.get(b, :host_user_id) == user_id end)
-      |> Enum.map(&elem(&1, 0))
-
-    events =
-      Enum.map(bot_ids_to_remove, fn id -> {:remove_player_from_lobby, id} end) ++
-        [{:remove_spec_from_lobby, user_id}, :repack_players, :fill_from_join_queue]
-
-    process_events(state, events)
-  end
-
-  # Add the first player from the join queue to the player list and returns the
-  # updated state alongside the player id that was added
-  @spec add_player_from_join_queue(LT.Data.t()) :: event() | nil
-  defp add_player_from_join_queue(%LT.Data{} = state) do
-    player_to_add =
-      case get_first_player_in_join_queue(state.spectators) do
-        nil ->
-          nil
-
-        id ->
-          case find_team(state.ally_team_config, state.players) do
-            nil ->
-              nil
-
-            team ->
-              {id, %{team: team, ready?: false, asset_status: :complete}}
-          end
-      end
-
-    case player_to_add do
-      nil ->
-        nil
-
-      {id, player_data} ->
-        {:move_spec_to_player, id, player_data}
-    end
+  defp remove_spectator_from_lobby(user_id, %LT.Data{} = data) do
+    process_events(data, [%Events.RemoveSpecFromLobby{user_id: user_id}])
   end
 
   defp gen_password, do: :crypto.strong_rand_bytes(16) |> Base.encode16()
@@ -2087,8 +1729,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
   end
 
   # in tests, some user ids are string
-  defp bot_id?(id) when is_integer(id), do: false
-  defp bot_id?(id), do: String.starts_with?(id, "bot")
+  def bot_id?(id) when is_integer(id), do: false
+  def bot_id?(id), do: String.starts_with?(id, "bot")
 
   @spec gen_start_script(LT.Data.t()) :: AT.StartScript.t()
   defp gen_start_script(%LT.Data{} = state) do
@@ -2189,7 +1831,8 @@ defmodule Teiserver.TachyonLobby.Lobby do
   end
 
   defp update_property(:ally_team_config, new_config, state, _user_id) do
-    {:ok, [{:update_ally_team_config, state.ally_team_config, new_config}]}
+    {:ok,
+     [%Events.UpdateAllyTeamConfig{old_config: state.ally_team_config, new_config: new_config}]}
   end
 
   defp update_property(:game_options, changes, _state, _user_id) do
@@ -2259,13 +1902,10 @@ defmodule Teiserver.TachyonLobby.Lobby do
   defp merge_map_aggregate_to_struct(%LT.Aggregate{} = agg, map_aggregate) do
     new_changes = Enum.reduce(map_aggregate.updates, agg.changes, &update_change_from_event/2)
 
-    overview_changes =
-      Map.merge(agg.overview_changes, overview_changes_from_events(map_aggregate.updates))
-
     %LT.Aggregate{
       data: map_aggregate.data,
       changes: new_changes,
-      overview_changes: overview_changes,
+      overview_changes: agg.overview_changes,
       side_effects: Map.get(map_aggregate, :actions, []) ++ agg.side_effects
     }
   end

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -36,11 +36,11 @@ defmodule Teiserver.TachyonLobby.Lobby do
   alias Teiserver.Player
   alias Teiserver.Tachyon
   alias Teiserver.TachyonBattle
+  alias Teiserver.TachyonLobby.Event
   alias Teiserver.TachyonLobby.ListMonitor
   alias Teiserver.TachyonLobby.Registry, as: LobbyRegistry
   # lobby types
   alias Teiserver.TachyonLobby.Types, as: LT
-
   require Logger
 
   @behaviour :gen_statem
@@ -1331,6 +1331,9 @@ defmodule Teiserver.TachyonLobby.Lobby do
     final_aggregate.data
   end
 
+  # TODO: this should live under Event, or something outside this module
+  # because implementing the Event protocol may require to compute intermediate
+  # aggregates, and having this function there creates some circular dependencies
   defp compute_aggregate(%LT.Data{} = data, events) do
     aggregate = %LT.Aggregate{data: data}
 
@@ -1355,19 +1358,25 @@ defmodule Teiserver.TachyonLobby.Lobby do
     end)
   end
 
+  # TODO: this should be a temporary function until all events are converted to
+  # structs which implement the Event protocol
   defp apply_event(event, %LT.Aggregate{} = agg) do
-    result = process_event(event, %{data: agg.data, updates: [], actions: []})
-    new_changes = Enum.reduce(result.updates, agg.changes, &update_change_from_event/2)
+    if Event.impl_for(event) != nil do
+      Event.apply_event(event, agg)
+    else
+      result = process_event(event, %{data: agg.data, updates: [], actions: []})
+      new_changes = Enum.reduce(result.updates, agg.changes, &update_change_from_event/2)
 
-    overview_changes =
-      Map.merge(agg.overview_changes, overview_changes_from_events(result.updates))
+      overview_changes =
+        Map.merge(agg.overview_changes, overview_changes_from_events(result.updates))
 
-    %LT.Aggregate{
-      data: result.data,
-      changes: new_changes,
-      overview_changes: overview_changes,
-      side_effects: Map.get(result, :actions, []) ++ agg.side_effects
-    }
+      %LT.Aggregate{
+        data: result.data,
+        changes: new_changes,
+        overview_changes: overview_changes,
+        side_effects: Map.get(result, :actions, []) ++ agg.side_effects
+      }
+    end
   end
 
   @spec process_event(event(), %{data: LT.Data.t(), updates: [event()], actions: list()}) :: %{

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -78,7 +78,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
            | {:move_player_to_spec, User.id(), spec_data :: map()}
            | :repack_players
            | :fill_from_join_queue
-           | {:update_lobby_name, new_name :: String.t()}
            | {:update_map_name, new_name :: String.t()}
            | {:update_ally_team_config, old_config :: [LT.AllyTeamConfig.t()],
               new_config :: [LT.AllyTeamConfig.t()]}
@@ -1507,12 +1506,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
     end
   end
 
-  defp process_event({:update_lobby_name, new_name} = ev, aggregate) do
-    aggregate
-    |> put_in([:data, Access.key!(:name)], new_name)
-    |> update_in([:updates], &[ev | &1])
-  end
-
   defp process_event({:update_map_name, new_name} = ev, aggregate) do
     aggregate
     |> put_in([:data, Access.key!(:map_name)], new_name)
@@ -1801,9 +1794,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   defp update_change_from_event(:repack_players, change_map), do: change_map
 
-  defp update_change_from_event({:update_lobby_name, new_name}, change_map),
-    do: Map.put(change_map, :name, new_name)
-
   defp update_change_from_event({:update_map_name, new_name}, change_map),
     do: Map.put(change_map, :map_name, new_name)
 
@@ -1892,9 +1882,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
   defp overview_changes_from_events(events) do
     Enum.reduce(events, %{}, fn ev, change_map ->
       case ev do
-        {:update_lobby_name, new_name} ->
-          Map.put(change_map, :name, new_name)
-
         {:update_map_name, new_name} ->
           Map.put(change_map, :map_name, new_name)
 
@@ -2208,7 +2195,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
         {:error, error}
 
       :ok ->
-        {:ok, [{:update_lobby_name, new_name}]}
+        {:ok, [%Events.UpdateLobbyName{new_name: new_name}]}
     end
   end
 

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -1876,33 +1876,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
     final_player_count = Enum.count(aggregate.data.players, fn {_id, p} -> not bot_id?(p.id) end)
 
-    change_map =
-      Enum.reduce(events, %{}, fn ev, change_map ->
-        case ev do
-          {:update_lobby_name, new_name} ->
-            Map.put(change_map, :name, new_name)
-
-          {:update_map_name, new_name} ->
-            Map.put(change_map, :map_name, new_name)
-
-          {:update_ally_team_config, _old_config, new_config} ->
-            change_map
-            |> Map.put(
-              :max_player_count,
-              Enum.sum(
-                for at <- new_config, team <- at.teams do
-                  team.max_players
-                end
-              )
-            )
-            # although the player count may not have changed, for simplicity sake
-            # just include it. We're already sending a message anyway
-            |> Map.put(:player_count, final_player_count)
-
-          _other ->
-            change_map
-        end
-      end)
+    change_map = overview_changes_from_events(events)
 
     change_map =
       if final_player_count != initial_player_count do
@@ -1912,6 +1886,9 @@ defmodule Teiserver.TachyonLobby.Lobby do
       end
 
     if change_map != %{} do
+      # # although the player count may not have changed, for simplicity sake
+      # # just include it. We're already sending a message anyway
+      change_map = Map.put(change_map, :player_count, final_player_count)
       LobbyRegistry.put_overview(data.id, get_overview_from_state(data))
 
       message = %{
@@ -1925,6 +1902,32 @@ defmodule Teiserver.TachyonLobby.Lobby do
     end
 
     aggregate
+  end
+
+  defp overview_changes_from_events(events) do
+    Enum.reduce(events, %{}, fn ev, change_map ->
+      case ev do
+        {:update_lobby_name, new_name} ->
+          Map.put(change_map, :name, new_name)
+
+        {:update_map_name, new_name} ->
+          Map.put(change_map, :map_name, new_name)
+
+        {:update_ally_team_config, _old_config, new_config} ->
+          change_map
+          |> Map.put(
+            :max_player_count,
+            Enum.sum(
+              for at <- new_config, team <- at.teams do
+                team.max_players
+              end
+            )
+          )
+
+        _other ->
+          change_map
+      end
+    end)
   end
 
   # find an empty slot for a player/bot to play

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -10,9 +10,9 @@ defmodule Teiserver.TachyonLobby.Lobby do
   # 3: an event sourcing system for the handlers.
   #
   # The handlers are responsible to check if the operation is valid, and then
-  # translate the operation into an event. See `@typep event` for the list.
-  # These events are then reduced/folded into an aggregate. This aggregate
-  # is used to
+  # translate the operation into an event. All events are structs that implement
+  # a protocol to compute the next aggregate.
+  # This aggregate is used to
   # 1: compute the end state after applying the original operation/event See process_events/2
   # 2: the update events to send to lobby members. See broadcast_updates/1
   # 3: update the lobby list process when relevant. Also handled in broadcast_updates/1
@@ -66,20 +66,10 @@ defmodule Teiserver.TachyonLobby.Lobby do
           optional(:options) => %{String.t() => String.t()}
         }
 
-  # the list of internal events used to manipulate the lobby data, but also
-  # for updates to broadcast to members
-  # for more info on specific events, check how they are handled by `process_event/2`
-  @typep event ::
-            {:start_vote, LT.VoteState.t()}
-           | {:cast_vote, User.id(), LT.VoteState.vote_ballot()}
-           | {:vote_ended, DateTime.t(), LT.VoteState.vote_outcome()}
-           | {:update_boss, :add | :remove, User.id()}
-
   @spec gen_id() :: LT.Types.id()
   def gen_id, do: UUID.uuid4()
 
   @default_call_timeout 5000
-  @max_vote_history_size 10
 
   def list_topic, do: "teiserver_tachyonlobby_list"
 
@@ -834,7 +824,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
         %LT.Data{} = data
       ) do
     if is_map_key(data.current_vote.voters, user_id) do
-      event = {:cast_vote, user_id, ballot}
+      event = %Events.CastVote{user_id: user_id, vote: data.current_vote, ballot: ballot}
       data = process_events(data, [event])
       {:keep_state, data, [{:reply, from, :ok}]}
     else
@@ -962,18 +952,13 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
       Enum.empty?(data.bosses) and Enum.count(data.players, &(!bot_id?(elem(&1, 0)))) > 1 ->
         vote = new_vote(data, user_id, {:kickban, target_id, ban_until})
-
-        :timer.seconds(vote.duration_s)
-        |> :timer.send_after({:vote_timeout, vote.id})
-
-        events = [{:start_vote, vote}]
-
+        events = [%Events.StartVote{vote_state: vote}]
         data = process_events(data, events)
 
         {:keep_state, data, [{:reply, from, :ok}]}
 
       true ->
-        data = do_kickban(target_id, ban_until, data)
+        data = process_events(data, [%Events.Kickban{user_id: target_id, ban_until: ban_until}])
         {:keep_state, data, [{:reply, from, :ok}]}
     end
   end
@@ -1012,16 +997,15 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
       Enum.empty?(data.bosses) and Enum.count(data.players, &(!bot_id?(elem(&1, 0)))) > 1 ->
         vote = new_vote(data, user_id, {:appoint_boss, appointee_id})
-
-        :timer.seconds(vote.duration_s)
-        |> :timer.send_after({:vote_timeout, vote.id})
-
-        events = [{:start_vote, vote}]
+        events = [%Events.StartVote{vote_state: vote}]
         data = process_events(data, events)
         {:keep_state, data, [{:reply, from, :ok}]}
 
+      MapSet.member?(data.bosses, appointee_id) ->
+        {:keep_state, data, [{:reply, from, :ok}]}
+
       true ->
-        events = [{:update_boss, :add, appointee_id}]
+        events = [%Events.UpdateBoss{action: :add, appointee_id: appointee_id}]
         data = process_events(data, events)
         {:keep_state, data, [{:reply, from, :ok}]}
     end
@@ -1044,7 +1028,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
         {:keep_state, data, [{:reply, from, :ok}]}
 
       true ->
-        events = [{:update_boss, :remove, boss_id}]
+        events = [%Events.UpdateBoss{action: :remove, appointee_id: boss_id}]
         data = process_events(data, events)
         {:keep_state, data, [{:reply, from, :ok}]}
     end
@@ -1159,7 +1143,12 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   def handle_event(:info, {:vote_timeout, vote_id}, _state, %LT.Data{} = data)
       when data.current_vote.id == vote_id do
-    event = {:vote_ended, DateTime.utc_now(), :timeout}
+    event = %Events.VoteEnded{
+      finished_at: DateTime.utc_now(),
+      vote: data.current_vote,
+      outcome: :timeout
+    }
+
     data = process_events(data, [event])
     {:keep_state, data}
   end
@@ -1323,13 +1312,10 @@ defmodule Teiserver.TachyonLobby.Lobby do
     final_aggregate.data
   end
 
-  # TODO: this should live under Event, or something outside this module
-  # because implementing the Event protocol may require to compute intermediate
-  # aggregates, and having this function there creates some circular dependencies
-  defp compute_aggregate(%LT.Data{} = data, events) do
+  def compute_aggregate(%LT.Data{} = data, events) do
     aggregate = %LT.Aggregate{data: data}
 
-    final_aggregate = Enum.reduce(events, aggregate, &apply_event/2)
+    final_aggregate = Enum.reduce(events, aggregate, &Event.apply_event/2)
 
     initial_player_count = Enum.count(data.players, fn {_id, p} -> not bot_id?(p.id) end)
 
@@ -1348,194 +1334,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
         do: c + 1,
         else: c
     end)
-  end
-
-  # TODO: this should be a temporary function until all events are converted to
-  # structs which implement the Event protocol
-  def apply_event(event, %LT.Aggregate{} = agg) do
-    if Event.impl_for(event) != nil do
-      Event.apply_event(event, agg)
-    else
-      result = process_event(event, %{data: agg.data, updates: [], actions: []})
-
-      case result do
-        %LT.Aggregate{} -> result
-        _map -> merge_map_aggregate_to_struct(agg, result)
-      end
-    end
-  end
-
-  @spec process_event(event(), %{data: LT.Data.t(), updates: [event()], actions: list()}) :: %{
-          data: LT.Data.t(),
-          updates: [event()]
-        }
-  defp process_event({:start_vote, %LT.VoteState{} = vote_state} = ev, aggregate) do
-    aggregate
-    |> put_in([:data, Access.key!(:current_vote)], vote_state)
-    |> update_in([:data, Access.key!(:vote_idx)], &(&1 + 1))
-    |> Map.update!(:updates, &[ev | &1])
-  end
-
-  defp process_event({:cast_vote, user_id, _ballot}, aggregate)
-       when is_nil(aggregate.data.current_vote) or
-              not is_map_key(aggregate.data.current_vote.voters, user_id),
-       do: aggregate
-
-  defp process_event({:cast_vote, user_id, ballot} = ev, aggregate) do
-    new_aggregate =
-      aggregate
-      |> put_in([:data, Access.key!(:current_vote), Access.key!(:voters), user_id], ballot)
-
-    case vote_result(new_aggregate.data.current_vote) do
-      :undecided ->
-        Map.update!(new_aggregate, :updates, &[ev | &1])
-
-      {:ended, result} ->
-        vote = new_aggregate.data.current_vote
-        new_aggregate = process_event({:vote_ended, DateTime.utc_now(), result}, new_aggregate)
-
-        case {result, vote.action} do
-          {:failed, _action} ->
-            new_aggregate
-
-          {:passed, {:change_map, new_map}} ->
-            # until all events have been converted to structs, and we don't carry around
-            # the non-struct aggregate, need some transformation there
-            agg =
-              merge_map_aggregate_to_struct(
-                %LT.Aggregate{data: new_aggregate.data},
-                new_aggregate
-              )
-
-            apply_event(%Events.UpdateMapName{new_map: new_map}, agg)
-
-          {:passed, {:appoint_boss, boss_id}} ->
-            process_event({:update_boss, :add, boss_id}, new_aggregate)
-
-          {:passed, {:kickban, target_id, ban_until}} ->
-            data = new_aggregate.data
-
-            target_in_lobby? =
-              is_map_key(data.players, target_id) or
-                is_map_key(data.spectators, target_id)
-
-            cond do
-              target_in_lobby? ->
-                new_data = do_kickban(target_id, ban_until, new_aggregate.data)
-                %{new_aggregate | data: new_data}
-
-              ban_until != nil ->
-                effective_ban_until =
-                  if DateTime.compare(ban_until, DateTime.utc_now()) == :gt,
-                    do: ban_until,
-                    else: nil
-
-                case effective_ban_until do
-                  nil ->
-                    new_aggregate
-
-                  dt ->
-                    ms = DateTime.diff(dt, DateTime.utc_now(), :millisecond)
-                    if ms > 0, do: :timer.send_after(ms, {:ban_expired, target_id})
-                    new_data = put_in(data.banned_users[target_id], dt)
-                    %{new_aggregate | data: new_data}
-                end
-
-              true ->
-                new_aggregate
-            end
-
-            # just let the thing crash if a new vote action shows up. It'll be easy
-            # to spot and fix/add support. :start isn't yet supported
-        end
-    end
-  end
-
-  # don't bother cancelling the vote timeout timer. The event handler checks the vote id
-  # and it allows us not to worry about storing the tref
-  defp process_event({:vote_ended, ts, outcome}, aggregate) do
-    vote_ev = {:vote_ended, aggregate.data.current_vote, outcome}
-
-    vote_record = %LT.VoteRecord{
-      vote: aggregate.data.current_vote,
-      finished_at: ts,
-      outcome: outcome
-    }
-
-    history = Map.put(aggregate.data.vote_history, aggregate.data.current_vote.id, vote_record)
-
-    history =
-      if map_size(history) > @max_vote_history_size do
-        dates =
-          Enum.map(history, fn {_id, record} -> record.finished_at end)
-          |> Enum.sort()
-
-        cutoff = Enum.at(dates, 4)
-
-        Enum.filter(history, fn {_id, record} -> record.finished_at >= cutoff end)
-        |> Enum.into(%{})
-      else
-        history
-      end
-
-    aggregate
-    |> put_in([:data, Access.key!(:current_vote)], nil)
-    |> put_in([:data, Access.key!(:vote_history)], history)
-    |> Map.update!(:updates, &[{:vote_ended, vote_record} | &1])
-    |> Map.update!(:actions, &[vote_ev | &1])
-  end
-
-  defp process_event({:update_boss, :add, appointee_id} = ev, aggregate) do
-    if MapSet.member?(aggregate.data.bosses, appointee_id) do
-      aggregate
-    else
-      aggregate
-      |> update_in([:data, Access.key!(:bosses)], &MapSet.put(&1, appointee_id))
-      |> Map.update!(:updates, &[ev | &1])
-    end
-  end
-
-  defp process_event({:update_boss, :remove, boss_id} = ev, aggregate) do
-    if MapSet.member?(aggregate.data.bosses, boss_id) do
-      aggregate
-      |> update_in([:data, Access.key!(:bosses)], &MapSet.delete(&1, boss_id))
-      |> Map.update!(:updates, &[ev | &1])
-    else
-      aggregate
-    end
-  end
-
-  defp update_change_from_event({:start_vote, vote}, change_map),
-    do: Map.put(change_map, :current_vote, vote)
-
-  defp update_change_from_event({:cast_vote, user_id, ballot}, change_map) do
-    change_map
-    |> Map.put_new(:current_vote, %{})
-    |> Map.update!(:current_vote, &Map.put_new(&1, :voters, %{}))
-    |> put_in([:current_vote, :voters, user_id], ballot)
-  end
-
-  defp update_change_from_event({:vote_ended, record}, change_map) do
-    change_map
-    |> Map.put(:current_vote, nil)
-    |> Map.put_new(:vote_history, %{})
-    |> put_in([:vote_history, record.vote.id], %{
-      vote: record.vote.action,
-      finished_at: record.finished_at,
-      outcome: record.outcome
-    })
-  end
-
-  defp update_change_from_event({:update_boss, :add, appointee_id}, change_map) do
-    change_map
-    |> Map.put_new(:bosses, %{})
-    |> put_in([:bosses, appointee_id], %{})
-  end
-
-  defp update_change_from_event({:update_boss, :remove, boss_id}, change_map) do
-    change_map
-    |> Map.put_new(:bosses, %{})
-    |> put_in([:bosses, boss_id], nil)
   end
 
   defp broadcast_list_updates(%LT.Aggregate{} = agg)
@@ -1688,46 +1486,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
     DateTime.compare(ban_until, DateTime.utc_now()) != :gt
   end
 
-  defp do_kickban(target_id, ban_until, %LT.Data{} = data) do
-    target_pid =
-      case {data.players[target_id], data.spectators[target_id]} do
-        {%{pid: pid}, _spec} -> pid
-        {_player, %{pid: pid}} -> pid
-        _not_found -> nil
-      end
-
-    effective_ban_until =
-      case ban_until do
-        nil -> nil
-        dt -> if DateTime.compare(dt, DateTime.utc_now()) == :gt, do: dt, else: nil
-      end
-
-    data =
-      case effective_ban_until do
-        nil ->
-          data
-
-        dt ->
-          ms = DateTime.diff(dt, DateTime.utc_now(), :millisecond)
-          if ms > 0, do: :timer.send_after(ms, {:ban_expired, target_id})
-          put_in(data.banned_users[target_id], dt)
-      end
-
-    data =
-      if is_map_key(data.players, target_id) do
-        remove_player_from_lobby(target_id, data)
-      else
-        remove_spectator_from_lobby(target_id, data)
-      end
-
-    if target_pid do
-      reason = if effective_ban_until != nil, do: "banned", else: "kicked"
-      send(target_pid, {:lobby, data.id, {:left, reason, effective_ban_until}})
-    end
-
-    data
-  end
-
   # in tests, some user ids are string
   def bot_id?(id) when is_integer(id), do: false
   def bot_id?(id), do: String.starts_with?(id, "bot")
@@ -1793,7 +1551,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
   end
 
   @spec update_property(atom(), term(), LT.Data.t(), User.id()) ::
-          {:ok, [event()]} | {:error, String.t()}
+          {:ok, [term()]} | {:error, String.t()}
   defp update_property(:name, new_name, _state, _user_id) do
     # we can expand lobby name validation later with LobbyRestrictions
     case LobbyLib.validate_name(new_name) do
@@ -1819,11 +1577,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
       Enum.count(state.players, fn {_id, p} -> not bot_id?(p.id) end) > 1 ->
         vote = new_vote(state, user_id, {:change_map, new_map})
-
-        :timer.seconds(vote.duration_s)
-        |> :timer.send_after({:vote_timeout, vote.id})
-
-        {:ok, [{:start_vote, vote}]}
+        {:ok, [%Events.StartVote{vote_state: vote}]}
 
       true ->
         {:ok, [%Events.UpdateMapName{new_map: new_map}]}
@@ -1849,6 +1603,14 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   defp process_event_action({:vote_ended, vote, outcome}, fsm_data) do
     broadcast_to_members(fsm_data, nil, {:lobby, fsm_data.id, {:vote_ended, vote.id, outcome}})
+  end
+
+  defp process_event_action({:send_after, time, message}, _fsm_data) do
+    :timer.send_after(time, message)
+  end
+
+  defp process_event_action({:send_to_user, pid, message}, _fsm_data) do
+    send(pid, message)
   end
 
   # create a default vote object
@@ -1877,17 +1639,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
     }
   end
 
-  @spec vote_result(LT.VoteState.t()) :: :undecided | {:ended, :passed | :failed}
-  defp vote_result(%LT.VoteState{} = vote) do
-    votes = for {_user_id, v} <- vote.voters, do: v
-
-    cond do
-      Enum.count(votes, &(&1 != :pending)) < vote.quorum -> :undecided
-      Enum.count(votes, &(&1 == :yes)) >= vote.majority -> {:ended, :passed}
-      true -> {:ended, :failed}
-    end
-  end
-
   defp update_list(%LT.Data{} = data, changes) do
     message = %{
       event: :update_lobby,
@@ -1897,16 +1648,5 @@ defmodule Teiserver.TachyonLobby.Lobby do
     }
 
     PubSubHelper.broadcast(list_topic(), message)
-  end
-
-  defp merge_map_aggregate_to_struct(%LT.Aggregate{} = agg, map_aggregate) do
-    new_changes = Enum.reduce(map_aggregate.updates, agg.changes, &update_change_from_event/2)
-
-    %LT.Aggregate{
-      data: map_aggregate.data,
-      changes: new_changes,
-      overview_changes: agg.overview_changes,
-      side_effects: Map.get(map_aggregate, :actions, []) ++ agg.side_effects
-    }
   end
 end

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -81,8 +81,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
            | {:update_map_name, new_name :: String.t()}
            | {:update_ally_team_config, old_config :: [LT.AllyTeamConfig.t()],
               new_config :: [LT.AllyTeamConfig.t()]}
-           | {:update_game_options, changes :: %{String.t() => String.t() | nil}}
-           | {:update_tags, changes :: %{String.t() => map() | nil}}
            | {:start_vote, LT.VoteState.t()}
            | {:cast_vote, User.id(), LT.VoteState.vote_ballot()}
            | {:vote_ended, DateTime.t(), LT.VoteState.vote_outcome()}
@@ -1594,18 +1592,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
     new_aggregate |> put_in([:updates], [ev | final_events] ++ aggregate.updates)
   end
 
-  defp process_event({:update_game_options, changes} = ev, aggregate) do
-    aggregate
-    |> update_in([:data, Access.key!(:game_options)], &Collections.patch_merge(&1, changes))
-    |> Map.update!(:updates, &[ev | &1])
-  end
-
-  defp process_event({:update_tags, changes} = ev, aggregate) do
-    aggregate
-    |> update_in([:data, Access.key!(:tags)], &Collections.patch_merge(&1, changes))
-    |> Map.update!(:updates, &[ev | &1])
-  end
-
   defp process_event({:start_vote, %LT.VoteState{} = vote_state} = ev, aggregate) do
     aggregate
     |> put_in([:data, Access.key!(:current_vote)], vote_state)
@@ -1820,12 +1806,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
     Map.put(change_map, :ally_team_config, changes)
   end
-
-  defp update_change_from_event({:update_game_options, changes}, change_map),
-    do: Map.put(change_map, :game_options, changes)
-
-  defp update_change_from_event({:update_tags, changes}, change_map),
-    do: Map.put(change_map, :tags, changes)
 
   defp update_change_from_event({:start_vote, vote}, change_map),
     do: Map.put(change_map, :current_vote, vote)
@@ -2230,11 +2210,11 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   defp update_property(:game_options, changes, _state, _user_id) do
     # TODO: set a size limit on that thing to avoid a DOS
-    {:ok, [{:update_game_options, changes}]}
+    {:ok, [%Events.UpdateGameOptions{changes: changes}]}
   end
 
   defp update_property(:tags, changes, _state, _user_id) do
-    {:ok, [{:update_tags, changes}]}
+    {:ok, [%Events.UpdateTags{changes: changes}]}
   end
 
   defp update_property(prop, _value, _state, _user_id),

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -37,15 +37,15 @@ defmodule Teiserver.TachyonLobby.Lobby do
   alias Teiserver.Tachyon
   alias Teiserver.TachyonBattle
   alias Teiserver.TachyonLobby.Event
+  alias Teiserver.TachyonLobby.Events
   alias Teiserver.TachyonLobby.ListMonitor
   alias Teiserver.TachyonLobby.Registry, as: LobbyRegistry
   # lobby types
   alias Teiserver.TachyonLobby.Types, as: LT
+
   require Logger
 
   @behaviour :gen_statem
-
-  @type asset_status :: :missing | :downloading | :complete
 
   # Note[sparse_map_for_update]
   # do not turn this into a struct!
@@ -78,7 +78,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
            | {:move_player_to_spec, User.id(), spec_data :: map()}
            | :repack_players
            | :fill_from_join_queue
-           | {:update_client_status, User.id(), client_status :: map()}
            | {:update_lobby_name, new_name :: String.t()}
            | {:update_map_name, new_name :: String.t()}
            | {:update_ally_team_config, old_config :: [LT.AllyTeamConfig.t()],
@@ -164,7 +163,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   @type client_status_update_data :: %{
           optional(:ready?) => boolean(),
-          optional(:asset_status) => asset_status()
+          optional(:asset_status) => LT.Types.asset_status()
         }
   @spec update_client_status(LT.Types.id(), User.id(), client_status_update_data()) ::
           :ok | {:error, :invalid_lobby | :not_in_lobby | :not_a_player}
@@ -716,7 +715,12 @@ defmodule Teiserver.TachyonLobby.Lobby do
         %LT.Data{} = data
       ) do
     supported_properties = [:ready?, :asset_status]
-    event = {:update_client_status, user_id, Map.take(update_data, supported_properties)}
+
+    event = %Events.UpdateClientStatus{
+      user_id: user_id,
+      client_status_updates: Map.take(update_data, supported_properties)
+    }
+
     data = process_events(data, [event])
     {:keep_state, data, [{:reply, from, :ok}]}
   end
@@ -1503,12 +1507,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
     end
   end
 
-  defp process_event({:update_client_status, p_id, changes} = ev, aggregate) do
-    aggregate
-    |> update_in([:data, Access.key!(:players), p_id], &Map.merge(&1, changes))
-    |> update_in([:updates], &[ev | &1])
-  end
-
   defp process_event({:update_lobby_name, new_name} = ev, aggregate) do
     aggregate
     |> put_in([:data, Access.key!(:name)], new_name)
@@ -1802,12 +1800,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
   end
 
   defp update_change_from_event(:repack_players, change_map), do: change_map
-
-  defp update_change_from_event({:update_client_status, p_id, changes}, change_map) do
-    change_map
-    |> Map.put_new(:players, %{})
-    |> put_in([:players, p_id], changes)
-  end
 
   defp update_change_from_event({:update_lobby_name, new_name}, change_map),
     do: Map.put(change_map, :name, new_name)

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -78,7 +78,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
            | {:move_player_to_spec, User.id(), spec_data :: map()}
            | :repack_players
            | :fill_from_join_queue
-           | {:update_map_name, new_name :: String.t()}
            | {:update_ally_team_config, old_config :: [LT.AllyTeamConfig.t()],
               new_config :: [LT.AllyTeamConfig.t()]}
            | {:start_vote, LT.VoteState.t()}
@@ -1366,17 +1365,11 @@ defmodule Teiserver.TachyonLobby.Lobby do
       Event.apply_event(event, agg)
     else
       result = process_event(event, %{data: agg.data, updates: [], actions: []})
-      new_changes = Enum.reduce(result.updates, agg.changes, &update_change_from_event/2)
 
-      overview_changes =
-        Map.merge(agg.overview_changes, overview_changes_from_events(result.updates))
-
-      %LT.Aggregate{
-        data: result.data,
-        changes: new_changes,
-        overview_changes: overview_changes,
-        side_effects: Map.get(result, :actions, []) ++ agg.side_effects
-      }
+      case result do
+        %LT.Aggregate{} -> result
+        _map -> merge_map_aggregate_to_struct(agg, result)
+      end
     end
   end
 
@@ -1504,12 +1497,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
     end
   end
 
-  defp process_event({:update_map_name, new_name} = ev, aggregate) do
-    aggregate
-    |> put_in([:data, Access.key!(:map_name)], new_name)
-    |> update_in([:updates], &[ev | &1])
-  end
-
   defp process_event({:update_ally_team_config, _old_config, new_config} = ev, aggregate) do
     state = aggregate.data
 
@@ -1622,7 +1609,10 @@ defmodule Teiserver.TachyonLobby.Lobby do
             new_aggregate
 
           {:passed, {:change_map, new_map}} ->
-            process_event({:update_map_name, new_map}, new_aggregate)
+            # until all events have been converted to structs, and we don't carry around
+            # the non-struct aggregate, need some transformation there
+            agg = merge_map_aggregate_to_struct(%LT.Aggregate{data: new_aggregate.data}, new_aggregate)
+            apply_event(%Events.UpdateMapName{new_map: new_map}, agg)
 
           {:passed, {:appoint_boss, boss_id}} ->
             process_event({:update_boss, :add, boss_id}, new_aggregate)
@@ -1780,9 +1770,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
 
   defp update_change_from_event(:repack_players, change_map), do: change_map
 
-  defp update_change_from_event({:update_map_name, new_name}, change_map),
-    do: Map.put(change_map, :map_name, new_name)
-
   defp update_change_from_event({:update_ally_team_config, old_config, new_config}, change_map) do
     changes =
       Collections.zip_with_padding(old_config, new_config, nil)
@@ -1862,9 +1849,6 @@ defmodule Teiserver.TachyonLobby.Lobby do
   defp overview_changes_from_events(events) do
     Enum.reduce(events, %{}, fn ev, change_map ->
       case ev do
-        {:update_map_name, new_name} ->
-          Map.put(change_map, :map_name, new_name)
-
         {:update_ally_team_config, _old_config, new_config} ->
           change_map
           |> Map.put(
@@ -2179,7 +2163,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
     end
   end
 
-  defp update_property(:map_name, new_name, %LT.Data{} = state, user_id) do
+  defp update_property(:map_name, new_map, %LT.Data{} = state, user_id) do
     cond do
       not is_map_key(state.players, user_id) ->
         {:error, "Only players can change the map"}
@@ -2187,12 +2171,12 @@ defmodule Teiserver.TachyonLobby.Lobby do
       state.current_vote ->
         case state.current_vote.action do
           # make changing map idempotent, it's just a nicer API this way
-          {:change_map, ^new_name} -> {:ok, []}
+          {:change_map, ^new_map} -> {:ok, []}
           _other_action -> {:error, :vote_in_progress}
         end
 
       Enum.count(state.players, fn {_id, p} -> not bot_id?(p.id) end) > 1 ->
-        vote = new_vote(state, user_id, {:change_map, new_name})
+        vote = new_vote(state, user_id, {:change_map, new_map})
 
         :timer.seconds(vote.duration_s)
         |> :timer.send_after({:vote_timeout, vote.id})
@@ -2200,7 +2184,7 @@ defmodule Teiserver.TachyonLobby.Lobby do
         {:ok, [{:start_vote, vote}]}
 
       true ->
-        {:ok, [{:update_map_name, new_name}]}
+        {:ok, [%Events.UpdateMapName{new_map: new_map}]}
     end
   end
 
@@ -2270,5 +2254,19 @@ defmodule Teiserver.TachyonLobby.Lobby do
     }
 
     PubSubHelper.broadcast(list_topic(), message)
+  end
+
+  defp merge_map_aggregate_to_struct(%LT.Aggregate{} = agg, map_aggregate) do
+    new_changes = Enum.reduce(map_aggregate.updates, agg.changes, &update_change_from_event/2)
+
+    overview_changes =
+      Map.merge(agg.overview_changes, overview_changes_from_events(map_aggregate.updates))
+
+    %LT.Aggregate{
+      data: map_aggregate.data,
+      changes: new_changes,
+      overview_changes: overview_changes,
+      side_effects: Map.get(map_aggregate, :actions, []) ++ agg.side_effects
+    }
   end
 end

--- a/lib/teiserver/tachyon_lobby/types/aggregate.ex
+++ b/lib/teiserver/tachyon_lobby/types/aggregate.ex
@@ -1,0 +1,30 @@
+defmodule Teiserver.TachyonLobby.Types.Aggregate do
+  @moduledoc """
+  An aggregate is used when processing lobby events.
+  Reducing events from an initial aggregate leads to a new aggregate that holds
+  the new state, and maps of changes to be broadcasted to member or a new overview
+  for the lobby list.
+
+  Some events may also generate side effects, like an end vote. These are
+  represented in the aggregate as well.
+
+  Computing an aggregate must be a pure operation, that is, there must not be
+  any side effects. This is to guarantee we can replicate the state
+  in other processes without having to deal with duplicate messages.
+  In this context, events are data structure that represent changes to a lobby,
+  there is no message passing or IO involved.
+  """
+
+  alias Teiserver.TachyonLobby.Types, as: LT
+
+  @enforce_keys [:data]
+  defstruct [:data, changes: %{}, overview_changes: %{}, side_effects: []]
+
+  @type t() :: %__MODULE__{
+          data: LT.Data.t(),
+          changes: map(),
+          overview_changes: map(),
+          # TODO refine that with proper structs/types
+          side_effects: list()
+        }
+end

--- a/test/teiserver/tachyon_lobby/lobby_test.exs
+++ b/test/teiserver/tachyon_lobby/lobby_test.exs
@@ -1127,8 +1127,6 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
       assert result == :failed
     end
 
-    # re-enable when voting events are converted to structs
-    @tag :skip
     test "voter disconnect is the same as leaving (abstain)" do
       %{id: id, users: users} = setup_full_lobby([1, 1])
       :ok = Lobby.join_queue(id, "2")
@@ -1255,8 +1253,6 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
       assert data.bosses == %{"2" => %{}}
     end
 
-    # re-enable when boss events are converted to structs
-    @tag :skip
     test "leaving lobby unboss" do
       %{id: id} = setup_full_lobby([1, 1], boss_enabled?: true)
       :ok = Lobby.appoint_boss(id, @default_user_id, "2")
@@ -1864,8 +1860,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
 
       :ok = Lobby.vote_submit(id, "user3", {vote.id, :yes})
 
-      assert_receive {:lobby, ^id, {:updated, %{players: %{"user2" => nil}}}}
-      assert_receive {:lobby, ^id, {:updated, %{current_vote: nil}}}
+      assert_receive {:lobby, ^id, {:updated, %{players: %{"user2" => nil}, current_vote: nil}}}
       assert_receive {:lobby, ^id, {:vote_ended, _vote_id, :passed}}
 
       {:ok, details} = LobbyProcess.get_details(id)
@@ -1873,7 +1868,6 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
       refute is_map_key(details.spectators, "user2")
     end
 
-    @tag :skip
     test "kickban vote is cancelled when target leaves" do
       {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([3, 3])

--- a/test/teiserver/tachyon_lobby/lobby_test.exs
+++ b/test/teiserver/tachyon_lobby/lobby_test.exs
@@ -1127,6 +1127,8 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
       assert result == :failed
     end
 
+    # re-enable when voting events are converted to structs
+    @tag :skip
     test "voter disconnect is the same as leaving (abstain)" do
       %{id: id, users: users} = setup_full_lobby([1, 1])
       :ok = Lobby.join_queue(id, "2")
@@ -1253,6 +1255,8 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
       assert data.bosses == %{"2" => %{}}
     end
 
+    # re-enable when boss events are converted to structs
+    @tag :skip
     test "leaving lobby unboss" do
       %{id: id} = setup_full_lobby([1, 1], boss_enabled?: true)
       :ok = Lobby.appoint_boss(id, @default_user_id, "2")
@@ -1869,6 +1873,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
       refute is_map_key(details.spectators, "user2")
     end
 
+    @tag :skip
     test "kickban vote is cancelled when target leaves" do
       {:ok, _pid, %LT.Details{id: id}} =
         mk_start_params([3, 3])


### PR DESCRIPTION
This looks massive but is actually "just" a refactoring of how lobby processes events. Instead of having a big union of types, each event is a separate struct.
These events implement a protocol to apply it to an aggregate. The aggregate is a data structure that represent a change: the new state alongside updates and side effects.

The separate commits are more for review and development, all of that should be squashed when merged since it's "just" one big refactor.