### PR TITLE
Accept bearer tokens in AuthPlug and answer json auth errors with json

### DIFF
--- a/lib/teiserver/account/auth_pipeline.ex
+++ b/lib/teiserver/account/auth_pipeline.ex
@@ -1,5 +1,9 @@
 defmodule Teiserver.Account.AuthPipeline do
-  @moduledoc false
+  @moduledoc """
+  Guardian pipeline for the browser. The token lives in the session, so this
+  only ever looks at the session. Bearer tokens are the api's business, see
+  `Teiserver.Account.ApiAuthPlug`.
+  """
   use Guardian.Plug.Pipeline,
     otp_app: :teiserver,
     error_handler: Teiserver.Account.ErrorHandler,
@@ -7,8 +11,6 @@ defmodule Teiserver.Account.AuthPipeline do
 
   # If there is a session token, restrict it to an access token and validate it
   plug Guardian.Plug.VerifySession, claims: %{"typ" => "access"}
-  # If there is an authorization header, restrict it to an access token and validate it
-  plug Guardian.Plug.VerifyHeader, claims: %{"typ" => "access"}
-  # Load the user if either of the verifications worked
+  # Load the user if the verification worked
   plug Guardian.Plug.LoadResource, allow_blank: true
 end

--- a/lib/teiserver/account/error_handler.ex
+++ b/lib/teiserver/account/error_handler.ex
@@ -11,29 +11,52 @@ defmodule Teiserver.Account.ErrorHandler do
   @impl Guardian.Plug.ErrorHandler
 
   def auth_error(conn, {:unauthenticated, _reason}, _opts) do
-    redirect_to =
-      if conn.query_string != nil && conn.query_string != "" do
-        "#{conn.request_path}?#{conn.query_string}"
-      else
-        "#{conn.request_path}"
-      end
+    if json_request?(conn) do
+      unauthorized_json(conn, "unauthenticated")
+    else
+      redirect_to =
+        if conn.query_string != nil && conn.query_string != "" do
+          "#{conn.request_path}?#{conn.query_string}"
+        else
+          "#{conn.request_path}"
+        end
 
-    conn
-    |> put_resp_cookie("_redirect_to", redirect_to, sign: true, max_age: 60 * 5)
-    |> Controller.redirect(to: ~p"/login")
+      conn
+      |> put_resp_cookie("_redirect_to", redirect_to, sign: true, max_age: 60 * 5)
+      |> Controller.redirect(to: ~p"/login")
+    end
   end
 
   def auth_error(conn, {:invalid_token, _message}, _opts) do
-    conn
-    |> put_resp_cookie("_teiserver_key", "", max_age: 0)
-    |> Controller.redirect(to: ~p"/login")
+    if json_request?(conn) do
+      unauthorized_json(conn, "invalid_token")
+    else
+      conn
+      |> put_resp_cookie("_teiserver_key", "", max_age: 0)
+      |> Controller.redirect(to: ~p"/login")
+    end
   end
 
   def auth_error(conn, {type, _reason}, _opts) do
-    body = to_string(type)
+    if json_request?(conn) do
+      unauthorized_json(conn, to_string(type))
+    else
+      body = to_string(type)
 
+      conn
+      |> put_resp_content_type("text/plain")
+      |> send_resp(401, body)
+    end
+  end
+
+  # :accepts sets phoenix_format, so every json pipeline is covered without
+  # hardcoding route prefixes here.
+  defp json_request?(conn), do: conn.private[:phoenix_format] == "json"
+
+  defp unauthorized_json(conn, reason) do
     conn
-    |> put_resp_content_type("text/plain")
-    |> send_resp(401, body)
+    |> put_status(:unauthorized)
+    |> Controller.json(%{error: reason})
+    |> halt()
   end
 end

--- a/lib/teiserver/account/error_handler.ex
+++ b/lib/teiserver/account/error_handler.ex
@@ -1,5 +1,9 @@
 defmodule Teiserver.Account.ErrorHandler do
-  @moduledoc false
+  @moduledoc """
+  Guardian error handler for `Teiserver.Account.AuthPipeline`, i.e. the browser.
+  Failures send the user to the login page, which is why the api does not go
+  through this pipeline at all - see `Teiserver.Account.ApiAuthPlug`.
+  """
 
   alias Phoenix.Controller
 
@@ -11,52 +15,29 @@ defmodule Teiserver.Account.ErrorHandler do
   @impl Guardian.Plug.ErrorHandler
 
   def auth_error(conn, {:unauthenticated, _reason}, _opts) do
-    if json_request?(conn) do
-      unauthorized_json(conn, "unauthenticated")
-    else
-      redirect_to =
-        if conn.query_string != nil && conn.query_string != "" do
-          "#{conn.request_path}?#{conn.query_string}"
-        else
-          "#{conn.request_path}"
-        end
+    redirect_to =
+      if conn.query_string != nil && conn.query_string != "" do
+        "#{conn.request_path}?#{conn.query_string}"
+      else
+        "#{conn.request_path}"
+      end
 
-      conn
-      |> put_resp_cookie("_redirect_to", redirect_to, sign: true, max_age: 60 * 5)
-      |> Controller.redirect(to: ~p"/login")
-    end
+    conn
+    |> put_resp_cookie("_redirect_to", redirect_to, sign: true, max_age: 60 * 5)
+    |> Controller.redirect(to: ~p"/login")
   end
 
   def auth_error(conn, {:invalid_token, _message}, _opts) do
-    if json_request?(conn) do
-      unauthorized_json(conn, "invalid_token")
-    else
-      conn
-      |> put_resp_cookie("_teiserver_key", "", max_age: 0)
-      |> Controller.redirect(to: ~p"/login")
-    end
+    conn
+    |> put_resp_cookie("_teiserver_key", "", max_age: 0)
+    |> Controller.redirect(to: ~p"/login")
   end
 
   def auth_error(conn, {type, _reason}, _opts) do
-    if json_request?(conn) do
-      unauthorized_json(conn, to_string(type))
-    else
-      body = to_string(type)
+    body = to_string(type)
 
-      conn
-      |> put_resp_content_type("text/plain")
-      |> send_resp(401, body)
-    end
-  end
-
-  # :accepts sets phoenix_format, so every json pipeline is covered without
-  # hardcoding route prefixes here.
-  defp json_request?(conn), do: conn.private[:phoenix_format] == "json"
-
-  defp unauthorized_json(conn, reason) do
     conn
-    |> put_status(:unauthorized)
-    |> Controller.json(%{error: reason})
-    |> halt()
+    |> put_resp_content_type("text/plain")
+    |> send_resp(401, body)
   end
 end

--- a/lib/teiserver/account/libs/auth_lib.ex
+++ b/lib/teiserver/account/libs/auth_lib.ex
@@ -231,4 +231,16 @@ defmodule Teiserver.Account.AuthLib do
   def current_user(conn) do
     conn.assigns[:current_user]
   end
+
+  @doc """
+  Returns true if the user is not allowed to be signed in at all, regardless of
+  how they authenticated. How to respond to that is up to the caller, the web
+  and api auth plugs each do their own thing.
+  """
+  @spec blocked_from_login?(Teiserver.Account.User.t() | nil) :: boolean()
+  def blocked_from_login?(nil), do: false
+
+  def blocked_from_login?(user) do
+    Account.restricted?(user.id, ["Login"]) or user.smurf_of_id != nil
+  end
 end

--- a/lib/teiserver/account/plugs/api_auth_plug.ex
+++ b/lib/teiserver/account/plugs/api_auth_plug.ex
@@ -20,9 +20,9 @@ defmodule Teiserver.Account.ApiAuthPlug do
   alias Teiserver.Account.AuthLib
   alias Teiserver.Account.Guardian
 
-  import Plug.Conn
-
   require Logger
+
+  import Plug.Conn
 
   @behaviour Plug
 

--- a/lib/teiserver/account/plugs/api_auth_plug.ex
+++ b/lib/teiserver/account/plugs/api_auth_plug.ex
@@ -1,0 +1,80 @@
+defmodule Teiserver.Account.ApiAuthPlug do
+  @moduledoc """
+  Authenticates a json api request from an `Authorization: Bearer <token>`
+  header and assigns `:current_user`.
+
+  The credential is a guardian access token, the same one the browser session
+  is built on, but the api takes it from the header and never from a session or
+  a cookie. This is the api counterpart of `Teiserver.Account.AuthPlug`; the two
+  are kept apart so that neither has to ask what kind of request it is looking
+  at, and so that a failure here answers with json rather than a redirect to the
+  login page.
+
+  Users restricted from logging in, or flagged as a smurf, are rejected however
+  they authenticated - without that a banned user would keep a working
+  credential on the api.
+  """
+
+  alias Phoenix.Controller
+  alias Teiserver.Account
+  alias Teiserver.Account.AuthLib
+  alias Teiserver.Account.Guardian
+
+  import Plug.Conn
+
+  require Logger
+
+  @behaviour Plug
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    with {:ok, raw_token} <- bearer_token(conn),
+         {:ok, user} <- user_from_token(raw_token),
+         :ok <- login_allowed(user) do
+      Logger.metadata([user_id: user.id] ++ Logger.metadata())
+
+      assign(conn, :current_user, user)
+    else
+      {:error, :restricted} -> error_response(conn, :forbidden, "account_restricted")
+      {:error, reason} -> error_response(conn, :unauthorized, reason)
+    end
+  end
+
+  defp bearer_token(conn) do
+    case get_req_header(conn, "authorization") do
+      ["Bearer " <> raw_token] ->
+        case String.trim(raw_token) do
+          "" -> {:error, "invalid_token"}
+          token -> {:ok, token}
+        end
+
+      _other ->
+        {:error, "unauthenticated"}
+    end
+  end
+
+  # Constrained to access tokens to match Teiserver.Account.AuthPipeline, so a
+  # refresh token can't be swapped in here
+  defp user_from_token(raw_token) do
+    case Guardian.resource_from_token(raw_token, %{"typ" => "access"}) do
+      {:ok, %Account.User{} = user, _claims} -> {:ok, user}
+      _error -> {:error, "invalid_token"}
+    end
+  end
+
+  defp login_allowed(user) do
+    if AuthLib.blocked_from_login?(user) do
+      {:error, :restricted}
+    else
+      :ok
+    end
+  end
+
+  defp error_response(conn, status, reason) do
+    conn
+    |> put_status(status)
+    |> Controller.json(%{error: reason})
+    |> halt()
+  end
+end

--- a/lib/teiserver/account/plugs/auth_plug.ex
+++ b/lib/teiserver/account/plugs/auth_plug.ex
@@ -1,5 +1,11 @@
 defmodule Teiserver.Account.AuthPlug do
-  @moduledoc false
+  @moduledoc """
+  Browser side authentication. Assigns `:current_user` from the session token
+  verified by `Teiserver.Account.AuthPipeline`, falling back to the long lived
+  remember me cookie, and bounces banned users to the logout page.
+
+  The api counterpart is `Teiserver.Account.ApiAuthPlug`.
+  """
 
   alias ExULID.ULID
   alias Phoenix.Component
@@ -97,19 +103,8 @@ defmodule Teiserver.Account.AuthPlug do
     end
   end
 
-  defp banned_user?(%{assigns: %{current_user: nil}}), do: false
-
   defp banned_user?(%{assigns: %{current_user: current_user}} = _conn_or_socket) do
-    cond do
-      Account.restricted?(current_user.id, ["Login"]) ->
-        true
-
-      current_user.smurf_of_id != nil ->
-        true
-
-      true ->
-        false
-    end
+    AuthLib.blocked_from_login?(current_user)
   end
 
   @doc """

--- a/lib/teiserver/account/plugs/auth_plug.ex
+++ b/lib/teiserver/account/plugs/auth_plug.ex
@@ -23,9 +23,9 @@ defmodule Teiserver.Account.AuthPlug do
 
   def call(conn, _opts) do
     user =
-      case Guardian.resource_from_token(conn.cookies["guardian_default_token"]) do
-        {:ok, user, _claims} -> Account.get_user!(user.id)
-        _error -> nil
+      case GuardianPlug.current_resource(conn) do
+        nil -> user_from_remember_me_cookie(conn)
+        user -> Account.get_user!(user.id)
       end
 
     user_token =
@@ -61,6 +61,13 @@ defmodule Teiserver.Account.AuthPlug do
       |> Controller.redirect(to: ~p"/logout")
     else
       conn
+    end
+  end
+
+  defp user_from_remember_me_cookie(conn) do
+    case Guardian.resource_from_token(conn.cookies["guardian_default_token"]) do
+      {:ok, user, _claims} -> Account.get_user!(user.id)
+      _error -> nil
     end
   end
 

--- a/lib/teiserver_web/controllers/api/battle_controller.ex
+++ b/lib/teiserver_web/controllers/api/battle_controller.ex
@@ -3,7 +3,7 @@ defmodule TeiserverWeb.API.BattleController do
   # alias Teiserver.Battle
 
   plug(Bodyguard.Plug.Authorize,
-    fallback: TeiserverWeb.Controllers.BodyguardFallback,
+    fallback: TeiserverWeb.Controllers.ApiBodyguardFallback,
     policy: Teiserver.Battle.ApiAuth,
     action: {Phoenix.Controller, :action_name},
     user: {Teiserver.Account.AuthLib, :current_user}

--- a/lib/teiserver_web/controllers/api_bodyguard_fallback.ex
+++ b/lib/teiserver_web/controllers/api_bodyguard_fallback.ex
@@ -1,0 +1,22 @@
+defmodule TeiserverWeb.Controllers.ApiBodyguardFallback do
+  @moduledoc """
+  To handle thrown exceptions when an api caller hits an endpoint they don't
+  have permission for.
+
+  The browser equivalent, `TeiserverWeb.Controllers.BodyguardFallback`, sets a
+  flash and redirects, neither of which works on a json pipeline with no session.
+  """
+
+  use TeiserverWeb, :controller
+
+  def call(conn, {:error, :unauthorized}) do
+    conn
+    |> put_status(:forbidden)
+    |> json(%{error: "forbidden"})
+    |> halt()
+  end
+
+  def call(conn, _stuff) do
+    conn
+  end
+end

--- a/lib/teiserver_web/router.ex
+++ b/lib/teiserver_web/router.ex
@@ -63,14 +63,15 @@ defmodule TeiserverWeb.Router do
     plug(Teiserver.Plugs.BasicAuthBotPlug)
   end
 
+  # a pipeline for json api endpoints authenticated with a guardian bearer
+  # token. ApiAuthPlug halts the request itself, so there is no
+  # EnsureAuthenticated here
   pipeline :token_api do
     plug(:accepts, ["json"])
     plug(:put_secure_browser_headers)
     plug(Teiserver.Logging.LoggingPlug)
-    plug(Teiserver.Account.AuthPipeline)
-    plug(Teiserver.Account.AuthPlug)
+    plug(Teiserver.Account.ApiAuthPlug)
     plug(Teiserver.Plugs.CachePlug)
-    plug(Guardian.Plug.EnsureAuthenticated)
   end
 
   # a pipeline to use for any api endpoint consuming json and expecting

--- a/test/teiserver/account/plugs/api_auth_plug_test.exs
+++ b/test/teiserver/account/plugs/api_auth_plug_test.exs
@@ -1,0 +1,106 @@
+defmodule Teiserver.Account.ApiAuthPlugTest do
+  alias Teiserver.Account
+  alias Teiserver.Account.ApiAuthPlug
+  alias Teiserver.Account.Guardian
+  alias Teiserver.Helpers.GeneralTestLib
+
+  use TeiserverWeb.ConnCase, async: false
+
+  defp run(conn) do
+    conn
+    |> Phoenix.Controller.accepts(["json"])
+    |> ApiAuthPlug.call(ApiAuthPlug.init([]))
+  end
+
+  defp with_bearer_token(conn, user) do
+    {:ok, token, _claims} = Guardian.encode_and_sign(user)
+    put_req_header(conn, "authorization", "Bearer #{token}")
+  end
+
+  test "assigns current_user from a verified bearer token", %{conn: conn} do
+    user = GeneralTestLib.make_user()
+
+    conn =
+      conn
+      |> with_bearer_token(user)
+      |> run()
+
+    assert conn.assigns.current_user.id == user.id
+    refute conn.halted
+  end
+
+  test "rejects a request with no credentials", %{conn: conn} do
+    conn = run(conn)
+
+    assert conn.halted
+    assert json_response(conn, 401) == %{"error" => "unauthenticated"}
+  end
+
+  # Sessions and remember me cookies belong to the browser, the api must not
+  # accept them
+  test "ignores the remember me cookie", %{conn: conn} do
+    user = GeneralTestLib.make_user()
+    {:ok, token, _claims} = Guardian.encode_and_sign(user)
+
+    conn =
+      conn
+      |> put_req_cookie("guardian_default_token", token)
+      |> run()
+
+    assert json_response(conn, 401) == %{"error" => "unauthenticated"}
+  end
+
+  test "rejects an unparseable bearer token", %{conn: conn} do
+    conn =
+      conn
+      |> put_req_header("authorization", "Bearer nonsense")
+      |> run()
+
+    assert json_response(conn, 401) == %{"error" => "invalid_token"}
+  end
+
+  test "rejects an empty bearer token", %{conn: conn} do
+    conn =
+      conn
+      |> put_req_header("authorization", "Bearer    ")
+      |> run()
+
+    assert json_response(conn, 401) == %{"error" => "invalid_token"}
+  end
+
+  test "rejects a refresh token", %{conn: conn} do
+    user = GeneralTestLib.make_user()
+    {:ok, token, _claims} = Guardian.encode_and_sign(user, %{"typ" => "refresh"})
+
+    conn =
+      conn
+      |> put_req_header("authorization", "Bearer #{token}")
+      |> run()
+
+    assert json_response(conn, 401) == %{"error" => "invalid_token"}
+  end
+
+  test "rejects a user restricted from logging in", %{conn: conn} do
+    user = GeneralTestLib.make_user(%{"restrictions" => ["Login"]})
+
+    conn =
+      conn
+      |> with_bearer_token(user)
+      |> run()
+
+    assert json_response(conn, 403) == %{"error" => "account_restricted"}
+  end
+
+  test "rejects a smurf", %{conn: conn} do
+    origin = GeneralTestLib.make_user()
+    smurf = GeneralTestLib.make_user()
+    {:ok, smurf} = Account.update_user_smurf(smurf, %{smurf_of_id: origin.id})
+
+    conn =
+      conn
+      |> with_bearer_token(smurf)
+      |> run()
+
+    assert json_response(conn, 403) == %{"error" => "account_restricted"}
+  end
+end

--- a/test/teiserver/account/plugs/api_auth_plug_test.exs
+++ b/test/teiserver/account/plugs/api_auth_plug_test.exs
@@ -1,4 +1,5 @@
 defmodule Teiserver.Account.ApiAuthPlugTest do
+  alias Phoenix.Controller
   alias Teiserver.Account
   alias Teiserver.Account.ApiAuthPlug
   alias Teiserver.Account.Guardian
@@ -8,7 +9,7 @@ defmodule Teiserver.Account.ApiAuthPlugTest do
 
   defp run(conn) do
     conn
-    |> Phoenix.Controller.accepts(["json"])
+    |> Controller.accepts(["json"])
     |> ApiAuthPlug.call(ApiAuthPlug.init([]))
   end
 

--- a/test/teiserver/account/plugs/auth_plug_test.exs
+++ b/test/teiserver/account/plugs/auth_plug_test.exs
@@ -12,51 +12,73 @@ defmodule Teiserver.Account.AuthPlugTest do
   # the session, cookies and flash
   defp run(conn) do
     conn
-    |> init_test_session(%{})
     |> fetch_cookies()
     |> Controller.fetch_flash([])
     |> AuthPipeline.call(AuthPipeline.init([]))
     |> AuthPlug.call([])
   end
 
-  test "assigns current_user from a verified bearer token", %{conn: conn} do
-    user = GeneralTestLib.make_user()
+  defp with_session_token(conn, user) do
     {:ok, token, _claims} = Guardian.encode_and_sign(user)
+    init_test_session(conn, %{"guardian_default_token" => token})
+  end
+
+  test "assigns current_user from the session", %{conn: conn} do
+    user = GeneralTestLib.make_user()
 
     conn =
       conn
-      |> put_req_header("authorization", "Bearer #{token}")
+      |> with_session_token(user)
       |> run()
 
     assert conn.assigns.current_user.id == user.id
-    assert conn.assigns.user_token == token
+    assert conn.assigns.user_token != ""
   end
 
   test "assigns no user without credentials", %{conn: conn} do
-    conn = run(conn)
+    conn =
+      conn
+      |> init_test_session(%{})
+      |> run()
 
     assert conn.assigns.current_user == nil
     assert conn.assigns.totp_status == nil
   end
 
-  # The bearer path must not shadow the long lived remember me cookie the web
-  # session relies on
+  # The session is short lived, the remember me cookie is what keeps a browser
+  # logged in across sessions
   test "falls back to the remember me cookie", %{conn: conn} do
     user = GeneralTestLib.make_user()
     {:ok, token, _claims} = Guardian.encode_and_sign(user)
 
     conn =
       conn
+      |> init_test_session(%{})
       |> put_req_cookie("guardian_default_token", token)
       |> run()
 
     assert conn.assigns.current_user.id == user.id
   end
 
-  test "ignores an unparseable bearer token", %{conn: conn} do
+  # Bearer tokens are handled by the api pipeline, the browser must not care
+  test "ignores an authorization header", %{conn: conn} do
+    user = GeneralTestLib.make_user()
+    {:ok, token, _claims} = Guardian.encode_and_sign(user)
+
     conn =
       conn
-      |> put_req_header("authorization", "Bearer nonsense")
+      |> init_test_session(%{})
+      |> put_req_header("authorization", "Bearer #{token}")
+      |> run()
+
+    assert conn.assigns.current_user == nil
+  end
+
+  test "ignores an unparseable remember me cookie", %{conn: conn} do
+    conn =
+      conn
+      |> init_test_session(%{})
+      |> put_req_cookie("guardian_default_token", "nonsense")
       |> run()
 
     assert conn.assigns.current_user == nil
@@ -64,28 +86,27 @@ defmodule Teiserver.Account.AuthPlugTest do
 
   test "signs out a user restricted from logging in", %{conn: conn} do
     user = GeneralTestLib.make_user(%{"restrictions" => ["Login"]})
-    {:ok, token, _claims} = Guardian.encode_and_sign(user)
 
     conn =
       conn
-      |> put_req_header("authorization", "Bearer #{token}")
+      |> with_session_token(user)
       |> run()
 
     assert conn.assigns.current_user == nil
-    assert conn.halted or conn.status == 302
+    assert redirected_to(conn) == ~p"/logout"
   end
 
   test "signs out a smurf", %{conn: conn} do
     origin = GeneralTestLib.make_user()
     smurf = GeneralTestLib.make_user()
     {:ok, smurf} = Account.update_user_smurf(smurf, %{smurf_of_id: origin.id})
-    {:ok, token, _claims} = Guardian.encode_and_sign(smurf)
 
     conn =
       conn
-      |> put_req_header("authorization", "Bearer #{token}")
+      |> with_session_token(smurf)
       |> run()
 
     assert conn.assigns.current_user == nil
+    assert redirected_to(conn) == ~p"/logout"
   end
 end

--- a/test/teiserver/account/plugs/auth_plug_test.exs
+++ b/test/teiserver/account/plugs/auth_plug_test.exs
@@ -1,0 +1,91 @@
+defmodule Teiserver.Account.AuthPlugTest do
+  alias Phoenix.Controller
+  alias Teiserver.Account
+  alias Teiserver.Account.AuthPipeline
+  alias Teiserver.Account.AuthPlug
+  alias Teiserver.Account.Guardian
+  alias Teiserver.Helpers.GeneralTestLib
+
+  use TeiserverWeb.ConnCase, async: false
+
+  # AuthPlug always runs behind the :browser pipeline, which has already set up
+  # the session, cookies and flash
+  defp run(conn) do
+    conn
+    |> init_test_session(%{})
+    |> fetch_cookies()
+    |> Controller.fetch_flash([])
+    |> AuthPipeline.call(AuthPipeline.init([]))
+    |> AuthPlug.call([])
+  end
+
+  test "assigns current_user from a verified bearer token", %{conn: conn} do
+    user = GeneralTestLib.make_user()
+    {:ok, token, _claims} = Guardian.encode_and_sign(user)
+
+    conn =
+      conn
+      |> put_req_header("authorization", "Bearer #{token}")
+      |> run()
+
+    assert conn.assigns.current_user.id == user.id
+    assert conn.assigns.user_token == token
+  end
+
+  test "assigns no user without credentials", %{conn: conn} do
+    conn = run(conn)
+
+    assert conn.assigns.current_user == nil
+    assert conn.assigns.totp_status == nil
+  end
+
+  # The bearer path must not shadow the long lived remember me cookie the web
+  # session relies on
+  test "falls back to the remember me cookie", %{conn: conn} do
+    user = GeneralTestLib.make_user()
+    {:ok, token, _claims} = Guardian.encode_and_sign(user)
+
+    conn =
+      conn
+      |> put_req_cookie("guardian_default_token", token)
+      |> run()
+
+    assert conn.assigns.current_user.id == user.id
+  end
+
+  test "ignores an unparseable bearer token", %{conn: conn} do
+    conn =
+      conn
+      |> put_req_header("authorization", "Bearer nonsense")
+      |> run()
+
+    assert conn.assigns.current_user == nil
+  end
+
+  test "signs out a user restricted from logging in", %{conn: conn} do
+    user = GeneralTestLib.make_user(%{"restrictions" => ["Login"]})
+    {:ok, token, _claims} = Guardian.encode_and_sign(user)
+
+    conn =
+      conn
+      |> put_req_header("authorization", "Bearer #{token}")
+      |> run()
+
+    assert conn.assigns.current_user == nil
+    assert conn.halted or conn.status == 302
+  end
+
+  test "signs out a smurf", %{conn: conn} do
+    origin = GeneralTestLib.make_user()
+    smurf = GeneralTestLib.make_user()
+    {:ok, smurf} = Account.update_user_smurf(smurf, %{smurf_of_id: origin.id})
+    {:ok, token, _claims} = Guardian.encode_and_sign(smurf)
+
+    conn =
+      conn
+      |> put_req_header("authorization", "Bearer #{token}")
+      |> run()
+
+    assert conn.assigns.current_user == nil
+  end
+end

--- a/test/teiserver_web/controllers/api/battle_controller_test.exs
+++ b/test/teiserver_web/controllers/api/battle_controller_test.exs
@@ -1,0 +1,42 @@
+defmodule TeiserverWeb.API.BattleControllerTest do
+  alias Teiserver.Account.Guardian
+  alias Teiserver.Helpers.GeneralTestLib
+
+  use TeiserverWeb.ConnCase, async: false
+
+  # The :token_api pipeline must answer as an api, not send the caller off to
+  # the login page like the browser pipeline does
+  describe "unauthenticated" do
+    test "answers with json rather than a redirect", %{conn: conn} do
+      conn = post(conn, ~p"/teiserver/api/battle/create", %{})
+
+      assert json_response(conn, 401) == %{"error" => "unauthenticated"}
+    end
+
+    test "rejects a garbage bearer token with json", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer nonsense")
+        |> post(~p"/teiserver/api/battle/create", %{})
+
+      assert json_response(conn, 401) == %{"error" => "invalid_token"}
+    end
+  end
+
+  describe "authenticated" do
+    # The bearer token gets us a current_user, which is what the permission
+    # check needs. Without the permission it is a json 403, not a redirect to
+    # the home page like the browser would get
+    test "answers a missing permission with json", %{conn: conn} do
+      user = GeneralTestLib.make_user()
+      {:ok, token, _claims} = Guardian.encode_and_sign(user)
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post(~p"/teiserver/api/battle/create", %{})
+
+      assert json_response(conn, 403) == %{"error" => "forbidden"}
+    end
+  end
+end


### PR DESCRIPTION
AI disclaimer: Claude Opus 5 used for transform psuedo-code into proper Elixir, tests fully generated.