### PR TITLE
Refactor communication autohost session/connection

### DIFF
--- a/lib/teiserver/autohost/session.ex
+++ b/lib/teiserver/autohost/session.ex
@@ -52,20 +52,6 @@ defmodule Teiserver.Autohost.Session do
   end
 
   @doc """
-  Meant for the tachyon handler to notify back the session that it got the
-  response to autohost/start
-  """
-  @spec reply_start_battle(
-          pid(),
-          TachyonBattle.id(),
-          {:ok, start_response()} | {:error, term()}
-        ) :: :ok
-
-  def reply_start_battle(session_pid, battle_id, resp) do
-    send(session_pid, {:reply_start_battle, battle_id, resp})
-  end
-
-  @doc """
   send a message to the autohost with the given id
   this calls returns when the ack to the request has been received.
   """
@@ -77,11 +63,6 @@ defmodule Teiserver.Autohost.Session do
     |> :gen_statem.call({:send_message, payload}, @default_call_timeout)
   catch
     :exit, {:noproc, _details} -> {:error, :no_autohost}
-  end
-
-  @spec reply_send_message(pid(), reference(), :ok | {:error, reason :: term()}) :: :ok
-  def reply_send_message(session_pid, ref, resp) do
-    send(session_pid, {:reply_send_message, ref, resp})
   end
 
   @doc """
@@ -112,11 +93,6 @@ defmodule Teiserver.Autohost.Session do
     :exit, {:noproc, _details} -> {:error, :no_autohost}
   end
 
-  @spec reply_kill_battle(pid(), reference(), :ok | {:error, reason :: term()}) :: :ok
-  def reply_kill_battle(session_pid, ref, resp) do
-    send(session_pid, {:reply_kill_battle, ref, resp})
-  end
-
   @spec add_player(pid(), TachyonBattle.Types.add_player_data()) :: :ok | {:error, term()}
   def add_player(session_pid, add_data) do
     :gen_statem.call(session_pid, {:add_player, add_data}, @default_call_timeout)
@@ -124,9 +100,8 @@ defmodule Teiserver.Autohost.Session do
     :exit, {:noproc, _details} -> {:error, :no_autohost}
   end
 
-  @spec reply_add_player(pid(), reference(), :ok | {:error, reason :: term()}) :: :ok
-  def reply_add_player(session_pid, ref, resp) do
-    send(session_pid, {:reply_add_player, ref, resp})
+  def async_reply(session_pid, cb_state, resp) do
+    send(session_pid, {:async_reply, cb_state, resp})
   end
 
   @doc """
@@ -181,11 +156,11 @@ defmodule Teiserver.Autohost.Session do
         _state,
         data
       ) do
-    TachyonHandler.start_battle(data.conn_pid, battle_id, start_script)
+    cb_state = {:start_battle_cb, battle_id, start_script, from}
+    TachyonHandler.start_battle(data.conn_pid, battle_id, start_script, cb_state)
 
     data =
       data
-      |> Map.update!(:pending_battles, &Map.put(&1, battle_id, {from, start_script}))
       |> Map.update!(:monitors, &MC.monitor(&1, battle_pid, {:battle, battle_id}))
 
     {:keep_state, data}
@@ -205,9 +180,8 @@ defmodule Teiserver.Autohost.Session do
       do: {:keep_state, data, [{:reply, from, {:error, :invalid_battle}}]}
 
   def handle_event({:call, from}, {:send_message, payload}, _state, %AT.SessionData{} = data) do
-    ref = make_ref()
-    TachyonHandler.send_message(data.conn_pid, ref, payload)
-    data = Map.update!(data, :pending_replies, &Map.put(&1, ref, from))
+    cb_state = {:genserver_reply, from}
+    TachyonHandler.send_message(data.conn_pid, cb_state, payload)
     {:keep_state, data}
   end
 
@@ -220,9 +194,8 @@ defmodule Teiserver.Autohost.Session do
       do: {:keep_state, data, [{:reply, from, {:error, :invalid_battle}}]}
 
   def handle_event({:call, from}, {:kill_battle, battle_id}, _state, %AT.SessionData{} = data) do
-    ref = make_ref()
-    TachyonHandler.kill_battle(data.conn_pid, ref, battle_id)
-    data = Map.update!(data, :pending_replies, &Map.put(&1, ref, from))
+    cb_state = {:genserver_reply, from}
+    TachyonHandler.kill_battle(data.conn_pid, cb_state, battle_id)
     {:keep_state, data}
   end
 
@@ -235,9 +208,8 @@ defmodule Teiserver.Autohost.Session do
       do: {:keep_state, data, [{:reply, from, {:error, :invalid_battle}}]}
 
   def handle_event({:call, from}, {:add_player, add_data}, _state, %AT.SessionData{} = data) do
-    ref = make_ref()
-    TachyonHandler.add_player(data.conn_pid, ref, add_data)
-    data = Map.update!(data, :pending_replies, &Map.put(&1, ref, from))
+    cb_state = {:genserver_reply, from}
+    TachyonHandler.add_player(data.conn_pid, cb_state, add_data)
     {:keep_state, data}
   end
 
@@ -250,15 +222,15 @@ defmodule Teiserver.Autohost.Session do
     {:keep_state, data, [{:reply, from, get_subscription_start(data)}]}
   end
 
-  def handle_event(:info, {:reply_kill_battle, ref, _resp}, _state, %AT.SessionData{} = data)
-      when not is_map_key(data.pending_replies, ref),
-      do: {:keep_state, data}
+  def handle_event(:info, {:async_reply, cb_state, resp}, _state, %AT.SessionData{} = data) do
+    case cb_state do
+      {:start_battle_cb, battle_id, start_script, from} ->
+        battle_started(battle_id, start_script, from, resp, data)
 
-  def handle_event(:info, {:reply_kill_battle, ref, resp}, _state, %AT.SessionData{} = data) do
-    {from, pending_replies} = Map.pop!(data.pending_replies, ref)
-    data = %{data | pending_replies: pending_replies}
-    GenServer.reply(from, resp)
-    {:keep_state, data}
+      {:genserver_reply, from} ->
+        GenServer.reply(from, resp)
+        {:keep_state, data}
+    end
   end
 
   def handle_event(:info, {:reply_add_player, ref, _resp}, _state, %AT.SessionData{} = data)
@@ -285,7 +257,6 @@ defmodule Teiserver.Autohost.Session do
       case val do
         {:battle, battle_id} ->
           data
-          |> Map.update!(:pending_battles, &Map.delete(&1, battle_id))
           |> Map.update!(:active_battles, &Map.delete(&1, battle_id))
       end
 
@@ -320,57 +291,6 @@ defmodule Teiserver.Autohost.Session do
       :handshaking -> {:next_state, :connected, data}
       _other -> {:keep_state, data}
     end
-  end
-
-  def handle_event(
-        :info,
-        {:reply_start_battle, battle_id, _resp},
-        _state,
-        %AT.SessionData{} = data
-      )
-      when not is_map_key(data.pending_battles, battle_id), do: {:keep_state, data}
-
-  def handle_event(
-        :info,
-        {:reply_start_battle, battle_id, resp},
-        _state,
-        %AT.SessionData{} = data
-      ) do
-    {{from, start_script}, pending_battles} = Map.pop!(data.pending_battles, battle_id)
-
-    case resp do
-      {:error, reason} ->
-        GenServer.reply(from, {:error, reason})
-        {:keep_state, data}
-
-      {:ok, start_response} ->
-        battle_data = %AT.BattleData{
-          start_script: start_script,
-          ips: start_response.ips,
-          port: start_response.port
-        }
-
-        data =
-          data
-          |> Map.replace!(:pending_battles, pending_battles)
-          |> Map.update!(:active_battles, &Map.put(&1, battle_id, battle_data))
-
-        GenServer.reply(from, {:ok, self(), start_response})
-
-        {:keep_state, data}
-    end
-  end
-
-  def handle_event(:info, {:reply_send_message, ref, _resp}, _state, %AT.SessionData{} = data)
-      when not is_map_key(data.pending_replies, ref) do
-    {:keep_state, data}
-  end
-
-  def handle_event(:info, {:reply_send_message, ref, resp}, _state, %AT.SessionData{} = data) do
-    {from, pending_replies} = Map.pop!(data.pending_replies, ref)
-    data = %{data | pending_replies: pending_replies}
-    GenServer.reply(from, resp)
-    {:keep_state, data}
   end
 
   # TODO: will need to "resurrect" a battle if we ever get into this situation.
@@ -457,5 +377,27 @@ defmodule Teiserver.Autohost.Session do
     end
     |> Enum.reject(&is_nil/1)
     |> Enum.min(fn -> DateTime.utc_now() end)
+  end
+
+  defp battle_started(battle_id, start_script, from, resp, %AT.SessionData{} = data) do
+    case resp do
+      {:error, reason} ->
+        Logger.error("failed to start a battle: #{inspect(reason)}")
+        GenServer.reply(from, {:error, reason})
+        {:keep_state, data}
+
+      {:ok, start_response} ->
+        battle_data = %AT.BattleData{
+          start_script: start_script,
+          ips: start_response.ips,
+          port: start_response.port
+        }
+
+        data = %{data | active_battles: Map.put(data.active_battles, battle_id, battle_data)}
+
+        GenServer.reply(from, {:ok, self(), start_response})
+
+        {:keep_state, data}
+    end
   end
 end

--- a/lib/teiserver/autohost/tachyon_handler.ex
+++ b/lib/teiserver/autohost/tachyon_handler.ex
@@ -25,8 +25,8 @@ defmodule Teiserver.Autohost.TachyonHandler do
           state: :handshaking | :connected
         }
 
-  def start_battle(conn_pid, battle_id, start_script) do
-    send(conn_pid, {:start_battle, battle_id, start_script})
+  def start_battle(conn_pid, battle_id, start_script, cb_state) do
+    send(conn_pid, {:start_battle, battle_id, start_script, cb_state})
   end
 
   @spec subscribe_updates(pid(), DateTime.t()) :: :ok | {:error, reason :: term()}
@@ -56,21 +56,21 @@ defmodule Teiserver.Autohost.TachyonHandler do
   @doc """
   send a message to the autohost with the given pid
   """
-  @spec send_message(pid(), reference(), %{battle_id: TachyonBattle.id(), message: String.t()}) ::
+  @spec send_message(pid(), term(), %{battle_id: TachyonBattle.id(), message: String.t()}) ::
           :ok
-  def send_message(conn_pid, ref, payload) when is_pid(conn_pid) do
-    send(conn_pid, {:send_message, ref, payload})
+  def send_message(conn_pid, cb_state, payload) when is_pid(conn_pid) do
+    send(conn_pid, {:send_message, cb_state, payload})
   end
 
-  @spec kill_battle(pid(), reference(), TachyonBattle.id()) :: :ok | {:error, reason :: term()}
-  def kill_battle(conn_pid, ref, battle_id) when is_pid(conn_pid) do
-    send(conn_pid, {:kill_battle, ref, battle_id})
+  @spec kill_battle(pid(), term(), TachyonBattle.id()) :: :ok | {:error, reason :: term()}
+  def kill_battle(conn_pid, cb_state, battle_id) when is_pid(conn_pid) do
+    send(conn_pid, {:kill_battle, cb_state, battle_id})
   end
 
-  @spec add_player(pid(), reference(), TachyonBattle.Types.add_player_data()) ::
+  @spec add_player(pid(), term(), TachyonBattle.Types.add_player_data()) ::
           :ok | {:error, reason :: term()}
-  def add_player(conn_pid, ref, add_data) do
-    send(conn_pid, {:add_player, ref, add_data})
+  def add_player(conn_pid, cb_state, add_data) do
+    send(conn_pid, {:add_player, cb_state, add_data})
   end
 
   @impl Handler
@@ -96,7 +96,7 @@ defmodule Teiserver.Autohost.TachyonHandler do
   end
 
   @impl Handler
-  def handle_info({:start_battle, battle_id, start_script}, state) do
+  def handle_info({:start_battle, battle_id, start_script, cb_state}, state) do
     mappings = %{
       engine_version: :engineVersion,
       game_name: :gameName,
@@ -120,7 +120,7 @@ defmodule Teiserver.Autohost.TachyonHandler do
       |> Collections.remove_nil_vals()
       |> Map.put(:battleId, battle_id)
 
-    opts = [cb_state: battle_id]
+    opts = [cb_state: cb_state]
     {:request, "autohost/start", start_script, opts, state}
   end
 
@@ -222,32 +222,12 @@ defmodule Teiserver.Autohost.TachyonHandler do
   def handle_response("autohost/start", _battle_id, _resp, state) when state.session_pid == nil,
     do: {:ok, state}
 
-  def handle_response("autohost/start", battle_id, response, state) do
-    resp =
-      case response do
-        %{"status" => "failed", "reason" => reason} ->
-          msg =
-            case response["details"] do
-              nil -> reason
-              details -> "#{reason} - #{details}"
-            end
-
-          Logger.error("failed to start a battle: #{msg}")
-          {:error, msg}
-
-        %{"status" => "success", "data" => data} ->
-          {:ok, %{ips: data["ips"], port: data["port"]}}
-      end
-
-    Session.reply_start_battle(state.session_pid, battle_id, resp)
-    {:ok, state}
-  end
-
-  def handle_response("autohost/sendMessage", ref, response, state) do
+  def handle_response("autohost/" <> command, cb_state, response, state)
+      when command in ["start", "sendMessage", "kill", "addPlayer"] do
     resp =
       case response["status"] do
         "success" ->
-          :ok
+          parse_response(command, response["data"])
 
         "failed" ->
           err = response["reason"]
@@ -258,45 +238,7 @@ defmodule Teiserver.Autohost.TachyonHandler do
           end
       end
 
-    Session.reply_send_message(state.session_pid, ref, resp)
-    {:ok, state}
-  end
-
-  def handle_response("autohost/kill", ref, response, state) do
-    resp =
-      case response["status"] do
-        "success" ->
-          :ok
-
-        "failed" ->
-          err = response["reason"]
-
-          case Map.get(response, "details") do
-            nil -> {:error, err}
-            details -> {:error, "#{err} - #{details}"}
-          end
-      end
-
-    Session.reply_kill_battle(state.session_pid, ref, resp)
-    {:ok, state}
-  end
-
-  def handle_response("autohost/addPlayer", ref, response, state) do
-    resp =
-      case response["status"] do
-        "success" ->
-          :ok
-
-        "failed" ->
-          err = response["reason"]
-
-          case Map.get(response, "details") do
-            nil -> {:error, err}
-            details -> {:error, "#{err} - #{details}"}
-          end
-      end
-
-    Session.reply_add_player(state.session_pid, ref, resp)
+    Session.async_reply(state.session_pid, cb_state, resp)
     {:ok, state}
   end
 
@@ -463,4 +405,10 @@ defmodule Teiserver.Autohost.TachyonHandler do
       name: b.name
     }
   end
+
+  defp parse_response("start", data) do
+    {:ok, %{ips: data["ips"], port: data["port"]}}
+  end
+
+  defp parse_response(_command, nil), do: :ok
 end

--- a/test/teiserver/autohost/autohost_test.exs
+++ b/test/teiserver/autohost/autohost_test.exs
@@ -55,11 +55,11 @@ defmodule Teiserver.Autohost.AutohostTest do
         Autohost.start_battle(autohost.id, "battle_id", self(), BotFixtures.start_script())
       end)
 
-      refute_receive {:start_battle, "battle_id", _}
+      refute_receive {:start_battle, "battle_id", _, _}
       # need to update capacity first, only then the autohost is considered fully online
       Session.update_capacity(sess_pid, 10, 0)
 
-      assert_receive {:start_battle, "battle_id", _}
+      assert_receive {:start_battle, "battle_id", _, _}
     end
 
     test "default subscribe messages from now" do
@@ -152,8 +152,9 @@ defmodule Teiserver.Autohost.AutohostTest do
       :timer.sleep(:infinity)
     end)
 
-    assert_receive {:start_battle, ^battle_id, _}
-    Session.reply_start_battle(pid, battle_id, {:ok, %{ips: ["1.2.3.4"], port: 1234}})
+    assert_receive {:start_battle, ^battle_id, _start_script, cb_state}
+    resp = {:ok, %{ips: ["1.2.3.4"], port: 1234}}
+    Session.async_reply(pid, cb_state, resp)
     %{battle_id: battle_id}
   end
 

--- a/test/teiserver/tachyon_battle/battle_test.exs
+++ b/test/teiserver/tachyon_battle/battle_test.exs
@@ -21,8 +21,8 @@ defmodule Teiserver.TachyonBattle.BattleTest do
       %{battle_id: battle_id, autohost_pid: autohost_pid} = setup_autohost_and_battle()
       msg_task = Task.async(fn -> Battle.send_message(battle_id, "hello") end)
 
-      assert_receive {:send_message, ref, %{battle_id: ^battle_id, message: "hello"}}
-      Session.reply_send_message(autohost_pid, ref, :ok)
+      assert_receive {:send_message, cb_state, %{battle_id: ^battle_id, message: "hello"}}
+      Session.async_reply(autohost_pid, cb_state, :ok)
       Task.await(msg_task)
     end
   end
@@ -31,8 +31,8 @@ defmodule Teiserver.TachyonBattle.BattleTest do
     %{battle_id: battle_id, autohost_pid: autohost_pid} = setup_autohost_and_battle()
 
     task = Task.async(fn -> Battle.kill(battle_id) end)
-    assert_receive {:kill_battle, ref, ^battle_id}
-    Session.reply_kill_battle(autohost_pid, ref, :ok)
+    assert_receive {:kill_battle, cb_state, ^battle_id}
+    Session.async_reply(autohost_pid, cb_state, :ok)
     assert Task.await(task) == :ok
   end
 
@@ -40,7 +40,7 @@ defmodule Teiserver.TachyonBattle.BattleTest do
     %{battle_id: battle_id, autohost_pid: autohost_pid} = setup_autohost_and_battle()
     task = Task.async(fn -> Battle.add_player(battle_id, 12345, "playername", "hunter2") end)
 
-    assert_receive {:add_player, ref,
+    assert_receive {:add_player, cb_state,
                     %{
                       name: "playername",
                       user_id: 12345,
@@ -48,7 +48,7 @@ defmodule Teiserver.TachyonBattle.BattleTest do
                       battle_id: ^battle_id
                     }}
 
-    Session.reply_add_player(autohost_pid, ref, :ok)
+    Session.async_reply(autohost_pid, cb_state, :ok)
     {:ok, %{port: _port, ips: _ips}} = Task.await(task)
 
     re_add = Task.async(fn -> Battle.add_player(battle_id, 12345, "playername", "hunter2") end)
@@ -85,13 +85,13 @@ defmodule Teiserver.TachyonBattle.BattleTest do
     add_tasks =
       Enum.map(1..players_to_add, fn i ->
         Task.async(fn ->
-          Battle.add_player(battle_id, 10000 + i, "playername#{i}", "hunted#{i}")
+          Battle.add_player(battle_id, 10000 + i, "playername#{i}", "hunter#{i}")
         end)
       end)
 
     Enum.each(1..players_to_add, fn _i ->
-      assert_receive {:add_player, ref, _}
-      Session.reply_add_player(autohost_pid, ref, :ok)
+      assert_receive {:add_player, cb_state, _}
+      Session.async_reply(autohost_pid, cb_state, :ok)
     end)
 
     Task.await_many(add_tasks)
@@ -121,9 +121,9 @@ defmodule Teiserver.TachyonBattle.BattleTest do
           Battle.start_battle_process(autohost_id, match_id, BotFixtures.start_script())
       end)
 
-    assert_receive {:start_battle, battle_id, start_script}
+    assert_receive {:start_battle, battle_id, start_script, cb_state}
     resp = %{ips: ["1.2.3.4"], port: 12345}
-    Session.reply_start_battle(autohost_pid, battle_id, {:ok, resp})
+    Session.async_reply(autohost_pid, cb_state, {:ok, resp})
     Task.await(start_task)
 
     %{


### PR DESCRIPTION
This abstracts away the response from the connection, so that what kind of logic is run on a response is wholly contained in the session module.