### PR TITLE
temp stuff not to break clients

### DIFF
--- a/lib/teiserver/event_sourcing/aggregate.ex
+++ b/lib/teiserver/event_sourcing/aggregate.ex
@@ -1,0 +1,17 @@
+defmodule Teiserver.EventSourcing.Aggregate do
+  @moduledoc """
+  An aggregate is used when processing lobby events.
+  Reducing events from an initial aggregate leads to a new aggregate that holds
+  the new state, and maps of changes to be broadcasted to member or a new overview
+  for the lobby list.
+
+  Some events may also generate side effects, like an end vote. These are
+  represented in the aggregate as well.
+
+  Computing an aggregate must be a pure operation, that is, there must not be
+  any side effects. This is to guarantee we can replicate the state
+  in other processes without having to deal with duplicate messages.
+  In this context, events are data structure that represent changes to a lobby,
+  there is no message passing or IO involved.
+  """
+end

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -1048,6 +1048,8 @@ defmodule Teiserver.Player.TachyonHandler do
         outgoingFriendRequest: outgoing,
         incomingFriendRequest: incoming,
         ignoreIds: [],
+        # TODO: see https://github.com/beyond-all-reason/teiserver/issues/1450
+        matchmaking: %{state: :no_matchmaking},
         currentLobby: sess_state[:current_lobby],
         roles: roles_to_tachyon(user.roles)
       }

--- a/priv/tachyon/schema/definitions/privateUser.json
+++ b/priv/tachyon/schema/definitions/privateUser.json
@@ -45,6 +45,73 @@
                 },
                 "currentLobby": {
                     "anyOf": [{ "type": "string" }, { "type": "null" }]
+                },
+                "matchmaking": {
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "state": { "const": "no_matchmaking" }
+                            },
+                            "required": ["state"]
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "state": { "const": "queuing" },
+                                "queues": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "id": { "type": "string" },
+                                            "version": { "type": "string" }
+                                        },
+                                        "required": ["id", "version"]
+                                    },
+                                    "minItems": 1
+                                }
+                            },
+                            "required": ["state", "queues"]
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "state": { "const": "found" },
+                                "queue": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": { "type": "string" },
+                                        "version": { "type": "string" },
+                                        "timeoutAt": {
+                                            "$ref": "../definitions/unixTime.json"
+                                        },
+                                        "hasAlreadyReadied": {
+                                            "type": "boolean"
+                                        }
+                                    },
+                                    "required": [
+                                        "id",
+                                        "version",
+                                        "timeoutAt",
+                                        "hasAlreadyReadied"
+                                    ]
+                                },
+                                "otherQueues": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "id": { "type": "string" },
+                                            "version": { "type": "string" }
+                                        },
+                                        "required": ["id", "version"]
+                                    }
+                                }
+                            },
+                            "required": ["state", "queue", "otherQueues"]
+                        }
+                    ]
                 }
             },
             "required": [
@@ -54,7 +121,8 @@
                 "outgoingFriendRequest",
                 "incomingFriendRequest",
                 "ignoreIds",
-                "currentLobby"
+                "currentLobby",
+                "matchmaking"
             ]
         }
     ]


### PR DESCRIPTION
because this is a required field, if clients upgrade to the new schema, they will break. This is incorrect but at least it won't trigger a parse error.