### PR TITLE
Updates user email change process

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -158,6 +158,5 @@
   {"lib/teiserver_web/templates/admin/lobby/server_chat.html.heex", :call},
   {"lib/teiserver_web/live/moderation/action_live/smurf_link.ex", :callback_arg_type_mismatch},
   {"lib/teiserver_web/live/moderation/action_live/smurf_link.ex", :call},
-  {"lib/teiserver/account/tasks/merge_accounts_task.ex", :no_return},
-  {"lib/teiserver_web/controllers/account/general_controller.ex", :no_return}
+  {"lib/teiserver/account/tasks/merge_accounts_task.ex", :no_return}
 ]

--- a/lib/teiserver/account.ex
+++ b/lib/teiserver/account.ex
@@ -109,9 +109,9 @@ defmodule Teiserver.Account do
           {:ok, User.t()} | {:error, Ecto.Changeset.t()}
   defdelegate update_user_plain_password(user, attrs), to: UserLib
 
-  @spec update_user_user_email(User.t(), map, String.t()) ::
+  @spec update_user_email(User.t(), map, String.t()) ::
           {:ok, User.t()} | {:error, Ecto.Changeset.t()}
-  defdelegate update_user_user_email(user, attrs, ip), to: UserLib
+  defdelegate update_user_email(user, attrs, ip), to: UserLib
 
   @spec server_limited_update_user(User.t(), map) ::
           {:ok, User.t()} | {:error, Ecto.Changeset.t()}

--- a/lib/teiserver/account.ex
+++ b/lib/teiserver/account.ex
@@ -109,8 +109,9 @@ defmodule Teiserver.Account do
           {:ok, User.t()} | {:error, Ecto.Changeset.t()}
   defdelegate update_user_plain_password(user, attrs), to: UserLib
 
-  @spec update_user_user_form(User.t(), map) :: {:ok, User.t()} | {:error, Ecto.Changeset.t()}
-  defdelegate update_user_user_form(user, attrs), to: UserLib
+  @spec update_user_user_email(User.t(), map, String.t()) ::
+          {:ok, User.t()} | {:error, Ecto.Changeset.t()}
+  defdelegate update_user_user_email(user, attrs, ip), to: UserLib
 
   @spec server_limited_update_user(User.t(), map) ::
           {:ok, User.t()} | {:error, Ecto.Changeset.t()}

--- a/lib/teiserver/account/libs/auth_lib.ex
+++ b/lib/teiserver/account/libs/auth_lib.ex
@@ -254,9 +254,11 @@ defmodule Teiserver.Account.AuthLib do
   """
   @spec need_to_mfa_refresh?(User.id()) :: boolean()
   def need_to_mfa_refresh?(user_id) do
+    max_age = Application.get_env(:teiserver, Teiserver)[:mfa_privilege_refresh_max_age] || 300
+
     case get_user_mfa_age_in_seconds(user_id) do
       :inactive -> false
-      age -> age > 300
+      age -> age > max_age
     end
   end
 end

--- a/lib/teiserver/account/libs/auth_lib.ex
+++ b/lib/teiserver/account/libs/auth_lib.ex
@@ -10,6 +10,8 @@ defmodule Teiserver.Account.AuthLib do
   alias Teiserver.Account.Auth
   alias Teiserver.Account.Role
   alias Teiserver.Account.RoleLib
+  alias Teiserver.Account.TOTPLib
+  alias Teiserver.Account.User
 
   @spec icon :: String.t()
   def icon, do: "fa-solid fa-address-card"
@@ -230,5 +232,31 @@ defmodule Teiserver.Account.AuthLib do
   @spec current_user(Plug.Conn.t()) :: Teiserver.Account.User.t() | nil
   def current_user(conn) do
     conn.assigns[:current_user]
+  end
+
+  @doc """
+  Returns how many seconds ago they last used their MFA
+  """
+  @spec get_user_mfa_age_in_seconds(User.id()) :: :inactive | non_neg_integer()
+  def get_user_mfa_age_in_seconds(user_id) do
+    case TOTPLib.get_last_used(user_id) do
+      :inactive ->
+        :inactive
+
+      %DateTime{} = last_used_dt ->
+        DateTime.diff(DateTime.utc_now(), last_used_dt)
+    end
+  end
+
+  @doc """
+  Returns a boolean saying if the MFA of a user needs to refresh (it was last used
+  more than 5 minutes ago), in the event the user has no MFA it will not require a refresh.
+  """
+  @spec need_to_mfa_refresh?(User.id()) :: boolean()
+  def need_to_mfa_refresh?(user_id) do
+    case get_user_mfa_age_in_seconds(user_id) do
+      :inactive -> false
+      age -> age > 300
+    end
   end
 end

--- a/lib/teiserver/account/libs/user_lib.ex
+++ b/lib/teiserver/account/libs/user_lib.ex
@@ -1,6 +1,7 @@
 defmodule Teiserver.Account.UserLib do
   @moduledoc false
 
+  alias Ecto.Changeset
   alias Phoenix.PubSub
   alias Teiserver.Account
   alias Teiserver.Account.Auth
@@ -11,6 +12,7 @@ defmodule Teiserver.Account.UserLib do
   alias Teiserver.CacheUser
   alias Teiserver.Client
   alias Teiserver.Config
+  alias Teiserver.EmailHelper
   alias Teiserver.Helper.StylingHelper
   alias Teiserver.Logging
   alias Teiserver.Repo
@@ -254,15 +256,56 @@ defmodule Teiserver.Account.UserLib do
     |> UserCacheLib.decache_user_on_ok()
   end
 
-  def update_user_user_form(%User{} = user, attrs) do
+  @doc """
+  Updates the user email, if the update is successful then the
+  old and new emails will be informed of the change.
+  """
+  def update_user_user_email(%User{} = user, attrs, ip_address) do
     Account.deprecated_recache_user(user.id)
 
-    user
-    |> User.changeset(attrs, :user_form)
-    |> Repo.update()
-    |> broadcast_update_user()
-    |> cache_put_on_ok(:users_by_id)
-    |> UserCacheLib.decache_user_on_ok()
+    # We do everything as a transaction so we can revert the change if something goes wrong
+    # with the email sending. Unfortunately there is no way to un-send the email to the old
+    # address if something goes wrong with sending to the new address
+    result =
+      Repo.transact(fn ->
+        with %Changeset{valid?: true} = changeset <- User.changeset(user, attrs, :email),
+             {:ok, %User{} = user} <- Repo.update(changeset),
+             {:ok, %{}} <- EmailHelper.email_changed(user) do
+          Logging.add_audit_log(user.id, ip_address, "email_change_success", %{})
+
+          {:ok, user}
+          |> broadcast_update_user()
+          |> cache_put_on_ok(:users_by_id)
+          |> UserCacheLib.decache_user_on_ok()
+        else
+          {:error, %Changeset{} = changeset} ->
+            {:error, changeset}
+
+          result ->
+            {:error, result}
+        end
+      end)
+
+    # If the transaction fails, we will insert an audit log. We have to do this outside
+    # of the transaction or the log creation will be rolled back
+    case result do
+      {:ok, user} ->
+        {:ok, user}
+
+      {:error, %Changeset{valid?: false} = changeset} ->
+        Logging.add_audit_log(user.id, ip_address, "email_change_failure", %{
+          reason: "Invalid changeset"
+        })
+
+        {:error, changeset}
+
+      {:error, err} ->
+        Logging.add_audit_log(user.id, ip_address, "email_change_failure", %{
+          reason: "Unexpected result"
+        })
+
+        raise "Unexpected result: #{inspect(err)}"
+    end
   end
 
   def server_limited_update_user(%User{} = user, attrs) do

--- a/lib/teiserver/account/libs/user_lib.ex
+++ b/lib/teiserver/account/libs/user_lib.ex
@@ -260,7 +260,7 @@ defmodule Teiserver.Account.UserLib do
   Updates the user email, if the update is successful then the
   old and new emails will be informed of the change.
   """
-  def update_user_user_email(%User{} = user, attrs, ip_address) do
+  def update_user_email(%User{} = user, attrs, ip_address) do
     Account.deprecated_recache_user(user.id)
 
     # We do everything as a transaction so we can revert the change if something goes wrong

--- a/lib/teiserver/account/schemas/user.ex
+++ b/lib/teiserver/account/schemas/user.ex
@@ -17,6 +17,7 @@ defmodule Teiserver.Account.User do
   typed_schema "account_users" do
     field :name, :string
     field :email, :string
+    field :previous_emails, {:array, :string}, default: []
     field :password, :string, redact: true
 
     field :icon, :string
@@ -36,6 +37,7 @@ defmodule Teiserver.Account.User do
     field :last_login, :utc_datetime
     field :last_played, :utc_datetime
     field :last_logout, :utc_datetime
+    field :email_last_changed_at, :utc_datetime
 
     field :discord_id, :integer
     field :discord_dm_channel_id, :integer
@@ -127,66 +129,50 @@ defmodule Teiserver.Account.User do
   end
 
   def changeset(user, attrs, :server_limited_update_user) do
-    attrs =
-      attrs
-      |> remove_whitespace([:email])
-
     user
     |> cast(
       attrs,
-      ~w(name email icon colour data roles permissions)a
+      ~w(name icon colour data roles permissions)a
     )
-    |> validate_required(~w(name email)a)
-    |> unique_constraint(:email)
+    |> validate_required([:name])
     |> validate_name_change()
   end
 
   def changeset(user, attrs, :limited_with_data) do
-    attrs =
-      attrs
-      |> remove_whitespace([:email])
-
     user
-    |> cast(attrs, ~w(name email icon colour data)a)
-    |> validate_required([:name, :email])
-    |> unique_constraint(:email)
+    |> cast(attrs, ~w(name icon colour data)a)
+    |> validate_required([:name])
     |> validate_name_change()
   end
 
-  # Updating email or name from user update form requires plain text password confirmation
-  def changeset(user, attrs, :user_form) do
-    attrs =
-      attrs
-      |> remove_whitespace([:email])
+  # Requires the password to be used for email address changes
+  def changeset(%User{email: old_email} = user, attrs, :email) do
+    attrs = remove_whitespace(attrs, [:email])
 
-    cond do
-      attrs["password"] == nil or attrs["password"] == "" ->
-        user
-        |> cast(attrs, [:name, :email])
-        |> validate_required([:name, :email])
-        |> add_error(
-          :password_confirmation,
-          "Please enter your password to change your account details."
-        )
+    new_previous_emails = [old_email | user.previous_emails]
 
-      Account.verify_plain_password(attrs["password"], user.password) == false ->
-        user
-        |> cast(attrs, [:name, :email])
-        |> validate_required([:name, :email])
-        |> add_error(:password_confirmation, "Incorrect password")
-
-      true ->
-        user
-        |> cast(attrs, [:name, :email])
-        |> validate_required([:name, :email])
-        |> unique_constraint(:email)
-        |> validate_name_change()
-        |> validate_change(:email, fn :email, email ->
-          case CacheUser.valid_email?(email) do
-            :ok -> []
-            {:error, reason} -> [{:email, reason}]
-          end
-        end)
+    if Account.verify_plain_password(attrs["password"] || "", user.password) do
+      user
+      |> cast(attrs, [:email])
+      |> cast(
+        %{previous_emails: new_previous_emails, email_last_changed_at: DateTime.utc_now()},
+        [
+          :previous_emails,
+          :email_last_changed_at
+        ]
+      )
+      |> validate_required([:email, :previous_emails])
+      |> unique_constraint(:email)
+      |> validate_change(:email, fn :email, email ->
+        case CacheUser.valid_email?(email) do
+          :ok -> []
+          {:error, reason} -> [{:email, reason}]
+        end
+      end)
+    else
+      user
+      |> cast(attrs, [:email])
+      |> add_error(:password, "Incorrect password")
     end
   end
 

--- a/lib/teiserver/common/email_helper.ex
+++ b/lib/teiserver/common/email_helper.ex
@@ -2,11 +2,17 @@ defmodule Teiserver.EmailHelper do
   @moduledoc false
   alias Swoosh.Email
   alias Teiserver.Account
+  alias Teiserver.Account.User
   alias Teiserver.Config
   alias Teiserver.Helper.DateHelper
   alias Teiserver.Mailer
   alias Teiserver.Telemetry
+
   require Logger
+
+  defp host, do: Application.get_env(:teiserver, TeiserverWeb.Endpoint)[:url][:host]
+
+  defp privacy_email, do: Application.get_env(:teiserver, Teiserver)[:privacy_email]
 
   def new_user(user) do
     case Config.get_site_config_cache("teiserver.Require email verification") do
@@ -88,8 +94,7 @@ defmodule Teiserver.EmailHelper do
         code
       end
 
-    host = Application.get_env(:teiserver, TeiserverWeb.Endpoint)[:url][:host]
-    url = "https://#{host}/password_reset/#{code.value}"
+    url = "https://#{host()}/password_reset/#{code.value}"
 
     html_body = """
     <p>A password reset has been requested for your account. To reset your password follow the link below. If you did not request this reset please ignore this email. The code will expire in 24 hours.</p>
@@ -129,11 +134,10 @@ defmodule Teiserver.EmailHelper do
 
   defp do_new_user(user) do
     stats = Account.get_user_stat_data(user.id)
-    host = Application.get_env(:teiserver, TeiserverWeb.Endpoint)[:url][:host]
     website_url = Application.get_env(:teiserver, Teiserver)[:main_website]
     verification_code = stats["verification_code"]
 
-    message_id = "<#{UUID.uuid4()}@#{host}>"
+    message_id = "<#{UUID.uuid4()}@#{host()}>"
 
     game_name = Application.get_env(:teiserver, Teiserver)[:game_name]
     discord = Application.get_env(:teiserver, Teiserver)[:discord]
@@ -168,6 +172,105 @@ defmodule Teiserver.EmailHelper do
     |> Email.to({user.name, user.email})
     |> Email.from({"BAR Teiserver", Mailer.noreply_address()})
     |> Email.subject("BAR - New account")
+    |> Email.header("Date", date)
+    |> Email.header("Message-Id", message_id)
+    |> Email.html_body(html_body)
+    |> Email.text_body(text_body)
+    |> Mailer.deliver(response: true)
+  end
+
+  def email_changed(%User{} = user) do
+    # We specifically send to the old address first to ensure if something goes wrong we
+    # do not send anything to the new address
+    {:ok, _success} = email_changed_old_address(user)
+    {:ok, _success} = email_changed_new_address(user)
+  end
+
+  defp email_changed_old_address(%User{} = user) do
+    now = Calendar.strftime(DateTime.utc_now(), "%a, %d %b %Y %H:%M:%S %z")
+
+    # The email to privacy@beyondallreason.info used as a link is intended to be replaced by a
+    # link to the support ticketing system we will later make use of
+    html_body = """
+    Hello,
+
+    The email address on the Beyond All Reason account #{user.name} was changed on #{now}. This address will no longer receive messages about that account.
+
+    If this was you, nothing further is needed.
+
+    If this was not you, act now: someone may have access to your account. Open a ticket with us immediately at <a href="mailto:#{privacy_email()}">#{privacy_email()}</a>, replying from this address, and we will help you recover it. Do not reply with your password; we will never ask for it.
+
+    For security, account deletion cannot be requested through our self-service page for 14 days after an email change.
+
+    Beyond All Reason <a href="mailto:#{privacy_email()}">#{privacy_email()}</a>
+    """
+
+    text_body = """
+    Hello,
+
+    The email address on the Beyond All Reason account #{user.name} was changed on #{now}. This address will no longer receive messages about that account.
+
+    If this was you, nothing further is needed.
+
+    If this was not you, act now: someone may have access to your account. Open a ticket with us immediately at #{privacy_email()}, replying from this address, and we will help you recover it. Do not reply with your password; we will never ask for it.
+
+    For security, account deletion cannot be requested through our self-service page for 14 days after an email change.
+
+    Beyond All Reason: #{privacy_email()}
+    """
+
+    message_id = "<#{UUID.uuid4()}@#{host()}>"
+    date = DateHelper.date_to_str(DateTime.utc_now(), format: :email_date)
+
+    old_email = hd(user.previous_emails)
+
+    Email.new()
+    |> Email.to({user.name, old_email})
+    |> Email.from({"BAR Teiserver", Mailer.noreply_address()})
+    |> Email.subject("BAR - Your Beyond All Reason email address was changed")
+    |> Email.header("Date", date)
+    |> Email.header("Message-Id", message_id)
+    |> Email.html_body(html_body)
+    |> Email.text_body(text_body)
+    |> Mailer.deliver(response: true)
+  end
+
+  defp email_changed_new_address(%User{} = user) do
+    now = Calendar.strftime(DateTime.utc_now(), "%a, %d %b %Y %H:%M:%S %z")
+
+    # The email to #{privacy_email()} used as a link is intended to be replaced by a
+    # link to the support ticketing system we will later make use of
+    html_body = """
+    Hello,
+
+    This address is now the email address for the Beyond All Reason account #{user.name} was changed on #{now}. The previous address has been notified as well.
+
+    If you did not make this change, open a ticket with us at <a href="mailto:#{privacy_email()}">#{privacy_email()}</a> straight away. Do not reply with your password; we will never ask for it.
+
+    For security, account deletion cannot be requested through our self-service page for 14 days after an email change.
+
+    Beyond All Reason <a href="mailto:#{privacy_email()}">#{privacy_email()}</a>
+    """
+
+    text_body = """
+    Hello,
+
+    This address is now the email address for the Beyond All Reason account #{user.name} was changed on #{now}. The previous address has been notified as well.
+
+    If you did not make this change, open a ticket with us at #{privacy_email()} straight away. Do not reply with your password; we will never ask for it.
+
+    For security, account deletion cannot be requested through our self-service page for 14 days after an email change.
+
+    Beyond All Reason #{privacy_email()}
+    """
+
+    message_id = "<#{UUID.uuid4()}@#{host()}>"
+    date = DateHelper.date_to_str(DateTime.utc_now(), format: :email_date)
+
+    Email.new()
+    |> Email.to({user.name, user.email})
+    |> Email.from({"BAR Teiserver", Mailer.noreply_address()})
+    |> Email.subject("BAR - Your Beyond All Reason email address was changed")
     |> Email.header("Date", date)
     |> Email.header("Message-Id", message_id)
     |> Email.html_body(html_body)

--- a/lib/teiserver/logging/lib/logging_test_lib.ex
+++ b/lib/teiserver/logging/lib/logging_test_lib.ex
@@ -2,6 +2,7 @@ defmodule Teiserver.Logging.LoggingTestLib do
   @moduledoc false
 
   alias Teiserver.AccountFixtures
+  alias Teiserver.Logging
   alias Teiserver.Logging.AggregateViewLog
   alias Teiserver.Logging.AggregateViewLogLib
   alias Teiserver.Logging.AuditLog
@@ -80,5 +81,10 @@ defmodule Teiserver.Logging.LoggingTestLib do
          aggregate_logs: aggregate_logs,
          page_view_logs: page_view_logs
        ]}
+  end
+
+  def get_most_recent_audit_log_for_user(user_id) do
+    Logging.list_audit_logs(where: [user_id: user_id], limit: 1, order_by: "Newest first")
+    |> List.first()
   end
 end

--- a/lib/teiserver/protocols/spring/spring_in.ex
+++ b/lib/teiserver/protocols/spring/spring_in.ex
@@ -437,43 +437,26 @@ defmodule Teiserver.Protocols.SpringIn do
     reply(:okay, url, msg_id, state)
   end
 
-  defp do_handle("CHANGEEMAILREQUEST", new_email, msg_id, state) do
-    result = CacheUser.request_email_change(state.user, new_email)
+  defp do_handle("CHANGEEMAILREQUEST", _new_email, msg_id, state) do
+    reply(
+      :change_email_request_denied,
+      "This feature is no longer supported in client, please use the website to change your email address.",
+      msg_id,
+      state
+    )
 
-    case result do
-      {:error, reason} ->
-        reply(:change_email_request_denied, reason, msg_id, state)
-        state
-
-      {:ok, new_user} ->
-        reply(:change_email_request_accepted, nil, msg_id, state)
-        %{state | user: new_user}
-    end
+    state
   end
 
-  defp do_handle("CHANGEEMAIL", data, msg_id, state) do
-    case Regex.run(~r/(\S+) (\S+)/, data) do
-      [_full_match, new_email, supplied_code] ->
-        [correct_code, expected_email] = state.user.email_change_code
+  defp do_handle("CHANGEEMAIL", _data, msg_id, state) do
+    reply(
+      :change_email_denied,
+      "This feature is no longer supported in client, please use the website to change your email address.",
+      msg_id,
+      state
+    )
 
-        cond do
-          correct_code != supplied_code ->
-            reply(:change_email_denied, "bad code", msg_id, state)
-            state
-
-          new_email != expected_email ->
-            reply(:change_email_denied, "bad email", msg_id, state)
-            state
-
-          true ->
-            new_user = CacheUser.change_email(state.user, new_email)
-            reply(:change_email_accepted, nil, msg_id, state)
-            %{state | user: new_user}
-        end
-
-      _no_match_result ->
-        _no_match(state, "CHANGEEMAIL", msg_id, data)
-    end
+    state
   end
 
   defp do_handle("EXIT", _reason, _msg_id, state) do

--- a/lib/teiserver/protocols/spring/spring_out.ex
+++ b/lib/teiserver/protocols/spring/spring_out.ex
@@ -404,16 +404,8 @@ defmodule Teiserver.Protocols.SpringOut do
   end
 
   # Email change request
-  defp do_reply(:change_email_accepted, nil) do
-    "CHANGEEMAILACCEPTED\n"
-  end
-
   defp do_reply(:change_email_denied, reason) do
     "CHANGEEMAILDENIED #{reason}\n"
-  end
-
-  defp do_reply(:change_email_request_accepted, nil) do
-    "CHANGEEMAILREQUESTACCEPTED\n"
   end
 
   # SLDB

--- a/lib/teiserver_web/components/layouts/public_tw.heex
+++ b/lib/teiserver_web/components/layouts/public_tw.heex
@@ -1,0 +1,20 @@
+<div>
+  <TeiserverWeb.NavComponents.top_navbar_tw
+    active={assigns[:site_menu_active]}
+    current_user={@current_user}
+  />
+
+  <.flash_group flash={@flash} />
+
+  <main>
+    <div class="px-3 my-0">
+      {@inner_content}
+    </div>
+  </main>
+
+  <footer class="footer mt-auto pt-2 pb-1 px-2">
+    <div style="text-align: right;">
+      &nbsp;
+    </div>
+  </footer>
+</div>

--- a/lib/teiserver_web/controllers/account/general_controller.ex
+++ b/lib/teiserver_web/controllers/account/general_controller.ex
@@ -57,7 +57,7 @@ defmodule TeiserverWeb.Account.GeneralController do
 
       ip = LoggingPlug.get_ip_from_conn(conn)
 
-      case Account.update_user_user_email(user, user_params, ip) do
+      case Account.update_user_email(user, user_params, ip) do
         {:ok, _user} ->
           conn
           |> put_flash(:info, "Account details updated successfully.")

--- a/lib/teiserver_web/controllers/account/general_controller.ex
+++ b/lib/teiserver_web/controllers/account/general_controller.ex
@@ -2,7 +2,8 @@ defmodule TeiserverWeb.Account.GeneralController do
   @moduledoc false
 
   alias Teiserver.Account
-  alias Teiserver.Config
+  alias Teiserver.Account.AuthLib
+  alias Teiserver.Logging.LoggingPlug
 
   use TeiserverWeb, :controller
 
@@ -21,38 +22,50 @@ defmodule TeiserverWeb.Account.GeneralController do
   @spec edit_details(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def edit_details(conn, _params) do
     user = Account.get_user!(conn.assigns.current_user.id)
-    changeset = Account.change_user(user)
 
-    conn
-    |> add_breadcrumb(name: "Details", url: conn.request_path)
-    |> assign(:changeset, changeset)
-    |> assign(:user, user)
-    |> render("edit_details.html")
+    if AuthLib.need_to_mfa_refresh?(user.id) do
+      conn
+      |> add_breadcrumb(name: "Details", url: conn.request_path)
+      |> assign(:user, user)
+      |> assign(:redirect, ~p"/teiserver/account/details")
+      |> render("mfa_refresh.html")
+    else
+      changeset = Account.change_user(user)
+
+      conn
+      |> add_breadcrumb(name: "Details", url: conn.request_path)
+      |> assign(:changeset, changeset)
+      |> assign(:user, user)
+      |> render("edit_details.html")
+    end
   end
 
   @spec update_details(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def update_details(conn, %{"user" => user_params}) do
     user = Account.get_user!(conn.assigns.current_user.id)
 
-    Account.decache_user(user.id)
+    if AuthLib.need_to_mfa_refresh?(user.id) do
+      conn
+      |> add_breadcrumb(name: "Details", url: conn.request_path)
+      |> assign(:user, user)
+      |> assign(:redirect, ~p"/teiserver/account/details")
+      |> render("mfa_refresh.html")
+    else
+      Account.decache_user(user.id)
 
-    user_params = Map.put(user_params, "password", user_params["password_confirmation"])
+      user_params = Map.put(user_params, "password", user_params["password_confirmation"])
 
-    user_params =
-      if Config.get_site_config_cache("user.Enable renames") do
-        user_params
-      else
-        Map.drop(user_params, ["name"])
+      ip = LoggingPlug.get_ip_from_conn(conn)
+
+      case Account.update_user_user_email(user, user_params, ip) do
+        {:ok, _user} ->
+          conn
+          |> put_flash(:info, "Account details updated successfully.")
+          |> redirect(to: ~p"/profile/#{user.id}")
+
+        {:error, %Ecto.Changeset{} = changeset} ->
+          render(conn, "edit_details.html", user: user, changeset: changeset)
       end
-
-    case Account.update_user_user_form(user, user_params) do
-      {:ok, _user} ->
-        conn
-        |> put_flash(:info, "Account details updated successfully.")
-        |> redirect(to: ~p"/profile/#{user.id}")
-
-      {:error, %Ecto.Changeset{} = changeset} ->
-        render(conn, "edit_details.html", user: user, changeset: changeset)
     end
   end
 end

--- a/lib/teiserver_web/controllers/account/session_controller.ex
+++ b/lib/teiserver_web/controllers/account/session_controller.ex
@@ -98,6 +98,41 @@ defmodule TeiserverWeb.Account.SessionController do
     end
   end
 
+  def refresh_totp(conn, %{"user_id" => user_id, "otp" => otp, "redirect" => redirect}) do
+    user = UserLib.get_user(user_id)
+
+    case Account.validate_totp(user, otp) do
+      :ok ->
+        conn
+        |> redirect(to: redirect)
+
+      {:error, reason} ->
+        flash_message =
+          case reason do
+            :used ->
+              "Code has already been used."
+
+            :invalid ->
+              "Invalid code."
+
+            :locked ->
+              login_reply(
+                {:error,
+                 "The MFA one time password has been entered wrong too many times. Please reset your password to remove MFA from your account."},
+                conn
+              )
+
+            _other ->
+              "There was a problem verifying the code."
+          end
+
+        conn
+        |> put_flash(:warning, flash_message)
+        |> assign(:user, user)
+        |> render("totp.html")
+    end
+  end
+
   @spec one_time_login(Conn.t(), map()) :: Conn.t()
   def one_time_login(conn, %{"value" => value}) do
     ip =

--- a/lib/teiserver_web/router.ex
+++ b/lib/teiserver_web/router.ex
@@ -144,6 +144,7 @@ defmodule TeiserverWeb.Router do
     post("/login", SessionController, :login)
     get("/otp", SessionController, :otp)
     post("/otp", SessionController, :verify_totp)
+    post("/refresh_otp", SessionController, :refresh_totp)
     get("/logout", SessionController, :logout)
     post("/logout", SessionController, :logout)
     delete("/logout", SessionController, :logout)

--- a/lib/teiserver_web/templates/account/general/mfa_refresh.heex
+++ b/lib/teiserver_web/templates/account/general/mfa_refresh.heex
@@ -1,0 +1,47 @@
+<TeiserverWeb.AccountComponents.sub_menu active="details" view_colour={view_colour()} />
+
+<div class="row" style="padding-top: 10vh;">
+  <div class="col-sm-10 col-sm-offset-1 col-md-6 offset-md-3 col-xl-6 offset-xl-3">
+    <div class="card mb-3">
+      <div class="card-header">
+        <h3>
+          <img
+            src={~p"/images/logo/logo_favicon.png"}
+            height="42"
+            style="margin-right: 5px;"
+            class="d-inline align-top"
+          /> Security validation
+        </h3>
+      </div>
+      <div class="card-body">
+        <p>You must enter your Multi-Factor authentication number to use this page.</p>
+
+        <form action={~p"/refresh_otp"} method="post">
+          <input type="hidden" name="_csrf_token" value={get_csrf_token()} />
+          <input type="hidden" name="user_id" value={@user.id} />
+          <input type="hidden" name="redirect" value={@redirect} />
+          <input type="password" style="display:none" />
+
+          <div class="form-group">
+            <label for="otp">One Time Password</label>
+
+            <input
+              type="text"
+              name="otp"
+              id="otp"
+              class="form-control"
+              autofocus
+              required
+              autocomplete="one-time-code"
+              placeholder="Enter 6-digit code"
+            />
+          </div>
+
+          <div class="mt-3">
+            <input type="submit" value="Verify OTP" class="btn btn-primary btn-block" />
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/lib/teiserver_web/templates/admin/user/tab_details.html.heex
+++ b/lib/teiserver_web/templates/admin/user/tab_details.html.heex
@@ -84,6 +84,12 @@
       value={@user.discord_id}
       width={200}
     />
+
+    <.detail_line
+      label="Last email(s)"
+      value={Enum.join(Enum.reverse(@user.previous_emails), ", ")}
+      width={200}
+    />
   </div>
 
   <%= if allow?(@conn, "Server") do %>

--- a/priv/repo/migrations/20260820084520_add_user_email_last-changed.exs
+++ b/priv/repo/migrations/20260820084520_add_user_email_last-changed.exs
@@ -1,0 +1,10 @@
+defmodule Teiserver.Repo.Migrations.AddUserEmailLastChanged do
+  use Ecto.Migration
+
+  def change do
+    alter table(:account_users) do
+      add :email_last_changed_at, :timestamp, nullable: true
+      add :previous_emails, {:array, :string}, nullable: true
+    end
+  end
+end

--- a/test/teiserver/account/user_lib_test.exs
+++ b/test/teiserver/account/user_lib_test.exs
@@ -5,6 +5,7 @@ defmodule Teiserver.Account.UserLibTest do
   alias Teiserver.Account.User
   alias Teiserver.Account.UserLib
   alias Teiserver.AccountFixtures
+  alias Teiserver.Logging.LoggingTestLib
 
   use Teiserver.DataCase, async: false
 
@@ -27,7 +28,127 @@ defmodule Teiserver.Account.UserLibTest do
     end
   end
 
-  describe "disallow renaming to names with disallowed characters" do
+  describe "update_user_user_email/3" do
+    setup do
+      user = AccountFixtures.user_fixture()
+      %{user: user}
+    end
+
+    test "no password confirmation", %{user: user} do
+      result =
+        UserLib.update_user_user_email(
+          user,
+          %{
+            "email" => "test@test.com"
+          },
+          "127.0.1.1"
+        )
+
+      assert match?({:error, %{errors: [password: {"Incorrect password", []}]}}, result)
+
+      audit_log = LoggingTestLib.get_most_recent_audit_log_for_user(user.id)
+      assert audit_log.action == "email_change_failure"
+      assert audit_log.details["reason"] == "Invalid changeset"
+      assert audit_log.ip == "127.0.1.1"
+    end
+
+    test "wrong password", %{user: user} do
+      result =
+        UserLib.update_user_user_email(
+          user,
+          %{
+            "email" => "test@test.com",
+            "password" => "no password"
+          },
+          "127.0.1.2"
+        )
+
+      assert match?({:error, %{errors: [password: {"Incorrect password", []}]}}, result)
+
+      audit_log = LoggingTestLib.get_most_recent_audit_log_for_user(user.id)
+      assert audit_log.action == "email_change_failure"
+      assert audit_log.details["reason"] == "Invalid changeset"
+      assert audit_log.ip == "127.0.1.2"
+    end
+
+    test "invalid email", %{user: user} do
+      result =
+        UserLib.update_user_user_email(
+          user,
+          %{
+            "email" => "test@test",
+            "password" => "password"
+          },
+          "127.0.1.3"
+        )
+
+      assert match?({:error, %{errors: [email: {"invalid email", []}]}}, result)
+
+      audit_log = LoggingTestLib.get_most_recent_audit_log_for_user(user.id)
+      assert audit_log.action == "email_change_failure"
+      assert audit_log.details["reason"] == "Invalid changeset"
+      assert audit_log.ip == "127.0.1.3"
+    end
+
+    test "correct email", %{user: user} do
+      %User{email: old_email} = user
+
+      {:ok, new_user} =
+        UserLib.update_user_user_email(
+          user,
+          %{
+            "email" => "test@test.com",
+            "password" => "password"
+          },
+          "127.0.1.4"
+        )
+
+      assert new_user.email == "test@test.com"
+      assert new_user.previous_emails == [old_email]
+
+      # Old user email_last_changed_at should be nil, the new one not
+      assert user.email_last_changed_at == nil
+      assert match?(%DateTime{}, new_user.email_last_changed_at)
+
+      # Successful audit log result too
+      audit_log = LoggingTestLib.get_most_recent_audit_log_for_user(user.id)
+      assert audit_log.action == "email_change_success"
+      assert audit_log.ip == "127.0.1.4"
+
+      # Changing it again should result in a refresh of the last_changed_at and
+      # two emails in the list. We sleep for 1 second to ensure the email_last_changed_at
+      # value is a second ahead of the other allowing our comparison test to work
+      :timer.sleep(1000)
+
+      # Re-get the user
+      user = Account.get_user_by_id!(user.id)
+
+      {:ok, new_user2} =
+        UserLib.update_user_user_email(
+          user,
+          %{
+            "email" => "example@example.com",
+            "password" => "password"
+          },
+          "127.0.1.5"
+        )
+
+      assert new_user2.email == "example@example.com"
+      assert new_user2.previous_emails == ["test@test.com", old_email]
+
+      # New email_last_changed_at value should be greater than the last
+      assert DateTime.compare(new_user2.email_last_changed_at, new_user.email_last_changed_at) ==
+               :gt
+
+      # Successful audit log result too, we used a different IP so we can be sure
+      # it is a new one
+      audit_log = LoggingTestLib.get_most_recent_audit_log_for_user(user.id)
+      assert audit_log.action == "email_change_success"
+      assert audit_log.ip == "127.0.1.5"
+    end
+  end
+
+  describe "user create and update" do
     # create_ first
     test "create_user/1" do
       user_vars = %{name: @disallowed_name, email: "test@test.test", password: "password"}
@@ -67,16 +188,6 @@ defmodule Teiserver.Account.UserLibTest do
                UserLib.update_user_plain_password(user, %{
                  "name" => @disallowed_name,
                  "existing" => "password"
-               })
-    end
-
-    test "update_user_user_form/2" do
-      user = AccountFixtures.user_fixture()
-
-      assert {:error, %{errors: [name: _error]}} =
-               UserLib.update_user_user_form(user, %{
-                 "name" => @disallowed_name,
-                 "password" => "password"
                })
     end
 

--- a/test/teiserver/account/user_lib_test.exs
+++ b/test/teiserver/account/user_lib_test.exs
@@ -28,7 +28,7 @@ defmodule Teiserver.Account.UserLibTest do
     end
   end
 
-  describe "update_user_user_email/3" do
+  describe "update_user_email/3" do
     setup do
       user = AccountFixtures.user_fixture()
       %{user: user}
@@ -36,7 +36,7 @@ defmodule Teiserver.Account.UserLibTest do
 
     test "no password confirmation", %{user: user} do
       result =
-        UserLib.update_user_user_email(
+        UserLib.update_user_email(
           user,
           %{
             "email" => "test@test.com"
@@ -54,7 +54,7 @@ defmodule Teiserver.Account.UserLibTest do
 
     test "wrong password", %{user: user} do
       result =
-        UserLib.update_user_user_email(
+        UserLib.update_user_email(
           user,
           %{
             "email" => "test@test.com",
@@ -73,7 +73,7 @@ defmodule Teiserver.Account.UserLibTest do
 
     test "invalid email", %{user: user} do
       result =
-        UserLib.update_user_user_email(
+        UserLib.update_user_email(
           user,
           %{
             "email" => "test@test",
@@ -94,7 +94,7 @@ defmodule Teiserver.Account.UserLibTest do
       %User{email: old_email} = user
 
       {:ok, new_user} =
-        UserLib.update_user_user_email(
+        UserLib.update_user_email(
           user,
           %{
             "email" => "test@test.com",
@@ -124,7 +124,7 @@ defmodule Teiserver.Account.UserLibTest do
       user = Account.get_user_by_id!(user.id)
 
       {:ok, new_user2} =
-        UserLib.update_user_user_email(
+        UserLib.update_user_email(
           user,
           %{
             "email" => "example@example.com",

--- a/test/teiserver/protocols/spring/spring_auth_test.exs
+++ b/test/teiserver/protocols/spring/spring_auth_test.exs
@@ -532,41 +532,13 @@ CLIENTS test_room #{user.name}\n"
     _send_raw(socket, "EXIT\n")
   end
 
-  test "CHANGEEMAIL", %{socket: socket, user: user} do
-    # Make the request
+  test "CHANGEEMAIL", %{socket: socket} do
+    # We no longer support this command, we just need to ensure calling it doesn't cause an exception
     _send_raw(socket, "CHANGEEMAILREQUEST new_email@email.com\n")
     reply = _recv_raw(socket)
-    assert reply == "CHANGEEMAILREQUESTACCEPTED\n"
-    new_user = UserCacheLib.deprecated_get_user_by_id(user.id)
-    [code, new_email] = new_user.email_change_code
-    assert new_email == "new_email@email.com"
 
-    # Submit a bad code
-    _send_raw(socket, "CHANGEEMAIL new_email@email.com bad_code\n")
-    reply = _recv_raw(socket)
-    assert reply == "CHANGEEMAILDENIED bad code\n"
-
-    # Submit a bad email
-    _send_raw(socket, "CHANGEEMAIL bad_email #{code}\n")
-    reply = _recv_raw(socket)
-    assert reply == "CHANGEEMAILDENIED bad email\n"
-
-    # Now do it correctly
-    _send_raw(socket, "CHANGEEMAIL new_email@email.com #{code}\n")
-    reply = _recv_raw(socket)
-    assert reply == "CHANGEEMAILACCEPTED\n"
-    new_user = UserCacheLib.deprecated_get_user_by_id(user.id)
-    assert new_user.email == "new_email@email.com"
-    assert new_user.email_change_code == [nil, nil]
-  end
-
-  test "CHANGEEMAIL to email already taken", %{socket: socket} do
-    other_user = TeiserverTestLib.new_user()
-
-    # Make the request
-    _send_raw(socket, "CHANGEEMAILREQUEST #{other_user.email}\n")
-    reply = _recv_raw(socket)
-    assert reply == "CHANGEEMAILREQUESTDENIED Email already in use\n"
+    assert reply ==
+             "CHANGEEMAILREQUESTDENIED This feature is no longer supported in client, please use the website to change your email address.\n"
   end
 
   test "CREATEBOTACCOUNT - no mod", %{socket: socket, user: user} do


### PR DESCRIPTION
Updating a user email now:
- Tracks previous email
- Tracks datetime of email change
- Emails previous and new email regarding the change
- Audit logs the event
- Performs the entire process inside a transaction

We also disable the Spring commands for email changes and update the web interface to accomodate the new changes.