### PR TITLE
Raise the chat limit for mapmetadata modoption commands

### DIFF
--- a/lib/teiserver/protocols/spring/spring_in.ex
+++ b/lib/teiserver/protocols/spring/spring_in.ex
@@ -49,7 +49,12 @@ defmodule Teiserver.Protocols.SpringIn do
 
   # Battle chat commands that carry more data than a normal message (e.g. modoption
   # key=value pairs) and so get a 1024-char allowance instead of the default 256.
-  @long_battle_command_prefixes ["$welcome-message", "!welcome-message", "!mode "]
+  @long_battle_command_prefixes [
+    "$welcome-message",
+    "!welcome-message",
+    "!mode ",
+    "!bset mapmetadata"
+  ]
 
   # Commands that don't require the user to be logged in
   @unauthenticated_commands ~w(


### PR DESCRIPTION
Startbox overrides set with !bSet are being cut off at 256 characters, so SPADS stores a truncated value, the game quietly falls back to the map defaults, and the player who moved the boxes sees their change accepted.

The lobby used to send one !addbox per box, about 20 characters each, which never came near the limit. It now sends the whole arrangement as a single encoded modoption, and that falls into the default 256 char slice. After the key name that leaves 221 characters of value, which is roughly 10 rectangular boxes or 4 small polygons, so this already affects large lobbies rather than only the polygon work that turned it up.

Matching on the mapmetadata prefix rather than the single key because all four mapmetadata modoptions are the same base64 zlib json payload from the same pipeline, and 1024 covers any of them comfortably.

I measured the cut by setting the override to a 400 character value with its own position stamped every 10 characters; it came back ending at 221 every time, regardless of content.

AI disclosure: written with assistance from Claude Code.
