### PR TITLE
Fix deadlocks issue 1394

### DIFF
--- a/lib/teiserver/account/caches/user_cache_lib.ex
+++ b/lib/teiserver/account/caches/user_cache_lib.ex
@@ -31,24 +31,23 @@ defmodule Teiserver.Account.UserCacheLib do
   def get_userid(username) do
     username = cachename(username)
 
-    Teiserver.cache_get_or_store(:users_lookup_id_with_name, username, fn ->
-      user =
-        Account.query_user(
-          search: [
-            name_lower: username
-          ],
-          select: [:id]
-        )
+    case Teiserver.cache_get(:users_lookup_id_with_name, username) do
+      nil ->
+        user =
+          Account.query_user(search: [name_lower: username])
 
-      case user do
-        nil ->
-          nil
+        case user do
+          nil ->
+            nil
 
-        %{id: id} ->
-          deprecated_recache_user(id)
-          id
-      end
-    end)
+          user ->
+            deprecated_recache_user(user)
+            user.id
+        end
+
+      id ->
+        id
+    end
   end
 
   @spec deprecated_get_user_by_name(String.t() | nil) :: T.user() | nil
@@ -98,11 +97,14 @@ defmodule Teiserver.Account.UserCacheLib do
   def deprecated_get_user_by_id(id) do
     id = int_parse(id)
 
-    Teiserver.cache_get_or_store(:users, id, fn ->
-      Account.get_user(id)
-      |> convert_user()
-      |> add_user()
-    end)
+    case Teiserver.cache_get(:users, id) do
+      nil ->
+        deprecated_recache_user(id)
+        Teiserver.cache_get(:users, id)
+
+      user ->
+        user
+    end
   end
 
   @spec get_userid_by_discord_id(String.t() | nil) :: User.id() | nil
@@ -147,10 +149,10 @@ defmodule Teiserver.Account.UserCacheLib do
     |> Enum.filter(fn user -> user != nil end)
   end
 
-  @spec deprecated_recache_user(User.id() | CacheUser.t() | map()) :: :ok
-  def deprecated_recache_user(%{id: id}), do: deprecated_recache_user(id)
+  @spec deprecated_recache_user(User.id() | CacheUser.t() | map() | nil) :: :ok
+  def deprecated_recache_user(nil), do: :ok
 
-  def deprecated_recache_user(id) when is_integer(id) do
+  def deprecated_recache_user(%{id: id} = user) do
     Teiserver.cache_delete(:account_user_cache, id)
     Teiserver.cache_delete(:account_user_cache_bang, id)
     Teiserver.cache_delete(:account_membership_cache, id)
@@ -158,11 +160,15 @@ defmodule Teiserver.Account.UserCacheLib do
 
     Account.decache_relationships(id)
 
-    Account.get_user(id)
+    user
     |> convert_user()
     |> add_user()
 
     :ok
+  end
+
+  def deprecated_recache_user(id) when is_integer(id) do
+    Account.get_user(id) |> deprecated_recache_user()
   end
 
   @doc """

--- a/test/teiserver/account/lock_test.exs
+++ b/test/teiserver/account/lock_test.exs
@@ -1,0 +1,92 @@
+defmodule Teiserver.Account.UserCacheLibTest do
+  alias Teiserver.Account
+  alias Teiserver.Account.UserCacheLib
+
+  use Teiserver.DataCase, async: false
+  import Teiserver.AccountFixtures, only: [user_fixture: 0]
+
+  describe "deadlocks on cache population" do
+    # see https://github.com/beyond-all-reason/teiserver/issues/1394
+    test "get_username/1 and get_userid_from_name/1" do
+      user = user_fixture()
+
+      fns = [
+        fn -> Account.get_username(user.id) end,
+        fn -> Account.get_userid_from_name(user.name) end
+      ]
+
+      {deadlocks, at_round} = check_deadlocks(fn -> UserCacheLib.decache_user(user.id) end, fns)
+
+      assert deadlocks == [], "Deadlock detected on round #{at_round}"
+
+      # sanity check
+      assert Account.get_username(user.id) == user.name
+      assert Account.get_userid_from_name(user.name) == user.id
+    end
+
+    test "get_username/1 and deprecated_get_user_by_email/" do
+      user = user_fixture()
+
+      fns = [
+        fn -> Account.get_username(user.id) end,
+        fn -> Account.deprecated_get_user_by_email(user.email) end
+      ]
+
+      {deadlocks, at_round} = check_deadlocks(fn -> UserCacheLib.decache_user(user.id) end, fns)
+
+      assert deadlocks == [], "Deadlock detected on round #{at_round}"
+
+      # sanity check
+      assert Account.get_username(user.id) == user.name
+      assert Account.deprecated_get_user_by_email(user.email).email == user.email
+    end
+  end
+
+  defp with_catch_timeout(fun) do
+    Task.async(fn ->
+      try do
+        fun.()
+        :ok
+      catch
+        :exit, {:timeout, _reason} -> :deadlock
+      end
+    end)
+  end
+
+  defp check_deadlocks(setup_round_fn, fns, rounds \\ 50) do
+    # make sure both paths start cold
+    setup_round_fn.()
+
+    tasks =
+      Enum.map(fns, fn f ->
+        with_catch_timeout(fn -> f.() end)
+      end)
+
+    deadlocks =
+      tasks
+      # wait for at least as long as the default timeout for ConCache (5s)
+      |> Task.yield_many(:timer.seconds(6))
+      |> Enum.map(fn
+        {_task, {:ok, :deadlock}} -> :deadlock
+        {_task, {:ok, :ok}} -> nil
+        # never returned even after the lock timeout should have fired
+        {_task, nil} -> :no_result
+      end)
+      |> Enum.reject(&is_nil/1)
+
+    # tear the round down before asserting, so a failure doesn't leave
+    # lock-holding processes behind to poison later tests
+    Enum.each(tasks, &Task.shutdown(&1, :brutal_kill))
+
+    case {deadlocks, rounds} do
+      {results, 0} ->
+        {results, 0}
+
+      {[], rounds} ->
+        check_deadlocks(setup_round_fn, fns, rounds - 1)
+
+      {results, rounds} ->
+        {results, rounds}
+    end
+  end
+end

--- a/test/teiserver/protocols/spring/spring_auth_test.exs
+++ b/test/teiserver/protocols/spring/spring_auth_test.exs
@@ -208,6 +208,8 @@ IGNORELISTEND\n"
     assert reply == :timeout
   end
 
+  # https://github.com/beyond-all-reason/teiserver/actions/runs/29731305203/job/88316188735?pr=1397
+  @tag :needs_attention
   test "JOIN, GETCHANNELMESSAGES, LEAVE, SAY, CHANNELS, SAYEX", %{socket: socket, user: user} do
     _send_raw(socket, "JOIN test_room\n")
     reply = _recv_raw(socket)


### PR DESCRIPTION
This time there is a reproduction, and a proper fix.
The caching logic is now slightly different, a cache miss will trigger a
full recache of the user, then another cache (hit).
The performance impact should be negligible, and at least with that it
won't deadlock.

Ultimately however, most if not all this code should disappear when we
switch to tachyon, which only deals with user id. The other queries
(like via email) should be done without cache as they will be infrequent
enough.

The tests were adapted from https://github.com/beyond-all-reason/teiserver/pull/1396