### PR TITLE
Reject obviously incorrect user ids

### DIFF
--- a/lib/teiserver/account/libs/user_lib.ex
+++ b/lib/teiserver/account/libs/user_lib.ex
@@ -115,8 +115,10 @@ defmodule Teiserver.Account.UserLib do
   """
   @spec get_user_by_id(User.id() | String.t()) :: User.t() | nil
   def get_user_by_id(user_id) do
-    user_id = int_parse!(user_id)
-    cache_get_or_store(:users_by_id, user_id, fn -> get_user(user_id) end)
+    case User.parse_user_id(user_id) do
+      {:ok, user_id} -> cache_get_or_store(:users_by_id, user_id, fn -> get_user(user_id) end)
+      {:error, _reason} -> nil
+    end
   end
 
   @doc """

--- a/lib/teiserver/account/schemas/user.ex
+++ b/lib/teiserver/account/schemas/user.ex
@@ -358,4 +358,28 @@ defmodule Teiserver.Account.User do
 
   @spec authorize(any, Plug.Conn.t(), atom) :: boolean
   def authorize(_action, conn, _data), do: allow?(conn, "admin.user")
+
+  @doc """
+  Ensure the user id is at least somewhat correct
+  """
+  @spec parse_user_id(id() | String.t()) :: {:ok, id()} | {:error, reason :: term()}
+  def parse_user_id(user_id) when is_integer(user_id) do
+    # this is a postgres constraint since user id are also bigints
+    bigint_max = Integer.pow(2, 63) - 1
+
+    if user_id >= 0 && user_id < bigint_max do
+      {:ok, user_id}
+    else
+      {:error, :out_of_range}
+    end
+  end
+
+  def parse_user_id(user_id) when is_binary(user_id) do
+    case user_id |> String.trim() |> Integer.parse() do
+      {id, ""} -> parse_user_id(id)
+      _err -> {:error, :invalid}
+    end
+  end
+
+  def parse_user_id(_user_id), do: {:error, :invalid}
 end

--- a/test/teiserver/account/user_lib_test.exs
+++ b/test/teiserver/account/user_lib_test.exs
@@ -10,6 +10,23 @@ defmodule Teiserver.Account.UserLibTest do
 
   @disallowed_name ".,:;<>{}()+-*/="
 
+  describe "basic checks on user id" do
+    test "reject malformed id" do
+      assert Account.get_user_by_id("can-i-haz-user") == nil
+    end
+
+    test "reject negative uid" do
+      assert Account.get_user_by_id("-3") == nil
+      assert Account.get_user_by_id(-3) == nil
+    end
+
+    test "reject out of bound uid" do
+      bigint = Integer.pow(2, 64)
+      assert Account.get_user_by_id(bigint) == nil
+      assert Account.get_user_by_id(bigint) == nil
+    end
+  end
+
   describe "disallow renaming to names with disallowed characters" do
     # create_ first
     test "create_user/1" do


### PR DESCRIPTION
This is a bit of a cheap fix since it doesn't propagate the error, but it'll do for now™.