### PR TITLE
Bring User struct up to parity with CacheUser fields

### DIFF
--- a/lib/teiserver/account/caches/user_cache_lib.ex
+++ b/lib/teiserver/account/caches/user_cache_lib.ex
@@ -241,8 +241,6 @@ defmodule Teiserver.Account.UserCacheLib do
       lobby_hash: user_data.lobby_hash,
       chobby_hash: user_data.chobby_hash,
       lobby_client: user_data.lobby_client,
-      print_client_messages: user_data.print_client_messages,
-      print_server_messages: user_data.print_server_messages,
       discord_dm_channel: user_data.discord_dm_channel
     }
   end
@@ -280,7 +278,7 @@ defmodule Teiserver.Account.UserCacheLib do
       |> Map.new(fn k -> {to_string(k), Map.get(user, k, Account.default_data()[k])} end)
 
     obj_attrs =
-      CacheUser.keys()
+      (CacheUser.keys() ++ CacheUser.duplicated_keys())
       |> Map.new(fn k -> {to_string(k), Map.get(user, k, Account.default_data()[k])} end)
 
     Account.script_update_user(db_user, Map.put(obj_attrs, "data", data))

--- a/lib/teiserver/account/schemas/user.ex
+++ b/lib/teiserver/account/schemas/user.ex
@@ -39,6 +39,16 @@ defmodule Teiserver.Account.User do
     field :discord_dm_channel_id, :integer
     field :steam_id, :integer
 
+    field :rank, :integer, default: 0
+    field :country, :string, default: "??"
+    field :bot, :boolean, default: false
+    field :email_change_code, :string
+    field :last_login_mins, :integer
+    field :lobby_hash, :string
+    field :chobby_hash, :string
+    field :lobby_client, :string
+    field :discord_dm_channel, :integer
+
     has_many :user_configs, Teiserver.Config.UserConfig
 
     # Extra user.ex relations go here
@@ -62,8 +72,6 @@ defmodule Teiserver.Account.User do
       shadowbanned: false,
       lobby_hash: [],
       chobby_hash: nil,
-      print_client_messages: false,
-      print_server_messages: false,
       discord_id: nil,
       discord_dm_channel: nil,
       discord_dm_channel_id: nil,
@@ -81,7 +89,7 @@ defmodule Teiserver.Account.User do
     user
     |> cast(
       attrs,
-      ~w(name email password icon colour data roles permissions restrictions restricted_until shadowbanned last_login last_played last_logout discord_id discord_dm_channel_id steam_id smurf_of_id)a
+      ~w(name email password icon colour data roles permissions restrictions restricted_until shadowbanned last_login last_played last_logout discord_id discord_dm_channel_id steam_id smurf_of_id country bot email_change_code last_login_mins lobby_hash chobby_hash lobby_client discord_dm_channel)a
     )
     |> validate_required([:name, :email, :password, :permissions])
     |> unique_constraint(:email)
@@ -97,7 +105,7 @@ defmodule Teiserver.Account.User do
     user
     |> cast(
       attrs,
-      ~w(name email password icon colour data roles permissions restrictions restricted_until shadowbanned last_login last_played last_logout discord_id discord_dm_channel_id steam_id smurf_of_id)a
+      ~w(name email password icon colour data roles permissions restrictions restricted_until shadowbanned last_login last_played last_logout discord_id discord_dm_channel_id steam_id smurf_of_id rank country bot email_change_code last_login_mins lobby_hash chobby_hash lobby_client discord_dm_channel)a
     )
     |> validate_required([:name, :email, :password, :permissions])
     |> unique_constraint(:email)

--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -12,6 +12,7 @@ defmodule Teiserver.CacheUser do
   alias Teiserver.Account.LoginThrottleServer
   alias Teiserver.Account.User
   alias Teiserver.Account.UserCacheLib
+  alias Teiserver.Account.UserQueries
   alias Teiserver.Battle
   alias Teiserver.CacheUser
   alias Teiserver.Chat
@@ -21,9 +22,11 @@ defmodule Teiserver.CacheUser do
   alias Teiserver.Data.Types, as: T
   alias Teiserver.EmailHelper
   alias Teiserver.Geoip
+  alias Teiserver.Helper.QueryHelpers
   alias Teiserver.Moderation
   alias Teiserver.Moderation.Tasks.ExternalIPCheckTask
   alias Teiserver.Plugins
+  alias Teiserver.Repo
   alias Teiserver.Telemetry
 
   use Plugins
@@ -78,8 +81,6 @@ defmodule Teiserver.CacheUser do
     :lobby_hash,
     :chobby_hash,
     :lobby_client,
-    :print_client_messages,
-    :print_server_messages,
     :discord_dm_channel
   ]
 
@@ -114,8 +115,6 @@ defmodule Teiserver.CacheUser do
           lobby_hash: String.t() | nil,
           chobby_hash: String.t() | nil,
           lobby_client: String.t(),
-          print_client_messages: boolean(),
-          print_server_messages: boolean(),
           discord_dm_channel: String.t() | nil
         }
 
@@ -132,14 +131,29 @@ defmodule Teiserver.CacheUser do
     :lobby_hash,
     :chobby_hash,
     :lobby_client,
-    :print_client_messages,
-    :print_server_messages,
     :discord_id,
     :discord_dm_channel,
     :discord_dm_channel_id,
     :steam_id
   ]
   def data_keys, do: @data_keys
+
+  @doc """
+  Keys duplicated in both data and the user profile
+  """
+  def duplicated_keys do
+    [
+      :rank,
+      :country,
+      :bot,
+      :email_change_code,
+      :last_login_mins,
+      :lobby_hash,
+      :chobby_hash,
+      :lobby_client,
+      :discord_dm_channel
+    ]
+  end
 
   @spec clean_name(String.t()) :: String.t()
   def clean_name(name) do
@@ -1231,5 +1245,85 @@ defmodule Teiserver.CacheUser do
       true ->
         :ok
     end
+  end
+
+  # These functions will be removed as part of the CacheUser struct being removed.
+  # They exist purely to facilitate and assist with the transfer
+
+  @doc """
+  A function to assist in validation we have converted the user struct correctly.
+
+  Returns a map of the differences between the cache and db users in the form:
+  %{
+    field: {cache_user_value, db_user_value}
+  }
+
+  An empty map represents an overlap of values
+  """
+  def compare_to_db_user(user_id) do
+    db_user = Account.get_user!(user_id)
+    cache_user = get_user_by_id(user_id)
+
+    cache_user
+    |> Map.keys()
+    |> List.delete(:__struct__)
+    |> Enum.map(fn key ->
+      cache_value = Map.get(cache_user, key, :not_set)
+      db_value = Map.get(db_user, key, :not_set)
+
+      if db_value != cache_value do
+        {key, {cache_value, db_value}}
+      end
+    end)
+    |> Enum.reject(&is_nil/1)
+    |> Map.new()
+  end
+
+  @doc """
+  Given a user_id, populates the user fields from their own data so the field is stored
+  in a column rather than in the data blob.
+  """
+  def populate_user_fields_from_data(user_id) do
+    user = Account.get_user!(user_id)
+
+    Account.script_update_user(user, %{
+      rank: user.data["rank"],
+      country: user.data["country"],
+      bot: user.data["bot"],
+      email_change_code: user.data["email_change_code"],
+      last_login_mins: user.data["last_login_mins"],
+      lobby_hash: user.data["lobby_hash"],
+      chobby_hash: user.data["chobby_hash"],
+      lobby_client: user.data["lobby_client"],
+      discord_dm_channel: user.data["discord_dm_channel"]
+    })
+  end
+
+  @doc """
+  Populates the new user fields from their data field in chunks with a sleep in between each
+  chunk so as to minimise load disruption.<!--  -->
+  """
+  def populate_all_new_user_fields do
+    user_id_chunks =
+      UserQueries.users()
+      |> QueryHelpers.query_select([:id])
+      |> Repo.all()
+      |> Enum.map(& &1.id)
+      |> Enum.chunk_every(2000)
+
+    chunk_count = length(user_id_chunks)
+
+    IO.puts("#{chunk_count} chunks")
+
+    user_id_chunks
+    |> Enum.with_index()
+    |> Enum.map(fn {chunk_ids, idx} ->
+      IO.puts("Populating #{idx}")
+
+      Enum.each(chunk_ids, &populate_user_fields_from_data/1)
+
+      # Sleep to ensure we don't cause too much load on the server
+      :timer.sleep(2000)
+    end)
   end
 end

--- a/lib/teiserver/data/client.ex
+++ b/lib/teiserver/data/client.ex
@@ -43,8 +43,6 @@ defmodule Teiserver.Client do
         side: 0,
         role: "spectator",
         lobby_id: nil,
-        print_client_messages: false,
-        print_server_messages: false,
         chat_times: [],
         temp_mute_count: 0,
         ip: nil,
@@ -150,15 +148,6 @@ defmodule Teiserver.Client do
         event: :connected
       }
     )
-
-    # Message logging
-    if user.print_client_messages do
-      enable_client_message_print(user.id)
-    end
-
-    if user.print_server_messages do
-      enable_server_message_print(user.id)
-    end
 
     # Lets give everything a chance to propagate
     :timer.sleep(150)
@@ -332,53 +321,5 @@ defmodule Teiserver.Client do
     client = get_client_by_id(userid)
     update(%{client | awaiting_warn_ack: false}, :silent)
     :ok
-  end
-
-  @spec enable_client_message_print(User.id()) :: :ok
-  def enable_client_message_print(userid) do
-    case get_client_by_id(userid) do
-      nil ->
-        :ok
-
-      client ->
-        send(client.tcp_pid, {:put, :print_client_messages, true})
-        :ok
-    end
-  end
-
-  @spec disable_client_message_print(User.id()) :: :ok
-  def disable_client_message_print(userid) do
-    case get_client_by_id(userid) do
-      nil ->
-        :ok
-
-      client ->
-        send(client.tcp_pid, {:put, :print_client_messages, false})
-        :ok
-    end
-  end
-
-  @spec enable_server_message_print(User.id()) :: :ok
-  def enable_server_message_print(userid) do
-    case get_client_by_id(userid) do
-      nil ->
-        :ok
-
-      client ->
-        send(client.tcp_pid, {:put, :print_server_messages, true})
-        :ok
-    end
-  end
-
-  @spec disable_server_message_print(User.id()) :: :ok
-  def disable_server_message_print(userid) do
-    case get_client_by_id(userid) do
-      nil ->
-        :ok
-
-      client ->
-        send(client.tcp_pid, {:put, :print_server_messages, false})
-        :ok
-    end
   end
 end

--- a/lib/teiserver/libs/teiserver_configs.ex
+++ b/lib/teiserver/libs/teiserver_configs.ex
@@ -18,7 +18,6 @@ defmodule Teiserver.TeiserverConfigs do
     moderation_configs()
     discord_configs()
     lobby_configs()
-    debugging_configs()
     profile_configs()
     rating_configs()
     tachyon_configs()
@@ -746,27 +745,6 @@ defmodule Teiserver.TeiserverConfigs do
       type: "integer",
       permissions: ["Admin"],
       description: "The discord ID for the channel broadcasting lobby count"
-    })
-  end
-
-  @spec debugging_configs :: :ok
-  def debugging_configs do
-    add_site_config_type(%{
-      key: "debug.Print outgoing messages",
-      section: "Debug",
-      type: "boolean",
-      default: false,
-      permissions: ["Admin"],
-      description: "Print all outgoing messages"
-    })
-
-    add_site_config_type(%{
-      key: "debug.Print incoming messages",
-      section: "Debug",
-      type: "boolean",
-      default: false,
-      permissions: ["Admin"],
-      description: "Print all incoming messages"
     })
   end
 

--- a/lib/teiserver/protocols/spring/spring_in.ex
+++ b/lib/teiserver/protocols/spring/spring_in.ex
@@ -60,15 +60,6 @@ defmodule Teiserver.Protocols.SpringIn do
 
   @spec data_in(String.t(), map()) :: map()
   def data_in(data, state) do
-    if Config.get_site_config_cache("debug.Print incoming messages") or
-         state.print_client_messages do
-      if String.contains?(data, "c.user.get_token") or String.contains?(data, "LOGIN") do
-        Logger.info("<-- #{state.username}: LOGIN/c.user.get_token")
-      else
-        Logger.info("<-- #{state.username}: #{Spring.format_log(data)}")
-      end
-    end
-
     new_state =
       if String.ends_with?(data, "\n") do
         data = state.message_part <> data

--- a/lib/teiserver/protocols/spring/spring_out.ex
+++ b/lib/teiserver/protocols/spring/spring_out.ex
@@ -11,7 +11,6 @@ defmodule Teiserver.Protocols.SpringOut do
   alias Teiserver.Account.Auth
   alias Teiserver.Battle
   alias Teiserver.Client
-  alias Teiserver.Config
   alias Teiserver.Coordinator
   alias Teiserver.Data.Types, as: T
   alias Teiserver.Lobby
@@ -56,18 +55,6 @@ defmodule Teiserver.Protocols.SpringOut do
     :telemetry.execute([:spring, :out], %{duration: elapsed, count: 1}, %{
       command: reply_cmd
     })
-
-    if Config.get_site_config_cache("debug.Print outgoing messages") or
-         state.print_server_messages do
-      if is_list(msg) do
-        msg
-        |> Enum.each(fn m ->
-          Logger.info("--> #{state.username}: #{Spring.format_log(m)}")
-        end)
-      else
-        Logger.info("--> #{state.username}: #{Spring.format_log(msg)}")
-      end
-    end
 
     if Enum.member?([nil, ""], msg) do
       state

--- a/lib/teiserver/tcp/spring/spring_tcp_server.ex
+++ b/lib/teiserver/tcp/spring/spring_tcp_server.ex
@@ -1307,8 +1307,6 @@ defmodule Teiserver.SpringTcpServer do
             room_member_cache: %{},
             known_users: %{},
             known_battles: [],
-            print_client_messages: false,
-            print_server_messages: false,
             script_password: nil,
             exempt_from_cmd_throttle: false,
             status_timestamps: [],

--- a/lib/teiserver_web/live/clients/show.ex
+++ b/lib/teiserver_web/live/clients/show.ex
@@ -54,23 +54,6 @@ defmodule TeiserverWeb.ClientLive.Show do
         client = Account.get_client_by_id(id)
         user = CacheUser.get_user_by_id(id)
 
-        connection_state =
-          cond do
-            client == nil ->
-              %{}
-
-            Process.alive?(client.tcp_pid) == true ->
-              :sys.get_state(client.tcp_pid)
-
-            true ->
-              %{}
-          end
-
-        # If viewing an internal server process you it won't have these keys and thus we use
-        # this method
-        server_debug_messages = Map.get(connection_state, :print_server_messages, false)
-        client_debug_messages = Map.get(connection_state, :print_client_messages, false)
-
         if client && user do
           {:noreply,
            socket
@@ -78,9 +61,7 @@ defmodule TeiserverWeb.ClientLive.Show do
            |> add_breadcrumb(name: user.name, url: ~p"/teiserver/admin/client/#{id}")
            |> assign(:id, id)
            |> assign(:client, client)
-           |> assign(:user, user)
-           |> assign(:client_debug_messages, client_debug_messages)
-           |> assign(:server_debug_messages, server_debug_messages)}
+           |> assign(:user, user)}
         else
           {:noreply,
            socket
@@ -166,38 +147,6 @@ defmodule TeiserverWeb.ClientLive.Show do
   end
 
   @impl Phoenix.LiveView
-  def handle_event("enable-server-message-logging", _event, socket) do
-    Client.enable_server_message_print(socket.assigns.id)
-
-    {:noreply,
-     socket
-     |> assign(:server_debug_messages, true)}
-  end
-
-  def handle_event("disable-server-message-logging", _event, socket) do
-    Client.disable_server_message_print(socket.assigns.id)
-
-    {:noreply,
-     socket
-     |> assign(:server_debug_messages, false)}
-  end
-
-  def handle_event("enable-client-message-logging", _event, socket) do
-    Client.enable_client_message_print(socket.assigns.id)
-
-    {:noreply,
-     socket
-     |> assign(:client_debug_messages, true)}
-  end
-
-  def handle_event("disable-client-message-logging", _event, socket) do
-    Client.disable_client_message_print(socket.assigns.id)
-
-    {:noreply,
-     socket
-     |> assign(:client_debug_messages, false)}
-  end
-
   def handle_event("force-error-log", _event, socket) do
     p = Account.get_client_by_id(socket.assigns.id) |> Map.get(:tcp_pid)
     send(p, :error_log)

--- a/lib/teiserver_web/live/clients/show.html.heex
+++ b/lib/teiserver_web/live/clients/show.html.heex
@@ -57,32 +57,6 @@
         <br />
 
         <div class="float-end">
-          <%= if @server_debug_messages do %>
-            <span class={"btn btn-#{bsname} mx-2"} phx-click="disable-server-message-logging">
-              Disable server message logging
-            </span>
-          <% else %>
-            <span
-              class={"btn btn-outline-#{bsname} mx-2"}
-              phx-click="enable-server-message-logging"
-            >
-              Enable server message logging
-            </span>
-          <% end %>
-
-          <%= if @client_debug_messages do %>
-            <span class={"btn btn-#{bsname} mx-2"} phx-click="disable-client-message-logging">
-              Disable client message logging
-            </span>
-          <% else %>
-            <span
-              class={"btn btn-outline-#{bsname} mx-2"}
-              phx-click="enable-client-message-logging"
-            >
-              Enable client message logging
-            </span>
-          <% end %>
-
           <%= if @client != nil and @client.lobby_client == "LuaLobby Chobby" do %>
             <span class="btn btn-warning mx-2" phx-click="force-error-log">
               Error log

--- a/priv/repo/migrations/20260707101652_expand_user_fields.exs
+++ b/priv/repo/migrations/20260707101652_expand_user_fields.exs
@@ -1,0 +1,17 @@
+defmodule Teiserver.Repo.Migrations.ExpandUserFields do
+  use Ecto.Migration
+
+  def change do
+    alter table(:account_users) do
+      add :rank, :integer, default: 0
+      add :country, :text, default: "??"
+      add :bot, :boolean, default: false
+      add :email_change_code, :text
+      add :last_login_mins, :integer
+      add :lobby_hash, :text
+      add :chobby_hash, :text
+      add :lobby_client, :text
+      add :discord_dm_channel, :bigint
+    end
+  end
+end

--- a/test/support/teiserver_test_lib.ex
+++ b/test/support/teiserver_test_lib.ex
@@ -235,8 +235,6 @@ defmodule Teiserver.TeiserverTestLib do
       room_member_cache: %{},
       known_users: %{},
       known_battles: [],
-      print_client_messages: false,
-      print_server_messages: false,
       exempt_from_cmd_throttle: true,
       script_password: nil,
       last_message_invalid: false
@@ -267,8 +265,6 @@ defmodule Teiserver.TeiserverTestLib do
       room_member_cache: %{},
       known_users: %{},
       known_battles: [],
-      print_client_messages: false,
-      print_server_messages: false,
       exempt_from_cmd_throttle: true,
       script_password: nil,
       last_message_invalid: false
@@ -303,8 +299,6 @@ defmodule Teiserver.TeiserverTestLib do
       room_member_cache: %{},
       known_users: %{},
       known_battles: [],
-      print_client_messages: false,
-      print_server_messages: false,
       exempt_from_cmd_throttle: true,
       script_password: nil,
       last_message_invalid: false

--- a/test/teiserver/account/cache_user_test.exs
+++ b/test/teiserver/account/cache_user_test.exs
@@ -1,0 +1,52 @@
+defmodule Teiserver.Account.CacheUserTest do
+  alias Teiserver.Account
+  alias Teiserver.AccountFixtures
+  alias Teiserver.CacheUser
+
+  use Teiserver.DataCase, async: true
+
+  test "persisting a user updates the extra fields" do
+    user = AccountFixtures.user_fixture()
+    cache_user = CacheUser.get_user_by_id(user.id)
+
+    # Update it without persisting the change, we do not expect
+    # it to update the database
+    cache_user = Map.merge(cache_user, %{rank: 3, lobby_hash: "blobby"})
+    cache_user = CacheUser.update_user(cache_user)
+
+    user = Account.get_user!(user.id)
+
+    # Assert the actual values, expect them to be different at this stage
+    assert {cache_user.rank, user.rank} == {3, 0}
+    assert {cache_user.lobby_hash, user.lobby_hash} == {"blobby", nil}
+
+    # Now if we persist it we expect the two line up
+    cache_user =
+      Map.merge(cache_user, %{
+        rank: 2,
+        country: "DE",
+        bot: true,
+        email_change_code: "123",
+        last_login_mins: 123,
+        lobby_hash: "some-hash",
+        chobby_hash: "c-hash",
+        lobby_client: "client-name",
+        discord_dm_channel: 456
+      })
+
+    cache_user = CacheUser.update_user(cache_user, persist: true)
+
+    user = Account.get_user!(user.id)
+
+    # We assert as a tuple to make it easy to see where the difference lies when they differ
+    assert {cache_user.rank, user.rank} == {2, 2}
+    assert {cache_user.country, user.country} == {"DE", "DE"}
+    assert {cache_user.bot, user.bot} == {true, true}
+    assert {cache_user.email_change_code, user.email_change_code} == {"123", "123"}
+    assert {cache_user.last_login_mins, user.last_login_mins} == {123, 123}
+    assert {cache_user.lobby_hash, user.lobby_hash} == {"some-hash", "some-hash"}
+    assert {cache_user.chobby_hash, user.chobby_hash} == {"c-hash", "c-hash"}
+    assert {cache_user.lobby_client, user.lobby_client} == {"client-name", "client-name"}
+    assert {cache_user.discord_dm_channel, user.discord_dm_channel} == {456, 456}
+  end
+end

--- a/test/teiserver_web/live/account/profile/overview_test.exs
+++ b/test/teiserver_web/live/account/profile/overview_test.exs
@@ -109,7 +109,7 @@ defmodule TeiserverWeb.Live.Account.Profile.OverviewTest do
 
   defp login_user(user) do
     user
-    |> Map.merge(%{rank: 1, print_client_messages: false, print_server_messages: false})
+    |> Map.merge(%{rank: 1})
     |> Client.login(:spring, "127.0.0.1")
   end
 end


### PR DESCRIPTION
This is the first stage of removing the CacheUser struct. It aims to allow User structs to be used in place of CacheUser structs without needing to change any other code.

For day to day running the data will be double-written, first to the existing column in the data field but then also to the new extra columns. For users not currently active there is a long running function which will allow the entire table to be updated.

This commit is expected to introduce no behavioural changes to the general system aside from the double-writing of the user data.