### PR TITLE
Adds the AntiAbuseRecord struct

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -158,5 +158,7 @@
   {"lib/teiserver_web/templates/admin/lobby/server_chat.html.heex", :call},
   {"lib/teiserver_web/live/moderation/action_live/smurf_link.ex", :callback_arg_type_mismatch},
   {"lib/teiserver_web/live/moderation/action_live/smurf_link.ex", :call},
-  {"lib/teiserver/account/tasks/merge_accounts_task.ex", :no_return}
+  {"lib/teiserver/account/tasks/merge_accounts_task.ex", :no_return},
+  {"test/support/fixtures/moderation_fixtures.ex"},
+  {"lib/teiserver/moderation.ex"}
 ]

--- a/lib/teiserver/account/scope.ex
+++ b/lib/teiserver/account/scope.ex
@@ -1,0 +1,38 @@
+defmodule Teiserver.Account.Scope do
+  @moduledoc """
+  Defines the scope of the caller to be used throughout the app.
+
+  The `Teiserver.Account.Scope` allows public interfaces to receive
+  information about the caller, such as if the call is initiated from an
+  end-user, and if so, which user. Additionally, such a scope can carry fields
+  such as "super user" or other privileges for use as authorization, or to
+  ensure specific code paths can only be access for a given scope.
+
+  It is useful for logging as well as for scoping pubsub subscriptions and
+  broadcasts when a caller subscribes to an interface or performs a particular
+  action.
+
+  Feel free to extend the fields on this struct to fit the needs of
+  growing application requirements.
+  """
+
+  alias Teiserver.Account.User
+
+  defstruct user: nil, ip: nil
+
+  @type t :: %{
+          user: User.t() | nil,
+          ip: String.t() | nil
+        }
+
+  @doc """
+  Creates a scope for the given user.
+
+  Returns nil if no user is given.
+  """
+  def for_user(%User{} = user) do
+    %__MODULE__{user: user}
+  end
+
+  def for_user(nil), do: nil
+end

--- a/lib/teiserver/helpers/general_test_lib.ex
+++ b/lib/teiserver/helpers/general_test_lib.ex
@@ -3,6 +3,8 @@ defmodule Teiserver.Helpers.GeneralTestLib do
 
   alias Teiserver.Account
   alias Teiserver.Account.Guardian
+  alias Teiserver.Account.Scope
+  alias Teiserver.Account.User
   alias Teiserver.Helper.StringHelper
   alias TeiserverWeb.UserSocket
 
@@ -122,5 +124,15 @@ defmodule Teiserver.Helpers.GeneralTestLib do
       end
 
     {:ok, r: r, user: user, jwt: jwt, conn: conn, user_token: jwt, socket: socket}
+  end
+
+  @doc """
+  Creates a scope fixture from the user provided
+  """
+  def scope_fixture(%User{} = user, attrs \\ %{}) do
+    %Scope{
+      user: user,
+      ip: attrs[:ip] || "127.0.0.1"
+    }
   end
 end

--- a/lib/teiserver/logging/lib/audit_log_lib.ex
+++ b/lib/teiserver/logging/lib/audit_log_lib.ex
@@ -114,6 +114,6 @@ defmodule Teiserver.Logging.AuditLogLib do
 
   def order_by(query, "Newest first") do
     from logs in query,
-      order_by: [desc: logs.inserted_at]
+      order_by: [desc: logs.inserted_at, desc: logs.id]
   end
 end

--- a/lib/teiserver/logging/lib/logging_helpers.ex
+++ b/lib/teiserver/logging/lib/logging_helpers.ex
@@ -39,7 +39,7 @@ defmodule Teiserver.Logging.Helpers do
     {:ok, the_log} =
       Logging.create_audit_log(%{
         action: action,
-        user_id: scope.user.id,
+        user_id: scope.user && scope.user.id,
         details: details,
         ip: scope.ip
       })

--- a/lib/teiserver/logging/lib/logging_helpers.ex
+++ b/lib/teiserver/logging/lib/logging_helpers.ex
@@ -1,6 +1,7 @@
 defmodule Teiserver.Logging.Helpers do
   @moduledoc false
 
+  alias Teiserver.Account.Scope
   alias Teiserver.Logging
 
   @spec add_anonymous_audit_log(String.t(), map()) :: Teiserver.Logging.AuditLog.t()
@@ -32,8 +33,20 @@ defmodule Teiserver.Logging.Helpers do
     the_log
   end
 
-  @spec add_audit_log(Plug.Conn.t() | Phoenix.LiveView.Socket.t(), String.t(), map()) ::
+  @spec add_audit_log(Scope.t() | Plug.Conn.t() | Phoenix.LiveView.Socket.t(), String.t(), map()) ::
           Teiserver.Logging.AuditLog.t()
+  def add_audit_log(%Scope{} = scope, action, details) do
+    {:ok, the_log} =
+      Logging.create_audit_log(%{
+        action: action,
+        user_id: scope.user.id,
+        details: details,
+        ip: scope.ip
+      })
+
+    the_log
+  end
+
   def add_audit_log(%Phoenix.LiveView.Socket{} = socket, action, details) do
     {:ok, the_log} =
       Logging.create_audit_log(%{

--- a/lib/teiserver/logging/lib/logging_plug.ex
+++ b/lib/teiserver/logging/lib/logging_plug.ex
@@ -17,10 +17,6 @@ defmodule Teiserver.Logging.LoggingPlug do
 
     ip = get_ip_from_conn(conn) || "Error finding IP"
 
-    # conn = Map.put(conn, :remote_ip, ip)
-    # new_peer = {ip, conn.peer |> elem(1)}
-    # conn = Map.put(conn, :peer, new_peer)
-
     Conn.register_before_send(conn, fn conn ->
       if conn.status == 500 do
         # log_error(conn)
@@ -83,11 +79,24 @@ defmodule Teiserver.Logging.LoggingPlug do
     end
   end
 
+  @doc """
+  Return the IP used by the Conn struct
+  """
   def get_ip_from_conn(conn) do
     case List.keyfind(conn.req_headers, "x-real-ip", 0) do
-      {_key, ip} -> convert_from_x_real_ip(ip)
-      nil -> conn.remote_ip
-      _other -> nil
+      {_key, ip} ->
+        convert_from_x_real_ip(ip)
+
+      nil ->
+        # If it's the tuple then that's local development
+        # and we want to represent it using 127.0.0.1
+        case conn.remote_ip do
+          {0, 0, 0, 0, 0, 65535, 32512, 1} -> "127.0.0.1"
+          ip -> ip
+        end
+
+      _other ->
+        nil
     end
   end
 end

--- a/lib/teiserver/moderation.ex
+++ b/lib/teiserver/moderation.ex
@@ -3,10 +3,14 @@ defmodule Teiserver.Moderation do
 
   alias Phoenix.PubSub
   alias Teiserver.Account
+  alias Teiserver.Account.Scope
   alias Teiserver.Data.Types, as: T
   alias Teiserver.Helper.QueryHelpers
+  alias Teiserver.Logging.Helpers, as: LoggingHelper
   alias Teiserver.Moderation.Action
   alias Teiserver.Moderation.ActionLib
+  alias Teiserver.Moderation.AntiAbuseRecord
+  alias Teiserver.Moderation.AntiAbuseRecordQueries
   alias Teiserver.Moderation.Ban
   alias Teiserver.Moderation.BanLib
   alias Teiserver.Moderation.BannedDomain
@@ -1248,5 +1252,146 @@ defmodule Teiserver.Moderation do
       {:error, :einval} ->
         false
     end
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking anti_abuse_record changes.
+
+  ## Examples
+
+      iex> change_anti_abuse_record(anti_abuse_record)
+      %Ecto.Changeset{source: %AntiAbuseRecord{}}
+
+  """
+  @spec change_anti_abuse_record(AntiAbuseRecord.t()) :: Ecto.Changeset.t()
+  def change_anti_abuse_record(%AntiAbuseRecord{} = anti_abuse_record) do
+    AntiAbuseRecord.changeset(anti_abuse_record, %{})
+  end
+
+  @doc """
+  Gets a single anti_abuse_record.
+
+  Returns `nil` if the AntiAbuseRecord does not exist.
+
+  ## Examples
+
+      iex> get_anti_abuse_record(123, scope)
+      %AntiAbuseRecord{}
+
+      iex> get_anti_abuse_record(456, scope)
+      nil
+
+  """
+  def get_anti_abuse_record(id, %Scope{} = scope) do
+    AntiAbuseRecordQueries.anti_abuse_records()
+    |> AntiAbuseRecordQueries.where_id(id)
+    |> Repo.one()
+    |> log_anti_abuse_record_access(scope, :get)
+  end
+
+  @doc """
+  Creates a anti_abuse_record.
+
+  ## Examples
+
+      iex> create_anti_abuse_record(%{field: value})
+      {:ok, %AntiAbuseRecord{}}
+
+      iex> create_anti_abuse_record(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  @spec create_anti_abuse_record(map(), Scope.t()) ::
+          {:ok, AntiAbuseRecord.t()} | {:error, Ecto.Changeset.t()}
+  def create_anti_abuse_record(attrs, %Scope{} = scope) do
+    %AntiAbuseRecord{}
+    |> AntiAbuseRecord.changeset(attrs)
+    |> Repo.insert()
+    |> log_anti_abuse_record_access(scope, :create)
+  end
+
+  @doc """
+  Updates a anti_abuse_record.
+
+  ## Examples
+
+      iex> update_anti_abuse_record(anti_abuse_record, %{field: new_value})
+      {:ok, %AntiAbuseRecord{}}
+
+      iex> update_anti_abuse_record(anti_abuse_record, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  @spec update_anti_abuse_record(AntiAbuseRecord.t(), map(), Scope.t()) ::
+          {:ok, AntiAbuseRecord.t()} | {:error, Ecto.Changeset.t()}
+  def update_anti_abuse_record(%AntiAbuseRecord{} = anti_abuse_record, attrs, scope) do
+    anti_abuse_record
+    |> AntiAbuseRecord.changeset(attrs)
+    |> Repo.update()
+    |> log_anti_abuse_record_access(scope, :update)
+  end
+
+  @doc """
+  Deletes a AntiAbuseRecord.
+
+  ## Examples
+
+      iex> delete_anti_abuse_record(anti_abuse_record)
+      {:ok, %AntiAbuseRecord{}}
+
+      iex> delete_anti_abuse_record(anti_abuse_record)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  @spec delete_anti_abuse_record(AntiAbuseRecord.t(), Scope.t()) ::
+          {:ok, AntiAbuseRecord.t()} | {:error, Ecto.Changeset.t()}
+  def delete_anti_abuse_record(%AntiAbuseRecord{} = anti_abuse_record, scope) do
+    Repo.delete(anti_abuse_record)
+    |> log_anti_abuse_record_access(scope, :delete)
+  end
+
+  @doc """
+  Logs access to something related to anti-abuse records. Intended to take a piped argument
+  and pass through that argument while using it to populate the AuditLog.
+  """
+  def log_anti_abuse_record_access({:ok, %AntiAbuseRecord{} = record}, %Scope{} = scope, action) do
+    LoggingHelper.add_audit_log(scope, "access_anti_abuse_record", %{
+      id: record.id,
+      action: action
+    })
+
+    {:ok, record}
+  end
+
+  def log_anti_abuse_record_access(%AntiAbuseRecord{} = record, %Scope{} = scope, action) do
+    LoggingHelper.add_audit_log(scope, "access_anti_abuse_record", %{
+      id: record.id,
+      action: action
+    })
+
+    record
+  end
+
+  # If the changeset has an error in it we want to know they tried to use a changeset but it borked
+  def log_anti_abuse_record_access({:error, %Ecto.Changeset{} = chg}, %Scope{} = scope, action) do
+    LoggingHelper.add_audit_log(scope, "access_anti_abuse_record", %{
+      id: Map.get(chg.data, :id),
+      action: action,
+      changeset_action: chg.action
+    })
+
+    {:error, chg}
+  end
+
+  def log_anti_abuse_record_access(nil, %Scope{} = scope, action) do
+    LoggingHelper.add_audit_log(scope, "access_anti_abuse_record", %{id: nil, action: action})
+    nil
+  end
+
+  # Fallback, ideally we never see this but we'd rather log that something
+  # anti_abuse_record was happening than not log it at all
+  def log_anti_abuse_record_access(piped_value, %Scope{} = scope, action) do
+    LoggingHelper.add_audit_log(scope, "anti_abuse_record_log_fallback", %{action: action})
+    piped_value
   end
 end

--- a/lib/teiserver/moderation/queries/anti_abuse_record_queries.ex
+++ b/lib/teiserver/moderation/queries/anti_abuse_record_queries.ex
@@ -1,0 +1,20 @@
+defmodule Teiserver.Moderation.AntiAbuseRecordQueries do
+  @moduledoc false
+  alias Ecto.Query
+  alias Teiserver.Moderation.AntiAbuseRecord
+
+  use TeiserverWeb, :queries
+
+  @type t :: Query.t()
+
+  @spec anti_abuse_records() :: t()
+  def anti_abuse_records do
+    from(anti_abuse_records in AntiAbuseRecord, as: :anti_abuse_records)
+  end
+
+  @spec where_id(t(), AntiAbuseRecord.id()) :: t()
+  def where_id(query, id) do
+    from anti_abuse_records in query,
+      where: anti_abuse_records.id == ^id
+  end
+end

--- a/lib/teiserver/moderation/schemas/anti_abuse_record.ex
+++ b/lib/teiserver/moderation/schemas/anti_abuse_record.ex
@@ -1,0 +1,43 @@
+defmodule Teiserver.Moderation.AntiAbuseRecord do
+  @moduledoc """
+  Records for tracking abuse related data for forgotten accounts. All hashes are salted to prevent
+  scanning the entire table.
+
+  AuditLogs are created every time one is accessed.
+  """
+  alias Ecto.UUID
+
+  use TeiserverWeb, :schema
+
+  @type id :: UUID.t()
+
+  @primary_key {:id, UUID, autogenerate: true}
+  typed_schema "moderation_anti_abuse_records" do
+    belongs_to :user, Teiserver.Account.User
+
+    field :expires_at, :utc_datetime
+    field :clean, :boolean
+    field :hashes, :map
+    field :notes, :string
+
+    field :restored_at, :utc_datetime
+    belongs_to :restored_by, Teiserver.Account.User
+
+    timestamps()
+  end
+
+  @spec changeset(map(), map()) :: Ecto.Changeset.t()
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [
+      :user_id,
+      :expires_at,
+      :clean,
+      :hashes,
+      :notes,
+      :restored_at,
+      :restored_by_id
+    ])
+    |> validate_required([:user_id, :expires_at, :clean, :hashes])
+  end
+end

--- a/lib/teiserver_web/router.ex
+++ b/lib/teiserver_web/router.ex
@@ -3,6 +3,8 @@ defmodule TeiserverWeb.Router do
 
   use TeiserverWeb, :router
 
+  import TeiserverWeb.UserAuthentication
+
   pipeline :logging_live_auth do
     plug Bodyguard.Plug.Authorize,
       fallback: TeiserverWeb.Controllers.BodyguardFallback,
@@ -36,6 +38,7 @@ defmodule TeiserverWeb.Router do
     plug(Teiserver.Account.AuthPipeline)
     plug(Teiserver.Account.AuthPlug)
     plug(Teiserver.Plugs.CachePlug)
+    plug :fetch_current_scope_for_user
   end
 
   pipeline :tailwind do

--- a/lib/teiserver_web/user_authentication.ex
+++ b/lib/teiserver_web/user_authentication.ex
@@ -9,7 +9,9 @@ defmodule TeiserverWeb.UserAuthentication do
   alias Teiserver.Account
   alias Teiserver.Account.AuthLib
   alias Teiserver.Account.Guardian
+  alias Teiserver.Account.Scope
   alias Teiserver.Account.User
+  alias Teiserver.Logging.LoggingPlug
 
   use TeiserverWeb, :verified_routes
 
@@ -148,4 +150,19 @@ defmodule TeiserverWeb.UserAuthentication do
   defp maybe_store_return_to(conn), do: conn
 
   defp signed_in_path(_conn), do: ~p"/"
+
+  @doc """
+  Populates the scope for the user if one is assigned
+  """
+  def fetch_current_scope_for_user(%{assigns: %{current_user: %User{} = user}} = conn, _opts) do
+    scope = %Scope{
+      user: user,
+      ip: LoggingPlug.get_ip_from_conn(conn)
+    }
+
+    assign(conn, :scope, scope)
+  end
+
+  # Fallback for no user assigned
+  def fetch_current_scope_for_user(conn, _opts), do: conn
 end

--- a/priv/repo/migrations/20260825101904_add_anti_abuse_record.exs
+++ b/priv/repo/migrations/20260825101904_add_anti_abuse_record.exs
@@ -1,0 +1,20 @@
+defmodule Teiserver.Repo.Migrations.AddAntiAbuseRecord do
+  use Ecto.Migration
+
+  def change do
+    create_if_not_exists table(:moderation_anti_abuse_records, primary_key: false) do
+      add :id, :uuid, primary_key: true, null: false
+
+      add :user_id, references(:account_users, on_delete: :nothing), null: false
+      add :expires_at, :utc_datetime, null: false
+      add :clean, :boolean, null: false
+      add :hashes, :jsonb, null: false
+      add :notes, :text
+
+      add :restored_at, :utc_datetime
+      add :restored_by_id, references(:account_users, on_delete: :nothing)
+
+      timestamps()
+    end
+  end
+end

--- a/test/support/fixtures/moderation_fixtures.ex
+++ b/test/support/fixtures/moderation_fixtures.ex
@@ -4,6 +4,8 @@ defmodule Teiserver.ModerationFixtures do
   entities via the `Teiserver.Moderation` context.
   """
 
+  alias Teiserver.Account.Scope
+  alias Teiserver.AccountFixtures
   alias Teiserver.Moderation
 
   @doc """
@@ -55,5 +57,26 @@ defmodule Teiserver.ModerationFixtures do
       |> Moderation.create_banned_phrase()
 
     banned_phrase
+  end
+
+  def anti_abuse_record_fixture(%Scope{} = scope) do
+    anti_abuse_record_fixture(%{scope: scope})
+  end
+
+  def anti_abuse_record_fixture(attrs) do
+    {:ok, anti_abuse_record} =
+      attrs
+      |> Enum.into(%{
+        user_id: attrs[:user_id] || AccountFixtures.user_fixture().id,
+        expires_at: attrs[:expires_at] || DateTime.utc_now() |> DateTime.shift(year: 2),
+        clean: attrs[:clean] == true,
+        hashes: attrs[:hashes] || %{},
+        notes: attrs[:notes] || "",
+        restored_at: attrs[:restored_at],
+        restored_by_id: attrs[:restored_by_id] || AccountFixtures.user_fixture().id
+      })
+      |> Moderation.create_anti_abuse_record(attrs[:scope])
+
+    anti_abuse_record
   end
 end

--- a/test/teiserver/logging/audit_log_test.exs
+++ b/test/teiserver/logging/audit_log_test.exs
@@ -1,7 +1,9 @@
 defmodule Teiserver.Logging.AuditLogTests do
+  alias Teiserver.Account.Scope
   alias Teiserver.Logging
   alias Teiserver.Logging.AuditLog
   alias Teiserver.Logging.AuditLogLib
+  alias Teiserver.Logging.Helpers
 
   use Teiserver.DataCase, async: false
 
@@ -31,5 +33,10 @@ defmodule Teiserver.Logging.AuditLogTests do
 
     got = AuditLogLib.list_audit_types() |> Enum.sort()
     assert got == actions
+  end
+
+  test "add audit log with no-user scope" do
+    scope = %Scope{}
+    assert %AuditLog{} = Helpers.add_audit_log(scope, "action", %{})
   end
 end

--- a/test/teiserver/moderation/anti_abuse_record_test.exs
+++ b/test/teiserver/moderation/anti_abuse_record_test.exs
@@ -1,0 +1,144 @@
+defmodule Teiserver.Moderation.AntiAbuseRecordTest do
+  # A little different from the other struct test files in that we also need to ensure access to
+  # these is logged correctly
+
+  alias Teiserver.AccountFixtures
+  alias Teiserver.Helpers.GeneralTestLib
+  alias Teiserver.Moderation
+  alias Teiserver.Moderation.AntiAbuseRecord
+
+  use Teiserver.DataCase, async: true
+
+  import Teiserver.ModerationFixtures
+  import Teiserver.Logging.LoggingTestLib, only: [get_most_recent_audit_log_for_user: 1]
+
+  setup do
+    user = AccountFixtures.user_fixture()
+    scope = GeneralTestLib.scope_fixture(user)
+
+    %{user: user, scope: scope}
+  end
+
+  describe "anti_abuse_record standard utility functions" do
+    test "get_anti_abuse_record/1 returns the anti_abuse_record with given id", %{
+      user: user,
+      scope: scope
+    } do
+      anti_abuse_record = anti_abuse_record_fixture(scope)
+      assert Moderation.get_anti_abuse_record(anti_abuse_record.id, scope) == anti_abuse_record
+
+      log = get_most_recent_audit_log_for_user(user.id)
+      assert log.action == "access_anti_abuse_record"
+      assert log.details["id"] == anti_abuse_record.id
+      assert log.details["action"] == "get"
+    end
+
+    test "create_anti_abuse_record/1 with valid data creates a anti_abuse_record", %{
+      user: user,
+      scope: scope
+    } do
+      valid_attrs = %{
+        user_id: AccountFixtures.user_fixture().id,
+        expires_at: DateTime.utc_now() |> DateTime.shift(year: 2),
+        clean: true,
+        hashes: %{},
+        notes: "some_notes"
+      }
+
+      assert {:ok, %AntiAbuseRecord{} = anti_abuse_record} =
+               Moderation.create_anti_abuse_record(valid_attrs, scope)
+
+      assert anti_abuse_record.notes == "some_notes"
+      assert anti_abuse_record.restored_at == nil
+
+      log = get_most_recent_audit_log_for_user(user.id)
+      assert log.action == "access_anti_abuse_record"
+      assert log.details["id"] == anti_abuse_record.id
+      assert log.details["action"] == "create"
+    end
+
+    test "create_anti_abuse_record/1 with invalid data returns error changeset", %{
+      user: user,
+      scope: scope
+    } do
+      assert {:error, %Ecto.Changeset{}} =
+               Moderation.create_anti_abuse_record(%{notes: nil}, scope)
+
+      log = get_most_recent_audit_log_for_user(user.id)
+      assert log.action == "access_anti_abuse_record"
+      assert log.details == %{"action" => "create", "changeset_action" => "insert", "id" => nil}
+    end
+
+    test "update_anti_abuse_record/2 with valid data updates the anti_abuse_record", %{
+      user: user,
+      scope: scope
+    } do
+      anti_abuse_record = anti_abuse_record_fixture(scope)
+
+      update_attrs = %{
+        notes: "some_notes"
+      }
+
+      assert {:ok, %AntiAbuseRecord{} = anti_abuse_record} =
+               Moderation.update_anti_abuse_record(anti_abuse_record, update_attrs, scope)
+
+      assert anti_abuse_record.notes == "some_notes"
+
+      log = get_most_recent_audit_log_for_user(user.id)
+      assert log.action == "access_anti_abuse_record"
+      assert log.details["id"] == anti_abuse_record.id
+      assert log.details["action"] == "update"
+    end
+
+    test "update_anti_abuse_record/2 with invalid data returns error changeset", %{
+      user: user,
+      scope: scope
+    } do
+      anti_abuse_record = anti_abuse_record_fixture(scope)
+
+      assert {:error, %Ecto.Changeset{}} =
+               Moderation.update_anti_abuse_record(
+                 anti_abuse_record,
+                 %{user_id: nil, notes: "new notes"},
+                 scope
+               )
+
+      log = get_most_recent_audit_log_for_user(user.id)
+      assert log.action == "access_anti_abuse_record"
+
+      assert log.details == %{
+               "action" => "update",
+               "changeset_action" => "update",
+               "id" => anti_abuse_record.id
+             }
+
+      # Test the update didn't go through
+      assert anti_abuse_record == Moderation.get_anti_abuse_record(anti_abuse_record.id, scope)
+    end
+
+    test "delete_anti_abuse_record/1 deletes the anti_abuse_record", %{user: user, scope: scope} do
+      anti_abuse_record = anti_abuse_record_fixture(scope)
+
+      assert {:ok, %AntiAbuseRecord{}} =
+               Moderation.delete_anti_abuse_record(anti_abuse_record, scope)
+
+      log = get_most_recent_audit_log_for_user(user.id)
+      assert log.action == "access_anti_abuse_record"
+
+      assert log.details == %{
+               "action" => "delete",
+               "id" => anti_abuse_record.id
+             }
+
+      assert Moderation.get_anti_abuse_record(anti_abuse_record.id, scope) == nil
+
+      log = get_most_recent_audit_log_for_user(user.id)
+      assert log.action == "access_anti_abuse_record"
+
+      assert log.details == %{
+               "action" => "get",
+               "id" => nil
+             }
+    end
+  end
+end


### PR DESCRIPTION
Sits inside Moderation, different from other structs in that all access functions will log access via the Scope.

Added a slightly modified Scope from a default Phoenix project to allow more powerful access control in the future and to make passing around acces context for AntiAbuseRecord structs easier.

Also:
- Added a default `get_ip_from_conn` result of "127.0.0.1" for local environments