### PR TITLE
Remove a dead link to the ratings progression page

### DIFF
--- a/lib/teiserver_web/live/battles/match/match_components.ex
+++ b/lib/teiserver_web/live/battles/match/match_components.ex
@@ -32,15 +32,6 @@ defmodule TeiserverWeb.Battle.MatchComponents do
       Ratings
     </.section_menu_button>
 
-    <.section_menu_button
-      bsname={@view_colour}
-      icon={StylingHelper.icon(:chart)}
-      active={@active == "progression"}
-      url={~p"/battle/progression"}
-    >
-      Progression
-    </.section_menu_button>
-
     <%= if @match_id do %>
       <.section_menu_button
         bsname={@view_colour}


### PR DESCRIPTION
This page was removed (potentially in error) as part of a previous PR but has always been an at best infrequently used page which we plan to remove in the future so the preference is to remove the link rather than cherry-pick-revert the previous PR.