### PR TITLE
Fix a flaky test

### DIFF
--- a/test/teiserver/player/login_queue_test.exs
+++ b/test/teiserver/player/login_queue_test.exs
@@ -1,4 +1,5 @@
 defmodule Teiserver.Player.LoginQueueTest do
+  alias Teiserver.Helpers.BurstyRateLimiter
   alias Teiserver.Player.LoginQueue
 
   use Teiserver.DataCase, async: false
@@ -128,7 +129,8 @@ defmodule Teiserver.Player.LoginQueueTest do
     p2 = fake_conn(:p2)
 
     set_capacity(10)
-    LoginQueue.set_rate(1, true)
+    LoginQueue.set_rate(1, false)
+    :timer.sleep(1)
 
     assert LoginQueue.attempt_login(user1.id) == true
     assert LoginQueue.attempt_login(user2.id, p2) == false


### PR DESCRIPTION
When setting the rate limiter as full, if there is a tiny bit of time between the 2 acquire requests, then both will go through. Because it's a bursty rate limiter, if there is even 1e-5 permit available the request will still be accepted.

Setting the rate limiter with a slow replenish rate, then wait 1 ms fixes the problem by making sure that the number of stored permit is well into the negative after the first request with no chance to go positive between the 2 calls.