### PR TITLE
Update name displayed of bridged messages

### DIFF
--- a/lib/teiserver/bridge/discord_bridge_bot.ex
+++ b/lib/teiserver/bridge/discord_bridge_bot.ex
@@ -574,7 +574,8 @@ defmodule Teiserver.Bridge.DiscordBridgeBot do
          author: author,
          content: content,
          channel_id: channel_id,
-         mentions: mentions
+         mentions: mentions,
+         member: %{nick: nick}
        }) do
     # Mentions come through encoded in a way we don't want to preserve, this substitutes them
     new_content =
@@ -602,11 +603,18 @@ defmodule Teiserver.Bridge.DiscordBridgeBot do
     #     end
     # end
 
+    name =
+      if nick == nil do
+        author.global_name
+      else
+        nick
+      end
+
     message =
       if from_id == bridge_user_id do
         new_content
         |> Enum.map(fn row ->
-          "#{author.username}: #{row}"
+          "#{name}: #{row}"
         end)
       else
         new_content

--- a/lib/teiserver/bridge/discord_bridge_bot.ex
+++ b/lib/teiserver/bridge/discord_bridge_bot.ex
@@ -603,12 +603,7 @@ defmodule Teiserver.Bridge.DiscordBridgeBot do
     #     end
     # end
 
-    name =
-      if nick == nil do
-        author.global_name
-      else
-        nick
-      end
+    name = nick || author.global_name
 
     message =
       if from_id == bridge_user_id do


### PR DESCRIPTION
This PR updates the messaged bridged from discord to the game to use the discord server specific nick name, or the global display name instead of the account name