### PR TITLE
Fixes smurf links coming undone

### DIFF
--- a/lib/teiserver/account.ex
+++ b/lib/teiserver/account.ex
@@ -126,6 +126,10 @@ defmodule Teiserver.Account do
           {:ok, User.t()} | {:error, Ecto.Changeset.t()}
   defdelegate password_reset_update_user(user, attrs), to: UserLib
 
+  @spec update_user_smurf(User.t(), map) ::
+          {:ok, User.t()} | {:error, Ecto.Changeset.t()}
+  defdelegate update_user_smurf(user, attrs), to: UserLib
+
   @spec delete_user(User.t()) :: {:ok, User.t()} | {:error, Ecto.Changeset.t()}
   defdelegate delete_user(user), to: UserLib
 

--- a/lib/teiserver/account/libs/user_lib.ex
+++ b/lib/teiserver/account/libs/user_lib.ex
@@ -307,6 +307,15 @@ defmodule Teiserver.Account.UserLib do
     |> UserCacheLib.decache_user_on_ok()
   end
 
+  def update_user_smurf(%User{} = user, attrs) do
+    user
+    |> User.smurf_changeset(attrs)
+    |> Repo.update()
+    |> broadcast_update_user()
+    |> cache_put_on_ok(:users_by_id)
+    |> UserCacheLib.decache_user_on_ok()
+  end
+
   @doc """
   Deletes a user.
 
@@ -557,7 +566,7 @@ defmodule Teiserver.Account.UserLib do
     result =
       Repo.transact(fn ->
         with {:ok, _updated_user} <-
-               script_update_user(smurf, %{"smurf_of_id" => actual_origin_id}),
+               update_user_smurf(smurf, %{smurf_of_id: actual_origin_id}),
              {:ok, %User{}} <- Auth.add_roles(origin.id, ["Smurfer"]),
              :ok <- Account.deprecated_recache_user(smurf.id) do
           add_audit_log(

--- a/lib/teiserver/account/schemas/user.ex
+++ b/lib/teiserver/account/schemas/user.ex
@@ -4,6 +4,7 @@ defmodule Teiserver.Account.User do
   alias Argon2
   alias Ecto.Changeset
   alias Teiserver.Account
+  alias Teiserver.Account.User
   alias Teiserver.CacheUser
   alias Teiserver.Helper.StylingHelper
 
@@ -90,7 +91,7 @@ defmodule Teiserver.Account.User do
     user
     |> cast(
       attrs,
-      ~w(name email password icon colour data roles permissions restrictions restricted_until shadowbanned last_login last_played last_logout discord_id discord_dm_channel_id steam_id smurf_of_id country bot email_change_code last_login_mins lobby_hash chobby_hash lobby_client discord_dm_channel)a
+      ~w(name email password icon colour data roles permissions restrictions restricted_until shadowbanned last_login last_played last_logout discord_id discord_dm_channel_id steam_id country bot email_change_code last_login_mins lobby_hash chobby_hash lobby_client discord_dm_channel)a
     )
     |> validate_required([:name, :email, :password, :permissions])
     |> unique_constraint(:email)
@@ -107,7 +108,7 @@ defmodule Teiserver.Account.User do
     user
     |> cast(
       attrs,
-      ~w(name email password icon colour data roles permissions restrictions restricted_until shadowbanned last_login last_played last_logout discord_id discord_dm_channel_id steam_id smurf_of_id rank country bot email_change_code last_login_mins lobby_hash chobby_hash lobby_client discord_dm_channel)a
+      ~w(name email password icon colour data roles permissions restrictions restricted_until shadowbanned last_login last_played last_logout discord_id discord_dm_channel_id steam_id rank country bot email_change_code last_login_mins lobby_hash chobby_hash lobby_client discord_dm_channel)a
     )
     |> validate_required([:name, :email, :password, :permissions])
     |> unique_constraint(:email)
@@ -249,7 +250,7 @@ defmodule Teiserver.Account.User do
     user
     |> cast(
       attrs,
-      ~w(name email password icon colour data roles permissions restrictions restricted_until shadowbanned last_login last_played last_logout discord_id discord_dm_channel_id steam_id smurf_of_id)a
+      ~w(name email password icon colour data roles permissions restrictions restricted_until shadowbanned last_login last_played last_logout discord_id discord_dm_channel_id steam_id)a
     )
     |> validate_required([:name, :email, :password, :permissions])
     |> unique_constraint(:email)
@@ -305,6 +306,10 @@ defmodule Teiserver.Account.User do
         :md5_password -> put_md5_password_hash(changeset)
       end
     end)
+  end
+
+  def smurf_changeset(%User{} = user, attrs) do
+    cast(user, attrs, [:smurf_of_id])
   end
 
   defp change_plain_password(user, attrs) do

--- a/lib/teiserver/coordinator/automod_server.ex
+++ b/lib/teiserver/coordinator/automod_server.ex
@@ -194,7 +194,7 @@ defmodule Teiserver.Coordinator.AutomodServer do
 
   def enact_ban([ban | _rest], userid) do
     user = Account.get_user!(userid)
-    {:ok, _update_result} = Account.server_update_user(user, %{"smurf_of_id" => ban.source_id})
+    {:ok, _update_result} = Account.server_update_user(user, %{smurf_of_id: ban.source_id})
 
     add_audit_log(
       Coordinator.get_coordinator_userid(),

--- a/lib/teiserver_web/controllers/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/admin/user_controller.ex
@@ -852,7 +852,7 @@ defmodule TeiserverWeb.Admin.UserController do
 
     case UserLib.has_access(user, conn) do
       {true, _role} ->
-        case Account.script_update_user(user, %{"smurf_of_id" => nil}) do
+        case Account.update_user_smurf(user, %{smurf_of_id: nil}) do
           {:ok, user} ->
             add_audit_log(conn, "Moderation:Cancel smurf mark", %{
               smurf_userid: user.id,

--- a/test/teiserver/account/user_lib_test.exs
+++ b/test/teiserver/account/user_lib_test.exs
@@ -213,7 +213,7 @@ defmodule Teiserver.Account.UserLibTest do
       # If A is a smurf of B, B cannot be made a smurf of A
       {:ok, %User{} = moderator} = Auth.add_roles(moderator.id, ["Moderator"])
 
-      {:ok, origin} = Account.script_update_user(origin, %{smurf_of_id: smurf.id})
+      {:ok, origin} = Account.update_user_smurf(origin, %{smurf_of_id: smurf.id})
 
       result = UserLib.mark_user_as_smurf_of(moderator, %{smurf: smurf, origin: origin})
       assert result == {:error, "Invalid combination of users selected"}


### PR DESCRIPTION
The script_update_user, when not suppied with a smurf_of_id can set the smurf_of_id value to nil. This swaps smurf linking to a different changeset.