### PR TITLE
Fix flaky test with rate limiter

### DIFF
--- a/lib/teiserver/general/rate_limit.ex
+++ b/lib/teiserver/general/rate_limit.ex
@@ -4,5 +4,5 @@ defmodule Teiserver.General.RateLimit do
   rate limiting
   """
 
-  use Hammer, backend: :ets
+  use Hammer, backend: :ets, algorithm: :sliding_window
 end

--- a/test/teiserver/player/login_queue_test.exs
+++ b/test/teiserver/player/login_queue_test.exs
@@ -143,7 +143,8 @@ defmodule Teiserver.Player.LoginQueueTest do
     p2 = fake_conn(:p2)
 
     set_capacity(0)
-    LoginQueue.set_rate(1, true)
+    LoginQueue.set_rate(1, false)
+    :timer.sleep(1)
     assert LoginQueue.attempt_login(user1.id, p1) == false
     assert LoginQueue.attempt_login(user2.id, p2) == false
 
@@ -160,7 +161,8 @@ defmodule Teiserver.Player.LoginQueueTest do
     p2 = fake_conn(:p2)
 
     set_capacity(10)
-    LoginQueue.set_rate(1, true)
+    LoginQueue.set_rate(1, false)
+    :timer.sleep(1)
 
     assert LoginQueue.attempt_login(user1.id) == true
     assert LoginQueue.attempt_login(user2.id, p2) == false

--- a/test/teiserver/protocols/spring/spring_raw_test.exs
+++ b/test/teiserver/protocols/spring/spring_raw_test.exs
@@ -176,18 +176,18 @@ defmodule Teiserver.SpringRawTest do
     _recv_raw(socket)
 
     # Incorrect password
-    for _idx <- 1..4 do
+    for _idx <- 1..5 do
       _send_raw(
         socket,
         "LOGIN #{user.name} IncorrectPassword 0 * LuaLobby Chobby\t1993717506 0d04a635e200f308\tb sp\n"
       )
 
-      reply = _recv_until(socket)
-      "DENIED " <> _message = reply
-
       # Clear the much shorter lived flood protection
       Teiserver.cache_put(:teiserver_login_count, user.id, 0)
     end
+
+    [_r1, _r2, _r3, _r4, _r5] = _recv_until(socket) |> String.split("\n", trim: true)
+    Teiserver.cache_put(:teiserver_login_count, user.id, 0)
 
     # The rate limit should now be triggering
     _send_raw(
@@ -195,16 +195,14 @@ defmodule Teiserver.SpringRawTest do
       "LOGIN #{user.name} IncorrectPassword 0 * LuaLobby Chobby\t1993717506 0d04a635e200f308\tb sp\n"
     )
 
-    reply = _recv_until(socket)
-    assert reply == "DENIED Flood protection\n"
-
     # Even with the correct password we should still have a rate limit
     _send_raw(
       socket,
       "LOGIN #{user.name} X03MO1qnZdYdgyfeuILPmQ== 0 * LuaLobby Chobby\t1993717506 0d04a635e200f308\tb sp\n"
     )
 
-    reply = _recv_until(socket)
-    assert reply == "DENIED Flood protection\n"
+    [invalid_pass, valid_pass] = _recv_until(socket) |> String.split("\n", trim: true)
+    assert invalid_pass == "DENIED Flood protection"
+    assert valid_pass == "DENIED Flood protection"
   end
 end


### PR DESCRIPTION
This is the same as 0ff812f563e602df19ebabaeb920c9c70c17fd17 but for the tachyon rate limiter.

Also change the algorithm used by hammer to sliding window since it was creating some flakyness