### PR TITLE
Avoid timeout race in party invites

### DIFF
--- a/lib/teiserver/player/session.ex
+++ b/lib/teiserver/player/session.ex
@@ -951,7 +951,7 @@ defmodule Teiserver.Player.Session do
     msg = {:party, {:invite, state.party.current_party, user_id}}
 
     try do
-      case user_id |> via_tuple() |> GenServer.call(msg) do
+      case user_id |> via_tuple() |> GenServer.call(msg, :timer.seconds(2)) do
         :ok -> {:reply, :ok, state}
         {:error, reason} -> {:reply, {:error, reason}, state}
       end


### PR DESCRIPTION
The nested `GenServer.call` is inside the handler for another call. If they use the same default timeout value, when the inner one times out, the outer one will have already timed out, making the precaution to avoid crashing the session less useful.

The value for the shorter time out is taken somewhat arbitrarily.