### PR TITLE
Add github CI for image building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,12 +4,9 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
-    inputs:
-      tags:
-        description: Tag to push the image with
-        required: false
-        type: string
+  release:
+    types:
+      - published
 
 jobs:
   build:
@@ -34,7 +31,7 @@ jobs:
         buildah push $IMAGE:latest
 
     - name: Build tagged image
-      if: inputs.tags
+      if: github.event_name == 'release'
       run: |
-        buildah bud -t $IMAGE:${{ inputs.tags }} .
-        buildah push $IMAGE:${{ inputs.tags }}
+        buildah bud -t $IMAGE:${{ github.event.release.tag_name }} .
+        buildah push $IMAGE:${{ github.event.release.tag_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,6 @@ jobs:
     - name: Push sha tagged image
       run: buildah push $IMAGE:latest $IMAGE:${{ github.sha }}
 
-    - name: Push tagged image
+    - name: Push release tagged image
       if: github.event_name == 'release'
       run: buildah push $IMAGE:latest $IMAGE:${{ github.event.release.tag_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,8 @@ jobs:
       contents: read
     env:
       REGISTRY: ghcr.io
-      IMAGE: ghcr.io/${{ github.repository }}
+#      IMAGE: ghcr.io/${{ github.repository }}
+      IMAGE: ghcr.io/chocobocoding/teiserver
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,7 @@ jobs:
       contents: read
     env:
       REGISTRY: ghcr.io
-#      IMAGE: ghcr.io/${{ github.repository }}
-      IMAGE: ghcr.io/chocobocoding/teiserver
+      IMAGE: ghcr.io/${{ github.repository }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,13 +25,15 @@ jobs:
     - name: Login to registry
       run: buildah login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} $REGISTRY
 
-    - name: Build latest image
-      run: |
-        buildah bud -t $IMAGE:latest .
-        buildah push $IMAGE:latest
+    - name: Build image
+      run: buildah bud -t $IMAGE:latest .
 
-    - name: Build tagged image
+    - name: Push latest image
+      run: buildah push $IMAGE:latest
+
+    - name: Push sha tagged image
+      run: buildah push $IMAGE:latest $IMAGE:${{ github.sha }}
+
+    - name: Push tagged image
       if: github.event_name == 'release'
-      run: |
-        buildah bud -t $IMAGE:${{ github.event.release.tag_name }} .
-        buildah push $IMAGE:${{ github.event.release.tag_name }}
+      run: buildah push $IMAGE:latest $IMAGE:${{ github.event.release.tag_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: build prod container image and push to registry
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: Tag to push the image with
+        required: false
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build prod container
+    permissions:
+      packages: write
+      contents: read
+    env:
+      REGISTRY: ghcr.io
+      IMAGE: ghcr.io/${{ github.repository }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Login to registry
+      run: buildah login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} $REGISTRY
+
+    - name: Build latest image
+      run: |
+        buildah bud -t $IMAGE:latest .
+        buildah push $IMAGE:latest
+
+    - name: Build tagged image
+      if: inputs.tags
+      run: |
+        buildah bud -t $IMAGE:${{ inputs.tags }} .
+        buildah push $IMAGE:${{ inputs.tags }}


### PR DESCRIPTION
The github CI creates a container image 
- tagged `latest` on push to main
- tagged `latest` and `release tag` on tagged releases

Adresses https://github.com/beyond-all-reason/ansible-teiserver/issues/13

I've used `buildah` instead of `podman build` as I am more familiar with that, but I don't mind changing it to use podman if desired.

Building and pushing of the correctly tagged images worked on my fork, and it seemed to run fine when run in a podman container

EDIT: Tests https://github.com/chocobocoding/teiserver/pkgs/container/teiserver