### PR TITLE
Use Large Team OS for Team FFA join restrictions

### DIFF
--- a/lib/teiserver/lobby/libs/lobby_restrictions.ex
+++ b/lib/teiserver/lobby/libs/lobby_restrictions.ex
@@ -182,7 +182,7 @@ defmodule Teiserver.Lobby.LobbyRestrictions do
     team_size = state.host_teamsize
     team_count = state.host_teamcount
 
-    rating_type = MatchLib.game_type(team_size, team_count)
+    rating_type = rating_type_for_restrictions(MatchLib.game_type(team_size, team_count))
 
     {player_rating, player_uncertainty} =
       BalanceLib.get_user_rating_value_uncertainty_pair(user_id, rating_type)
@@ -213,6 +213,16 @@ defmodule Teiserver.Lobby.LobbyRestrictions do
         :ok
     end
   end
+
+  @doc """
+  OpenSkill rating type used when checking lobby join/play restrictions.
+
+  Team FFA uses Large Team OpenSkill for join/play restrictions
+  because Team FFA ratings are not currently reliable. (see https://github.com/beyond-all-reason/teiserver/issues/337)
+  """
+  @spec rating_type_for_restrictions(String.t()) :: String.t()
+  def rating_type_for_restrictions("Team FFA"), do: "Large Team"
+  def rating_type_for_restrictions(rating_type), do: rating_type
 
   @doc """
   You cannot have all welcome lobby name if there are restrictions

--- a/test/teiserver/lobby/libs/lobby_restrictions_test.exs
+++ b/test/teiserver/lobby/libs/lobby_restrictions_test.exs
@@ -57,4 +57,12 @@ defmodule Teiserver.Lobby.Libs.LobbyRestrictionsTest do
 
     assert result == "Rating: 4-20"
   end
+
+  test "team ffa join restrictions use large team openskill" do
+    assert LobbyRestrictions.rating_type_for_restrictions("Team FFA") == "Large Team"
+    assert LobbyRestrictions.rating_type_for_restrictions("Large Team") == "Large Team"
+    assert LobbyRestrictions.rating_type_for_restrictions("Small Team") == "Small Team"
+    assert LobbyRestrictions.rating_type_for_restrictions("FFA") == "FFA"
+    assert LobbyRestrictions.rating_type_for_restrictions("Duel") == "Duel"
+  end
 end


### PR DESCRIPTION
Per #337 , we no longer balanced by Team FFA rating. It seems weird to have OS restrictions still be based upon them. 

Currently:
OS restrictions done by Team FFA
Team balance done by Large Teams
OS updates done by Team FFA

This changes it so that OS restrictions are done by large teams as well. 


Currently: 
My large team rating is 42. That's what it shows in this lobby. If I set rating restrictions to 41-43, I get kicked to spec.
 
"You don't meet the rating requirements for this lobby (Rating: 41-43). Your Team FFA match rating is 20.23. Learn more about rating here:"

<img width="1893" height="1772" alt="image" src="https://github.com/user-attachments/assets/2c130817-9e3f-49e9-b99a-b05e21630d6a" />
