### PR TITLE
fix: tailwind classes missing in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,10 +53,10 @@ RUN mix deps.compile
 
 COPY priv priv
 COPY assets assets
+COPY lib lib
 RUN mix assets.deploy
 
 # Compile for prod
-COPY lib lib
 RUN mix compile
 
 # Create release files


### PR DESCRIPTION
## Description

Tailwind builds its classes by parsing templates in `lib/`

https://github.com/beyond-all-reason/teiserver/blob/7c8647e393d3d1443b827f3f63dba0bb3fffc316/assets/css/app.css#L7

However, the Docker build copies `lib/` only AFTER `assets.deploy` runs. Which is the part that runs the Tailwind build script.

https://github.com/beyond-all-reason/teiserver/blob/7c8647e393d3d1443b827f3f63dba0bb3fffc316/Dockerfile#L56-L59

This PR reorders those steps, so that `lib` is copied in first, before the tailwind build.

I'm not 100% sure of what knock-on effects this could cause and whether it's important that the `lib/` folder was copied in only after the `assets.deploy` step.

fixes #1340 
related to #1335