### PR TITLE
YOLOing issue #1394

### DIFF
--- a/lib/teiserver/account/caches/user_cache_lib.ex
+++ b/lib/teiserver/account/caches/user_cache_lib.ex
@@ -18,12 +18,10 @@ defmodule Teiserver.Account.UserCacheLib do
   def get_username_by_id(userid) do
     userid = int_parse(userid)
 
-    Teiserver.cache_get_or_store(:users_lookup_name_with_id, int_parse(userid), fn ->
-      case deprecated_get_user_by_id(userid) do
-        nil -> nil
-        user -> user.name
-      end
-    end)
+    case deprecated_get_user_by_id(userid) do
+      nil -> nil
+      user -> user.name
+    end
   end
 
   @spec get_userid(String.t() | nil) :: User.id() | nil
@@ -229,7 +227,6 @@ defmodule Teiserver.Account.UserCacheLib do
 
   def add_user(user) do
     deprecated_update_user(user)
-    Teiserver.cache_put(:users_lookup_name_with_id, user.id, user.name)
     Teiserver.cache_put(:users_lookup_id_with_name, cachename(user.name), user.id)
     Teiserver.cache_put(:users_lookup_id_with_email, cachename(user.email), user.id)
 
@@ -284,7 +281,6 @@ defmodule Teiserver.Account.UserCacheLib do
   """
   def decache_user_on_ok({:ok, %User{} = user} = result) do
     Teiserver.cache_delete(:users, user.id)
-    Teiserver.cache_delete(:users_lookup_name_with_id, user.id)
     Teiserver.cache_delete(:users_lookup_id_with_name, cachename(user.name))
     Teiserver.cache_delete(:users_lookup_id_with_email, cachename(user.email))
 
@@ -301,7 +297,6 @@ defmodule Teiserver.Account.UserCacheLib do
   def decache_user(userid) do
     user = deprecated_get_user_by_id(userid)
 
-    # Teiserver.cache_delete(:users, userid)
     if user do
       # This is used by the UserLib, to prevent us having to have both functions
       # call the other we instead have the UserLib call here and once this is removed
@@ -309,7 +304,6 @@ defmodule Teiserver.Account.UserCacheLib do
       Teiserver.cache_delete(:users_by_id, user.id)
 
       Teiserver.cache_delete(:users, user.id)
-      Teiserver.cache_delete(:users_lookup_name_with_id, user.id)
       Teiserver.cache_delete(:users_lookup_id_with_name, cachename(user.name))
       Teiserver.cache_delete(:users_lookup_id_with_email, cachename(user.email))
 

--- a/lib/teiserver/application.ex
+++ b/lib/teiserver/application.ex
@@ -103,7 +103,6 @@ defmodule Teiserver.Application do
         concache_perm_sup(:users_by_id),
 
         # Caches
-        concache_perm_sup(:users_lookup_name_with_id),
         concache_perm_sup(:users_lookup_id_with_name),
         concache_perm_sup(:users_lookup_id_with_email),
         concache_perm_sup(:users_lookup_id_with_discord),


### PR DESCRIPTION
I suspect the deadlocks are caused by some inconsistent acquisition order on the caches, and some unfortunate timings. Although I couldn't produce a test case or an explanation for such deadlock, I believe removing this cache should help.

We have a cache that does `user.id => %CacheUser{}`, so a different cache `user.id => username` is redundant.