### PR TITLE
Fix issues with RefreshUserRestrictionsTask

### DIFF
--- a/lib/teiserver/moderation/tasks/refresh_user_restrictions_task.ex
+++ b/lib/teiserver/moderation/tasks/refresh_user_restrictions_task.ex
@@ -5,6 +5,7 @@ defmodule Teiserver.Moderation.RefreshUserRestrictionsTask do
 
   alias Teiserver.Account
   alias Teiserver.Account.User
+  alias Teiserver.CacheUser
   alias Teiserver.Client
   alias Teiserver.Coordinator
   alias Teiserver.Helper.DateHelper
@@ -28,7 +29,8 @@ defmodule Teiserver.Moderation.RefreshUserRestrictionsTask do
         search: [
           data_less_than: {"restricted_until", now_as_string}
         ],
-        select: [:id]
+        select: [:id],
+        limit: :infinity
       )
       |> Enum.each(fn %{id: userid} ->
         refresh_user(userid)
@@ -95,6 +97,11 @@ defmodule Teiserver.Moderation.RefreshUserRestrictionsTask do
         update_client_with_restrictions(client, new_restrictions)
       end
     end
+
+    # There was a bug where not all users were refreshed correctly
+    # but the changes made after the fix didn't come into effect
+    # until after they were recached
+    CacheUser.deprecated_recache_user(user_id)
   end
 
   defp update_client_with_restrictions(client, new_restrictions) do


### PR DESCRIPTION
As per issue #1431 in some situations (inconsistently) a user would be restricted in some way and the restriction would not automatically expire as it should.

A live example was found and manual tests were done finding the query was limited to just 50 users by default while more than 50 were restricted. In theory this should not have caused a serious issue as the task runs frequently and the backlog would have cleared itself a few minutes later.

After manually running the task against the user in question it was found to still be showing out of date restrictions and upon hitting the "recache" link in the user admin panel the issue was fixed so we have introduced a manual recache to be safe.