### PR TITLE
Remove un-used roles, structify Role and add Senior moderator

### DIFF
--- a/lib/teiserver/account/caches/permission_cache.ex
+++ b/lib/teiserver/account/caches/permission_cache.ex
@@ -51,7 +51,7 @@ defmodule Teiserver.Account.PermissionCache do
     add_permission_set(
       "teiserver",
       "player",
-      ~w(account tester contributor dev streamer donor verified bot moderator)
+      ~w(account contributor dev verified bot moderator)
     )
 
     :ok = Startup.startup()

--- a/lib/teiserver/account/libs/auth_lib.ex
+++ b/lib/teiserver/account/libs/auth_lib.ex
@@ -8,6 +8,7 @@ defmodule Teiserver.Account.AuthLib do
   alias Plug.Conn
   alias Teiserver.Account
   alias Teiserver.Account.Auth
+  alias Teiserver.Account.Role
   alias Teiserver.Account.RoleLib
 
   @spec icon :: String.t()
@@ -43,13 +44,16 @@ defmodule Teiserver.Account.AuthLib do
     permission_list ++ sections ++ modules
   end
 
+  @doc """
+  Given a list of roles, extract a combined list of all the permissions granted by these roles.
+  """
   @spec get_permissions_from_roles([String.t()]) :: [String.t()]
   def get_permissions_from_roles(roles) do
     roles
     |> Enum.map(fn role_name ->
       case RoleLib.role_data(role_name) do
         nil -> [role_name]
-        %{contains: permissions} -> [role_name | permissions]
+        %Role{contains: permissions} -> [role_name | permissions]
       end
     end)
     |> List.flatten()

--- a/lib/teiserver/account/libs/role_lib.ex
+++ b/lib/teiserver/account/libs/role_lib.ex
@@ -8,265 +8,179 @@ defmodule Teiserver.Account.RoleLib do
   to update permissions in the database of each user
   """
 
-  @role_defaults %{
-    badge: false
-  }
+  alias Teiserver.Account.Role
 
-  # If Role A contains Role B, Role B needs to be listed first
-  @raw_role_data [
-    # Global
-    %{name: "Default", colour: "#666666", icon: "fa-solid fa-user", contains: ~w(), badge: true},
-    %{name: "Armada", colour: "#000066", icon: "fa-solid fa-a", contains: ~w(), badge: true},
-    %{name: "Cortex", colour: "#660000", icon: "fa-solid fa-c", contains: ~w(), badge: true},
-    %{name: "Legion", colour: "#006600", icon: "fa-solid fa-l", contains: ~w(), badge: true},
-    %{
-      name: "Raptor",
-      colour: "#AA6600",
-      icon: "fa-solid fa-egg",
-      contains: ~w(),
-      badge: true
-    },
-    %{
-      name: "Scavenger",
-      colour: "#660066",
-      icon: "fa-solid fa-robot",
-      contains: ~w(),
-      badge: true
-    },
+  @role_data [
+               # Property
+               %Role{
+                 name: "Trusted",
+                 colour: "#FFFFFF",
+                 icon: "fa-solid fa-check-square",
+                 contains: []
+               },
+               %Role{
+                 name: "Bot",
+                 colour: "#777777",
+                 icon: "fa-solid fa-user-robot",
+                 contains: []
+               },
+               %Role{
+                 name: "Verified",
+                 colour: "#66AA66",
+                 icon: "fa-solid fa-check",
+                 contains: []
+               },
+               %Role{
+                 name: "Tournament winner",
+                 colour: "#AA8833",
+                 icon: "fa-solid fa-trophy",
+                 contains: []
+               },
 
-    # Property
-    %{name: "Trusted", colour: "#FFFFFF", icon: "fa-solid fa-check-square", contains: ~w()},
-    %{
-      name: "BAR+",
-      colour: "#0066AA",
-      icon: "fa-solid fa-hexagon-plus",
-      contains: ~w(),
-      badge: false
-    },
-    %{name: "Bot", colour: "#777777", icon: "fa-solid fa-user-robot", contains: ~w()},
-    %{
-      name: "Verified",
-      colour: "#66AA66",
-      icon: "fa-solid fa-check",
-      contains: ~w()
-    },
-    %{
-      name: "Tournament winner",
-      colour: "#AA8833",
-      icon: "fa-solid fa-trophy",
-      contains: ~w()
-    },
+               # Privileged
+               %Role{
+                 name: "VIP",
+                 colour: "#AA8833",
+                 icon: "fa-solid fa-sparkles",
+                 contains: ~w(Trusted)
+               },
+               %Role{
+                 name: "Caster",
+                 colour: "#660066",
+                 icon: "fa-solid fa-microphone-lines",
+                 contains: [],
+                 badge: true
+               },
 
-    # Community team
-    %{
-      name: "Community team",
-      colour: "#66AA66",
-      icon: "fa-solid fa-thought-bubble",
-      contains: ~w(),
-      badge: true
-    },
-    %{
-      name: "Mentor",
-      colour: "#66AA66",
-      icon: "fa-solid fa-thought-bubble",
-      contains: ["Community team"],
-      badge: true
-    },
-    %{
-      name: "Academy manager",
-      colour: "#66AA66",
-      icon: "fa-solid fa-thought-bubble",
-      contains: ["Community team"],
-      badge: true
-    },
-    %{
-      name: "Promo team",
-      colour: "#66AA66",
-      icon: "fa-solid fa-thought-bubble",
-      contains: ["Community team"],
-      badge: true
-    },
-    %{
-      name: "Blog helper",
-      colour: "#66AA66",
-      icon: "fa-solid fa-blog",
-      contains: [],
-      badge: true
-    },
+               # Contributor/Staff
+               %Role{
+                 name: "Contributor",
+                 colour: "#66AA66",
+                 icon: "fa-solid fa-code-commit",
+                 contains: ["Trusted", "BAR+", "VIP"],
+                 badge: true
+               },
 
-    # Privileged
-    %{name: "VIP", colour: "#AA8833", icon: "fa-solid fa-sparkles", contains: ~w(Trusted)},
-    %{name: "Streamer", colour: "#660066", icon: "fa-brands fa-twitch", contains: ~w()},
-    %{
-      name: "Caster",
-      colour: "#660066",
-      icon: "fa-solid fa-microphone-lines",
-      contains: ~w(Streamer),
-      badge: true
-    },
-    %{name: "Donor", colour: "#0066AA", icon: "fa-solid fa-euro", contains: ~w(), badge: true},
+               # Authority
+               %Role{
+                 name: "Overwatch",
+                 colour: "#AA7733",
+                 icon: "fa-solid fa-clipboard-list-check",
+                 contains: ["BAR+", "Trusted"]
+               },
+               %Role{
+                 name: "Reviewer",
+                 colour: "#AA7700",
+                 icon: "fa-solid fa-user-magnifying-glass",
+                 contains: ["Overwatch", "BAR+", "Trusted"]
+               },
+               %Role{
+                 name: "Event Organizer",
+                 colour: "#00AA88",
+                 icon: "fa-solid fa-bullhorn",
+                 contains: [],
+                 badge: true
+               },
+               %Role{
+                 name: "Moderator",
+                 colour: "#FFAA00",
+                 icon: "fa-solid fa-gavel",
+                 contains: ["Reviewer", "Contributor", "Overwatch", "BAR+", "VIP", "Trusted"],
+                 badge: true
+               },
+               %Role{
+                 name: "Senior moderator",
+                 colour: "#FF7700",
+                 icon: "fa-solid fa-scale-unbalanced",
+                 contains: [
+                   "Moderator",
+                   "Reviewer",
+                   "Contributor",
+                   "Overwatch",
+                   "BAR+",
+                   "VIP",
+                   "Trusted"
+                 ],
+                 badge: true
+               },
+               %Role{
+                 name: "Admin",
+                 colour: "#204A88",
+                 icon: "fa-solid fa-user-tie",
+                 contains: [
+                   "Senior moderator",
+                   "Moderator",
+                   "Reviewer",
+                   "Contributor",
+                   "Overwatch",
+                   "BAR+",
+                   "VIP",
+                   "Trusted"
+                 ],
+                 badge: true
+               },
+               %Role{
+                 name: "Server",
+                 colour: "#AA2088",
+                 icon: "fa-solid fa-user-gear",
+                 contains: [
+                   "Admin",
+                   "Senior moderator",
+                   "Moderator",
+                   "Reviewer",
+                   "Contributor",
+                   "Overwatch",
+                   "BAR+",
+                   "VIP",
+                   "Trusted"
+                 ],
+                 badge: true
+               },
 
-    # Contributor/Staff
-    %{
-      name: "Tester",
-      colour: "#00AAAA",
-      icon: "fa-solid fa-vial",
-      contains: ~w(),
-      badge: true
-    },
-    %{
-      name: "Contributor",
-      colour: "#66AA66",
-      icon: "fa-solid fa-code-commit",
-      contains: ["Trusted", "BAR+", "Tester", "Blog helper", "VIP"],
-      badge: true
-    },
-    %{name: "Engine", colour: "#007700", icon: "fa-solid fa-engine", contains: ~w(Contributor)},
-    %{name: "Mapping", colour: "#007700", icon: "fa-solid fa-map", contains: ~w(Contributor)},
-    %{
-      name: "Gameplay",
-      colour: "#AA0000",
-      icon: "fa-solid fa-pen-ruler",
-      contains: ~w(Contributor),
-      badge: true
-    },
-    %{
-      name: "Infrastructure",
-      colour: "#007700",
-      icon: "fa-solid fa-server",
-      contains: ~w(Contributor)
-    },
-    %{
-      name: "Data export",
-      colour: "#007700",
-      icon: "fa-solid fa-download",
-      contains: ~w(Contributor)
-    },
-    %{
-      name: "Core",
-      colour: "#007700",
-      icon: "fa-solid fa-code-branch",
-      contains: ~w(Contributor),
-      badge: true
-    },
+               # Not manually used
+               %Role{
+                 name: "GDPR forgotten",
+                 colour: "#000000",
+                 icon: "fa-solid fa-question-mark",
+                 contains: [],
+                 badge: false
+               },
+               %Role{
+                 name: "Smurfer",
+                 colour: "#000000",
+                 icon: "fa-solid fa-question-mark",
+                 contains: [],
+                 badge: false
+               }
+             ]
+             |> Map.new(fn r -> {r.name, r} end)
 
-    # Authority
-    %{
-      name: "Overwatch",
-      colour: "#AA7733",
-      icon: "fa-solid fa-clipboard-list-check",
-      contains: ["BAR+"]
-    },
-    %{
-      name: "Reviewer",
-      colour: "#AA7700",
-      icon: "fa-solid fa-user-magnifying-glass",
-      contains: ~w(Overwatch)
-    },
-    %{
-      name: "Event Organizer",
-      colour: "#00AA88",
-      icon: "fa-solid fa-bullhorn",
-      contains: ~w(),
-      badge: true
-    },
-    %{
-      name: "Moderator",
-      colour: "#FFAA00",
-      icon: "fa-solid fa-gavel",
-      contains: ~w(Reviewer Contributor),
-      badge: true
-    },
-    %{
-      name: "Admin",
-      colour: "#204A88",
-      icon: "fa-solid fa-user-tie",
-      contains: ~w(Moderator Core),
-      badge: true
-    },
-    %{
-      name: "Server",
-      colour: "#AA2088",
-      icon: "fa-solid fa-user-gear",
-      contains: ~w(Admin),
-      badge: true
-    },
-
-    # Not manually used
-    %{
-      name: "GDPR forgotten",
-      colour: "#000000",
-      icon: "fa-solid fa-question-mark",
-      contains: ~w(),
-      badge: false
-    }
-  ]
-
-  @role_data @raw_role_data
-             |> Enum.reduce(%{}, fn role_def, temp_result ->
-               extra_contains =
-                 role_def.contains
-                 |> Enum.map(fn c -> [c | temp_result[c].contains] end)
-                 |> List.flatten()
-                 |> Enum.uniq()
-
-               new_def =
-                 @role_defaults
-                 |> Map.merge(role_def)
-                 |> Map.merge(%{
-                   contains: extra_contains
-                 })
-
-               Map.put(temp_result, new_def.name, new_def)
-             end)
-             |> Map.new()
-
-  @spec all_role_names() :: list()
+  @spec all_role_names() :: [String.t()]
   def all_role_names do
     Map.keys(@role_data)
   end
 
-  @spec role_data() :: map()
-  def role_data do
-    @role_data
-  end
+  @spec role_data() :: %{String.t() => Role.t()}
+  def role_data, do: @role_data
 
-  @spec role_data(String.t()) :: map() | nil
+  @spec role_data(String.t()) :: Role.t() | nil
   def role_data(role_name) do
     Map.get(@role_data, role_name)
   end
 
-  @spec role_data!(String.t()) :: map()
-  def role_data!(role_name) do
-    r = @role_data[role_name]
-    if r, do: r, else: raise("No role by name #{role_name}")
-  end
-
-  @spec global_roles :: [String.t()]
-  def global_roles do
-    ~w(Default Armada Cortex Raptor Scavenger)
-  end
-
   @spec management_roles :: [String.t()]
   def management_roles do
-    ~w(Server Admin)
+    ["Server", "Admin"]
   end
 
   @spec moderation_roles :: [String.t()]
   def moderation_roles do
-    ~w(Moderator Reviewer Overwatch)
+    ["Senior moderator", "Moderator", "Reviewer", "Overwatch"]
   end
 
   @spec staff_roles :: [String.t()]
   def staff_roles do
     [
-      "Core",
-      "Engine",
-      "Mapping",
-      "Gameplay",
-      "Infrastructure",
-      "Data export",
-      "Tester",
       "Contributor"
     ]
   end
@@ -274,23 +188,18 @@ defmodule Teiserver.Account.RoleLib do
   @spec community_roles :: [String.t()]
   def community_roles do
     [
-      "Mentor",
-      "Academy manager",
-      "Promo team",
-      "Community team",
-      "Blog helper",
       "Event Organizer"
     ]
   end
 
   @spec privileged_roles :: [String.t()]
   def privileged_roles do
-    ~w(Bot VIP Caster Donor)
+    ~w(Bot VIP Caster)
   end
 
   @spec property_roles :: [String.t()]
   def property_roles do
-    ["Trusted", "BAR+", "Verified", "Streamer", "Tournament winner"]
+    ["Trusted", "BAR+", "Verified", "Tournament winner"]
   end
 
   @spec allowed_role_management(String.t()) :: [String.t()]
@@ -301,11 +210,15 @@ defmodule Teiserver.Account.RoleLib do
   def allowed_role_management("Admin") do
     staff_roles() ++
       community_roles() ++
-      privileged_roles() ++ moderation_roles() ++ allowed_role_management("Moderator")
+      privileged_roles() ++ moderation_roles() ++ allowed_role_management("Senior moderator")
+  end
+
+  def allowed_role_management("Senior moderator") do
+    allowed_role_management("Moderator") ++ ["Overwatch"]
   end
 
   def allowed_role_management("Moderator") do
-    global_roles() ++ property_roles()
+    property_roles()
   end
 
   def allowed_role_management(_role) do

--- a/lib/teiserver/account/queries/user_queries.ex
+++ b/lib/teiserver/account/queries/user_queries.ex
@@ -255,51 +255,6 @@ defmodule Teiserver.Account.UserQueries do
     query
   end
 
-  def _where(query, :tester, "Trusted") do
-    from users in query,
-      where: "Trusted" in users.roles
-  end
-
-  def _where(query, :tester, "Tester") do
-    from users in query,
-      where: "Tester" in users.roles
-  end
-
-  def _where(query, :tester, "Normal") do
-    from users in query,
-      where: "Tester" not in users.roles
-  end
-
-  def _where(query, :streamer, "Streamer") do
-    from users in query,
-      where: "Streamer" in users.roles
-  end
-
-  def _where(query, :streamer, "Normal") do
-    from users in query,
-      where: "Streamer" not in users.roles
-  end
-
-  def _where(query, :donor, "Donor") do
-    from users in query,
-      where: "Donor" in users.roles
-  end
-
-  def _where(query, :donor, "Normal") do
-    from users in query,
-      where: "Donor" not in users.roles
-  end
-
-  def _where(query, :gdt_member, "GDT") do
-    from users in query,
-      where: "GDT" in users.roles
-  end
-
-  def _where(query, :gdt_member, "Normal") do
-    from users in query,
-      where: "GDT" not in users.roles
-  end
-
   def _where(query, :contributor, "Contributor") do
     from users in query,
       where: "Contributor" in users.roles

--- a/lib/teiserver/account/schemas/role.ex
+++ b/lib/teiserver/account/schemas/role.ex
@@ -1,0 +1,17 @@
+defmodule Teiserver.Account.Role do
+  @moduledoc """
+  A struct representing a role which can be held by user accounts.
+  """
+
+  alias Teiserver.Account.Role
+
+  @enforce_keys [:name]
+  defstruct [:name, :colour, :icon, contains: [], badge: false]
+
+  @type t() :: %Role{
+          name: String.t(),
+          colour: String.t(),
+          icon: String.t(),
+          contains: [String.t()]
+        }
+end

--- a/lib/teiserver/coordinator/consul_commands.ex
+++ b/lib/teiserver/coordinator/consul_commands.ex
@@ -1022,9 +1022,6 @@ defmodule Teiserver.Coordinator.ConsulCommands do
         "contributor" ->
           "contributor"
 
-        "dev" ->
-          "dev"
-
         "admin" ->
           "admin"
 
@@ -1038,7 +1035,7 @@ defmodule Teiserver.Coordinator.ConsulCommands do
           ChatLib.sayprivateex(
             state.coordinator_id,
             senderid,
-            "Shuffle types are party, friends, contributor, dev, admin, all and default; using 'default'",
+            "Shuffle types are party, friends, contributor, admin, all and default; using 'default'",
             state.lobby_id
           )
 
@@ -1102,17 +1099,6 @@ defmodule Teiserver.Coordinator.ConsulCommands do
           |> Enum.group_by(
             fn %{userid: userid} ->
               Auth.contributor?(userid)
-            end,
-            fn %{userid: userid} ->
-              userid
-            end
-          )
-
-        "dev" ->
-          all_possible_clients
-          |> Enum.group_by(
-            fn %{userid: userid} ->
-              Auth.has_any_role?(userid, "Core")
             end,
             fn %{userid: userid} ->
               userid

--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -1170,7 +1170,7 @@ defmodule Teiserver.CacheUser do
       Auth.has_any_role?(userid, ["Tournament winner"]) ->
         7
 
-      Auth.has_any_role?(userid, ~w(Core Contributor)) and
+      Auth.has_any_role?(userid, ~w(Contributor)) and
           !Account.hide_contributor_rank?(userid) ->
         6
 

--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -1170,7 +1170,7 @@ defmodule Teiserver.CacheUser do
       Auth.has_any_role?(userid, ["Tournament winner"]) ->
         7
 
-      Auth.has_any_role?(userid, ~w(Contributor)) and
+      Auth.contributor?(userid) and
           !Account.hide_contributor_rank?(userid) ->
         6
 

--- a/lib/teiserver/mix_tasks/update_user_permissions.ex
+++ b/lib/teiserver/mix_tasks/update_user_permissions.ex
@@ -6,6 +6,7 @@ defmodule Mix.Tasks.Teiserver.UpdateUserPermissions do
 
   alias Ecto.Adapters.SQL
   alias Teiserver.Account
+  alias Teiserver.Account.Role
   alias Teiserver.Account.RoleLib
   alias Teiserver.Repo
 
@@ -22,7 +23,7 @@ defmodule Mix.Tasks.Teiserver.UpdateUserPermissions do
       permissions =
         roles
         |> Enum.map(fn role_name ->
-          role_def = RoleLib.role_data(role_name)
+          %Role{} = role_def = RoleLib.role_data(role_name)
           [role_name | role_def.contains]
         end)
         |> List.flatten()

--- a/lib/teiserver_web/controllers/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/admin/user_controller.ex
@@ -4,6 +4,7 @@ defmodule TeiserverWeb.Admin.UserController do
   alias Teiserver.Account
   alias Teiserver.Account.Auth
   alias Teiserver.Account.AuthLib
+  alias Teiserver.Account.Role
   alias Teiserver.Account.RoleLib
   alias Teiserver.Account.SmurfMergeTask
   alias Teiserver.Account.Tasks.GdprForgetTask
@@ -259,7 +260,7 @@ defmodule TeiserverWeb.Admin.UserController do
         |> assign(:community_roles, RoleLib.community_roles())
         |> assign(:privileged_roles, RoleLib.privileged_roles())
         |> assign(:property_roles, RoleLib.property_roles())
-        |> assign(:role_styling_map, RoleLib.role_data())
+        |> assign(:role_data, RoleLib.role_data())
         |> assign(:has_active_mfa?, has_active_mfa?(user.id))
         |> add_breadcrumb(name: "Edit: #{user.name}", url: conn.request_path)
         |> render("edit.html")
@@ -286,6 +287,9 @@ defmodule TeiserverWeb.Admin.UserController do
 
         Enum.member?(current_user.roles, "Admin") ->
           RoleLib.allowed_role_management("Admin")
+
+        Enum.member?(current_user.roles, "Senior moderator") ->
+          RoleLib.allowed_role_management("Senior moderator")
 
         Enum.member?(current_user.roles, "Moderator") ->
           RoleLib.allowed_role_management("Moderator")
@@ -318,7 +322,7 @@ defmodule TeiserverWeb.Admin.UserController do
     permissions =
       new_roles
       |> Enum.map(fn role_name ->
-        role_def = RoleLib.role_data(role_name)
+        %Role{} = role_def = RoleLib.role_data(role_name)
         [role_name | role_def.contains]
       end)
       |> List.flatten()
@@ -373,7 +377,7 @@ defmodule TeiserverWeb.Admin.UserController do
             |> assign(:community_roles, RoleLib.community_roles())
             |> assign(:privileged_roles, RoleLib.privileged_roles())
             |> assign(:property_roles, RoleLib.property_roles())
-            |> assign(:role_styling_map, RoleLib.role_data())
+            |> assign(:role_data, RoleLib.role_data())
             |> assign(:has_active_mfa?, has_active_mfa?(user.id))
             |> render("edit.html", user: user, changeset: changeset)
         end
@@ -1041,7 +1045,7 @@ defmodule TeiserverWeb.Admin.UserController do
 
     case UserLib.has_access(user, conn) do
       {true, _role} ->
-        admin_action = AuthLib.allow?(conn, "admin.dev")
+        admin_action = AuthLib.allow?(conn, "Senior moderator")
 
         case CacheUser.rename_user(user.id, new_name, admin_action) do
           :success ->

--- a/lib/teiserver_web/live/account/profile/appearance.ex
+++ b/lib/teiserver_web/live/account/profile/appearance.ex
@@ -2,10 +2,18 @@ defmodule TeiserverWeb.Account.ProfileLive.Appearance do
   @moduledoc false
 
   alias Teiserver.Account
+  alias Teiserver.Account.Role
   alias Teiserver.Account.RoleLib
   alias Teiserver.Account.UserLib
   alias TeiserverWeb.Account.ProfileLive.Overview
   use TeiserverWeb, :live_view
+
+  @default_role %Role{
+    name: "Default",
+    colour: "#666666",
+    icon: "fa-solid fa-user",
+    contains: []
+  }
 
   @impl Phoenix.LiveView
   def mount(%{"userid" => user_id}, _session, socket) do
@@ -50,10 +58,10 @@ defmodule TeiserverWeb.Account.ProfileLive.Appearance do
         if RoleLib.role_data(role_name) do
           RoleLib.role_data(role_name)
         else
-          RoleLib.role_data("Default")
+          @default_role
         end
       else
-        RoleLib.role_data("Default")
+        @default_role
       end
 
     user = Account.get_user!(assigns.current_user.id)
@@ -84,7 +92,7 @@ defmodule TeiserverWeb.Account.ProfileLive.Appearance do
       end)
 
     options =
-      (RoleLib.global_roles() ++ filtered_roles)
+      filtered_roles
       |> Enum.map(fn r ->
         role_data[r]
       end)

--- a/lib/teiserver_web/live/battles/lobbies/show.ex
+++ b/lib/teiserver_web/live/battles/lobbies/show.ex
@@ -32,7 +32,7 @@ defmodule TeiserverWeb.Battle.LobbyLive.Show do
 
     moderator = allow?(socket, "Moderator")
     server_perms = allow?(socket, "Server")
-    tester_perms = allow?(socket, "Tester")
+    contributor_perms = allow?(socket, "Contributor")
 
     extra_content =
       if moderator do
@@ -62,7 +62,7 @@ defmodule TeiserverWeb.Battle.LobbyLive.Show do
       |> assign(:subbed, true)
       |> assign(:moderator, moderator)
       |> assign(:server_perms, server_perms)
-      |> assign(:tester_perms, tester_perms)
+      |> assign(:contributor_perms, contributor_perms)
 
     {:ok, socket}
   end

--- a/lib/teiserver_web/live/battles/lobbies/show.html.heex
+++ b/lib/teiserver_web/live/battles/lobbies/show.html.heex
@@ -103,7 +103,7 @@ spectators =
                 Queue size: {Enum.count(@consul.join_queue ++ @consul.low_priority_join_queue)}
               </li>
               <li>Balance algorithm: {@consul.balance_algorithm}</li>
-              <%= if @tester_perms do %>
+              <%= if @contributor_perms do %>
                 <li>Match ID: {Map.get(@modoptions, "game/server_match_id")}</li>
               <% end %>
 
@@ -150,7 +150,7 @@ spectators =
               <th>Party</th>
 
               <th>Rating</th>
-              <%= if @tester_perms do %>
+              <%= if @contributor_perms do %>
                 <th>Uncertainty</th>
 
                 <th>Winrate Team</th>
@@ -196,7 +196,7 @@ spectators =
                   <% end %>
 
                   <td>{Teiserver.Helper.NumberHelper.round(rating_value, 2)}</td>
-                  <%= if @tester_perms do %>
+                  <%= if @contributor_perms do %>
                     <td>{Teiserver.Helper.NumberHelper.round(uncertainty, 2)}</td>
 
                     <td>{@stats[user.id]["win_rate.team"]}</td>
@@ -245,7 +245,7 @@ spectators =
               <th>Name</th>
 
               <th>Rating</th>
-              <%= if @tester_perms do %>
+              <%= if @contributor_perms do %>
                 <th>Uncertainty</th>
               <% end %>
 
@@ -274,7 +274,7 @@ spectators =
                   <td>{user.name}</td>
 
                   <td>{Teiserver.Helper.NumberHelper.round(rating_value, 2)}</td>
-                  <%= if @tester_perms do %>
+                  <%= if @contributor_perms do %>
                     <td>{Teiserver.Helper.NumberHelper.round(uncertainty, 2)}</td>
                   <% end %>
 

--- a/lib/teiserver_web/live/battles/match/show.ex
+++ b/lib/teiserver_web/live/battles/match/show.ex
@@ -69,9 +69,8 @@ defmodule TeiserverWeb.Battle.MatchLive.Show do
 
   defp apply_action(%{assigns: %{match_name: match_name}} = socket, :balance, _params) do
     # Restrict the balance tab to certain roles.
-    # Note that Staff roles like Contributor will inherit Tester permissions
     socket
-    |> mount_require_any(["Reviewer", "Tester"])
+    |> mount_require_any(["Reviewer", "Contributor"])
     |> assign(:page_title, "#{match_name} - Balance")
   end
 

--- a/lib/teiserver_web/live/battles/match/show.html.heex
+++ b/lib/teiserver_web/live/battles/match/show.html.heex
@@ -33,7 +33,7 @@
       </h3>
       <br />
 
-      <%= if @rating_status != nil and allow?(@current_user, "Tester") do %>
+      <%= if @rating_status != nil and allow?(@current_user, "Contributor") do %>
         <% {alert_type, status} = @rating_status %>
         <div class={"alert alert-#{alert_type} alert-dismissible fade show"} role="alert">
           {status}
@@ -61,7 +61,7 @@
           </.tab_nav>
         <% end %>
 
-        <%= if @rating_logs != %{} and allow_any?(@current_user, ["Overwatch", "Tester"]) do %>
+        <%= if @rating_logs != %{} and allow_any?(@current_user, ["Overwatch", "Contributor"]) do %>
           <.tab_nav url={~p"/battle/#{@match.id}/balance"} selected={@tab == :balance}>
             <Fontawesome.icon icon="fa-solid fa-scale-balanced" style="solid" /> Balance
           </.tab_nav>
@@ -323,7 +323,7 @@
         </div>
       <% end %>
 
-      <%= if allow_any?(@current_user, ["Overwatch", "Tester"]) do %>
+      <%= if allow_any?(@current_user, ["Overwatch", "Contributor"]) do %>
         <div :if={@tab == :balance} class="p-4">
           <form method="post" class="">
             <.input

--- a/lib/teiserver_web/templates/admin/user/form.html.heex
+++ b/lib/teiserver_web/templates/admin/user/form.html.heex
@@ -14,13 +14,11 @@
       {error_tag(f, :name)}
     </div>
 
-    <%= if allow?(@conn, "Admin") do %>
-      <div class="col-xl-4 col-lg-4">
-        {label(f, :email, class: "control-label")}
-        {text_input(f, :email, class: "form-control")}
-        {error_tag(f, :email)}
-      </div>
-    <% end %>
+    <div :if={allow?(@conn, "Senior moderator")} class="col-xl-4 col-lg-4">
+      {label(f, :email, class: "control-label")}
+      {text_input(f, :email, class: "form-control")}
+      {error_tag(f, :email)}
+    </div>
 
     <div class="col-xl-4 col-lg-4">
       <%= if assigns[:user].smurf_of_id do %>
@@ -35,19 +33,17 @@
 
   <div class="form-group row px-3 py-2">
     <div :if={not @has_active_mfa?} class="alert alert-warning">
-      No MFA, cannot give privileged roles.
+      This user has no active MFA, cannot give privileged roles.
     </div>
 
     <div :if={allow?(@conn, "Server")} class="col">
       <h5>Management</h5>
       <%= for r <- @management_roles do %>
-        <% style = @role_styling_map[r]
+        <% role = @role_data[r]
 
         label =
-          if style do
-            raw(
-              "<i class='fa-fw #{style[:icon]}' style='color: #{style[:colour]}'></i> &nbsp;#{r}"
-            )
+          if role do
+            raw("<i class='fa-fw #{role.icon}' style='color: #{role.colour}'></i> &nbsp;#{r}")
           else
             r
           end %>
@@ -63,13 +59,11 @@
     <div :if={allow?(@conn, "Admin")} class="col">
       <h5>Moderation</h5>
       <%= for r <- @moderation_roles do %>
-        <% style = @role_styling_map[r]
+        <% role = @role_data[r]
 
         label =
-          if style do
-            raw(
-              "<i class='fa-fw #{style[:icon]}' style='color: #{style[:colour]}'></i> &nbsp;#{r}"
-            )
+          if role do
+            raw("<i class='fa-fw #{role.icon}' style='color: #{role.colour}'></i> &nbsp;#{r}")
           else
             r
           end %>
@@ -85,13 +79,11 @@
     <div :if={allow?(@conn, "Admin")} class="col">
       <h5>Staff</h5>
       <%= for r <- @staff_roles do %>
-        <% style = @role_styling_map[r]
+        <% role = @role_data[r]
 
         label =
-          if style do
-            raw(
-              "<i class='fa-fw #{style[:icon]}' style='color: #{style[:colour]}'></i> &nbsp;#{r}"
-            )
+          if role do
+            raw("<i class='fa-fw #{role.icon}' style='color: #{role.colour}'></i> &nbsp;#{r}")
           else
             r
           end %>
@@ -107,13 +99,11 @@
     <div :if={allow?(@conn, "Admin")} class="col">
       <h5>Community</h5>
       <%= for r <- @community_roles do %>
-        <% style = @role_styling_map[r]
+        <% role = @role_data[r]
 
         label =
-          if style do
-            raw(
-              "<i class='fa-fw #{style[:icon]}' style='color: #{style[:colour]}'></i> &nbsp;#{r}"
-            )
+          if role do
+            raw("<i class='fa-fw #{role.icon}' style='color: #{role.colour}'></i> &nbsp;#{r}")
           else
             r
           end %>
@@ -129,13 +119,11 @@
     <div :if={allow?(@conn, "Admin")} class="col">
       <h5>Privileged</h5>
       <%= for r <- @privileged_roles do %>
-        <% style = @role_styling_map[r]
+        <% role = @role_data[r]
 
         label =
-          if style do
-            raw(
-              "<i class='fa-fw #{style[:icon]}' style='color: #{style[:colour]}'></i> &nbsp;#{r}"
-            )
+          if role do
+            raw("<i class='fa-fw #{role.icon}' style='color: #{role.colour}'></i> &nbsp;#{r}")
           else
             r
           end %>
@@ -151,13 +139,11 @@
     <div class="col">
       <h5>Property</h5>
       <%= for r <- @property_roles do %>
-        <% style = @role_styling_map[r]
+        <% role = @role_data[r]
 
         label =
-          if style do
-            raw(
-              "<i class='fa-fw #{style[:icon]}' style='color: #{style[:colour]}'></i> &nbsp;#{r}"
-            )
+          if role do
+            raw("<i class='fa-fw #{role.icon}' style='color: #{role.colour}'></i> &nbsp;#{r}")
           else
             r
           end %>

--- a/test/support/teiserver_test_lib.ex
+++ b/test/support/teiserver_test_lib.ex
@@ -335,7 +335,7 @@ defmodule Teiserver.TeiserverTestLib do
 
   @spec staff_permissions() :: [String.t()]
   def staff_permissions do
-    ["Core", "Contributor"] ++ player_permissions()
+    ["Contributor"] ++ player_permissions()
   end
 
   @spec player_permissions() :: [String.t()]

--- a/test/teiserver/account/account_test.exs
+++ b/test/teiserver/account/account_test.exs
@@ -56,9 +56,6 @@ defmodule Teiserver.AccountTest do
         search: [
           bot: "Robot",
           moderator: "Moderator",
-          tester: "Tester",
-          streamer: "Streamer",
-          donor: "Donor",
           contributor: "Contributor",
           developer: "Developer"
         ]
@@ -69,9 +66,6 @@ defmodule Teiserver.AccountTest do
         search: [
           bot: "Person",
           moderator: "User",
-          tester: "Normal",
-          streamer: "Normal",
-          donor: "Normal",
           contributor: "Normal",
           developer: "Normal"
         ]

--- a/test/teiserver/account/auth_async_test.exs
+++ b/test/teiserver/account/auth_async_test.exs
@@ -1,0 +1,56 @@
+defmodule Teiserver.Account.AuthAsyncTest do
+  use Teiserver.DataCase, async: true
+
+  import Teiserver.Account.AuthLib, only: [allow?: 2]
+
+  describe "role permissions" do
+    test "Server Role" do
+      user = %{id: 123, roles: ["Server"]}
+
+      assert allow?(user, "Server")
+      assert allow?(user, "Admin")
+      assert allow?(user, "Senior moderator")
+      assert allow?(user, "Moderator")
+      assert allow?(user, "Overwatch")
+      assert allow?(user, "Contributor")
+      assert allow?(user, "BAR+")
+      assert allow?(user, "VIP")
+      assert allow?(user, "Trusted")
+
+      # Normally not allowed but server has automatic allowed access
+      assert allow?(user, "NotARole")
+    end
+
+    test "Admin Role" do
+      user = %{id: 123, roles: ["Admin"]}
+
+      refute allow?(user, "Server")
+      assert allow?(user, "Admin")
+      assert allow?(user, "Senior moderator")
+      assert allow?(user, "Moderator")
+      assert allow?(user, "Overwatch")
+      assert allow?(user, "Contributor")
+      assert allow?(user, "BAR+")
+      assert allow?(user, "VIP")
+      assert allow?(user, "Trusted")
+
+      refute allow?(user, "NotARole")
+    end
+
+    test "Moderator Role" do
+      user = %{id: 123, roles: ["Moderator"]}
+
+      refute allow?(user, "Server")
+      refute allow?(user, "Admin")
+      refute allow?(user, "Senior moderator")
+      assert allow?(user, "Moderator")
+      assert allow?(user, "Overwatch")
+      assert allow?(user, "Contributor")
+      assert allow?(user, "BAR+")
+      assert allow?(user, "VIP")
+      assert allow?(user, "Trusted")
+
+      refute allow?(user, "NotARole")
+    end
+  end
+end


### PR DESCRIPTION
Remove un-used roles, structify Role and add Senior moderator

Directly requested from [Issue 1399](https://github.com/beyond-all-reason/teiserver/issues/1399) but also address [Issue 1179](https://github.com/beyond-all-reason/teiserver/issues/1179)

We have a variety of roles no longer used, this commit removes those roles while also adding the Role struct and a Senior moderator role.

Senior moderators have been added to allow for paid moderators to be
given additional responsibilities, for now:
* Changing other user names outside of rate limits
* Altering user email addresses
* Appointing/demoting overwatch roles

Removes roles:
* Armada
* Cortex
* Legion
* Raptor
* Scavenger
* BAR+ (though the permission remains in some other roles)
* Community team
* Mentor
* Acachemy manager
* Promo team
* Blog helper
* Streamer
* Tester
* Engine
* Mapping
* Gameplay
* Infrastructure
* Data export
* Core

### Query to run after deploying the change
```sql
UPDATE account_users
SET roles = COALESCE(
    (
        SELECT array_agg(r)
        FROM unnest(roles) AS r
        WHERE r IN ('Admin', 'Bot', 'Caster', 'Contributor', 'Default', 'Event Organizer', 'GDPR forgotten', 'Moderator', 'Overwatch', 'Reviewer', 'Senior moderator', 'Server', 'Tournament winner', 'Trusted', 'VIP', 'Verified')
    ), 
    ARRAY[]::varchar[] -- If all roles were removed, set to empty array [] instead of NULL
)
WHERE EXISTS (
    SELECT 1 
    FROM unnest(roles) AS r 
    WHERE r NOT IN ('Admin', 'Bot', 'Caster', 'Contributor', 'Default', 'Event Organizer', 'GDPR forgotten', 'Moderator', 'Overwatch', 'Reviewer', 'Senior moderator', 'Server', 'Tournament winner', 'Trusted', 'VIP', 'Verified')
);
```

This will update approximately 10,000 users and took approximately 2 seconds to run on my local machine. We should expect potential fleeting interruptions to service but momentary only.