### PR TITLE
Update code of conduct reference in error message

### DIFF
--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -359,7 +359,7 @@ defmodule Teiserver.CacheUser do
         {:error, "That name is in restricted for use by the server, please choose another"}
 
       admin_action == false and WordLib.acceptable_name?(name) == false ->
-        {:error, "Not an acceptable name, please see section 1.4 of the code of conduct"}
+        {:error, "Not an acceptable name, please see section B3 of the code of conduct"}
 
       clean_name(name) |> String.length() > max_username_length ->
         {:error, "Max length #{max_username_length} characters"}


### PR DESCRIPTION
The code of conduct does not have a section 1.4. The correct reference is B3.
<img width="536" height="97" alt="image" src="https://github.com/user-attachments/assets/d7a8b21f-7be7-4d03-aeed-4d8bb21f7d2c" />
