### PR TITLE
$modme and $unmodme commands

### DIFF
--- a/lib/teiserver/account/libs/client_lib.ex
+++ b/lib/teiserver/account/libs/client_lib.ex
@@ -82,6 +82,11 @@ defmodule Teiserver.Account.ClientLib do
     cast_client(userid, {:update_values, partial_client})
   end
 
+  @spec set_moderator_bit(User.id(), boolean()) :: nil | :ok
+  def set_moderator_bit(userid, moderator?) do
+    cast_client(userid, {:set_moderator_bit, moderator?})
+  end
+
   @spec replace_update_client(
           map(),
           :silent | :client_updated_status | :client_updated_battlestatus

--- a/lib/teiserver/account/servers/client_server.ex
+++ b/lib/teiserver/account/servers/client_server.ex
@@ -114,6 +114,23 @@ defmodule Teiserver.Account.ClientServer do
     {:noreply, %{state | client: new_client}}
   end
 
+  def handle_cast({:set_moderator_bit, moderator?}, state) do
+    new_client = %{state.client | moderator: moderator?}
+
+    PubSub.broadcast(
+      Teiserver.PubSub,
+      "teiserver_global_user_updates",
+      %{
+        channel: "teiserver_global_user_updates",
+        event: :client_updated,
+        userid: state.userid,
+        client: new_client
+      }
+    )
+
+    {:noreply, %{state | client: new_client}}
+  end
+
   def handle_cast({:merge_update_client, partial_client}, state) do
     Logger.warning(":merge_update_client is still being used, instead use :update_values")
     new_client = Map.merge(state.client, partial_client)

--- a/lib/teiserver/coordinator/coordinator_commands.ex
+++ b/lib/teiserver/coordinator/coordinator_commands.ex
@@ -18,9 +18,9 @@ defmodule Teiserver.Coordinator.CoordinatorCommands do
   alias Teiserver.Moderation
 
   @splitter "---------------------------"
-  @always_allow ~w(help whoami whois discord coc mute unmute ignore unignore website party)
+  @always_allow ~w(help whoami whois discord coc mute unmute ignore unignore website party modme)
   # These commands are handled by coordinator commands, but are not on the always allow list
-  @mod_allow ~w(modparty unparty)
+  @mod_allow ~w(modparty unparty unmodme)
   @forward_to_consul ~w(s status players follow joinq leaveq splitlobby y yes n no explain)
   @admin_commands ~w(broadcast)
 
@@ -543,6 +543,14 @@ defmodule Teiserver.Coordinator.CoordinatorCommands do
     state
   end
 
+  defp do_handle(%{command: "modme", senderid: sender_id} = _cmd, state) do
+    if Auth.moderator?(sender_id) do
+      Client.set_moderator_bit(sender_id, true)
+    end
+
+    state
+  end
+
   # Admin commands
   defp do_handle(
          %{command: "broadcast", senderid: senderid, remaining: message},
@@ -557,6 +565,11 @@ defmodule Teiserver.Coordinator.CoordinatorCommands do
   end
 
   # Moderator commands
+  defp do_handle(%{command: "unmodme", senderid: sender_id} = _cmd, state) do
+    Client.set_moderator_bit(sender_id, false)
+    state
+  end
+
   defp do_handle(%{command: command, senderid: senderid} = _cmd, state) do
     CacheUser.send_direct_message(
       state.userid,

--- a/lib/teiserver/coordinator/coordinator_lib.ex
+++ b/lib/teiserver/coordinator/coordinator_lib.ex
@@ -125,7 +125,9 @@ Multiple locks can be engaged at the same time
       {"specafk", [],
        "Everybody is sent a message asking them to confirm they are not afk. If they don't respond within 40 seconds they are moved to spectators. Requires boss privileges.",
        :moderator},
-      {"playerlimit", ["limit"], "Sets a new player limit for this specific host.", :moderator}
+      {"playerlimit", ["limit"], "Sets a new player limit for this specific host.", :moderator},
+      {"modme", [], "(Re)gain moderator privileges", :moderator},
+      {"unmodme", [], "Drops moderator privileges for this session", :moderator}
     ]
 
     # $command - Coordinator command

--- a/lib/teiserver/data/client.ex
+++ b/lib/teiserver/data/client.ex
@@ -196,6 +196,9 @@ defmodule Teiserver.Client do
   @spec call_client(User.id(), any) :: any | nil
   defdelegate call_client(userid, msg), to: ClientLib
 
+  @spec set_moderator_bit(User.id(), boolean()) :: nil | :ok
+  defdelegate set_moderator_bit(user_id, moderator?), to: ClientLib
+
   @spec join_battle(T.client_id(), Integer.t(), boolean()) :: nil | T.client()
   def join_battle(userid, lobby_id, lobby_host) do
     case get_client_by_id(userid) do

--- a/lib/teiserver/tcp/spring/spring_tcp_server.ex
+++ b/lib/teiserver/tcp/spring/spring_tcp_server.ex
@@ -593,6 +593,14 @@ defmodule Teiserver.SpringTcpServer do
     {:noreply, new_state}
   end
 
+  def handle_info(
+        %{channel: "teiserver_global_user_updates", event: :client_updated} = msg,
+        state
+      ) do
+    new_state = client_status_update(msg.client, state)
+    {:noreply, new_state}
+  end
+
   def handle_info(%{channel: "teiserver_global_user_updates"}, state) do
     {:noreply, state}
   end

--- a/test/teiserver/coordinator/coordinator_commands_sync_test.exs
+++ b/test/teiserver/coordinator/coordinator_commands_sync_test.exs
@@ -1,7 +1,10 @@
 defmodule Teiserver.Coordinator.CoordinatorCommandsSyncTest do
   alias Teiserver.Account
+  alias Teiserver.Account.Auth
   alias Teiserver.Account.UserLib
+  alias Teiserver.BitParse
   alias Teiserver.CacheUser
+  alias Teiserver.TeiserverTestLib
 
   use Teiserver.ServerCase, async: false
 
@@ -49,6 +52,35 @@ defmodule Teiserver.Coordinator.CoordinatorCommandsSyncTest do
                "SAYPRIVATE Coordinator $website\nSAIDPRIVATE Coordinator Your role contains one or more privileged roles, you will need to manually login to the site at https://localhost\n"
 
       Application.put_env(:teiserver, Teiserver, config)
+    end
+
+    test "$modme/$unmodme", %{socket: socket} = ctx do
+      mod = TeiserverTestLib.new_user()
+      Auth.add_roles(mod.id, ["Moderator"])
+      %{socket: mod_socket} = TeiserverTestLib.auth_setup(ctx, mod)
+      [_adduser, status] = TeiserverTestLib._recv_until(socket) |> String.split("\n", trim: true)
+      ["CLIENTSTATUS", mod_name, str_status] = String.split(status)
+      assert mod_name == mod.name
+      BitParse.parse_bits(str_status, 7)
+      [_bot_bit, mod_bit | _rest] = BitParse.parse_bits(str_status, 7)
+      assert mod_bit == 1
+
+      _send_raw(mod_socket, "SAYPRIVATE coordinator $unmodme\n")
+      ["CLIENTSTATUS", mod_name, str_status] = _recv_until(socket) |> String.split()
+      assert mod_name == mod.name
+      [_bot_bit, mod_bit | _rest] = BitParse.parse_bits(str_status, 7)
+      assert mod_bit == 0
+
+      _send_raw(mod_socket, "SAYPRIVATE coordinator $modme\n")
+      ["CLIENTSTATUS", mod_name, str_status] = _recv_until(socket) |> String.split()
+      assert mod_name == mod.name
+      [_bot_bit, mod_bit | _rest] = BitParse.parse_bits(str_status, 7)
+      assert mod_bit == 1
+
+      # only mods can $modme
+      _recv_until(mod_socket)
+      _send_raw(socket, "SAYPRIVATE coordinator $modme\n")
+      assert _recv_until(mod_socket) == ""
     end
   end
 end


### PR DESCRIPTION
second attempt after https://github.com/beyond-all-reason/teiserver/pull/1307

`$unmodme` drops all moderator privilege for the user, `$modme` to regain them. This only has effect in the client itself, for the duration of the connection.

The main goal is so that you don't `!resign` the entire team without any vote by mistake, or force a map change when you just wanted a vote.