### PR TITLE
Help fix quantum mode being intermittendly buggy

### DIFF
--- a/lib/teiserver/coordinator.ex
+++ b/lib/teiserver/coordinator.ex
@@ -175,16 +175,6 @@ defmodule Teiserver.Coordinator do
     end
   end
 
-  @spec send_balancer(T.lobby_id(), any) :: any
-  def send_balancer(nil, _msg), do: :ok
-
-  def send_balancer(lobby_id, msg) when is_integer(lobby_id) do
-    case get_balancer_pid(lobby_id) do
-      nil -> nil
-      pid -> send(pid, msg)
-    end
-  end
-
   @spec call_balancer(pid() | T.lobby_id(), any) :: any
   def call_balancer(lobby_id, msg) when is_integer(lobby_id) do
     case get_balancer_pid(lobby_id) do

--- a/lib/teiserver/coordinator/consul_commands.ex
+++ b/lib/teiserver/coordinator/consul_commands.ex
@@ -1026,6 +1026,10 @@ defmodule Teiserver.Coordinator.ConsulCommands do
 
     # Make the game unranked
     Battle.set_modoption(state.lobby_id, "game/modoptions/ranked_game", "0")
+    Battle.set_modoption(state.lobby_id, "game/quantum/enabled", "1")
+
+    # This will fix_ids but also anything else we want to check on
+    send(self(), :tick)
 
     %{state | quantum_mode?: true}
   end
@@ -1041,6 +1045,8 @@ defmodule Teiserver.Coordinator.ConsulCommands do
       "#{sender_name} disabled Quantum mode. The game is still unranked.",
       state.lobby_id
     )
+
+    Battle.set_modoption(state.lobby_id, "game/quantum/enabled", "0")
 
     %{state | quantum_mode?: false}
   end

--- a/lib/teiserver/coordinator/consul_server.ex
+++ b/lib/teiserver/coordinator/consul_server.ex
@@ -372,9 +372,26 @@ defmodule Teiserver.Coordinator.ConsulServer do
   end
 
   def handle_info(
-        %{channel: "teiserver_lobby_updates", event: :updated_client_battlestatus},
+        %{channel: "teiserver_lobby_updates", event: :updated_client_battlestatus} = msg,
         state
       ) do
+    if state.quantum_mode? do
+      %{client: client, userid: userid} = msg
+
+      # If we are in quantum mode we want to try and keep these aligned
+      # if team_number is nil we don't want to change anything though
+      if client.team_number != nil and client.team_number != client.player_number do
+        # The map passed to us doesn't always have the full client so we need to
+        # get it to update it properly
+        client = Client.get_client_by_id(userid)
+
+        Client.update(
+          %{client | player_number: client.team_number},
+          :client_updated_battlestatus
+        )
+      end
+    end
+
     player_count_changed(state)
     {:noreply, state}
   end
@@ -468,6 +485,7 @@ defmodule Teiserver.Coordinator.ConsulServer do
 
       {:noreply, new_state}
     else
+      # Ranked is set to "1"
       if state.quantum_mode? do
         ChatLib.say(
           state.coordinator_id,
@@ -475,6 +493,8 @@ defmodule Teiserver.Coordinator.ConsulServer do
           state.lobby_id
         )
       end
+
+      Battle.set_modoption(state.lobby_id, "game/quantum/enabled", "0")
 
       {:noreply, %{state | ranked: true, quantum_mode?: false}}
     end
@@ -496,6 +516,8 @@ defmodule Teiserver.Coordinator.ConsulServer do
         state.lobby_id
       )
     end
+
+    Battle.set_modoption(state.lobby_id, "game/quantum/enabled", "0")
 
     # Default to ranked true
     LobbyLib.cast_lobby(state.lobby_id, :refresh_name)

--- a/lib/teiserver/libs/pubsub_listener.ex
+++ b/lib/teiserver/libs/pubsub_listener.ex
@@ -10,6 +10,20 @@ defmodule Teiserver.Common.PubsubListener do
   # Check mailbox
   messages = PubsubListener.get(listener)
   ```
+
+  The PubsubListener can also be used for debugging processes during a test, you can attach it to
+  a pid and it will store the messages sent to that process. Given the structure of them you may
+  want to use Enum.each to print them:
+  ```
+  messages = PubsubListener.get(listener)
+
+  messages
+  |> Enum.each(fn
+    {:trace, _pid, _rec_or_send, m} ->
+      IO.inspect m
+  end)
+  IO.puts length(messages)
+  ```
   """
 
   alias Phoenix.PubSub
@@ -23,6 +37,16 @@ defmodule Teiserver.Common.PubsubListener do
 
   def get(pid) do
     GenServer.call(pid, :get)
+  end
+
+  @doc """
+  Given a PID it will trace all messages sent to that PID as if it was subscribed to them
+  """
+  def trace(listener_pid, pid_to_trace) do
+    :erlang.trace(pid_to_trace, true, [
+      :receive,
+      {:tracer, listener_pid}
+    ])
   end
 
   def start_link(rooms) do
@@ -47,7 +71,8 @@ defmodule Teiserver.Common.PubsubListener do
   end
 
   def handle_call(:get, _from, state) do
-    {:reply, state, []}
+    # We prepend when building the list so need to reverse it here
+    {:reply, Enum.reverse(state), []}
   end
 
   def init(rooms) do

--- a/lib/teiserver_web/controllers/api/spads_controller.ex
+++ b/lib/teiserver_web/controllers/api/spads_controller.ex
@@ -162,6 +162,14 @@ defmodule TeiserverWeb.API.SpadsController do
 
             bot_result = %{}
 
+            # Tell the consul server to tick, there are certain things
+            # we might want to do after balance is applied and clientstatuses
+            # moved around
+            case Coordinator.get_consul_pid(client.lobby_id) do
+              nil -> :ok
+              pid -> :timer.send_after(100, pid, :tick)
+            end
+
             conn
             |> put_status(200)
             |> assign(:deviation, balance_result.deviation)

--- a/test/teiserver/coordinator/quantum_command_test.exs
+++ b/test/teiserver/coordinator/quantum_command_test.exs
@@ -1,0 +1,165 @@
+defmodule Teiserver.Coordinator.QuantumCommandTest do
+  alias Teiserver.Account
+  alias Teiserver.Account.ClientLib
+  alias Teiserver.AccountFixtures
+  alias Teiserver.Client
+  alias Teiserver.Coordinator
+  alias Teiserver.Lobby
+  alias Teiserver.Lobby.ChatLib
+
+  use Teiserver.ServerCase, async: false
+
+  import TeiserverTestLib,
+    only: [
+      auth_setup: 1,
+      auth_setup: 2,
+      # _recv_until: 1,
+      start_spring_server: 1
+    ]
+
+  setup(_context) do
+    {:ok, context} = start_spring_server(%{start_spring_server: :tcp})
+    TeiserverTestLib.start_coordinator!()
+
+    lobby_id = TeiserverTestLib.make_lobby()
+    lobby = Lobby.get_lobby(lobby_id)
+    host = Account.deprecated_get_user_by_id(lobby.founder_id)
+
+    u1 =
+      AccountFixtures.user_fixture(%{
+        roles: ["Server", "Bot"],
+        permissions: ["Server", "Bot"]
+      })
+
+    user1 = %{user: u1} = auth_setup(context, u1)
+    Client.login(u1, :test, "127.0.0.1")
+
+    user2 = %{user: u2} = auth_setup(context)
+    Client.login(u2, :test, "127.0.0.2")
+
+    user3 = %{user: u3} = auth_setup(context)
+    Client.login(u3, :test, "127.0.0.3")
+
+    user4 = %{user: u4} = auth_setup(context)
+    Client.login(u4, :test, "127.0.0.4")
+
+    Lobby.force_add_user_to_lobby(u1.id, lobby_id)
+    Lobby.force_add_user_to_lobby(u2.id, lobby_id)
+    Lobby.force_add_user_to_lobby(u3.id, lobby_id)
+    Lobby.force_add_user_to_lobby(u4.id, lobby_id)
+
+    ClientLib.update_client(u1.id, %{player: true, player_number: 1, team_number: 1})
+    ClientLib.update_client(u2.id, %{player: true, player_number: 2, team_number: 1})
+    ClientLib.update_client(u3.id, %{player: true, player_number: 3, team_number: 2})
+    ClientLib.update_client(u4.id, %{player: true, player_number: 4, team_number: 2})
+
+    {:ok, lobby_id: lobby_id, host: host, user1: user1, user2: user2, user3: user3, user4: user4}
+  end
+
+  defp setup_lobby(%{lobby_id: lobby_id, host: host}) do
+    Coordinator.send_consul(lobby_id, {:host_update, host.id, %{host_bosses: [host.id]}})
+
+    on_exit(fn ->
+      Lobby.close_lobby(lobby_id)
+    end)
+
+    {:ok, lobby_id: lobby_id, host: host}
+  end
+
+  describe "Quantum mode" do
+    setup [:setup_lobby]
+
+    test "Setting/Unsetting", context do
+      %{user1: %{user: user1}, lobby_id: lobby_id} = context
+
+      consul_state = Coordinator.call_consul(lobby_id, :get_consul_state)
+      refute consul_state.quantum_mode?
+
+      # Turn it on
+      ChatLib.say(user1.id, "$quantum", lobby_id)
+
+      consul_state = Coordinator.call_consul(lobby_id, :get_consul_state)
+      assert consul_state.quantum_mode?
+
+      # Give everything a moment to calm down, if we
+      # immediately tell it to swap back we create some thrashing
+      :timer.sleep(100)
+
+      # Turn it off
+      ChatLib.say(user1.id, "$quantum", lobby_id)
+
+      consul_state = Coordinator.call_consul(lobby_id, :get_consul_state, 1000)
+      refute consul_state.quantum_mode?
+    end
+
+    test "Balance does not disrupt", context do
+      %{
+        user1: %{user: user1},
+        user2: %{user: user2},
+        user3: %{user: user3},
+        user4: %{user: user4},
+        lobby_id: lobby_id
+      } = context
+
+      consul_state = Coordinator.call_consul(lobby_id, :get_consul_state)
+      refute consul_state.quantum_mode?
+
+      # We start by checking the ids don't already line up
+      # we don't care who is which id, just that we have all 4 present
+      ids =
+        [
+          ClientLib.get_client_by_id(user1.id).player_number,
+          ClientLib.get_client_by_id(user2.id).player_number,
+          ClientLib.get_client_by_id(user3.id).player_number,
+          ClientLib.get_client_by_id(user4.id).player_number
+        ]
+        |> Enum.sort()
+
+      assert ids == [1, 2, 3, 4]
+
+      # Turn it on
+      ChatLib.say(user1.id, "$quantum", lobby_id)
+
+      consul_state = Coordinator.call_consul(lobby_id, :get_consul_state)
+      assert consul_state.quantum_mode?
+
+      # It's async so we need to give it a moment to perform the changes
+      :timer.sleep(100)
+
+      c1 = ClientLib.get_client_by_id(user1.id)
+      assert c1.player_number == c1.team_number
+
+      c2 = ClientLib.get_client_by_id(user2.id)
+      assert c2.player_number == c2.team_number
+
+      c3 = ClientLib.get_client_by_id(user3.id)
+      assert c3.player_number == c3.team_number
+
+      c4 = ClientLib.get_client_by_id(user4.id)
+      assert c4.player_number == c4.team_number
+
+      # Now we "apply" balance, this is done by SPADS (the server tells it what the
+      # balance should be) so we will just fake it. The ConsulServer should
+      # detect the changes and set them back again
+      ClientLib.update_client(user1.id, %{player: true, player_number: 1, team_number: 1})
+      ClientLib.update_client(user2.id, %{player: true, player_number: 2, team_number: 1})
+      ClientLib.update_client(user3.id, %{player: true, player_number: 3, team_number: 2})
+      ClientLib.update_client(user4.id, %{player: true, player_number: 4, team_number: 2})
+
+      # Still async so give it a moment....
+      Coordinator.send_consul(lobby_id, :tick)
+      :timer.sleep(100)
+
+      ids =
+        [
+          ClientLib.get_client_by_id(user1.id).player_number,
+          ClientLib.get_client_by_id(user2.id).player_number,
+          ClientLib.get_client_by_id(user3.id).player_number,
+          ClientLib.get_client_by_id(user4.id).player_number
+        ]
+        |> Enum.sort()
+
+      assert ids == [1, 1, 2, 2]
+    end
+  end
+end


### PR DESCRIPTION
Quantum mode works in an isolated environment but when balance is performed it can break things. The solution for now is to manually tell the ConsulServer to :tick and in the process fix the IDs whenever balance is performed.