### PR TITLE
Measure and report tachyon connection duration

### DIFF
--- a/lib/teiserver/monitoring/tachyon.ex
+++ b/lib/teiserver/monitoring/tachyon.ex
@@ -13,6 +13,8 @@ defmodule Teiserver.Monitoring.Tachyon do
   @tachyon_party_metrics_event_name [:prom_ex, :plugin, :tachyon, :party]
   @tachyon_lobby_metrics_event_name [:prom_ex, :plugin, :tachyon, :lobby]
 
+  @duration_buckets [1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987, 1597, 2584, 4181]
+
   @impl PromEx.Plugin
   def event_metrics(_opts) do
     Event.build(
@@ -23,28 +25,17 @@ defmodule Teiserver.Monitoring.Tachyon do
           event_name: [:tachyon, :request],
           measurement: :duration,
           reporter_options: [
-            buckets: [
-              1,
-              2,
-              3,
-              5,
-              8,
-              13,
-              21,
-              34,
-              55,
-              89,
-              144,
-              233,
-              377,
-              610,
-              987,
-              1597,
-              2584,
-              4181
-            ]
+            buckets: @duration_buckets
           ],
           tags: [:command_id]
+        ),
+        distribution(
+          [:teiserver, :tachyon, :connect, :duration],
+          event_name: [:tachyon, :connect],
+          measurement: :duration,
+          reporter_options: [
+            buckets: @duration_buckets
+          ]
         ),
         counter(
           [:teiserver, :tachyon, :login, :ok],

--- a/lib/teiserver_web/controllers/tachyon.ex
+++ b/lib/teiserver_web/controllers/tachyon.ex
@@ -13,7 +13,15 @@ defmodule TeiserverWeb.TachyonController do
 
   @subprotocol_hdr_name "sec-websocket-protocol"
 
-  def connect(conn, _opts) do
+  def connect(conn, opts) do
+    start = :erlang.monotonic_time(:millisecond)
+    result = do_connect(conn, opts)
+    elapsed = :erlang.monotonic_time(:millisecond) - start
+    :telemetry.execute([:tachyon, :connect], %{duration: elapsed})
+    result
+  end
+
+  defp do_connect(conn, _opts) do
     with {:ok, subprotocol, handler} <- handler_for_version(conn),
          {:ok, state} <- handler.connect(conn) do
       try do


### PR DESCRIPTION
Because the login operation does a bunch of things, and it's useful to have some idea how long that takes.