### PR TITLE
Add quantum command

### DIFF
--- a/lib/teiserver/coordinator/consul_commands.ex
+++ b/lib/teiserver/coordinator/consul_commands.ex
@@ -1013,16 +1013,35 @@ defmodule Teiserver.Coordinator.ConsulCommands do
   # next step will be to add options to it allowing you to pick how many commanders
   # are shared on a team or which teams are used but for now we're keeping it simple
   def handle_command(
-        %{command: "quantum", remaining: _remaining, senderid: _senderid} = _cmd,
+        %{command: "quantum", remaining: _remaining, senderid: senderid} = _cmd,
         %{quantum_mode?: false} = state
       ) do
+    sender_name = Account.get_username_by_id(senderid)
+
+    ChatLib.say(
+      state.coordinator_id,
+      "#{sender_name} enabled Quantum mode, all players on a team will share the same commander and units. The game will not be ranked.",
+      state.lobby_id
+    )
+
+    # Make the game unranked
+    Battle.set_modoption(state.lobby_id, "game/modoptions/ranked_game", 0)
+
     %{state | quantum_mode?: true}
   end
 
   def handle_command(
-        %{command: "quantum", remaining: _remaining, senderid: _senderid} = _cmd,
+        %{command: "quantum", remaining: _remaining, senderid: senderid} = _cmd,
         %{quantum_mode?: true} = state
       ) do
+    sender_name = Account.get_username_by_id(senderid)
+
+    ChatLib.say(
+      state.coordinator_id,
+      "#{sender_name} disabled Quantum mode. The game is still unranked.",
+      state.lobby_id
+    )
+
     %{state | quantum_mode?: false}
   end
 

--- a/lib/teiserver/coordinator/consul_commands.ex
+++ b/lib/teiserver/coordinator/consul_commands.ex
@@ -1009,6 +1009,23 @@ defmodule Teiserver.Coordinator.ConsulCommands do
     end
   end
 
+  # Enables quantum mode where each team has 1 commander and full shared control
+  # next step will be to add options to it allowing you to pick how many commanders
+  # are shared on a team or which teams are used but for now we're keeping it simple
+  def handle_command(
+        %{command: "quantum", remaining: _remaining, senderid: _senderid} = _cmd,
+        %{quantum_mode?: false} = state
+      ) do
+    %{state | quantum_mode?: true}
+  end
+
+  def handle_command(
+        %{command: "quantum", remaining: _remaining, senderid: _senderid} = _cmd,
+        %{quantum_mode?: true} = state
+      ) do
+    %{state | quantum_mode?: false}
+  end
+
   #################### VIP Streamer
   def handle_command(%{command: "shuffle", remaining: remaining, senderid: senderid}, state) do
     mode =

--- a/lib/teiserver/coordinator/consul_server.ex
+++ b/lib/teiserver/coordinator/consul_server.ex
@@ -30,7 +30,7 @@ defmodule Teiserver.Coordinator.ConsulServer do
   import Teiserver.Helper.NumberHelper, only: [int_parse: 1]
 
   @always_allow ~w(status s y n follow joinq leaveq splitlobby afks roll password?)
-  @boss_commands ~w(balancealgorithm gatekeeper welcome-message reset-approval rename minchevlevel maxchevlevel resetchevlevels resetratinglevels minratinglevel maxratinglevel setratinglevels)
+  @boss_commands ~w(balancealgorithm gatekeeper welcome-message reset-approval rename minchevlevel maxchevlevel resetchevlevels resetratinglevels minratinglevel maxratinglevel setratinglevels quantum)
   @host_commands ~w(specunready makeready settag speclock forceplay lobbyban lobbybanmult unban forcespec lock unlock makebalance set-config-teaser)
   @admin_commands ~w(shuffle)
 
@@ -1060,8 +1060,9 @@ defmodule Teiserver.Coordinator.ConsulServer do
     end
   end
 
-  # Ensure no two players have the same player_number
-  defp fix_ids(state) do
+  # Ensure no two players have the same player_number unless it's quantum mode
+  # in which case there's going to be overlap
+  defp fix_ids(%{quantum_mode?: false} = state) do
     players = list_players(state)
 
     # Never do this for more than 256 players
@@ -1088,6 +1089,18 @@ defmodule Teiserver.Coordinator.ConsulServer do
         end)
       end
     end
+  end
+
+  # At this stage quantum mode will set all players in a team to have the same shared
+  # commander
+  defp fix_ids(%{quantum_mode?: true} = state) do
+    list_players(state)
+    |> Enum.each(fn player_client ->
+      Client.update(
+        %{player_client | player_number: player_client.team_number, ready: true},
+        :client_updated_battlestatus
+      )
+    end)
   end
 
   @spec afk_check_update(map()) :: map()
@@ -1359,6 +1372,7 @@ defmodule Teiserver.Coordinator.ConsulServer do
       afk_check_list: [],
       afk_check_at: nil,
       last_seen_map: %{},
+      quantum_mode?: false,
 
       # Toggle with Coordinator.cast_consul(lobby_id, {:put, :unready_can_play, true})
       unready_can_play: false,

--- a/lib/teiserver/coordinator/consul_server.ex
+++ b/lib/teiserver/coordinator/consul_server.ex
@@ -63,7 +63,7 @@ defmodule Teiserver.Coordinator.ConsulServer do
 
   def handle_call(:get_consul_state, _from, state) do
     result =
-      ~w(gatekeeper minimum_rating_to_play maximum_rating_to_play minimum_rank_to_play maximum_rank_to_play level_to_spectate locks bans timeouts welcome_message join_queue low_priority_join_queue approved_users host_bosses host_preset host_teamsize host_teamcount player_limit ranked)a
+      ~w(gatekeeper minimum_rating_to_play maximum_rating_to_play minimum_rank_to_play maximum_rank_to_play level_to_spectate locks bans timeouts welcome_message join_queue low_priority_join_queue approved_users host_bosses host_preset host_teamsize host_teamcount player_limit ranked quantum_mode?)a
       |> Map.new(fn key ->
         {key, Map.get(state, key)}
       end)
@@ -468,10 +468,19 @@ defmodule Teiserver.Coordinator.ConsulServer do
 
       {:noreply, new_state}
     else
-      {:noreply, %{state | ranked: true}}
+      if state.quantum_mode? do
+        ChatLib.say(
+          state.coordinator_id,
+          "Ranked mode has been enabled, we have disabled Quantum mode as a result.",
+          state.lobby_id
+        )
+      end
+
+      {:noreply, %{state | ranked: true, quantum_mode?: false}}
     end
   end
 
+  # Ranked set to true
   def handle_info(
         %{
           channel: "teiserver_lobby_updates",
@@ -480,9 +489,17 @@ defmodule Teiserver.Coordinator.ConsulServer do
         },
         state
       ) do
+    if state.quantum_mode? do
+      ChatLib.say(
+        state.coordinator_id,
+        "Ranked mode has been enabled, we have disabled Quantum mode as a result.",
+        state.lobby_id
+      )
+    end
+
     # Default to ranked true
     LobbyLib.cast_lobby(state.lobby_id, :refresh_name)
-    {:noreply, %{state | ranked: true}}
+    {:noreply, %{state | ranked: true, quantum_mode?: false}}
   end
 
   def handle_info(%{channel: "teiserver_lobby_updates"}, state) do

--- a/lib/teiserver/lobby/servers/lobby_server.ex
+++ b/lib/teiserver/lobby/servers/lobby_server.ex
@@ -559,7 +559,8 @@ defmodule Teiserver.Battle.LobbyServer do
         teaser,
         LobbyRestrictions.get_rank_bounds_for_title(consul_state),
         LobbyRestrictions.get_rating_bounds_for_title(consul_state),
-        if(consul_state == nil or consul_state.ranked, do: nil, else: "Unranked")
+        if(consul_state == nil or consul_state.ranked, do: nil, else: "Unranked"),
+        if(consul_state != nil and consul_state.quantum_mode?, do: "Quantum")
       ]
       |> Enum.reject(&(&1 == nil))
       |> Enum.join(" | ")


### PR DESCRIPTION
Quantum mode is also known in Starcraft 2 as Archon mode and causes the
commanders to be combined and shared control given. Useful for coaching
or just a different way to cooperate with each other.

I tested the code manually (setting player_number etc) using IEX and got
it to work reliably. In the testing I force-started the game right away
to prevent any fixing of the IDs from taking place but here it should
be fixed by the consul server any time it is needed.

The intent for future commits is to fix any bugs that arise and add
options based on player feedback.