### PR TITLE
Fix for seasons less than 1 in leaderboard public API

### DIFF
--- a/lib/teiserver_web/controllers/api/public_controller.ex
+++ b/lib/teiserver_web/controllers/api/public_controller.ex
@@ -30,7 +30,7 @@ defmodule TeiserverWeb.API.PublicController do
             |> put_status(200)
             |> json(ratings)
 
-          season < active_season ->
+          season > 0 and season < active_season ->
             # 35 days before last match of the season for older seasons
             activity_time =
               Account.list_ratings(

--- a/test/teiserver_web/controllers/api/public_controller_test.exs
+++ b/test/teiserver_web/controllers/api/public_controller_test.exs
@@ -1,0 +1,29 @@
+defmodule TeiserverWeb.API.PublicControllerTest do
+  alias Teiserver.Config
+
+  use TeiserverWeb.ConnCase, async: false
+
+  describe "leaderboard" do
+    test "season and game type list is public", %{conn: conn} do
+      conn = get(conn, ~p"/teiserver/api/public/leaderboard/")
+      assert response(conn, 200)
+    end
+
+    test "season leaderboard is public", %{conn: conn} do
+      conn = get(conn, ~p"/teiserver/api/public/leaderboard/1")
+      assert response(conn, 200)
+    end
+
+    test "lowest season is 1", %{conn: conn} do
+      conn = get(conn, ~p"/teiserver/api/public/leaderboard/0")
+      assert response(conn, 400)
+    end
+
+    test "can't get seasons above current season", %{conn: conn} do
+      Config.update_site_config("rating.Season", 2)
+
+      conn = get(conn, ~p"/teiserver/api/public/leaderboard/3")
+      assert response(conn, 400)
+    end
+  end
+end


### PR DESCRIPTION
Fixes internal server error when attempting to get leaderboard for seasons less than 1 (season 1 is the lowest season).