### PR TITLE
Make the database in container usable for local dev

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -80,13 +80,17 @@ services:
   database:
     image: postgres:17.10
     container_name: teiserver-database
+    command: -c 'max_connections=200'
     environment:
       - POSTGRES_DB=teiserver_dev
       - POSTGRES_USER=teiserver_dev
       - POSTGRES_PASSWORD=123456789
     volumes:
+      - ./containers/init-multiple-databases.sh:/docker-entrypoint-initdb.d/init-multiple-databases.sh
       - ./containers/database:/var/lib/postgresql
     restart: unless-stopped
+    ports:
+      - "5432:5432"
 
   mailserver:
     image: "axllent/mailpit"

--- a/containers/init-multiple-databases.sh
+++ b/containers/init-multiple-databases.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Adapted from https://github.com/mrts/docker-postgresql-multiple-databases/blob/master/create-multiple-postgresql-databases.sh
+
+set -euo pipefail
+
+function create_user_and_database() {
+  local database=$1
+  echo "  Creating user and database '$database'"
+  echo "  using username $POSTGRES_USER"
+  psql --username "$POSTGRES_USER" <<-EOSQL
+    DO \$\$
+    BEGIN
+      IF EXISTS (SELECT FROM pg_user WHERE  usename = '$database') THEN
+        RAISE NOTICE 'SKIP ROLE MAKER!';
+      ELSE
+        CREATE ROLE $database LOGIN PASSWORD '$POSTGRES_PASSWORD' SUPERUSER;
+      END IF;
+    END
+    \$\$;
+    CREATE DATABASE $database;
+    GRANT ALL PRIVILEGES ON DATABASE $database TO $database;
+EOSQL
+}
+
+create_user_and_database teiserver_dev
+create_user_and_database teiserver_test


### PR DESCRIPTION
This allow one to access it from the host, and also creates a test database in the same container.
This way, one can run `mix test` from the host with the db running in a container and everything works out.