### PR TITLE
Mark many CacheUser functions as deprecated

### DIFF
--- a/lib/teiserver/account.ex
+++ b/lib/teiserver/account.ex
@@ -2150,29 +2150,26 @@ defmodule Teiserver.Account do
   @spec get_userid_from_name(String.t()) :: integer() | nil
   def get_userid_from_name(name), do: UserCacheLib.get_userid(name)
 
-  @spec get_user_by_name(String.t()) :: T.user() | nil
-  defdelegate get_user_by_name(username), to: UserCacheLib
+  @spec deprecated_get_user_by_name(String.t()) :: T.user() | nil
+  defdelegate deprecated_get_user_by_name(username), to: UserCacheLib
 
-  @spec get_user_by_email(String.t()) :: T.user() | nil
-  defdelegate get_user_by_email(email), to: UserCacheLib
+  @spec deprecated_get_user_by_email(String.t()) :: T.user() | nil
+  defdelegate deprecated_get_user_by_email(email), to: UserCacheLib
 
-  @spec get_user_by_discord_id(String.t()) :: T.user() | nil
-  defdelegate get_user_by_discord_id(discord_id), to: UserCacheLib
+  @spec deprecated_get_user_by_discord_id(String.t()) :: T.user() | nil
+  defdelegate deprecated_get_user_by_discord_id(discord_id), to: UserCacheLib
 
   @spec get_userid_by_discord_id(String.t()) :: User.id() | nil
   defdelegate get_userid_by_discord_id(discord_id), to: UserCacheLib
 
-  @spec get_user_by_token(String.t()) :: T.user() | nil
-  defdelegate get_user_by_token(token), to: UserCacheLib
-
-  @spec get_user_by_id(User.id()) :: T.user() | nil
-  defdelegate get_user_by_id(id), to: UserCacheLib
+  @spec deprecated_get_user_by_id(User.id()) :: T.user() | nil
+  defdelegate deprecated_get_user_by_id(id), to: UserCacheLib
 
   @spec list_users_from_cache(list) :: list
-  def list_users_from_cache(id_list), do: UserCacheLib.list_users(id_list)
+  def list_users_from_cache(id_list), do: UserCacheLib.deprecated_list_users(id_list)
 
-  @spec recache_user(User.id() | User.t()) :: :ok
-  defdelegate recache_user(id), to: UserCacheLib
+  @spec deprecated_recache_user(User.id() | User.t()) :: :ok
+  defdelegate deprecated_recache_user(id), to: UserCacheLib
 
   @spec convert_user(T.user()) :: T.user()
   defdelegate convert_user(user), to: UserCacheLib

--- a/lib/teiserver/account/caches/user_cache_lib.ex
+++ b/lib/teiserver/account/caches/user_cache_lib.ex
@@ -2,7 +2,6 @@ defmodule Teiserver.Account.UserCacheLib do
   @moduledoc false
 
   alias Teiserver.Account
-  alias Teiserver.Account.Guardian
   alias Teiserver.Account.User
   alias Teiserver.CacheUser
   alias Teiserver.Data.Types, as: T
@@ -20,7 +19,7 @@ defmodule Teiserver.Account.UserCacheLib do
     userid = int_parse(userid)
 
     Teiserver.cache_get_or_store(:users_lookup_name_with_id, int_parse(userid), fn ->
-      case get_user_by_id(userid) do
+      case deprecated_get_user_by_id(userid) do
         nil -> nil
         user -> user.name
       end
@@ -48,27 +47,27 @@ defmodule Teiserver.Account.UserCacheLib do
           nil
 
         %{id: id} ->
-          recache_user(id)
+          deprecated_recache_user(id)
           id
       end
     end)
   end
 
-  @spec get_user_by_name(String.t() | nil) :: T.user() | nil
-  def get_user_by_name(nil), do: nil
-  def get_user_by_name(""), do: nil
+  @spec deprecated_get_user_by_name(String.t() | nil) :: T.user() | nil
+  def deprecated_get_user_by_name(nil), do: nil
+  def deprecated_get_user_by_name(""), do: nil
 
-  def get_user_by_name(username) do
+  def deprecated_get_user_by_name(username) do
     username
     |> get_userid()
-    |> get_user_by_id()
+    |> deprecated_get_user_by_id()
   end
 
-  @spec get_user_by_email(String.t()) :: T.user() | nil
-  def get_user_by_email(nil), do: nil
-  def get_user_by_email(""), do: nil
+  @spec deprecated_get_user_by_email(String.t()) :: T.user() | nil
+  def deprecated_get_user_by_email(nil), do: nil
+  def deprecated_get_user_by_email(""), do: nil
 
-  def get_user_by_email(email) do
+  def deprecated_get_user_by_email(email) do
     cachename_email = cachename(email)
 
     id =
@@ -86,33 +85,19 @@ defmodule Teiserver.Account.UserCacheLib do
             nil
 
           %{id: id} ->
-            recache_user(id)
+            deprecated_recache_user(id)
             id
         end
       end)
 
-    get_user_by_id(id)
+    deprecated_get_user_by_id(id)
   end
 
-  @spec get_user_by_token(String.t()) :: T.user() | nil
-  def get_user_by_token(nil), do: nil
-  def get_user_by_token(""), do: nil
+  @spec deprecated_get_user_by_id(User.id() | nil) :: T.user() | nil
+  def deprecated_get_user_by_id(nil), do: nil
+  def deprecated_get_user_by_id(""), do: nil
 
-  def get_user_by_token(token) do
-    case Guardian.resource_from_token(token) do
-      {:error, _bad_token} ->
-        nil
-
-      {:ok, db_user, _claims} ->
-        get_user_by_id(db_user.id)
-    end
-  end
-
-  @spec get_user_by_id(User.id() | nil) :: T.user() | nil
-  def get_user_by_id(nil), do: nil
-  def get_user_by_id(""), do: nil
-
-  def get_user_by_id(id) do
+  def deprecated_get_user_by_id(id) do
     id = int_parse(id)
 
     Teiserver.cache_get_or_store(:users, id, fn ->
@@ -140,32 +125,32 @@ defmodule Teiserver.Account.UserCacheLib do
           nil
 
         %{id: id} ->
-          recache_user(id)
+          deprecated_recache_user(id)
           id
       end
     end)
   end
 
-  @spec get_user_by_discord_id(String.t() | nil) :: T.user() | nil
-  def get_user_by_discord_id(nil), do: nil
-  def get_user_by_discord_id(""), do: nil
+  @spec deprecated_get_user_by_discord_id(String.t() | nil) :: T.user() | nil
+  def deprecated_get_user_by_discord_id(nil), do: nil
+  def deprecated_get_user_by_discord_id(""), do: nil
 
-  def get_user_by_discord_id(discord_id) do
+  def deprecated_get_user_by_discord_id(discord_id) do
     discord_id
     |> to_string()
     |> get_userid_by_discord_id()
-    |> get_user_by_id()
+    |> deprecated_get_user_by_id()
   end
 
-  @spec list_users(list) :: list
-  def list_users(id_list) do
+  @spec deprecated_list_users(list) :: list
+  def deprecated_list_users(id_list) do
     id_list
-    |> Enum.map(&get_user_by_id/1)
+    |> Enum.map(&deprecated_get_user_by_id/1)
     |> Enum.filter(fn user -> user != nil end)
   end
 
-  @spec recache_user(User.id() | CacheUser.t() | map()) :: :ok
-  def recache_user(id) when is_integer(id) do
+  @spec deprecated_recache_user(User.id() | CacheUser.t() | map()) :: :ok
+  def deprecated_recache_user(id) when is_integer(id) do
     Teiserver.cache_delete(:account_user_cache, id)
     Teiserver.cache_delete(:account_user_cache_bang, id)
     Teiserver.cache_delete(:account_membership_cache, id)
@@ -181,8 +166,8 @@ defmodule Teiserver.Account.UserCacheLib do
     :ok
   end
 
-  def recache_user(user) do
-    Account.recache_user(user.id)
+  def deprecated_recache_user(user) do
+    Account.deprecated_recache_user(user.id)
 
     user
     |> convert_user()
@@ -252,7 +237,7 @@ defmodule Teiserver.Account.UserCacheLib do
   def add_user(nil), do: nil
 
   def add_user(user) do
-    update_user(user)
+    deprecated_update_user(user)
     Teiserver.cache_put(:users_lookup_name_with_id, user.id, user.name)
     Teiserver.cache_put(:users_lookup_id_with_name, cachename(user.name), user.id)
     Teiserver.cache_put(:users_lookup_id_with_email, cachename(user.email), user.id)
@@ -284,8 +269,9 @@ defmodule Teiserver.Account.UserCacheLib do
     Account.script_update_user(db_user, Map.put(obj_attrs, "data", data))
   end
 
-  @spec update_user(CacheUser.t() | map(), [persist: boolean()] | nil) :: CacheUser.t() | map()
-  def update_user(user, opts \\ []) do
+  @spec deprecated_update_user(CacheUser.t() | map(), [persist: boolean()] | nil) ::
+          CacheUser.t() | map()
+  def deprecated_update_user(user, opts \\ []) do
     persist = Keyword.get(opts, :persist, false)
     Teiserver.cache_put(:users, user.id, user)
     if persist, do: persist_user(user)
@@ -294,7 +280,7 @@ defmodule Teiserver.Account.UserCacheLib do
 
   @spec update_cache_user(User.id(), map()) :: CacheUser.t() | map()
   def update_cache_user(userid, data) do
-    user = get_user_by_id(userid)
+    user = deprecated_get_user_by_id(userid)
     new_user = Map.merge(user, data)
     Teiserver.cache_put(:users, user.id, new_user)
     persist_user(new_user)
@@ -303,7 +289,7 @@ defmodule Teiserver.Account.UserCacheLib do
 
   @spec decache_user(User.id()) :: :ok | :no_user
   def decache_user(userid) do
-    user = get_user_by_id(userid)
+    user = deprecated_get_user_by_id(userid)
 
     # Teiserver.cache_delete(:users, userid)
     if user do

--- a/lib/teiserver/account/libs/client_lib.ex
+++ b/lib/teiserver/account/libs/client_lib.ex
@@ -279,7 +279,7 @@ defmodule Teiserver.Account.ClientLib do
   # not intended to be used as part of standard operation
   @spec refresh_client(User.id()) :: map()
   def refresh_client(userid) do
-    user = Account.get_user_by_id(userid)
+    user = Account.deprecated_get_user_by_id(userid)
     stats = Account.get_user_stat_data(user.id)
 
     client = get_client_by_id(userid)

--- a/lib/teiserver/account/libs/user_lib.ex
+++ b/lib/teiserver/account/libs/user_lib.ex
@@ -195,7 +195,7 @@ defmodule Teiserver.Account.UserLib do
 
   """
   def update_user(%User{} = user, attrs) do
-    Account.recache_user(user.id)
+    Account.deprecated_recache_user(user.id)
 
     user
     |> User.changeset(attrs, :limited_with_data)
@@ -204,7 +204,7 @@ defmodule Teiserver.Account.UserLib do
   end
 
   def update_user_plain_password(%User{} = user, attrs) do
-    Account.recache_user(user.id)
+    Account.deprecated_recache_user(user.id)
 
     user
     |> User.changeset(attrs, :password)
@@ -213,7 +213,7 @@ defmodule Teiserver.Account.UserLib do
   end
 
   def update_user_user_form(%User{} = user, attrs) do
-    Account.recache_user(user.id)
+    Account.deprecated_recache_user(user.id)
 
     user
     |> User.changeset(attrs, :user_form)
@@ -222,7 +222,7 @@ defmodule Teiserver.Account.UserLib do
   end
 
   def server_limited_update_user(%User{} = user, attrs) do
-    Account.recache_user(user.id)
+    Account.deprecated_recache_user(user.id)
 
     user
     |> User.changeset(attrs, :server_limited_update_user)
@@ -231,7 +231,7 @@ defmodule Teiserver.Account.UserLib do
   end
 
   def server_update_user(%User{} = user, attrs) do
-    Account.recache_user(user.id)
+    Account.deprecated_recache_user(user.id)
 
     user
     |> User.changeset(attrs)
@@ -240,7 +240,7 @@ defmodule Teiserver.Account.UserLib do
   end
 
   def script_update_user(%User{} = user, attrs) do
-    Account.recache_user(user.id)
+    Account.deprecated_recache_user(user.id)
 
     user
     |> User.changeset(attrs, :script)
@@ -249,7 +249,7 @@ defmodule Teiserver.Account.UserLib do
   end
 
   def password_reset_update_user(%User{} = user, attrs) do
-    Account.recache_user(user.id)
+    Account.deprecated_recache_user(user.id)
 
     user
     |> User.changeset(attrs, :password_reset)
@@ -507,7 +507,7 @@ defmodule Teiserver.Account.UserLib do
         with {:ok, _updated_user} <-
                script_update_user(smurf, %{"smurf_of_id" => actual_origin_id}),
              {:ok, %User{}} <- Auth.add_roles(origin.id, ["Smurfer"]),
-             :ok <- Account.recache_user(smurf.id) do
+             :ok <- Account.deprecated_recache_user(smurf.id) do
           add_audit_log(
             moderator_id,
             nil,

--- a/lib/teiserver/account/reports/accolade_report.ex
+++ b/lib/teiserver/account/reports/accolade_report.ex
@@ -93,7 +93,7 @@ defmodule Teiserver.Account.AccoladeReport do
     users =
       (giver_ids ++ recipient_ids ++ taker_userids ++ giver_userids)
       |> Enum.uniq()
-      |> Map.new(fn userid -> {userid, CacheUser.get_user_by_id(userid)} end)
+      |> Map.new(fn userid -> {userid, CacheUser.deprecated_get_user_by_id(userid)} end)
 
     assigns = %{
       counts: counts,

--- a/lib/teiserver/battle/libs/balance_lib.ex
+++ b/lib/teiserver/battle/libs/balance_lib.ex
@@ -662,7 +662,7 @@ defmodule Teiserver.Battle.BalanceLib do
     # which is permanent (and would be instantiated on login)
     # See application.ex for cache settings
 
-    %{name: name} = Account.get_user_by_id(userid)
+    %{name: name} = Account.deprecated_get_user_by_id(userid)
     %{rating: rating, rank: rank, name: name, uncertainty: uncertainty}
   end
 
@@ -673,7 +673,7 @@ defmodule Teiserver.Battle.BalanceLib do
     stats_data = Account.get_user_stat_data(userid)
     rank = Map.get(stats_data, "rank", 0)
 
-    %{name: name} = Account.get_user_by_id(userid)
+    %{name: name} = Account.deprecated_get_user_by_id(userid)
     %{rating: rating_value, rank: rank, name: name, uncertainty: uncertainty}
   end
 

--- a/lib/teiserver/battle/servers/match_monitor_server.ex
+++ b/lib/teiserver/battle/servers/match_monitor_server.ex
@@ -171,7 +171,7 @@ defmodule Teiserver.Battle.MatchMonitorServer do
 
   def handle_info({:direct_message, from_id, "broken_connection " <> username}, state) do
     if Auth.is_bot?(from_id) or Auth.admin?(from_id) or Auth.moderator?(from_id) do
-      user = Account.get_user_by_name(username)
+      user = Account.deprecated_get_user_by_name(username)
 
       if user do
         Telemetry.log_complex_server_event(user.id, "spads.broken_connection", %{from_id: from_id})
@@ -261,7 +261,7 @@ defmodule Teiserver.Battle.MatchMonitorServer do
     case Regex.run(~r/<(.*?)> (d|dallies|dspectators): (.+)$/, data) do
       [_all, username, to, msg] ->
         host = Client.get_client_by_id(from_id)
-        user = CacheUser.get_user_by_name(username)
+        user = CacheUser.deprecated_get_user_by_name(username)
 
         case to do
           "d" ->
@@ -299,7 +299,7 @@ defmodule Teiserver.Battle.MatchMonitorServer do
     case Regex.run(~r/<(.*?)>:<(.*?)> (d|dallies|dspectators): (.+)$/, data) do
       [_all, username, _user_num, to, msg] ->
         host = Client.get_client_by_id(from_id)
-        user = CacheUser.get_user_by_name(username)
+        user = CacheUser.deprecated_get_user_by_name(username)
 
         if host == nil do
           Logger.error("No host found for from_id: #{from_id} for message #{to}:#{msg}")
@@ -403,7 +403,7 @@ defmodule Teiserver.Battle.MatchMonitorServer do
   end
 
   defp handle_json_msg(%{"username" => username, "GPU" => _gpu} = contents, from_id) do
-    case CacheUser.get_user_by_name(username) do
+    case CacheUser.deprecated_get_user_by_name(username) do
       nil ->
         Logger.warning(
           "No username on handle_json_msg: #{username} - #{Kernel.inspect(contents)}"
@@ -527,7 +527,7 @@ defmodule Teiserver.Battle.MatchMonitorServer do
           country_override: Application.get_env(:teiserver, Teiserver)[:server_flag]
         })
 
-        CacheUser.recache_user(account.id)
+        CacheUser.deprecated_recache_user(account.id)
         account
 
       account ->

--- a/lib/teiserver/bridge/bridge_server.ex
+++ b/lib/teiserver/bridge/bridge_server.ex
@@ -50,7 +50,7 @@ defmodule Teiserver.Bridge.BridgeServer do
 
   @spec send_direct_message(User.id(), String.t()) :: :ok | nil
   def send_direct_message(userid, message) do
-    user = Account.get_user_by_id(userid)
+    user = Account.deprecated_get_user_by_id(userid)
 
     if user.discord_dm_channel && user.discord_dm_channel_id == nil do
       nil
@@ -445,7 +445,7 @@ defmodule Teiserver.Bridge.BridgeServer do
           country_override: Application.get_env(:teiserver, Teiserver)[:server_flag]
         })
 
-        CacheUser.recache_user(account.id)
+        CacheUser.deprecated_recache_user(account.id)
         account
 
       account ->

--- a/lib/teiserver/bridge/chat_commands.ex
+++ b/lib/teiserver/bridge/chat_commands.ex
@@ -20,7 +20,7 @@ defmodule Teiserver.Bridge.ChatCommands do
       }) do
     [cmd | remaining] = String.split(content, " ")
     remaining = Enum.join(remaining, " ")
-    user = Account.get_user_by_discord_id(author_id)
+    user = Account.deprecated_get_user_by_discord_id(author_id)
 
     if allow?(cmd, user) do
       handle_command({user, author_id, message_id}, cmd, remaining, channel_id)

--- a/lib/teiserver/bridge/commands/post_command.ex
+++ b/lib/teiserver/bridge/commands/post_command.ex
@@ -109,7 +109,7 @@ defmodule Teiserver.Bridge.Commands.PostCommand do
         "profile" ->
           name = args.value
 
-          case Account.get_user_by_name(name) do
+          case Account.deprecated_get_user_by_name(name) do
             nil ->
               "User \"#{name}\" not found"
 

--- a/lib/teiserver/bridge/message_commands.ex
+++ b/lib/teiserver/bridge/message_commands.ex
@@ -24,10 +24,11 @@ defmodule Teiserver.Bridge.MessageCommands do
 
     [cmd | remaining] = String.split(content, " ")
     remaining = Enum.join(remaining, " ")
-    user = CacheUser.get_user_by_discord_id(author)
+    user = CacheUser.deprecated_get_user_by_discord_id(author)
 
     if user do
-      CacheUser.update_user(%{user | discord_dm_channel_id: channel, discord_dm_channel: channel},
+      CacheUser.deprecated_update_user(
+        %{user | discord_dm_channel_id: channel, discord_dm_channel: channel},
         persist: true
       )
     end
@@ -75,9 +76,9 @@ defmodule Teiserver.Bridge.MessageCommands do
 
         if given_code == correct_code do
           Teiserver.cache_delete(:discord_bridge_account_codes, userid)
-          user = CacheUser.get_user_by_id(userid)
+          user = CacheUser.deprecated_get_user_by_id(userid)
 
-          CacheUser.update_user(
+          CacheUser.deprecated_update_user(
             %{
               user
               | discord_id: discord_id,
@@ -87,7 +88,7 @@ defmodule Teiserver.Bridge.MessageCommands do
             persist: true
           )
 
-          CacheUser.recache_user(user.id)
+          CacheUser.deprecated_recache_user(user.id)
 
           reply(channel, "Congratulations, your accounts are now linked.")
         else

--- a/lib/teiserver/chat/chat_room_cache.ex
+++ b/lib/teiserver/chat/chat_room_cache.ex
@@ -50,7 +50,7 @@ defmodule Teiserver.Room do
 
   @spec can_join_room?(User.id(), String.t()) :: true | {false, String.t()}
   def can_join_room?(userid, room_name) do
-    user = Account.get_user_by_id(userid)
+    user = Account.deprecated_get_user_by_id(userid)
 
     cond do
       user == nil ->

--- a/lib/teiserver/communication/libs/discord_channel_lib.ex
+++ b/lib/teiserver/communication/libs/discord_channel_lib.ex
@@ -259,7 +259,7 @@ defmodule Teiserver.Communication.DiscordChannelLib do
   @spec send_discord_dm(User.id(), String.t()) :: map | nil | {:error, any()}
   def send_discord_dm(userid, message) do
     if use_discord?() do
-      user = Account.get_user_by_id(userid)
+      user = Account.deprecated_get_user_by_id(userid)
 
       cond do
         user == nil ->

--- a/lib/teiserver/coordinator/consul_commands.ex
+++ b/lib/teiserver/coordinator/consul_commands.ex
@@ -1083,7 +1083,9 @@ defmodule Teiserver.Coordinator.ConsulCommands do
           )
 
         "friends" ->
-          sender_friends = [senderid | CacheUser.get_user_by_id(senderid) |> Map.get(:friends)]
+          sender_friends = [
+            senderid | CacheUser.deprecated_get_user_by_id(senderid) |> Map.get(:friends)
+          ]
 
           all_possible_clients
           |> Enum.group_by(

--- a/lib/teiserver/coordinator/consul_server.ex
+++ b/lib/teiserver/coordinator/consul_server.ex
@@ -579,7 +579,7 @@ defmodule Teiserver.Coordinator.ConsulServer do
       [now | user_times]
       |> Enum.filter(fn cmd_ts -> cmd_ts > limiter end)
 
-    user = CacheUser.get_user_by_id(userid)
+    user = CacheUser.deprecated_get_user_by_id(userid)
 
     cond do
       Auth.admin?(user.id) or Auth.moderator?(user.id) ->
@@ -699,7 +699,7 @@ defmodule Teiserver.Coordinator.ConsulServer do
   defp request_user_change_status(_new_client, nil, _state), do: {false, nil}
 
   defp request_user_change_status(new_client, %{userid: userid} = existing, state) do
-    user = Account.get_user_by_id(userid)
+    user = Account.deprecated_get_user_by_id(userid)
     list_status = get_list_status(userid, state)
 
     # We were using this as there were concerns over an autoready feature, leaving it here for now
@@ -836,7 +836,7 @@ defmodule Teiserver.Coordinator.ConsulServer do
   @spec user_allowed_to_play?(User.id(), map()) :: boolean()
   defp user_allowed_to_play?(userid, state) do
     user_allowed_to_play?(
-      Account.get_user_by_id(userid),
+      Account.deprecated_get_user_by_id(userid),
       Account.get_client_by_id(userid),
       state
     )
@@ -1302,7 +1302,7 @@ defmodule Teiserver.Coordinator.ConsulServer do
   @spec log_command(map(), map()) :: map()
   def log_command(cmd, state) do
     message = "$ " <> command_as_message(cmd)
-    sender = CacheUser.get_user_by_id(cmd.senderid)
+    sender = CacheUser.deprecated_get_user_by_id(cmd.senderid)
     ChatLib.persist_message(sender, message, state.lobby_id, :say)
     state
   end

--- a/lib/teiserver/coordinator/coordinator_commands.ex
+++ b/lib/teiserver/coordinator/coordinator_commands.ex
@@ -129,7 +129,7 @@ defmodule Teiserver.Coordinator.CoordinatorCommands do
   end
 
   defp do_handle(%{command: "whoami", senderid: senderid} = _cmd, state) do
-    sender = CacheUser.get_user_by_id(senderid)
+    sender = CacheUser.deprecated_get_user_by_id(senderid)
     stats = Account.get_user_stat_data(senderid)
 
     # Hours should be rounded down to make it more
@@ -205,7 +205,7 @@ defmodule Teiserver.Coordinator.CoordinatorCommands do
   end
 
   defp do_handle(%{command: "whois", senderid: senderid, remaining: remaining} = _cmd, state) do
-    case CacheUser.get_user_by_name(remaining) do
+    case CacheUser.deprecated_get_user_by_name(remaining) do
       nil ->
         CacheUser.send_direct_message(
           state.userid,
@@ -214,7 +214,7 @@ defmodule Teiserver.Coordinator.CoordinatorCommands do
         )
 
       user ->
-        sender = CacheUser.get_user_by_id(senderid)
+        sender = CacheUser.deprecated_get_user_by_id(senderid)
         stats = Account.get_user_stat_data(user.id)
 
         previous_names =
@@ -373,7 +373,7 @@ defmodule Teiserver.Coordinator.CoordinatorCommands do
   end
 
   defp do_handle(%{command: "discord", senderid: senderid} = _cmd, state) do
-    sender = CacheUser.get_user_by_id(senderid)
+    sender = CacheUser.deprecated_get_user_by_id(senderid)
 
     cond do
       sender.discord_id != nil ->
@@ -406,7 +406,7 @@ defmodule Teiserver.Coordinator.CoordinatorCommands do
     do: do_handle(%{cmd | command: "mute"}, state)
 
   defp do_handle(%{command: "mute", senderid: senderid, remaining: remaining} = _cmd, state) do
-    case CacheUser.get_user_by_name(remaining) do
+    case CacheUser.deprecated_get_user_by_name(remaining) do
       nil ->
         Coordinator.send_to_user(
           senderid,
@@ -440,7 +440,7 @@ defmodule Teiserver.Coordinator.CoordinatorCommands do
     do: do_handle(%{cmd | command: "unmute"}, state)
 
   defp do_handle(%{command: "unmute", senderid: senderid, remaining: remaining} = _cmd, state) do
-    case CacheUser.get_user_by_name(remaining) do
+    case CacheUser.deprecated_get_user_by_name(remaining) do
       nil ->
         Coordinator.send_to_user(
           senderid,

--- a/lib/teiserver/coordinator/coordinator_server.ex
+++ b/lib/teiserver/coordinator/coordinator_server.ex
@@ -161,7 +161,7 @@ defmodule Teiserver.Coordinator.CoordinatorServer do
         CacheUser.send_direct_message(state.userid, userid, "Thank you")
 
       _other_message ->
-        user = CacheUser.get_user_by_id(userid)
+        user = CacheUser.deprecated_get_user_by_id(userid)
         Logger.info("CoordinatorServer unhandled DM from #{user.name} of: #{message}")
 
         if not Auth.is_bot?(user) do
@@ -208,7 +208,7 @@ defmodule Teiserver.Coordinator.CoordinatorServer do
   def handle_info(%{channel: "client_inout"}, state), do: {:noreply, state}
 
   def handle_info({:do_client_inout, :login, userid}, state) do
-    user = CacheUser.get_user_by_id(userid)
+    user = CacheUser.deprecated_get_user_by_id(userid)
     db_user = Account.get_user(userid)
 
     if user do
@@ -356,7 +356,7 @@ defmodule Teiserver.Coordinator.CoordinatorServer do
           country_override: Application.get_env(:teiserver, Teiserver)[:server_flag]
         })
 
-        CacheUser.recache_user(account.id)
+        CacheUser.deprecated_recache_user(account.id)
         account
 
       account ->

--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -287,7 +287,7 @@ defmodule Teiserver.CacheUser do
   end
 
   def register_bot(bot_name, bot_host_id) do
-    existing_bot = get_user_by_name(bot_name)
+    existing_bot = deprecated_get_user_by_name(bot_name)
 
     cond do
       allow?(bot_host_id, :moderator) == false ->
@@ -297,7 +297,7 @@ defmodule Teiserver.CacheUser do
         existing_bot
 
       true ->
-        host = get_user_by_id(bot_host_id)
+        host = deprecated_get_user_by_id(bot_host_id)
 
         params =
           user_register_params_with_md5(bot_name, host.email, host.password, %{
@@ -407,7 +407,7 @@ defmodule Teiserver.CacheUser do
   defp do_rename_user(userid, new_name) do
     client = Account.get_client_by_id(userid)
 
-    user = get_user_by_id(userid)
+    user = deprecated_get_user_by_id(userid)
     old_name = user.name
 
     set_flood_level(user.id, 10)
@@ -429,7 +429,7 @@ defmodule Teiserver.CacheUser do
     })
 
     # We need to re-get the user to ensure we don't overwrite our banned flag
-    user = get_user_by_id(userid)
+    user = deprecated_get_user_by_id(userid)
     decache_user(user.id)
 
     db_user = Account.get_user!(userid)
@@ -440,7 +440,7 @@ defmodule Teiserver.CacheUser do
     end
 
     Teiserver.cache_delete(:users_lookup_id_with_name, old_name)
-    recache_user(userid)
+    deprecated_recache_user(userid)
     :ok
   end
 
@@ -456,7 +456,7 @@ defmodule Teiserver.CacheUser do
     Account.update_user(db_user, %{"name" => new_name})
 
     :timer.sleep(100)
-    recache_user(userid)
+    deprecated_recache_user(userid)
     :ok
   end
 
@@ -464,10 +464,10 @@ defmodule Teiserver.CacheUser do
   def request_email_change(nil, _new_email), do: {:error, "no user"}
 
   def request_email_change(user, new_email) do
-    case get_user_by_email(new_email) do
+    case deprecated_get_user_by_email(new_email) do
       nil ->
         code = :rand.uniform(899_999) + 100_000
-        {:ok, update_user(%{user | email_change_code: ["#{code}", new_email]})}
+        {:ok, deprecated_update_user(%{user | email_change_code: ["#{code}", new_email]})}
 
       _existing_user ->
         {:error, "Email already in use"}
@@ -477,7 +477,10 @@ defmodule Teiserver.CacheUser do
   @spec change_email(T.user(), String.t()) :: T.user()
   def change_email(user, new_email) do
     decache_user(user.id)
-    update_user(%{user | email: new_email, email_change_code: [nil, nil]}, persist: true)
+
+    deprecated_update_user(%{user | email: new_email, email_change_code: [nil, nil]},
+      persist: true
+    )
   end
 
   # Cache functions
@@ -487,29 +490,26 @@ defmodule Teiserver.CacheUser do
   @spec get_userid(String.t()) :: integer() | nil
   defdelegate get_userid(username), to: UserCacheLib
 
-  @spec get_user_by_name(String.t()) :: T.user() | nil
-  defdelegate get_user_by_name(username), to: UserCacheLib
+  @spec deprecated_get_user_by_name(String.t()) :: T.user() | nil
+  defdelegate deprecated_get_user_by_name(username), to: UserCacheLib
 
-  @spec get_user_by_email(String.t()) :: T.user() | nil
-  defdelegate get_user_by_email(email), to: UserCacheLib
+  @spec deprecated_get_user_by_email(String.t()) :: T.user() | nil
+  defdelegate deprecated_get_user_by_email(email), to: UserCacheLib
 
-  @spec get_user_by_discord_id(String.t()) :: T.user() | nil
-  defdelegate get_user_by_discord_id(discord_id), to: UserCacheLib
+  @spec deprecated_get_user_by_discord_id(String.t()) :: T.user() | nil
+  defdelegate deprecated_get_user_by_discord_id(discord_id), to: UserCacheLib
 
   @spec get_userid_by_discord_id(String.t()) :: User.id() | nil
   defdelegate get_userid_by_discord_id(discord_id), to: UserCacheLib
 
-  @spec get_user_by_token(String.t()) :: T.user() | nil
-  defdelegate get_user_by_token(token), to: UserCacheLib
+  @spec deprecated_get_user_by_id(User.id()) :: T.user() | nil
+  defdelegate deprecated_get_user_by_id(id), to: UserCacheLib
 
-  @spec get_user_by_id(User.id()) :: T.user() | nil
-  defdelegate get_user_by_id(id), to: UserCacheLib
+  @spec deprecated_list_users(list) :: list
+  defdelegate deprecated_list_users(id_list), to: UserCacheLib
 
-  @spec list_users(list) :: list
-  defdelegate list_users(id_list), to: UserCacheLib
-
-  @spec recache_user(Integer.t()) :: :ok
-  defdelegate recache_user(id), to: UserCacheLib
+  @spec deprecated_recache_user(Integer.t()) :: :ok
+  defdelegate deprecated_recache_user(id), to: UserCacheLib
 
   @spec convert_user(T.user()) :: T.user()
   defdelegate convert_user(user), to: UserCacheLib
@@ -517,8 +517,8 @@ defmodule Teiserver.CacheUser do
   @spec add_user(T.user()) :: T.user()
   defdelegate add_user(user), to: UserCacheLib
 
-  @spec update_user(T.user(), [persist: boolean()] | nil) :: T.user()
-  defdelegate update_user(user, persist \\ []), to: UserCacheLib
+  @spec deprecated_update_user(T.user(), [persist: boolean()] | nil) :: T.user()
+  defdelegate deprecated_update_user(user, persist \\ []), to: UserCacheLib
 
   @spec decache_user(User.id()) :: :ok | :no_user
   defdelegate decache_user(userid), to: UserCacheLib
@@ -705,7 +705,7 @@ defmodule Teiserver.CacheUser do
 
   @spec internal_client_login(User.id()) :: {:ok, T.user(), T.client()} | :error
   def internal_client_login(userid) do
-    case get_user_by_id(userid) do
+    case deprecated_get_user_by_id(userid) do
       nil ->
         :error
 
@@ -740,7 +740,7 @@ defmodule Teiserver.CacheUser do
         {:error, "token_login_failed"}
 
       {:ok, db_user, _claims} ->
-        user = get_user_by_id(db_user.id)
+        user = deprecated_get_user_by_id(db_user.id)
 
         cond do
           user.smurf_of_id != nil ->
@@ -823,7 +823,7 @@ defmodule Teiserver.CacheUser do
   def try_md5_login(username, md5_password, ip, lobby, lobby_hash) do
     wait_for_startup()
 
-    case get_user_by_name(username) do
+    case deprecated_get_user_by_name(username) do
       nil ->
         {:error, "No user found for '#{username}'"}
 
@@ -831,7 +831,7 @@ defmodule Teiserver.CacheUser do
         # # If they're a smurf, log them in as the smurf!
         # {user, username} =
         #   if user.smurf_of_id != nil do
-        #     origin_user = get_user_by_id(user.smurf_of_id)
+        #     origin_user = deprecated_get_user_by_id(user.smurf_of_id)
 
         #     {origin_user, origin_user.name}
         #   else
@@ -1030,7 +1030,7 @@ defmodule Teiserver.CacheUser do
         lobby_hash: lobby_hash
     }
 
-    update_user(user, persist: true)
+    deprecated_update_user(user, persist: true)
 
     Account.update_user_stat(user.id, %{
       bot: bot?,
@@ -1103,7 +1103,7 @@ defmodule Teiserver.CacheUser do
   def shadowbanned?(nil), do: true
 
   def shadowbanned?(userid) when is_integer(userid),
-    do: shadowbanned?(get_user_by_id(userid))
+    do: shadowbanned?(deprecated_get_user_by_id(userid))
 
   def shadowbanned?(%{shadowbanned: true}), do: true
   def shadowbanned?(_user), do: false
@@ -1204,7 +1204,7 @@ defmodule Teiserver.CacheUser do
   def allow?(nil, _required), do: false
 
   def allow?(userid, required) when is_integer(userid),
-    do: allow?(get_user_by_id(userid), required)
+    do: allow?(deprecated_get_user_by_id(userid), required)
 
   def allow?(user, required) do
     db_user = Account.get_user(user.id)
@@ -1262,7 +1262,7 @@ defmodule Teiserver.CacheUser do
   """
   def compare_to_db_user(user_id) do
     db_user = Account.get_user!(user_id)
-    cache_user = get_user_by_id(user_id)
+    cache_user = deprecated_get_user_by_id(user_id)
 
     cache_user
     |> Map.keys()

--- a/lib/teiserver/data/hook_server.ex
+++ b/lib/teiserver/data/hook_server.ex
@@ -83,10 +83,10 @@ defmodule Teiserver.HookServer do
         nil
 
       :create_user ->
-        CacheUser.recache_user(payload.id)
+        CacheUser.deprecated_recache_user(payload.id)
 
       :update_user ->
-        CacheUser.recache_user(payload.id)
+        CacheUser.deprecated_recache_user(payload.id)
 
       :create_report ->
         :ok

--- a/lib/teiserver/lobby.ex
+++ b/lib/teiserver/lobby.ex
@@ -329,7 +329,7 @@ defmodule Teiserver.Lobby do
 
   @spec kick_user_from_battle(User.id(), T.lobby_id()) :: nil | :ok | {:error, any}
   def kick_user_from_battle(userid, lobby_id) do
-    user = Account.get_user_by_id(userid)
+    user = Account.deprecated_get_user_by_id(userid)
 
     if Auth.admin?(user) or Auth.moderator?(user) do
       :ok

--- a/lib/teiserver/lobby/libs/command_lib.ex
+++ b/lib/teiserver/lobby/libs/command_lib.ex
@@ -93,7 +93,7 @@ defmodule Teiserver.Lobby.CommandLib do
   @spec log_command(map, T.lobby_id()) :: any()
   def log_command(cmd, lobby_id) do
     message = "$ " <> command_as_message(cmd)
-    sender = Account.get_user_by_id(cmd.userid)
+    sender = Account.deprecated_get_user_by_id(cmd.userid)
     ChatLib.persist_message(sender, message, lobby_id, :say)
   end
 

--- a/lib/teiserver/mix_tasks/fake_data.ex
+++ b/lib/teiserver/mix_tasks/fake_data.ex
@@ -494,7 +494,7 @@ defmodule Mix.Tasks.Teiserver.Fakedata do
   end
 
   defp make_one_time_code do
-    root_user = Account.get_user_by_email("root@localhost")
+    root_user = Account.deprecated_get_user_by_email("root@localhost")
 
     Config.update_site_config("user.Enable one time links", "true")
 

--- a/lib/teiserver/moderation/tasks/refresh_user_restrictions_task.ex
+++ b/lib/teiserver/moderation/tasks/refresh_user_restrictions_task.ex
@@ -98,7 +98,7 @@ defmodule Teiserver.Moderation.RefreshUserRestrictionsTask do
   end
 
   defp update_client_with_restrictions(client, new_restrictions) do
-    Account.recache_user(client.userid)
+    Account.deprecated_recache_user(client.userid)
 
     if Enum.member?(new_restrictions, "All chat") or Enum.member?(new_restrictions, "Battle chat") do
       Coordinator.send_to_host(client.lobby_id, "!mute #{client.name}")

--- a/lib/teiserver/o_auth/tasks/gen_token.ex
+++ b/lib/teiserver/o_auth/tasks/gen_token.ex
@@ -35,9 +35,9 @@ defmodule Teiserver.OAuth.Tasks.GenToken do
   defp get_user(username_or_email) do
     user =
       if String.contains?(username_or_email, "@") do
-        UserCacheLib.get_user_by_email(username_or_email)
+        UserCacheLib.deprecated_get_user_by_email(username_or_email)
       else
-        UserCacheLib.get_user_by_name(username_or_email)
+        UserCacheLib.deprecated_get_user_by_name(username_or_email)
       end
 
     if is_nil(user) do

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -445,7 +445,7 @@ defmodule Teiserver.Player.TachyonHandler do
 
   def handle_command("user/info", "request", _message_id, msg, state) do
     user_id = msg["data"]["userId"]
-    user = Account.get_user_by_id(user_id)
+    user = Account.deprecated_get_user_by_id(user_id)
     db_user = Account.get_user(user_id)
 
     if user != nil do

--- a/lib/teiserver/plugs/basic_auth_bot_plug.ex
+++ b/lib/teiserver/plugs/basic_auth_bot_plug.ex
@@ -12,7 +12,7 @@ defmodule Teiserver.Plugs.BasicAuthBotPlug do
     with ["Basic " <> encoded] <- get_req_header(conn, "authorization"),
          {:ok, decoded} <- Base.decode64(encoded),
          [username, password] <- String.split(decoded, ":", parts: 2),
-         %{id: id} <- Account.get_user_by_name(username),
+         %{id: id} <- Account.deprecated_get_user_by_name(username),
          %User{} = db_user <- Account.get_user(id),
          true <- Auth.is_bot?(db_user),
          true <- Account.verify_plain_password(password, db_user.password) do

--- a/lib/teiserver/plugs/teiserver_plug.ex
+++ b/lib/teiserver/plugs/teiserver_plug.ex
@@ -16,7 +16,7 @@ defmodule Teiserver.ServerUserPlug do
 
   def call(%{assigns: %{current_user: current_user}} = conn, _opts) do
     userid = current_user.id
-    server_user = CacheUser.get_user_by_id(userid)
+    server_user = CacheUser.deprecated_get_user_by_id(userid)
 
     conn
     |> assign(:server_user, server_user)
@@ -33,7 +33,7 @@ defmodule Teiserver.ServerUserPlug do
 
   def live_call(%{assigns: %{current_user: current_user}} = socket) do
     userid = current_user.id
-    server_user = CacheUser.get_user_by_id(userid)
+    server_user = CacheUser.deprecated_get_user_by_id(userid)
 
     socket
     |> LiveViewUtils.assign(:server_user, server_user)

--- a/lib/teiserver/protocols/spring/spring_in.ex
+++ b/lib/teiserver/protocols/spring/spring_in.ex
@@ -345,7 +345,7 @@ defmodule Teiserver.Protocols.SpringIn do
   end
 
   defp do_handle("CONFIRMAGREEMENT", code, msg_id, %{unverified_id: userid} = state) do
-    case CacheUser.get_user_by_id(userid) do
+    case CacheUser.deprecated_get_user_by_id(userid) do
       nil ->
         Logger.error("CONFIRMAGREEMENT - No user found for ID of '#{userid}'")
         state
@@ -521,7 +521,7 @@ defmodule Teiserver.Protocols.SpringIn do
 
   defp do_handle("GETUSERID", data, msg_id, state) do
     if CacheUser.allow?(state.userid, :bot) do
-      target = CacheUser.get_user_by_name(data)
+      target = CacheUser.deprecated_get_user_by_name(data)
       hash = target.lobby_hash
       reply(:user_id, {data, hash, target.id}, msg_id, state)
     else

--- a/lib/teiserver/protocols/spring/spring_out.ex
+++ b/lib/teiserver/protocols/spring/spring_out.ex
@@ -485,7 +485,7 @@ defmodule Teiserver.Protocols.SpringOut do
 
   defp do_reply(:chat_message, {from_id, room_name, messages, state_user})
        when is_list(messages) do
-    from_user = Account.get_user_by_id(from_id)
+    from_user = Account.deprecated_get_user_by_id(from_id)
 
     if not Account.does_a_ignore_b?(state_user.id, from_id) or
          Auth.admin?(from_user) or

--- a/lib/teiserver/protocols/spring/spring_party_in.ex
+++ b/lib/teiserver/protocols/spring/spring_party_in.ex
@@ -39,7 +39,7 @@ defmodule Teiserver.Protocols.Spring.PartyIn do
     cmd_id = "c.party.invite_to_party"
 
     with [username] <- String.split(data) |> Enum.map(&String.trim/1),
-         user when not is_nil(user) <- UserCacheLib.get_user_by_name(username),
+         user when not is_nil(user) <- UserCacheLib.deprecated_get_user_by_name(username),
          # this check isn't great, it should be done in the party server
          # which is the source of truth for parties, but I'm taking a shortcut
          :ok <- if(state.party_id != nil, do: :ok, else: :not_in_party),
@@ -126,7 +126,7 @@ defmodule Teiserver.Protocols.Spring.PartyIn do
     cmd_id = "c.party.cancel_invite_to_party"
 
     with [username] <- String.split(data) |> Enum.map(&String.trim/1),
-         user when not is_nil(user) <- UserCacheLib.get_user_by_name(username),
+         user when not is_nil(user) <- UserCacheLib.deprecated_get_user_by_name(username),
          :ok <- if(state.party_id != nil, do: :ok, else: :not_in_party),
          :ok <- if(Account.client_exists?(user.id), do: :ok, else: :no_client) do
       party_id = state.party_id
@@ -209,7 +209,7 @@ defmodule Teiserver.Protocols.Spring.PartyIn do
         %{event: :updated_values, party_id: party_id, operation: {:member_added, userid}},
         state
       ) do
-    case UserCacheLib.get_user_by_id(userid) do
+    case UserCacheLib.deprecated_get_user_by_id(userid) do
       nil -> state
       user -> SpringOut.reply(:party, :member_added, {party_id, user.name}, message_id(), state)
     end
@@ -224,7 +224,7 @@ defmodule Teiserver.Protocols.Spring.PartyIn do
         :ok = PubSub.unsubscribe(Teiserver.PubSub, "teiserver_party:#{party_id}")
       end
 
-      case UserCacheLib.get_user_by_id(user_id) do
+      case UserCacheLib.deprecated_get_user_by_id(user_id) do
         nil ->
           state
 
@@ -240,7 +240,7 @@ defmodule Teiserver.Protocols.Spring.PartyIn do
         %{event: :updated_values, party_id: party_id, operation: {:member_removed, userid}},
         state
       ) do
-    case UserCacheLib.get_user_by_id(userid) do
+    case UserCacheLib.deprecated_get_user_by_id(userid) do
       nil ->
         state
 
@@ -253,7 +253,7 @@ defmodule Teiserver.Protocols.Spring.PartyIn do
         %{event: :updated_values, party_id: party_id, operation: {:invite_created, userid}},
         state
       ) do
-    case UserCacheLib.get_user_by_id(userid) do
+    case UserCacheLib.deprecated_get_user_by_id(userid) do
       nil ->
         state
 
@@ -269,7 +269,7 @@ defmodule Teiserver.Protocols.Spring.PartyIn do
     :ok = PubSub.unsubscribe(Teiserver.PubSub, "teiserver_party:#{party_id}")
 
     # chobby would like to receive a member_left message when the last member leaves
-    case UserCacheLib.get_user_by_id(userid) do
+    case UserCacheLib.deprecated_get_user_by_id(userid) do
       nil ->
         state
 

--- a/lib/teiserver/protocols/spring/spring_user_in.ex
+++ b/lib/teiserver/protocols/spring/spring_user_in.ex
@@ -14,7 +14,7 @@ defmodule Teiserver.Protocols.Spring.UserIn do
       userids_str
       |> String.split("\t")
       |> Enum.map(fn n ->
-        case Account.get_user_by_id(n) do
+        case Account.deprecated_get_user_by_id(n) do
           nil ->
             {n, :no_user}
 
@@ -34,7 +34,7 @@ defmodule Teiserver.Protocols.Spring.UserIn do
       userids_str
       |> String.split("\t")
       |> Enum.map(fn n ->
-        case Account.get_user_by_id(n) do
+        case Account.deprecated_get_user_by_id(n) do
           nil ->
             {n, :no_user}
 
@@ -64,7 +64,7 @@ defmodule Teiserver.Protocols.Spring.UserIn do
       userids_str
       |> String.split("\t")
       |> Enum.map(fn n ->
-        case Account.get_user_by_id(n) do
+        case Account.deprecated_get_user_by_id(n) do
           nil ->
             {n, :no_user}
 
@@ -84,7 +84,7 @@ defmodule Teiserver.Protocols.Spring.UserIn do
 
   def do_handle("whois", userid_str, msg_id, state) do
     result =
-      case Account.get_user_by_id(userid_str) do
+      case Account.deprecated_get_user_by_id(userid_str) do
         nil ->
           {:no_user, userid_str}
 
@@ -97,7 +97,7 @@ defmodule Teiserver.Protocols.Spring.UserIn do
 
   def do_handle("whoisName", userid_str, msg_id, state) do
     result =
-      case Account.get_user_by_name(userid_str) do
+      case Account.deprecated_get_user_by_name(userid_str) do
         nil ->
           {:no_user, userid_str}
 

--- a/lib/teiserver/tachyon/tasks/setup_apps.ex
+++ b/lib/teiserver/tachyon/tasks/setup_apps.ex
@@ -73,7 +73,7 @@ defmodule Teiserver.Tachyon.Tasks.SetupApps do
   end
 
   defp find_root_user! do
-    case Account.get_user_by_email("root@localhost") do
+    case Account.deprecated_get_user_by_email("root@localhost") do
       nil -> raise "Cannot find root user root@localhost, set it up first"
       root -> root
     end

--- a/lib/teiserver/tcp/spring/spring_tcp_server.ex
+++ b/lib/teiserver/tcp/spring/spring_tcp_server.ex
@@ -354,7 +354,7 @@ defmodule Teiserver.SpringTcpServer do
 
   # We were not able to login right away, instead we had to queue for a bit!
   def handle_info({:login_accepted, userid}, state) do
-    user = Account.get_user_by_id(userid)
+    user = Account.deprecated_get_user_by_id(userid)
     new_state = SpringOut.do_login_accepted(state, user, state.lobby)
 
     if state.lobby_hash == nil do
@@ -717,7 +717,7 @@ defmodule Teiserver.SpringTcpServer do
   end
 
   defp user_updated(fields, state) do
-    new_user = CacheUser.get_user_by_id(state.userid)
+    new_user = CacheUser.deprecated_get_user_by_id(state.userid)
     new_state = %{state | user: new_user}
 
     fields

--- a/lib/teiserver_web/controllers/account/session_controller.ex
+++ b/lib/teiserver_web/controllers/account/session_controller.ex
@@ -211,7 +211,7 @@ defmodule TeiserverWeb.Account.SessionController do
       if email == "" do
         %{id: -1}
       else
-        Account.get_user_by_email(email) || %{id: -1}
+        Account.deprecated_get_user_by_email(email) || %{id: -1}
       end
 
     existing_resets =

--- a/lib/teiserver_web/controllers/admin/accolade_controller.ex
+++ b/lib/teiserver_web/controllers/admin/accolade_controller.ex
@@ -33,7 +33,7 @@ defmodule TeiserverWeb.Admin.AccoladeController do
         order_by: "Newest first"
       )
 
-    user = Account.get_user_by_id(user_id)
+    user = Account.deprecated_get_user_by_id(user_id)
 
     conn
     |> assign(:accolades, accolades)

--- a/lib/teiserver_web/controllers/admin/match_controller.ex
+++ b/lib/teiserver_web/controllers/admin/match_controller.ex
@@ -94,7 +94,7 @@ defmodule TeiserverWeb.Admin.MatchController do
 
     total_pages = div(total_count - 1, limit) + 1
 
-    user = Account.get_user_by_id(userid)
+    user = Account.deprecated_get_user_by_id(userid)
 
     conn
     |> assign(:user, user)

--- a/lib/teiserver_web/controllers/admin/o_auth_application_controller.ex
+++ b/lib/teiserver_web/controllers/admin/o_auth_application_controller.ex
@@ -187,7 +187,7 @@ defmodule TeiserverWeb.Admin.OAuthApplicationController do
 
   # split the comma separated fields and map emails to users
   defp form_to_app(app, raw_scopes) do
-    user_id = Map.get(Account.get_user_by_email(app["owner_email"]) || %{}, :id)
+    user_id = Map.get(Account.deprecated_get_user_by_email(app["owner_email"]) || %{}, :id)
 
     scopes =
       Enum.filter(OAuth.allowed_scopes(), fn scope ->

--- a/lib/teiserver_web/controllers/admin/text_callback_controller.ex
+++ b/lib/teiserver_web/controllers/admin/text_callback_controller.ex
@@ -53,7 +53,9 @@ defmodule TeiserverWeb.Admin.TextCallbackController do
           order_by: "Newest first"
         )
         |> Enum.map(fn log ->
-          user = Account.get_user_by_discord_id(log.details["discord_user_id"]) || %{name: nil}
+          user =
+            Account.deprecated_get_user_by_discord_id(log.details["discord_user_id"]) ||
+              %{name: nil}
 
           channel =
             Communication.get_discord_channel("id:#{log.details["discord_channel_id"]}") ||

--- a/lib/teiserver_web/controllers/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/admin/user_controller.ex
@@ -206,7 +206,7 @@ defmodule TeiserverWeb.Admin.UserController do
             :data
           ])
 
-        cache_user = Account.get_user_by_id(user.id)
+        cache_user = Account.deprecated_get_user_by_id(user.id)
 
         extra_cache_keys =
           cache_user
@@ -650,7 +650,7 @@ defmodule TeiserverWeb.Admin.UserController do
           case action do
             "recache" ->
               RefreshUserRestrictionsTask.refresh_user(user.id)
-              CacheUser.recache_user(user.id)
+              CacheUser.deprecated_recache_user(user.id)
               {:ok, ""}
 
             "reset_flood_protection" ->
@@ -997,7 +997,7 @@ defmodule TeiserverWeb.Admin.UserController do
     end
 
     RefreshUserRestrictionsTask.refresh_user(user.id)
-    CacheUser.recache_user(user.id)
+    CacheUser.deprecated_recache_user(user.id)
 
     # Now we update stats for the origin
     smurf_count =
@@ -1122,7 +1122,7 @@ defmodule TeiserverWeb.Admin.UserController do
 
   @spec shadowban(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def shadowban(conn, %{"id" => id, "state" => state}) do
-    user = Account.get_user_by_id(id)
+    user = Account.deprecated_get_user_by_id(id)
 
     case UserLib.has_access(user, conn) do
       {true, _access} ->

--- a/lib/teiserver_web/controllers/api/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/api/admin/user_controller.ex
@@ -62,7 +62,7 @@ defmodule TeiserverWeb.API.Admin.UserController do
   end
 
   def refresh_token(conn, %{"email" => email}) do
-    with {:ok, user} <- get_user_by_email(email),
+    with {:ok, user} <- deprecated_get_user_by_email(email),
          :ok <- ensure_unprivileged(user),
          {:ok, app} <- get_generic_lobby_app(),
          {:ok, token} <- create_user_token(user, app) do
@@ -124,10 +124,10 @@ defmodule TeiserverWeb.API.Admin.UserController do
     end
   end
 
-  defp get_user_by_email(nil), do: {:error, :user_not_found}
-  defp get_user_by_email(""), do: {:error, :user_not_found}
+  defp deprecated_get_user_by_email(nil), do: {:error, :user_not_found}
+  defp deprecated_get_user_by_email(""), do: {:error, :user_not_found}
 
-  defp get_user_by_email(email) do
+  defp deprecated_get_user_by_email(email) do
     case Account.query_user(search: [email_lower: email]) do
       nil -> {:error, :user_not_found}
       user -> {:ok, user}

--- a/lib/teiserver_web/controllers/moderation/ban_controller.ex
+++ b/lib/teiserver_web/controllers/moderation/ban_controller.ex
@@ -223,7 +223,7 @@ defmodule TeiserverWeb.Moderation.BanController do
           |> List.flatten()
           |> Enum.map(fn %{user: user} -> user.id end)
           |> Enum.uniq()
-          |> Enum.map(fn userid -> Account.get_user_by_id(userid) end)
+          |> Enum.map(fn userid -> Account.deprecated_get_user_by_id(userid) end)
           |> Enum.reject(fn user ->
             Account.restricted?(user, ["Login"])
           end)

--- a/lib/teiserver_web/live/account/party/show.ex
+++ b/lib/teiserver_web/live/account/party/show.ex
@@ -25,7 +25,7 @@ defmodule TeiserverWeb.Account.PartyLive.Show do
         []
       end
 
-    user = Account.get_user_by_id(socket.assigns.current_user.id)
+    user = Account.deprecated_get_user_by_id(socket.assigns.current_user.id)
     friends = Account.list_friend_ids_of_user(socket.assigns.current_user.id)
 
     :ok =

--- a/lib/teiserver_web/live/account/profile/accolades.ex
+++ b/lib/teiserver_web/live/account/profile/accolades.ex
@@ -11,7 +11,7 @@ defmodule TeiserverWeb.Account.ProfileLive.Accolades do
   @impl Phoenix.LiveView
   def mount(%{"userid" => userid_str}, _session, socket) do
     userid = String.to_integer(userid_str)
-    user = Account.get_user_by_id(userid)
+    user = Account.deprecated_get_user_by_id(userid)
 
     socket =
       if is_nil(user) do

--- a/lib/teiserver_web/live/account/profile/appearance.ex
+++ b/lib/teiserver_web/live/account/profile/appearance.ex
@@ -10,7 +10,7 @@ defmodule TeiserverWeb.Account.ProfileLive.Appearance do
   @impl Phoenix.LiveView
   def mount(%{"userid" => userid_str}, _session, socket) do
     userid = String.to_integer(userid_str)
-    user = Account.get_user_by_id(userid)
+    user = Account.deprecated_get_user_by_id(userid)
 
     socket =
       if is_nil(user) do

--- a/lib/teiserver_web/live/account/profile/contributor.ex
+++ b/lib/teiserver_web/live/account/profile/contributor.ex
@@ -10,7 +10,7 @@ defmodule TeiserverWeb.Account.ProfileLive.Contributor do
   @impl Phoenix.LiveView
   def mount(%{"userid" => userid_str}, _session, socket) do
     userid = String.to_integer(userid_str)
-    user = Account.get_user_by_id(userid)
+    user = Account.deprecated_get_user_by_id(userid)
     hide_contributor_rank = Account.hide_contributor_rank?(userid)
 
     socket =
@@ -87,7 +87,7 @@ defmodule TeiserverWeb.Account.ProfileLive.Contributor do
         "bar_plus.flag" => assigns.temp_country_code
       })
 
-      Account.recache_user(assigns.user.id)
+      Account.deprecated_recache_user(assigns.user.id)
 
       {:noreply,
        socket
@@ -117,7 +117,7 @@ defmodule TeiserverWeb.Account.ProfileLive.Contributor do
       end
 
     Account.set_hide_contributor_rank(assigns.user.id, boolean_value)
-    Account.recache_user(assigns.user.id)
+    Account.deprecated_recache_user(assigns.user.id)
 
     {:noreply,
      socket

--- a/lib/teiserver_web/live/account/profile/matches.ex
+++ b/lib/teiserver_web/live/account/profile/matches.ex
@@ -15,7 +15,7 @@ defmodule TeiserverWeb.Account.ProfileLive.Matches do
   @impl Phoenix.LiveView
   def mount(%{"userid" => userid_str}, _session, socket) do
     userid = String.to_integer(userid_str)
-    user = Account.get_user_by_id(userid)
+    user = Account.deprecated_get_user_by_id(userid)
 
     socket =
       if is_nil(user) do

--- a/lib/teiserver_web/live/account/profile/overview.ex
+++ b/lib/teiserver_web/live/account/profile/overview.ex
@@ -14,7 +14,7 @@ defmodule TeiserverWeb.Account.ProfileLive.Overview do
   @impl Phoenix.LiveView
   def mount(%{"userid" => userid_str}, _session, socket) do
     userid = String.to_integer(userid_str)
-    user = Account.get_user_by_id(userid)
+    user = Account.deprecated_get_user_by_id(userid)
 
     socket =
       if is_nil(user) do

--- a/lib/teiserver_web/live/account/profile/playtime.ex
+++ b/lib/teiserver_web/live/account/profile/playtime.ex
@@ -9,7 +9,7 @@ defmodule TeiserverWeb.Account.ProfileLive.Playtime do
   @impl Phoenix.LiveView
   def mount(%{"userid" => userid_str}, _session, socket) do
     userid = String.to_integer(userid_str)
-    user = Account.get_user_by_id(userid)
+    user = Account.deprecated_get_user_by_id(userid)
 
     socket =
       if is_nil(user) do

--- a/lib/teiserver_web/live/account/profile/relationships.ex
+++ b/lib/teiserver_web/live/account/profile/relationships.ex
@@ -9,7 +9,7 @@ defmodule TeiserverWeb.Account.ProfileLive.Relationships do
   @impl Phoenix.LiveView
   def mount(%{"userid" => userid_str}, _session, socket) do
     userid = String.to_integer(userid_str)
-    user = Account.get_user_by_id(userid)
+    user = Account.deprecated_get_user_by_id(userid)
 
     socket =
       if is_nil(user) do

--- a/lib/teiserver_web/live/admin/chat/index.ex
+++ b/lib/teiserver_web/live/admin/chat/index.ex
@@ -35,7 +35,7 @@ defmodule TeiserverWeb.Admin.ChatLive.Index do
   def handle_params(params, _url, %{assigns: %{filters: filters}} = socket) do
     filters =
       if params["userid"] do
-        user = Account.get_user_by_id(params["userid"])
+        user = Account.deprecated_get_user_by_id(params["userid"])
 
         Map.merge(filters, %{
           "username" => user.name,

--- a/lib/teiserver_web/live/battles/lobbies/chat.ex
+++ b/lib/teiserver_web/live/battles/lobbies/chat.ex
@@ -65,7 +65,7 @@ defmodule TeiserverWeb.Battle.LobbyLive.Chat do
         players = id |> int_parse() |> Lobby.list_lobby_players!()
         clients = get_clients(players)
 
-        bar_user = Account.get_user_by_id(socket.assigns.current_user.id)
+        bar_user = Account.deprecated_get_user_by_id(socket.assigns.current_user.id)
         lobby = Map.put(lobby, :uuid, Battle.get_lobby_match_uuid(id))
 
         messages =
@@ -262,7 +262,7 @@ defmodule TeiserverWeb.Battle.LobbyLive.Chat do
       |> Enum.map(fn {id, _message} -> id end)
       |> Enum.uniq()
       |> Enum.filter(fn userid -> not Map.has_key?(user_map, userid) end)
-      |> Map.new(fn userid -> {userid, Account.get_user_by_id(userid)} end)
+      |> Map.new(fn userid -> {userid, Account.deprecated_get_user_by_id(userid)} end)
 
     socket
     |> assign(:user_map, Map.merge(user_map, extra_users))

--- a/lib/teiserver_web/live/battles/lobbies/show.ex
+++ b/lib/teiserver_web/live/battles/lobbies/show.ex
@@ -99,7 +99,7 @@ defmodule TeiserverWeb.Battle.LobbyLive.Show do
         {users, clients, ratings, parties, stats} =
           get_user_and_clients(lobby.players, consul_state)
 
-        bar_user = CacheUser.get_user_by_id(socket.assigns.current_user.id)
+        bar_user = CacheUser.deprecated_get_user_by_id(socket.assigns.current_user.id)
         lobby = Map.put(lobby, :uuid, Battle.get_lobby_match_uuid(id))
         modoptions = Battle.get_modoptions(id)
 
@@ -122,7 +122,7 @@ defmodule TeiserverWeb.Battle.LobbyLive.Show do
 
   defp get_user_and_clients(id_list, consul_state) do
     users =
-      CacheUser.list_users(id_list)
+      CacheUser.deprecated_list_users(id_list)
       |> Map.new(fn u -> {u.id, u} end)
 
     clients =

--- a/lib/teiserver_web/live/clients/index.ex
+++ b/lib/teiserver_web/live/clients/index.ex
@@ -26,7 +26,7 @@ defmodule TeiserverWeb.ClientLive.Index do
       |> Map.new(fn {userid, _client} ->
         {
           userid,
-          CacheUser.get_user_by_id(userid) |> limited_user()
+          CacheUser.deprecated_get_user_by_id(userid) |> limited_user()
         }
       end)
       |> Map.filter(fn {_key, value} -> not is_nil(value) end)
@@ -83,7 +83,7 @@ defmodule TeiserverWeb.ClientLive.Index do
         if Map.has_key?(assigns.users, userid) do
           assigns.users[userid]
         else
-          CacheUser.get_user_by_id(userid)
+          CacheUser.deprecated_get_user_by_id(userid)
           |> limited_user()
         end
       end)

--- a/lib/teiserver_web/live/clients/show.ex
+++ b/lib/teiserver_web/live/clients/show.ex
@@ -52,7 +52,7 @@ defmodule TeiserverWeb.ClientLive.Show do
         id = int_parse(id)
         PubSub.subscribe(Teiserver.PubSub, "teiserver_client_watch:#{id}")
         client = Account.get_client_by_id(id)
-        user = CacheUser.get_user_by_id(id)
+        user = CacheUser.deprecated_get_user_by_id(id)
 
         if client && user do
           {:noreply,

--- a/lib/teiserver_web/live/communication/chat/room.ex
+++ b/lib/teiserver_web/live/communication/chat/room.ex
@@ -51,7 +51,7 @@ defmodule TeiserverWeb.Communication.ChatLive.Room do
 
   @impl Phoenix.LiveView
   def handle_info(%{channel: "room_chat"} = event, socket) do
-    user = Account.get_user_by_id(event.user_id)
+    user = Account.deprecated_get_user_by_id(event.user_id)
 
     message = %{
       id: event.id,

--- a/lib/teiserver_web/live/microblog/admin/post/post_form_component.ex
+++ b/lib/teiserver_web/live/microblog/admin/post/post_form_component.ex
@@ -535,7 +535,7 @@ defmodule TeiserverWeb.Microblog.PostFormComponent do
   end
 
   defp create_discord_text(post) do
-    user = Account.get_user_by_id(post.poster_id)
+    user = Account.deprecated_get_user_by_id(post.poster_id)
 
     host = Application.get_env(:teiserver, TeiserverWeb.Endpoint)[:url][:host]
     create_discord_text(user, post, host)

--- a/lib/teiserver_web/live/moderation/report_user/index.ex
+++ b/lib/teiserver_web/live/moderation/report_user/index.ex
@@ -24,7 +24,7 @@ defmodule TeiserverWeb.Moderation.ReportUserLive.Index do
 
   @impl Phoenix.LiveView
   def handle_params(%{"id" => id}, _url, socket) do
-    user = Account.get_user_by_id(id)
+    user = Account.deprecated_get_user_by_id(id)
 
     socket =
       socket

--- a/test/support/teiserver_test_lib.ex
+++ b/test/support/teiserver_test_lib.ex
@@ -42,7 +42,7 @@ defmodule Teiserver.TeiserverTestLib do
   def new_user(name \\ nil, params \\ %{}) do
     name = name || new_user_name()
 
-    case CacheUser.get_user_by_name(name) do
+    case CacheUser.deprecated_get_user_by_name(name) do
       nil ->
         {:ok, user} =
           CacheUser.user_register_params_with_md5(
@@ -308,7 +308,7 @@ defmodule Teiserver.TeiserverTestLib do
   @spec conn_setup({:ok, list()}) :: {:ok, list()}
   def conn_setup({:ok, data}) do
     user = data[:user]
-    CacheUser.recache_user(user.id)
+    CacheUser.deprecated_recache_user(user.id)
 
     {:ok, data}
   end

--- a/test/teiserver/account/cache_user_test.exs
+++ b/test/teiserver/account/cache_user_test.exs
@@ -7,12 +7,12 @@ defmodule Teiserver.Account.CacheUserTest do
 
   test "persisting a user updates the extra fields" do
     user = AccountFixtures.user_fixture()
-    cache_user = CacheUser.get_user_by_id(user.id)
+    cache_user = CacheUser.deprecated_get_user_by_id(user.id)
 
     # Update it without persisting the change, we do not expect
     # it to update the database
     cache_user = Map.merge(cache_user, %{rank: 3, lobby_hash: "blobby"})
-    cache_user = CacheUser.update_user(cache_user)
+    cache_user = CacheUser.deprecated_update_user(cache_user)
 
     user = Account.get_user!(user.id)
 
@@ -34,7 +34,7 @@ defmodule Teiserver.Account.CacheUserTest do
         discord_dm_channel: 456
       })
 
-    cache_user = CacheUser.update_user(cache_user, persist: true)
+    cache_user = CacheUser.deprecated_update_user(cache_user, persist: true)
 
     user = Account.get_user!(user.id)
 

--- a/test/teiserver/coordinator/consul_commands_test.exs
+++ b/test/teiserver/coordinator/consul_commands_test.exs
@@ -19,7 +19,7 @@ defmodule Teiserver.Coordinator.ConsulCommandsTest do
   defp setup_lobby(_ctx) do
     lobby_id = TeiserverTestLib.make_lobby()
     lobby = Lobby.get_lobby(lobby_id)
-    host = Account.get_user_by_id(lobby.founder_id)
+    host = Account.deprecated_get_user_by_id(lobby.founder_id)
     Client.login(host, :test, "127.0.0.1")
 
     Coordinator.send_consul(lobby_id, {:host_update, host.id, %{host_bosses: [host.id]}})

--- a/test/teiserver/coordinator/coordinator_commands_sync_test.exs
+++ b/test/teiserver/coordinator/coordinator_commands_sync_test.exs
@@ -40,7 +40,7 @@ defmodule Teiserver.Coordinator.CoordinatorCommandsSyncTest do
       |> Account.get_user!()
       |> UserLib.script_update_user(%{roles: ["Admin"]})
 
-      CacheUser.recache_user(user.id)
+      CacheUser.deprecated_recache_user(user.id)
 
       _send_raw(socket, "SAYPRIVATE coordinator $website\n")
       reply = _recv_until(socket)

--- a/test/teiserver/logging/persist_server_day_task_test.exs
+++ b/test/teiserver/logging/persist_server_day_task_test.exs
@@ -32,7 +32,7 @@ defmodule Teiserver.Logging.Tasks.PersistServerDayTaskTest do
 
     user_ids =
       all_ids
-      |> CacheUser.list_users()
+      |> CacheUser.deprecated_list_users()
       |> Enum.filter(fn u -> u.bot == false end)
       |> Enum.map(fn u -> u.id end)
 

--- a/test/teiserver/logging/persist_server_month_task_test.exs
+++ b/test/teiserver/logging/persist_server_month_task_test.exs
@@ -39,7 +39,7 @@ defmodule Teiserver.Logging.Tasks.PersistServerMonthTaskTest do
 
     user_ids =
       all_ids
-      |> CacheUser.list_users()
+      |> CacheUser.deprecated_list_users()
       |> Enum.filter(fn u -> u.bot == false end)
       |> Enum.map(fn u -> u.id end)
 
@@ -119,7 +119,7 @@ defmodule Teiserver.Logging.Tasks.PersistServerMonthTaskTest do
     user_ids =
       Account.list_users()
       |> Enum.map(fn u -> u.id end)
-      |> CacheUser.list_users()
+      |> CacheUser.deprecated_list_users()
       |> Enum.filter(fn u -> u.bot == false end)
       |> Enum.map(fn u -> u.id end)
 

--- a/test/teiserver/protocols/spring/spring_auth_test.exs
+++ b/test/teiserver/protocols/spring/spring_auth_test.exs
@@ -434,9 +434,9 @@ CLIENTS test_room #{user.name}\n"
     _recv_raw(socket)
 
     # Check our starting situation
-    assert UserCacheLib.get_user_by_name(new_name) == nil
-    assert %{name: ^old_name} = UserCacheLib.get_user_by_name(old_name)
-    assert %{id: ^userid} = UserCacheLib.get_user_by_id(userid)
+    assert UserCacheLib.deprecated_get_user_by_name(new_name) == nil
+    assert %{name: ^old_name} = UserCacheLib.deprecated_get_user_by_name(old_name)
+    assert %{id: ^userid} = UserCacheLib.deprecated_get_user_by_id(userid)
     assert %{userid: ^userid} = Client.get_client_by_id(userid)
 
     # Rename with an invalid name
@@ -535,7 +535,7 @@ CLIENTS test_room #{user.name}\n"
     _send_raw(socket, "CHANGEEMAILREQUEST new_email@email.com\n")
     reply = _recv_raw(socket)
     assert reply == "CHANGEEMAILREQUESTACCEPTED\n"
-    new_user = UserCacheLib.get_user_by_id(user.id)
+    new_user = UserCacheLib.deprecated_get_user_by_id(user.id)
     [code, new_email] = new_user.email_change_code
     assert new_email == "new_email@email.com"
 
@@ -553,7 +553,7 @@ CLIENTS test_room #{user.name}\n"
     _send_raw(socket, "CHANGEEMAIL new_email@email.com #{code}\n")
     reply = _recv_raw(socket)
     assert reply == "CHANGEEMAILACCEPTED\n"
-    new_user = UserCacheLib.get_user_by_id(user.id)
+    new_user = UserCacheLib.deprecated_get_user_by_id(user.id)
     assert new_user.email == "new_email@email.com"
     assert new_user.email_change_code == [nil, nil]
   end
@@ -668,7 +668,7 @@ CLIENTS test_room #{user.name}\n"
     Account.verify_user(bad_user.id)
 
     # Need to add it as a client for the :add_user command to work
-    bad_user.id |> CacheUser.get_user_by_id() |> Client.login(:spring, "127.0.0.1")
+    bad_user.id |> CacheUser.deprecated_get_user_by_id() |> Client.login(:spring, "127.0.0.1")
 
     # Now see what happens when we add user
     pid = Client.get_client_by_id(user.id).tcp_pid

--- a/test/teiserver/protocols/spring/spring_raw_test.exs
+++ b/test/teiserver/protocols/spring/spring_raw_test.exs
@@ -63,7 +63,7 @@ defmodule Teiserver.SpringRawTest do
     _send_raw(socket, "REGISTER #{name} #{password} raw_register_email@email.com\n")
     reply = _recv_raw(socket)
     assert reply =~ "REGISTRATIONACCEPTED\n"
-    assert %{name: ^name} = UserCacheLib.get_user_by_name(name)
+    assert %{name: ^name} = UserCacheLib.deprecated_get_user_by_name(name)
 
     # Now check the DB!
     db_users = Account.list_users(search: [name: name])
@@ -81,7 +81,7 @@ defmodule Teiserver.SpringRawTest do
 
     _send_raw(socket, "REGISTER #{username} #{password} #{username}@email.e\n")
     _reply = _recv_raw(socket)
-    user = UserCacheLib.get_user_by_name(username)
+    user = UserCacheLib.deprecated_get_user_by_name(username)
     assert %{name: ^username} = user
     Account.verify_user(user.id)
 

--- a/test/teiserver/servers/spring_tcp_server_test.exs
+++ b/test/teiserver/servers/spring_tcp_server_test.exs
@@ -63,10 +63,10 @@ defmodule Teiserver.SpringTcpServerTest do
     reply = _recv_raw(socket)
     assert reply == "REGISTRATIONACCEPTED\n"
 
-    user = UserCacheLib.get_user_by_name(username)
+    user = UserCacheLib.deprecated_get_user_by_name(username)
     query = "UPDATE account_users SET inserted_at = '2020-01-01 01:01:01' WHERE id = #{user.id}"
     SQL.query(Repo, query, [])
-    UserCacheLib.recache_user(user.id)
+    UserCacheLib.deprecated_recache_user(user.id)
 
     _send_raw(
       socket,

--- a/test/teiserver_web/controllers/admin/user_controller_test.exs
+++ b/test/teiserver_web/controllers/admin/user_controller_test.exs
@@ -92,7 +92,7 @@ defmodule TeiserverWeb.Admin.UserControllerTest do
           "data" => %{}
         })
 
-      CacheUser.recache_user(user.id)
+      CacheUser.deprecated_recache_user(user.id)
 
       conn =
         put(conn, ~p"/teiserver/admin/users/rename_post/#{user.id}", new_name: "new_test_name")
@@ -110,7 +110,7 @@ defmodule TeiserverWeb.Admin.UserControllerTest do
           "data" => %{}
         })
 
-      CacheUser.recache_user(user.id)
+      CacheUser.deprecated_recache_user(user.id)
 
       conn =
         put(conn, ~p"/teiserver/admin/users/rename_post/#{user.id}",

--- a/test/teiserver_web/controllers/api/admin/user_controller_test.exs
+++ b/test/teiserver_web/controllers/api/admin/user_controller_test.exs
@@ -84,7 +84,7 @@ defmodule TeiserverWeb.API.Admin.UserControllerTest do
       assert resp["credentials"]["access_token"]
 
       # Verify the created user has the correct stats
-      user = Account.get_user_by_email("testuser2@example.com")
+      user = Account.deprecated_get_user_by_email("testuser2@example.com")
       user_stats = Account.get_user_stat_data(user.id)
       assert user_stats["mu"] == 1500
       assert user_stats["sigma"] == 100
@@ -185,7 +185,7 @@ defmodule TeiserverWeb.API.Admin.UserControllerTest do
       refute "Server" in resp["user"]["permissions"]
       refute "Admin" in resp["user"]["permissions"]
 
-      stored = Account.get_user_by_email("escalator@example.com")
+      stored = Account.deprecated_get_user_by_email("escalator@example.com")
       assert stored.roles == ["Verified"]
       refute "admin.dev.developer" in stored.permissions
     end
@@ -213,7 +213,7 @@ defmodule TeiserverWeb.API.Admin.UserControllerTest do
       {:ok, _promoted_user} =
         Account.script_update_user(user, %{roles: ["Admin"], permissions: ["Admin"]})
 
-      Account.recache_user(user.id)
+      Account.deprecated_recache_user(user.id)
 
       resp =
         conn

--- a/test/teiserver_web/tachyon/user_test.exs
+++ b/test/teiserver_web/tachyon/user_test.exs
@@ -9,7 +9,7 @@ defmodule TeiserverWeb.Tachyon.UserTest do
   describe "info" do
     test "works", %{user: user, client: client} do
       %{id: user_id, name: name} = user
-      %{country: country} = Account.get_user_by_id(user_id)
+      %{country: country} = Account.deprecated_get_user_by_id(user_id)
       user_id = to_string(user_id)
 
       assert %{


### PR DESCRIPTION
The intent is to replace all CacheUser related functions, as such those responsible for returning a CacheUser rather than a User are being renamed to allow new functions to replace them where User objects will instead be returned.
