### PR TITLE
list allowed origins

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -34,7 +34,6 @@ config :teiserver, TeiserverWeb.Endpoint,
   pubsub_server: Teiserver.PubSub,
   debug_errors: Config.config_env() == :dev,
   code_reloader: Config.config_env() == :dev,
-  check_origin: Config.config_env() == :prod,
   version: Mix.Project.config()[:version],
   https: [
     versions: [:"tlsv1.2"],

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -68,7 +68,7 @@ config :teiserver, Teiserver.Repo,
 
 check_origin =
   if Teiserver.ConfigHelpers.get_env("TEI_SHOULD_CHECK_ORIGIN", false, :bool) do
-    :conn
+    ["//#{domain_name}"]
   else
     false
   end

--- a/lib/teiserver/application.ex
+++ b/lib/teiserver/application.ex
@@ -5,6 +5,7 @@ defmodule Teiserver.Application do
 
   alias Phoenix.PubSub
   alias Teiserver.Helper.ObanLogger
+  alias Teiserver.Logging
   alias Teiserver.Plugins
   alias Teiserver.Startup
   alias TeiserverWeb.Endpoint
@@ -20,10 +21,7 @@ defmodule Teiserver.Application do
 
   @impl Application
   def start(_type, _args) do
-    LoggerBackends.add({LoggerFileBackend, :error_log})
-    LoggerBackends.add({LoggerFileBackend, :notice_log})
-    LoggerBackends.add({LoggerFileBackend, :info_log})
-    Logger.add_handlers(:teiserver)
+    Logging.setup_loggers()
 
     children =
       [

--- a/lib/teiserver/logging.ex
+++ b/lib/teiserver/logging.ex
@@ -7,6 +7,7 @@ defmodule Teiserver.Logging do
   alias Teiserver.Logging.AggregateViewLogLib
   alias Teiserver.Logging.AuditLog
   alias Teiserver.Logging.AuditLogLib
+  alias Teiserver.Logging.Filter
   alias Teiserver.Logging.MatchDayLog
   alias Teiserver.Logging.MatchDayLogLib
   alias Teiserver.Logging.MatchMonthLog
@@ -38,6 +39,14 @@ defmodule Teiserver.Logging do
 
   @spec icon() :: String.t()
   def icon, do: "fa-solid fa-bars"
+
+  def setup_loggers do
+    LoggerBackends.add({LoggerFileBackend, :error_log})
+    LoggerBackends.add({LoggerFileBackend, :notice_log})
+    LoggerBackends.add({LoggerFileBackend, :info_log})
+    Logger.add_handlers(:teiserver)
+    Filter.silence_bogus_origins()
+  end
 
   defp server_minute_log_query(args) do
     server_minute_log_query(nil, args)

--- a/lib/teiserver/logging/filter.ex
+++ b/lib/teiserver/logging/filter.ex
@@ -1,0 +1,19 @@
+defmodule Teiserver.Logging.Filter do
+  @moduledoc """
+  Some additional logging configuration
+  """
+
+  def filter(event, _args) do
+    if event.meta.mfa == {Phoenix.Socket.Transport, :check_origin, 5},
+      do: :stop,
+      else: :ignore
+  end
+
+  @doc """
+  add a filter to the loggers so that it doesn't show the very verbose message
+  about a connection's host that doesn't match the origin header.
+  """
+  def silence_bogus_origins do
+    :logger.add_primary_filter(:silence_bogus_origins, {&filter/2, []})
+  end
+end


### PR DESCRIPTION
When we switched off TLS handling for teiserver in https://github.com/beyond-all-reason/ansible-teiserver/pull/29 it broke websockets (liveviews).

This is because the `check_origin: :conn` checks the `scheme`, and in this case the browser would send `https`, but the conn would have `http`. I didn't find a way to check host+port match between the origin header and the connection.
The fix of listing all allowed domain is a bit meh since it's one more thing to support when moving/adding domains and we're going to forget that. But at the same time, it's also simple and shouldn't happen too often.