### PR TITLE
Added warning for actions on VIP users

### DIFF
--- a/lib/teiserver/account/libs/role_lib.ex
+++ b/lib/teiserver/account/libs/role_lib.ex
@@ -118,7 +118,7 @@ defmodule Teiserver.Account.RoleLib do
       name: "Contributor",
       colour: "#66AA66",
       icon: "fa-solid fa-code-commit",
-      contains: ["Trusted", "BAR+", "Tester", "Blog helper"],
+      contains: ["Trusted", "BAR+", "Tester", "Blog helper", "VIP"],
       badge: true
     },
     %{name: "Engine", colour: "#007700", icon: "fa-solid fa-engine", contains: ~w(Contributor)},

--- a/lib/teiserver_web/live/moderation/moderation_components.ex
+++ b/lib/teiserver_web/live/moderation/moderation_components.ex
@@ -1,6 +1,10 @@
 defmodule TeiserverWeb.Moderation.ModerationComponents do
   @moduledoc false
+  alias Teiserver.Account.Auth
+  alias Teiserver.Account.User
+
   use TeiserverWeb, :component
+
   import TeiserverWeb.NavComponents, only: [sub_menu_button: 1]
 
   @doc """
@@ -40,6 +44,21 @@ defmodule TeiserverWeb.Moderation.ModerationComponents do
       >
         Bans
       </.sub_menu_button>
+    </div>
+    """
+  end
+
+  @doc """
+  Displays (if appropriate) a warning that this user has some form of VIP status and to check with senior moderators/community management if this needs to be handled in a certain way.
+
+  <.action_warning user={@user} />
+  """
+  attr :user, User, required: true
+
+  def action_warning(assigns) do
+    ~H"""
+    <div :if={Auth.vip?(@user)} class="alert alert-info">
+      This user has VIP or Contributor credentials. Please check with senior moderators and/or community management if any additional communication needs to take place around this action.
     </div>
     """
   end

--- a/lib/teiserver_web/templates/moderation/action/new_with_user.html.heex
+++ b/lib/teiserver_web/templates/moderation/action/new_with_user.html.heex
@@ -43,6 +43,8 @@ bsname = view_colour() %>
           </a>
         </div>
 
+        <TeiserverWeb.Moderation.ModerationComponents.action_warning user={@user} />
+
         <h3>Adding action against {@user.name}</h3>
 
         <div class="row">

--- a/lib/teiserver_web/templates/moderation/ban/new_with_user.html.heex
+++ b/lib/teiserver_web/templates/moderation/ban/new_with_user.html.heex
@@ -63,6 +63,8 @@ type_icons = %{
           Warning, if you use this tool incorrectly you might end up banning innocent users. If you are not sure how to use it then do not use it.
         </div>
 
+        <TeiserverWeb.Moderation.ModerationComponents.action_warning user={@user} />
+
         <h3>Adding ban based on {@user.name}</h3>
 
         <div class="row">


### PR DESCRIPTION
Adds a block of text in an info window for any user with VIP status flagging that there might need to be additional communication around the action being applied to them.

<img width="1388" height="208" alt="image" src="https://github.com/user-attachments/assets/a584b27b-87af-403c-a12d-e63535a48f42" />
<img width="1401" height="288" alt="image" src="https://github.com/user-attachments/assets/f80b29df-8ed0-4f27-8f8d-3460252dc380" />
