### PR TITLE
Replace web uses of deprecated_get_user_by_id

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -160,5 +160,7 @@
   {"lib/teiserver_web/templates/admin/lobby/lobby_chat.html.heex", :call},
   {"lib/teiserver_web/templates/admin/lobby/server_chat.html.heex", :call},
   {"lib/teiserver_web/live/moderation/action_live/smurf_link.ex", :callback_arg_type_mismatch},
-  {"lib/teiserver_web/live/moderation/action_live/smurf_link.ex", :call}
+  {"lib/teiserver_web/live/moderation/action_live/smurf_link.ex", :call},
+  {"lib/teiserver/account/tasks/merge_accounts_task.ex", :no_return},
+  {"lib/teiserver_web/controllers/account/general_controller.ex", :no_return}
 ]

--- a/lib/teiserver.ex
+++ b/lib/teiserver.ex
@@ -53,9 +53,6 @@ defmodule Teiserver do
   @spec cache_insert_new(atom, any, any) :: :ok | {:error, any}
   defdelegate cache_insert_new(table, key, value), to: CacheHelper
 
-  @spec cache_update(atom, any, any) :: :ok | {:error, any}
-  defdelegate cache_update(table, key, func), to: CacheHelper
-
   @spec store_get(atom, any) :: any
   defdelegate store_get(table, key), to: CacheHelper
 

--- a/lib/teiserver/account.ex
+++ b/lib/teiserver/account.ex
@@ -2162,11 +2162,20 @@ defmodule Teiserver.Account do
   @spec get_userid_by_discord_id(String.t()) :: User.id() | nil
   defdelegate get_userid_by_discord_id(discord_id), to: UserCacheLib
 
+  @spec get_user_by_id(User.id()) :: User.t() | nil
+  defdelegate get_user_by_id(id), to: UserLib
+
+  @spec get_user_by_id!(User.id()) :: User.t()
+  defdelegate get_user_by_id!(id), to: UserLib
+
   @spec deprecated_get_user_by_id(User.id()) :: T.user() | nil
   defdelegate deprecated_get_user_by_id(id), to: UserCacheLib
 
   @spec list_users_from_cache(list) :: list
   def list_users_from_cache(id_list), do: UserCacheLib.deprecated_list_users(id_list)
+
+  @spec decache_user(User.t()) :: :ok
+  defdelegate decache_user(user_or_user_id), to: UserLib
 
   @spec deprecated_recache_user(User.id() | User.t()) :: :ok
   defdelegate deprecated_recache_user(id), to: UserCacheLib
@@ -2179,9 +2188,6 @@ defmodule Teiserver.Account do
 
   @spec update_cache_user(User.id(), map()) :: T.user()
   def update_cache_user(userid, user), do: UserCacheLib.update_cache_user(userid, user)
-
-  @spec decache_user(User.id()) :: :ok | :no_user
-  defdelegate decache_user(userid), to: UserCacheLib
 
   @spec make_bot_password() :: String.t()
   defdelegate make_bot_password(), to: UserLib

--- a/lib/teiserver/account/caches/user_cache_lib.ex
+++ b/lib/teiserver/account/caches/user_cache_lib.ex
@@ -150,26 +150,17 @@ defmodule Teiserver.Account.UserCacheLib do
   end
 
   @spec deprecated_recache_user(User.id() | CacheUser.t() | map()) :: :ok
+  def deprecated_recache_user(%{id: id}), do: deprecated_recache_user(id)
+
   def deprecated_recache_user(id) when is_integer(id) do
     Teiserver.cache_delete(:account_user_cache, id)
     Teiserver.cache_delete(:account_user_cache_bang, id)
     Teiserver.cache_delete(:account_membership_cache, id)
     Teiserver.cache_delete(:config_user_cache, id)
 
-    # decache_user(id)
     Account.decache_relationships(id)
 
     Account.get_user(id)
-    |> convert_user()
-    |> add_user()
-
-    :ok
-  end
-
-  def deprecated_recache_user(user) do
-    Account.deprecated_recache_user(user.id)
-
-    user
     |> convert_user()
     |> add_user()
 
@@ -287,12 +278,37 @@ defmodule Teiserver.Account.UserCacheLib do
     new_user
   end
 
+  @doc """
+  A function purely for UserLib to be able to flash the cache when a User is updated
+  and we want to ensure these caches are cleared correctly.
+  """
+  def decache_user_on_ok({:ok, %User{} = user} = result) do
+    Teiserver.cache_delete(:users, user.id)
+    Teiserver.cache_delete(:users_lookup_name_with_id, user.id)
+    Teiserver.cache_delete(:users_lookup_id_with_name, cachename(user.name))
+    Teiserver.cache_delete(:users_lookup_id_with_email, cachename(user.email))
+
+    if user.discord_id do
+      Teiserver.cache_delete(:users_lookup_id_with_discord, user.discord_id)
+    end
+
+    result
+  end
+
+  def decache_user_on_ok(result), do: result
+
   @spec decache_user(User.id()) :: :ok | :no_user
   def decache_user(userid) do
     user = deprecated_get_user_by_id(userid)
 
     # Teiserver.cache_delete(:users, userid)
     if user do
+      # This is used by the UserLib, to prevent us having to have both functions
+      # call the other we instead have the UserLib call here and once this is removed
+      # we just need to remove the call to this.
+      Teiserver.cache_delete(:users_by_id, user.id)
+
+      Teiserver.cache_delete(:users, user.id)
       Teiserver.cache_delete(:users_lookup_name_with_id, user.id)
       Teiserver.cache_delete(:users_lookup_id_with_name, cachename(user.name))
       Teiserver.cache_delete(:users_lookup_id_with_email, cachename(user.email))

--- a/lib/teiserver/account/libs/user_lib.ex
+++ b/lib/teiserver/account/libs/user_lib.ex
@@ -6,6 +6,7 @@ defmodule Teiserver.Account.UserLib do
   alias Teiserver.Account.Auth
   alias Teiserver.Account.RoleLib
   alias Teiserver.Account.User
+  alias Teiserver.Account.UserCacheLib
   alias Teiserver.Account.UserQueries
   alias Teiserver.CacheUser
   alias Teiserver.Client
@@ -16,6 +17,10 @@ defmodule Teiserver.Account.UserLib do
 
   use TeiserverWeb, :library_newform
 
+  import Teiserver.Helpers.CacheHelper,
+    only: [cache_get_or_store: 3, cache_put_on_ok: 2, cache_delete_on_ok: 2]
+
+  import Teiserver.Helper.NumberHelper, only: [int_parse!: 1]
   import Teiserver.Logging.Helpers, only: [add_audit_log: 4]
 
   # Functions
@@ -101,6 +106,37 @@ defmodule Teiserver.Account.UserLib do
     args
     |> UserQueries.count_users()
     |> Repo.aggregate(:count, :id)
+  end
+
+  @doc """
+  Attempts to get the user from the cache, failing that it will get it from the database.
+
+  Returns nil if no user found.
+  """
+  @spec get_user_by_id(User.id() | String.t()) :: User.t() | nil
+  def get_user_by_id(user_id) do
+    user_id = int_parse!(user_id)
+    cache_get_or_store(:users_by_id, user_id, fn -> get_user(user_id) end)
+  end
+
+  @doc """
+  Identical to `get_user_by_id/1` but with a raise instead of a nil result in the event of
+  no user found in the database.
+  """
+  @spec get_user_by_id!(User.id() | String.t()) :: User.t()
+  def get_user_by_id!(user_id) do
+    get_user_by_id(user_id) || raise "No user of the ID #{inspect(user_id)}"
+  end
+
+  @spec decache_user(User.t() | User.id()) :: :ok | {:error, any}
+  def decache_user(%User{id: user_id}), do: decache_user(user_id)
+
+  def decache_user(user_id) do
+    user_id = int_parse!(user_id)
+    Teiserver.cache_delete(:users_by_id, user_id)
+
+    # This to be removed as part of the removal of CacheUser removal
+    UserCacheLib.decache_user(user_id)
   end
 
   @doc """
@@ -201,6 +237,8 @@ defmodule Teiserver.Account.UserLib do
     |> User.changeset(attrs, :limited_with_data)
     |> Repo.update()
     |> broadcast_update_user()
+    |> cache_put_on_ok(:users_by_id)
+    |> UserCacheLib.decache_user_on_ok()
   end
 
   def update_user_plain_password(%User{} = user, attrs) do
@@ -210,6 +248,8 @@ defmodule Teiserver.Account.UserLib do
     |> User.changeset(attrs, :password)
     |> Repo.update()
     |> broadcast_update_user()
+    |> cache_put_on_ok(:users_by_id)
+    |> UserCacheLib.decache_user_on_ok()
   end
 
   def update_user_user_form(%User{} = user, attrs) do
@@ -219,6 +259,8 @@ defmodule Teiserver.Account.UserLib do
     |> User.changeset(attrs, :user_form)
     |> Repo.update()
     |> broadcast_update_user()
+    |> cache_put_on_ok(:users_by_id)
+    |> UserCacheLib.decache_user_on_ok()
   end
 
   def server_limited_update_user(%User{} = user, attrs) do
@@ -228,6 +270,8 @@ defmodule Teiserver.Account.UserLib do
     |> User.changeset(attrs, :server_limited_update_user)
     |> Repo.update()
     |> broadcast_update_user()
+    |> cache_put_on_ok(:users_by_id)
+    |> UserCacheLib.decache_user_on_ok()
   end
 
   def server_update_user(%User{} = user, attrs) do
@@ -237,6 +281,8 @@ defmodule Teiserver.Account.UserLib do
     |> User.changeset(attrs)
     |> Repo.update()
     |> broadcast_update_user()
+    |> cache_put_on_ok(:users_by_id)
+    |> UserCacheLib.decache_user_on_ok()
   end
 
   def script_update_user(%User{} = user, attrs) do
@@ -246,6 +292,8 @@ defmodule Teiserver.Account.UserLib do
     |> User.changeset(attrs, :script)
     |> Repo.update()
     |> broadcast_update_user()
+    |> cache_put_on_ok(:users_by_id)
+    |> UserCacheLib.decache_user_on_ok()
   end
 
   def password_reset_update_user(%User{} = user, attrs) do
@@ -255,6 +303,8 @@ defmodule Teiserver.Account.UserLib do
     |> User.changeset(attrs, :password_reset)
     |> Repo.update()
     |> broadcast_update_user()
+    |> cache_put_on_ok(:users_by_id)
+    |> UserCacheLib.decache_user_on_ok()
   end
 
   @doc """
@@ -271,6 +321,8 @@ defmodule Teiserver.Account.UserLib do
   """
   def delete_user(%User{} = user) do
     Repo.delete(user)
+    |> cache_delete_on_ok(:users_by_id)
+    |> UserCacheLib.decache_user_on_ok()
   end
 
   @doc """

--- a/lib/teiserver/account/schemas/user.ex
+++ b/lib/teiserver/account/schemas/user.ex
@@ -71,7 +71,7 @@ defmodule Teiserver.Account.User do
       restrictions: [],
       restricted_until: nil,
       shadowbanned: false,
-      lobby_hash: [],
+      lobby_hash: nil,
       chobby_hash: nil,
       discord_id: nil,
       discord_dm_channel: nil,

--- a/lib/teiserver/account/tasks/gdpr_forget_task.ex
+++ b/lib/teiserver/account/tasks/gdpr_forget_task.ex
@@ -14,10 +14,9 @@ defmodule Teiserver.Account.Tasks.GdprForgetTask do
   alias Teiserver.Account
   alias Teiserver.Account.User
   alias Teiserver.Account.UserLib
+  alias Teiserver.Helper.StringHelper
   alias Teiserver.Logging.Helpers, as: LoggingHelpers
   alias Teiserver.Repo
-
-  @alphanum ~c"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
   @doc """
   Given the conn of the user performing the forgetting and a user struct
@@ -66,11 +65,6 @@ defmodule Teiserver.Account.Tasks.GdprForgetTask do
   end
 
   defp forget_user_struct(%User{} = user) do
-    name =
-      1..20
-      |> Enum.map(fn _idx -> Enum.random(@alphanum) end)
-      |> List.to_string()
-
     # Wipe all the user fields that contain PII, this new user
     # is persisted via the update_cache_user call below which
     # will call the relevant changeset and update any caches
@@ -80,7 +74,7 @@ defmodule Teiserver.Account.Tasks.GdprForgetTask do
     # audit the forgetting process if needed
     new_user =
       Map.merge(user, %{
-        name: name,
+        name: StringHelper.random_name(),
         email: "#{user.id}@#{user.id}.#{user.id}",
         password: UserLib.make_bot_password(),
         icon: "",

--- a/lib/teiserver/application.ex
+++ b/lib/teiserver/application.ex
@@ -99,15 +99,10 @@ defmodule Teiserver.Application do
         concache_sup(:teiserver_user_ratings, global_ttl: 60_000),
         concache_sup(:teiserver_game_rating_types, global_ttl: 60_000),
 
+        # New user caches
+        concache_perm_sup(:users_by_id),
+
         # Caches
-
-        # Caches - User
-        # concache_sup(:users_lookup_name_with_id, [global_ttl: 300_000]),
-        # concache_sup(:users_lookup_id_with_name, [global_ttl: 300_000]),
-        # concache_sup(:users_lookup_id_with_email, [global_ttl: 300_000]),
-        # concache_sup(:users_lookup_id_with_discord, [global_ttl: 300_000]),
-        # concache_sup(:users, [global_ttl: 300_000]),
-
         concache_perm_sup(:users_lookup_name_with_id),
         concache_perm_sup(:users_lookup_id_with_name),
         concache_perm_sup(:users_lookup_id_with_email),

--- a/lib/teiserver/helpers/cache_helper.ex
+++ b/lib/teiserver/helpers/cache_helper.ex
@@ -8,7 +8,7 @@ defmodule Teiserver.Helpers.CacheHelper do
     ConCache.get(table, key) || default
   catch
     :exit, :noproc ->
-      Logger.warning("Cache #{table} is down")
+      Logger.warning("Cache #{table} is down (get)")
       default
   end
 
@@ -17,7 +17,7 @@ defmodule Teiserver.Helpers.CacheHelper do
     ConCache.get_or_store(table, key, func)
   catch
     :exit, :noproc ->
-      Logger.warning("Cache #{table} is down")
+      Logger.warning("Cache #{table} is down (get_or_store)")
       func.()
   end
 
@@ -38,7 +38,8 @@ defmodule Teiserver.Helpers.CacheHelper do
     )
   catch
     :exit, :noproc ->
-      Logger.warning("Cache #{table} is down")
+      # If the cache is down we don't need to delete stuff so this solves itself
+      :ok
   end
 
   def cache_delete(table, key), do: cache_delete(table, [key])
@@ -57,7 +58,7 @@ defmodule Teiserver.Helpers.CacheHelper do
     )
   catch
     :exit, :noproc ->
-      Logger.warning("Cache #{table} is down")
+      Logger.warning("Cache #{table} is down (put)")
   end
 
   @doc """
@@ -75,18 +76,44 @@ defmodule Teiserver.Helpers.CacheHelper do
   end
 
   @doc """
-  Puts the `value` into `key` for `table` across the entire cluster. Makes use of Phoenix.PubSub to do so.
-  """
-  @spec cache_update(atom, any, any) :: :ok | {:error, any}
-  def cache_update(table, key, func) do
-    ConCache.update(table, key, func)
+  The first argument is passed through.
 
-    Phoenix.PubSub.broadcast(
-      Teiserver.PubSub,
-      "cluster_hooks",
-      {:cluster_hooks, :update, Node.self(), table, key, func}
-    )
+  If passed an `{:ok, value}` as the first argument it will store the value in
+  the cache table under the key.
+
+  If no key is provided the `id` of the value in the ok'd tuple will be used.
+  """
+  @spec cache_put_on_ok({:ok, any()} | any(), atom) :: {:ok, any()} | any()
+  def cache_put_on_ok(result, table), do: cache_put_on_ok(result, table, nil)
+
+  @spec cache_put_on_ok({:ok, any()} | any(), atom, any()) :: {:ok, any()} | any()
+  def cache_put_on_ok({:ok, value}, table, key) do
+    key = key || value.id
+    cache_put(table, key, value)
+    {:ok, value}
   end
+
+  def cache_put_on_ok(error_value, _table, _key), do: error_value
+
+  @doc """
+  The first argument is passed through.
+
+  If passed an `{:ok, value}` as the first argument it will delete the cached
+  value for that table under that key.
+
+  If no key is provided the `id` of the value in the ok'd tuple will be used.
+  """
+  @spec cache_delete_on_ok({:ok, any()} | any(), atom) :: {:ok, any()} | any()
+  def cache_delete_on_ok(result, table), do: cache_delete_on_ok(result, table, nil)
+
+  @spec cache_delete_on_ok({:ok, any()} | any(), atom, any()) :: {:ok, any()} | any()
+  def cache_delete_on_ok({:ok, value}, table, key) do
+    key = key || value.id
+    cache_delete(table, key)
+    {:ok, value}
+  end
+
+  def cache_delete_on_ok(error_value, _table, _key), do: error_value
 
   # Stores
   @spec store_get(atom, any) :: any

--- a/lib/teiserver/helpers/general_test_lib.ex
+++ b/lib/teiserver/helpers/general_test_lib.ex
@@ -3,13 +3,13 @@ defmodule Teiserver.Helpers.GeneralTestLib do
 
   alias Teiserver.Account
   alias Teiserver.Account.Guardian
+  alias Teiserver.Helper.StringHelper
   alias TeiserverWeb.UserSocket
 
   import Phoenix.ChannelTest
   import Phoenix.ConnTest, only: [build_conn: 0, post: 3]
 
   @endpoint TeiserverWeb.Endpoint
-  @alphanum ~c"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
   # def make_combos(data), do: CombinatorLib.make_combos(data)
 
@@ -19,10 +19,7 @@ defmodule Teiserver.Helpers.GeneralTestLib do
   # unfortunately they have different signatures so it's not a find
   # and replace
   def make_user(params \\ %{}) do
-    name =
-      1..15
-      |> Enum.map(fn _idx -> Enum.random(@alphanum) end)
-      |> List.to_string()
+    name = StringHelper.random_name(15)
 
     {:ok, u} =
       Account.create_user(%{

--- a/lib/teiserver/helpers/number_helper.ex
+++ b/lib/teiserver/helpers/number_helper.ex
@@ -9,6 +9,17 @@ defmodule Teiserver.Helper.NumberHelper do
   def int_parse(l) when is_list(l), do: Enum.map(l, &int_parse/1)
   def int_parse(s), do: String.trim(s) |> String.to_integer()
 
+  @doc """
+  Allows us to parse a string as an integer but empty strings and nil
+  values will result in an error.
+
+  The intended purpose is to allow a common key to be used in caches
+  where a string representation of the id may be passed in (e.g. by web)
+  """
+  @spec int_parse!(String.t() | number()) :: Integer.t()
+  def int_parse!(i) when is_number(i), do: round(i)
+  def int_parse!(s), do: String.trim(s) |> String.to_integer()
+
   @spec float_parse(String.t() | nil | number() | List.t()) :: Float.t() | List.t()
   def float_parse(""), do: 0.0
   def float_parse(nil), do: 0.0

--- a/lib/teiserver/helpers/string_helper.ex
+++ b/lib/teiserver/helpers/string_helper.ex
@@ -166,4 +166,15 @@ defmodule Teiserver.Helper.StringHelper do
     |> String.replace("-", "")
     |> String.replace("_", "")
   end
+
+  @doc """
+  Generate a random alphanumeric string of characters of a given length
+  """
+  def random_name(len \\ 20) do
+    chars = ~c"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+    1..len
+    |> Enum.map(fn _idx -> Enum.random(chars) end)
+    |> List.to_string()
+  end
 end

--- a/lib/teiserver_web/controllers/admin/accolade_controller.ex
+++ b/lib/teiserver_web/controllers/admin/accolade_controller.ex
@@ -1,5 +1,6 @@
 defmodule TeiserverWeb.Admin.AccoladeController do
   alias Teiserver.Account
+  alias Teiserver.Account.User
 
   use TeiserverWeb, :controller
 
@@ -33,7 +34,7 @@ defmodule TeiserverWeb.Admin.AccoladeController do
         order_by: "Newest first"
       )
 
-    user = Account.deprecated_get_user_by_id(user_id)
+    %User{} = user = Account.get_user_by_id(user_id)
 
     conn
     |> assign(:accolades, accolades)

--- a/lib/teiserver_web/controllers/admin/match_controller.ex
+++ b/lib/teiserver_web/controllers/admin/match_controller.ex
@@ -1,5 +1,6 @@
 defmodule TeiserverWeb.Admin.MatchController do
   alias Teiserver.Account
+  alias Teiserver.Account.User
   alias Teiserver.Battle
 
   use TeiserverWeb, :controller
@@ -94,7 +95,7 @@ defmodule TeiserverWeb.Admin.MatchController do
 
     total_pages = div(total_count - 1, limit) + 1
 
-    user = Account.deprecated_get_user_by_id(userid)
+    %User{} = user = Account.get_user_by_id(userid)
 
     conn
     |> assign(:user, user)

--- a/lib/teiserver_web/controllers/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/admin/user_controller.ex
@@ -8,6 +8,7 @@ defmodule TeiserverWeb.Admin.UserController do
   alias Teiserver.Account.SmurfMergeTask
   alias Teiserver.Account.Tasks.GdprForgetTask
   alias Teiserver.Account.TOTPLib
+  alias Teiserver.Account.User
   alias Teiserver.Account.UserLib
   alias Teiserver.Battle
   alias Teiserver.Battle.BalanceLib
@@ -1122,7 +1123,7 @@ defmodule TeiserverWeb.Admin.UserController do
 
   @spec shadowban(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def shadowban(conn, %{"id" => id, "state" => state}) do
-    user = Account.deprecated_get_user_by_id(id)
+    %User{} = user = Account.get_user_by_id(id)
 
     case UserLib.has_access(user, conn) do
       {true, _access} ->

--- a/lib/teiserver_web/controllers/moderation/ban_controller.ex
+++ b/lib/teiserver_web/controllers/moderation/ban_controller.ex
@@ -223,7 +223,7 @@ defmodule TeiserverWeb.Moderation.BanController do
           |> List.flatten()
           |> Enum.map(fn %{user: user} -> user.id end)
           |> Enum.uniq()
-          |> Enum.map(fn userid -> Account.deprecated_get_user_by_id(userid) end)
+          |> Enum.map(fn userid -> Account.get_user_by_id(userid) end)
           |> Enum.reject(fn user ->
             Account.restricted?(user, ["Login"])
           end)

--- a/lib/teiserver_web/live/account/party/show.ex
+++ b/lib/teiserver_web/live/account/party/show.ex
@@ -2,6 +2,7 @@ defmodule TeiserverWeb.Account.PartyLive.Show do
   alias Phoenix.PubSub
   alias Teiserver.Account
   alias Teiserver.Account.PartyLib
+  alias Teiserver.Account.User
   alias Teiserver.Battle
 
   use TeiserverWeb, :live_view
@@ -25,7 +26,7 @@ defmodule TeiserverWeb.Account.PartyLive.Show do
         []
       end
 
-    user = Account.deprecated_get_user_by_id(socket.assigns.current_user.id)
+    %User{} = user = Account.get_user_by_id(socket.assigns.current_user.id)
     friends = Account.list_friend_ids_of_user(socket.assigns.current_user.id)
 
     :ok =

--- a/lib/teiserver_web/live/account/profile/accolades.ex
+++ b/lib/teiserver_web/live/account/profile/accolades.ex
@@ -9,9 +9,8 @@ defmodule TeiserverWeb.Account.ProfileLive.Accolades do
   import Teiserver.Helpers.ComponentHelper
 
   @impl Phoenix.LiveView
-  def mount(%{"userid" => userid_str}, _session, socket) do
-    userid = String.to_integer(userid_str)
-    user = Account.deprecated_get_user_by_id(userid)
+  def mount(%{"userid" => user_id}, _session, socket) do
+    user = Account.get_user_by_id(user_id)
 
     socket =
       if is_nil(user) do
@@ -21,7 +20,7 @@ defmodule TeiserverWeb.Account.ProfileLive.Accolades do
       else
         accolades =
           Account.list_accolades(
-            search: [recipient_id: userid, has_badge: true],
+            search: [recipient_id: user_id, has_badge: true],
             preload: [
               :giver,
               :recipient,

--- a/lib/teiserver_web/live/account/profile/appearance.ex
+++ b/lib/teiserver_web/live/account/profile/appearance.ex
@@ -8,9 +8,8 @@ defmodule TeiserverWeb.Account.ProfileLive.Appearance do
   use TeiserverWeb, :live_view
 
   @impl Phoenix.LiveView
-  def mount(%{"userid" => userid_str}, _session, socket) do
-    userid = String.to_integer(userid_str)
-    user = Account.deprecated_get_user_by_id(userid)
+  def mount(%{"userid" => user_id}, _session, socket) do
+    user = Account.get_user_by_id(user_id)
 
     socket =
       if is_nil(user) do

--- a/lib/teiserver_web/live/account/profile/contributor.ex
+++ b/lib/teiserver_web/live/account/profile/contributor.ex
@@ -8,14 +8,13 @@ defmodule TeiserverWeb.Account.ProfileLive.Contributor do
   use TeiserverWeb, :live_view
 
   @impl Phoenix.LiveView
-  def mount(%{"userid" => userid_str}, _session, socket) do
-    userid = String.to_integer(userid_str)
-    user = Account.deprecated_get_user_by_id(userid)
-    hide_contributor_rank = Account.hide_contributor_rank?(userid)
+  def mount(%{"userid" => user_id}, _session, socket) do
+    user = Account.get_user_by_id(user_id)
+    hide_contributor_rank = Account.hide_contributor_rank?(user.id)
 
     socket =
       cond do
-        user == nil ->
+        is_nil(user) ->
           socket
           |> put_flash(:info, "Unable to find that user")
           |> redirect(to: ~p"/")

--- a/lib/teiserver_web/live/account/profile/matches.ex
+++ b/lib/teiserver_web/live/account/profile/matches.ex
@@ -13,9 +13,8 @@ defmodule TeiserverWeb.Account.ProfileLive.Matches do
   import TeiserverWeb.PaginationComponents, only: [pagination: 1]
 
   @impl Phoenix.LiveView
-  def mount(%{"userid" => userid_str}, _session, socket) do
-    userid = String.to_integer(userid_str)
-    user = Account.deprecated_get_user_by_id(userid)
+  def mount(%{"userid" => user_id}, _session, socket) do
+    user = Account.get_user_by_id(user_id)
 
     socket =
       if is_nil(user) do

--- a/lib/teiserver_web/live/account/profile/overview.ex
+++ b/lib/teiserver_web/live/account/profile/overview.ex
@@ -12,9 +12,8 @@ defmodule TeiserverWeb.Account.ProfileLive.Overview do
   use TeiserverWeb, :live_view
 
   @impl Phoenix.LiveView
-  def mount(%{"userid" => userid_str}, _session, socket) do
-    userid = String.to_integer(userid_str)
-    user = Account.deprecated_get_user_by_id(userid)
+  def mount(%{"userid" => user_id}, _session, socket) do
+    user = Account.get_user_by_id(user_id)
 
     socket =
       if is_nil(user) do
@@ -25,7 +24,7 @@ defmodule TeiserverWeb.Account.ProfileLive.Overview do
         :ok =
           PubSub.subscribe(
             Teiserver.PubSub,
-            "teiserver_client_messages:#{userid}"
+            "teiserver_client_messages:#{user_id}"
           )
 
         socket
@@ -34,7 +33,7 @@ defmodule TeiserverWeb.Account.ProfileLive.Overview do
         |> assign(:view_colour, UserLib.colours())
         |> assign(:user, user)
         |> assign(:role_data, RoleLib.role_data())
-        |> assign(:client, Account.get_client_by_id(userid))
+        |> assign(:client, Account.get_client_by_id(user.id))
         |> get_relationships_and_permissions()
         |> assign_accolade_notification()
       end

--- a/lib/teiserver_web/live/account/profile/playtime.ex
+++ b/lib/teiserver_web/live/account/profile/playtime.ex
@@ -7,9 +7,8 @@ defmodule TeiserverWeb.Account.ProfileLive.Playtime do
   use TeiserverWeb, :live_view
 
   @impl Phoenix.LiveView
-  def mount(%{"userid" => userid_str}, _session, socket) do
-    userid = String.to_integer(userid_str)
-    user = Account.deprecated_get_user_by_id(userid)
+  def mount(%{"userid" => user_id}, _session, socket) do
+    user = Account.get_user_by_id(user_id)
 
     socket =
       if is_nil(user) do

--- a/lib/teiserver_web/live/account/profile/relationships.ex
+++ b/lib/teiserver_web/live/account/profile/relationships.ex
@@ -7,9 +7,8 @@ defmodule TeiserverWeb.Account.ProfileLive.Relationships do
   use TeiserverWeb, :live_view
 
   @impl Phoenix.LiveView
-  def mount(%{"userid" => userid_str}, _session, socket) do
-    userid = String.to_integer(userid_str)
-    user = Account.deprecated_get_user_by_id(userid)
+  def mount(%{"userid" => user_id}, _session, socket) do
+    user = Account.get_user_by_id(user_id)
 
     socket =
       if is_nil(user) do

--- a/lib/teiserver_web/live/admin/chat/index.ex
+++ b/lib/teiserver_web/live/admin/chat/index.ex
@@ -35,7 +35,7 @@ defmodule TeiserverWeb.Admin.ChatLive.Index do
   def handle_params(params, _url, %{assigns: %{filters: filters}} = socket) do
     filters =
       if params["userid"] do
-        user = Account.deprecated_get_user_by_id(params["userid"])
+        user = Account.get_user_by_id!(params["userid"])
 
         Map.merge(filters, %{
           "username" => user.name,

--- a/lib/teiserver_web/live/battles/lobbies/chat.ex
+++ b/lib/teiserver_web/live/battles/lobbies/chat.ex
@@ -65,7 +65,7 @@ defmodule TeiserverWeb.Battle.LobbyLive.Chat do
         players = id |> int_parse() |> Lobby.list_lobby_players!()
         clients = get_clients(players)
 
-        bar_user = Account.deprecated_get_user_by_id(socket.assigns.current_user.id)
+        bar_user = Account.get_user_by_id(socket.assigns.current_user.id)
         lobby = Map.put(lobby, :uuid, Battle.get_lobby_match_uuid(id))
 
         messages =
@@ -262,7 +262,7 @@ defmodule TeiserverWeb.Battle.LobbyLive.Chat do
       |> Enum.map(fn {id, _message} -> id end)
       |> Enum.uniq()
       |> Enum.filter(fn userid -> not Map.has_key?(user_map, userid) end)
-      |> Map.new(fn userid -> {userid, Account.deprecated_get_user_by_id(userid)} end)
+      |> Map.new(fn userid -> {userid, Account.get_user_by_id(userid)} end)
 
     socket
     |> assign(:user_map, Map.merge(user_map, extra_users))

--- a/lib/teiserver_web/live/battles/lobbies/show.ex
+++ b/lib/teiserver_web/live/battles/lobbies/show.ex
@@ -99,7 +99,7 @@ defmodule TeiserverWeb.Battle.LobbyLive.Show do
         {users, clients, ratings, parties, stats} =
           get_user_and_clients(lobby.players, consul_state)
 
-        bar_user = CacheUser.deprecated_get_user_by_id(socket.assigns.current_user.id)
+        bar_user = Account.get_user_by_id(socket.assigns.current_user.id)
         lobby = Map.put(lobby, :uuid, Battle.get_lobby_match_uuid(id))
         modoptions = Battle.get_modoptions(id)
 

--- a/lib/teiserver_web/live/clients/index.ex
+++ b/lib/teiserver_web/live/clients/index.ex
@@ -1,8 +1,8 @@
 defmodule TeiserverWeb.ClientLive.Index do
   alias Phoenix.PubSub
   alias Teiserver
+  alias Teiserver.Account
   alias Teiserver.Account.UserLib
-  alias Teiserver.CacheUser
   alias Teiserver.Client
 
   use TeiserverWeb, :live_view
@@ -26,7 +26,7 @@ defmodule TeiserverWeb.ClientLive.Index do
       |> Map.new(fn {userid, _client} ->
         {
           userid,
-          CacheUser.deprecated_get_user_by_id(userid) |> limited_user()
+          userid |> Account.get_user_by_id() |> limited_user()
         }
       end)
       |> Map.filter(fn {_key, value} -> not is_nil(value) end)
@@ -83,8 +83,7 @@ defmodule TeiserverWeb.ClientLive.Index do
         if Map.has_key?(assigns.users, userid) do
           assigns.users[userid]
         else
-          CacheUser.deprecated_get_user_by_id(userid)
-          |> limited_user()
+          userid |> Account.get_user_by_id() |> limited_user()
         end
       end)
       |> Enum.reject(&is_nil(&1))

--- a/lib/teiserver_web/live/clients/show.ex
+++ b/lib/teiserver_web/live/clients/show.ex
@@ -52,7 +52,7 @@ defmodule TeiserverWeb.ClientLive.Show do
         id = int_parse(id)
         PubSub.subscribe(Teiserver.PubSub, "teiserver_client_watch:#{id}")
         client = Account.get_client_by_id(id)
-        user = CacheUser.deprecated_get_user_by_id(id)
+        user = Account.get_user_by_id(id)
 
         if client && user do
           {:noreply,

--- a/lib/teiserver_web/live/communication/chat/room.ex
+++ b/lib/teiserver_web/live/communication/chat/room.ex
@@ -51,7 +51,7 @@ defmodule TeiserverWeb.Communication.ChatLive.Room do
 
   @impl Phoenix.LiveView
   def handle_info(%{channel: "room_chat"} = event, socket) do
-    user = Account.deprecated_get_user_by_id(event.user_id)
+    user = Account.get_user_by_id(event.user_id)
 
     message = %{
       id: event.id,

--- a/lib/teiserver_web/live/microblog/admin/post/post_form_component.ex
+++ b/lib/teiserver_web/live/microblog/admin/post/post_form_component.ex
@@ -535,7 +535,7 @@ defmodule TeiserverWeb.Microblog.PostFormComponent do
   end
 
   defp create_discord_text(post) do
-    user = Account.deprecated_get_user_by_id(post.poster_id)
+    user = Account.get_user_by_id(post.poster_id)
 
     host = Application.get_env(:teiserver, TeiserverWeb.Endpoint)[:url][:host]
     create_discord_text(user, post, host)

--- a/lib/teiserver_web/live/moderation/report_user/index.ex
+++ b/lib/teiserver_web/live/moderation/report_user/index.ex
@@ -24,7 +24,7 @@ defmodule TeiserverWeb.Moderation.ReportUserLive.Index do
 
   @impl Phoenix.LiveView
   def handle_params(%{"id" => id}, _url, socket) do
-    user = Account.deprecated_get_user_by_id(id)
+    user = Account.get_user_by_id(id)
 
     socket =
       socket

--- a/test/support/fixtures/account/account_fixtures.ex
+++ b/test/support/fixtures/account/account_fixtures.ex
@@ -5,8 +5,7 @@ defmodule Teiserver.AccountFixtures do
   """
   alias Teiserver.Account
   alias Teiserver.Account.AuthLib
-
-  @alphanum ~c"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+  alias Teiserver.Helper.StringHelper
 
   @doc """
   Generate a tag.
@@ -17,10 +16,7 @@ defmodule Teiserver.AccountFixtures do
       |> Map.get(:permissions, [])
       |> AuthLib.split_permissions()
 
-    name =
-      1..15
-      |> Enum.map(fn _idx -> Enum.random(@alphanum) end)
-      |> List.to_string()
+    name = StringHelper.random_name(15)
 
     {:ok, user} =
       attrs

--- a/test/teiserver/account/cache_user_test.exs
+++ b/test/teiserver/account/cache_user_test.exs
@@ -1,7 +1,10 @@
 defmodule Teiserver.Account.CacheUserTest do
   alias Teiserver.Account
+  alias Teiserver.Account.User
+  alias Teiserver.Account.UserCacheLib
   alias Teiserver.AccountFixtures
   alias Teiserver.CacheUser
+  alias Teiserver.Helper.StringHelper
 
   use Teiserver.DataCase, async: true
 
@@ -48,5 +51,85 @@ defmodule Teiserver.Account.CacheUserTest do
     assert {cache_user.chobby_hash, user.chobby_hash} == {"c-hash", "c-hash"}
     assert {cache_user.lobby_client, user.lobby_client} == {"client-name", "client-name"}
     assert {cache_user.discord_dm_channel, user.discord_dm_channel} == {456, 456}
+  end
+
+  describe "transfer checks" do
+    test "update User, expect fresh CacheUser" do
+      # This is the important test in this block, we are validating
+      # that updating the db_user and getting a cache_user will
+      # yield a fresh cache_user instead of the stale one
+      %User{id: user_id} = db_user = AccountFixtures.user_fixture()
+      %CacheUser{} = cache_user = CacheUser.deprecated_get_user_by_id(user_id)
+
+      # If they're not equal here something has gone wrong, given the changes
+      # being made to this system it is reasonable to be certain they are equal
+      # at this stage
+      assert_user_equals_cache_user(db_user, cache_user)
+
+      {:ok, updated_db_user} =
+        Account.script_update_user(
+          db_user,
+          %{name: StringHelper.random_name(), icon: "new-icon", colour: "new-colour"}
+        )
+
+      # We grab the db representation into a new value because this will test the cache for
+      # the db_user itself which should match the returned updated_db_user
+      %User{} = new_db_user = Account.get_user_by_id!(user_id)
+      %CacheUser{} = new_cache_user = CacheUser.deprecated_get_user_by_id(user_id)
+
+      assert_user_equals_cache_user(new_db_user, new_cache_user)
+      assert_user_equals_cache_user(updated_db_user, new_cache_user)
+    end
+
+    test "update CacheUser, expect fresh User" do
+      # This one is not used much, we mostly update the user object and then
+      # de-reference the CacheUser rather than the other way around
+      %User{id: user_id} = db_user = AccountFixtures.user_fixture()
+      %CacheUser{} = cache_user = CacheUser.deprecated_get_user_by_id(user_id)
+
+      # If they're not equal here something has gone wrong, given the changes
+      # being made to this system it is reasonable to be certain they are equal
+      # at this stage
+      assert_user_equals_cache_user(db_user, cache_user)
+
+      new_cache_user =
+        UserCacheLib.update_cache_user(
+          user_id,
+          %{name: StringHelper.random_name(), icon: "new-icon", colour: "new-colour"}
+        )
+
+      %User{} = new_db_user = Account.get_user_by_id(user_id)
+
+      assert_user_equals_cache_user(new_db_user, new_cache_user)
+    end
+
+    defp assert_user_equals_cache_user(%User{} = db_user, %CacheUser{} = cache_user) do
+      assert db_user.name == cache_user.name
+      assert db_user.email == cache_user.email
+      assert db_user.icon == cache_user.icon
+      assert db_user.colour == cache_user.colour
+      assert db_user.roles == cache_user.roles
+      assert db_user.permissions == cache_user.permissions
+      assert db_user.restrictions == cache_user.restrictions
+      assert db_user.restricted_until == cache_user.restricted_until
+      assert db_user.shadowbanned == cache_user.shadowbanned
+      assert db_user.last_login == cache_user.last_login
+      assert db_user.last_played == cache_user.last_played
+      assert db_user.last_logout == cache_user.last_logout
+      assert db_user.discord_id == cache_user.discord_id
+      assert db_user.discord_dm_channel_id == cache_user.discord_dm_channel_id
+      assert db_user.steam_id == cache_user.steam_id
+      assert db_user.smurf_of_id == cache_user.smurf_of_id
+      assert db_user.inserted_at == cache_user.inserted_at
+      assert db_user.rank == cache_user.rank
+      assert db_user.country == cache_user.country
+      assert db_user.bot == cache_user.bot
+      assert db_user.email_change_code == cache_user.email_change_code
+      assert db_user.last_login_mins == cache_user.last_login_mins
+      assert db_user.lobby_hash == cache_user.lobby_hash
+      assert db_user.chobby_hash == cache_user.chobby_hash
+      assert db_user.lobby_client == cache_user.lobby_client
+      assert db_user.discord_dm_channel == cache_user.discord_dm_channel
+    end
   end
 end

--- a/test/teiserver_web/tachyon/user_test.exs
+++ b/test/teiserver_web/tachyon/user_test.exs
@@ -9,7 +9,7 @@ defmodule TeiserverWeb.Tachyon.UserTest do
   describe "info" do
     test "works", %{user: user, client: client} do
       %{id: user_id, name: name} = user
-      %{country: country} = Account.deprecated_get_user_by_id(user_id)
+      %{country: country} = Account.get_user_by_id(user_id)
       user_id = to_string(user_id)
 
       assert %{


### PR DESCRIPTION
Given the non-critical nature of most of the pages this is a good first step towards pulling in data directly from the database.

A test is added to ensure updating either the CacheUser or User will result in the cache being cleared or updated for the other.