### PR TITLE
Fix mobile ratings filter navigation

### DIFF
--- a/lib/teiserver_web/live/battles/match/ratings.html.heex
+++ b/lib/teiserver_web/live/battles/match/ratings.html.heex
@@ -99,7 +99,7 @@
                 true ->
                   {"text-secondary column-delta", "pause"}
               end %>
-            <tr class="position-relative">
+            <tr phx-click={log.match && JS.navigate(~p"/battle/#{log.match_id}")}>
               <%= if log.match do %>
                 <td>
                   {log.match.map}
@@ -139,7 +139,9 @@
 
               <%= if log.match do %>
                 <td>
-                  <.link navigate={~p"/battle/#{log.match_id}"} class="stretched-link"></.link>
+                  <div class="visually-hidden">
+                    <.link navigate={~p"/battle/#{log.match_id}"}>Show</.link>
+                  </div>
                 </td>
               <% else %>
                 <td>&nbsp;</td>

--- a/test/teiserver_web/live/battles/match/ratings_live_test.exs
+++ b/test/teiserver_web/live/battles/match/ratings_live_test.exs
@@ -1,5 +1,8 @@
 defmodule TeiserverWeb.Battle.MatchLive.RatingsLiveTest do
   alias Teiserver.Helpers.GeneralTestLib
+  alias Teiserver.Battle
+  alias Teiserver.Game
+  alias Teiserver.Game.MatchRatingLib
   alias Teiserver.TeiserverTestLib
 
   use TeiserverWeb.ConnCase, async: true
@@ -24,5 +27,63 @@ defmodule TeiserverWeb.Battle.MatchLive.RatingsLiveTest do
 
     conn = get(conn, ~p"/battle/ratings")
     html_response(conn, 200)
+  end
+
+  test "match rows navigate without a stretched link overlay" do
+    {:ok, kw} =
+      GeneralTestLib.conn_setup()
+      |> TeiserverTestLib.conn_setup()
+
+    {:ok, conn} = Keyword.fetch(kw, :conn)
+    {:ok, user} = Keyword.fetch(kw, :user)
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    rating_type_id = MatchRatingLib.rating_type_name_lookup()["Large Team"]
+
+    {:ok, match} =
+      Battle.create_match(%{
+        uuid: Ecto.UUID.generate(),
+        server_uuid: Ecto.UUID.generate(),
+        map: "Comet Catcher",
+        tags: %{},
+        team_count: 2,
+        team_size: 8,
+        passworded: false,
+        game_type: "Large Team",
+        founder_id: user.id,
+        bots: %{},
+        started: now,
+        finished: now
+      })
+
+    {:ok, _membership} =
+      Battle.create_match_membership(%{
+        match_id: match.id,
+        user_id: user.id,
+        team_id: 0,
+        win: true
+      })
+
+    {:ok, _rating_log} =
+      Game.create_rating_log(%{
+        user_id: user.id,
+        rating_type_id: rating_type_id,
+        match_id: match.id,
+        season: MatchRatingLib.active_season(),
+        inserted_at: now,
+        value: %{
+          "skill" => 25.0,
+          "skill_change" => 1.0,
+          "uncertainty" => 5.0,
+          "uncertainty_change" => -1.0,
+          "rating_value" => 20.0,
+          "rating_value_change" => 2.0
+        }
+      })
+
+    {:ok, view, _html} = live(conn, ~p"/battle/ratings")
+
+    assert has_element?(view, "tr[phx-click] a[href='/battle/#{match.id}']", "Show")
+    refute has_element?(view, ".stretched-link")
+    refute has_element?(view, "tr.position-relative")
   end
 end

--- a/test/teiserver_web/live/battles/match/ratings_live_test.exs
+++ b/test/teiserver_web/live/battles/match/ratings_live_test.exs
@@ -1,8 +1,9 @@
 defmodule TeiserverWeb.Battle.MatchLive.RatingsLiveTest do
-  alias Teiserver.Helpers.GeneralTestLib
+  alias Ecto.UUID
   alias Teiserver.Battle
   alias Teiserver.Game
   alias Teiserver.Game.MatchRatingLib
+  alias Teiserver.Helpers.GeneralTestLib
   alias Teiserver.TeiserverTestLib
 
   use TeiserverWeb.ConnCase, async: true
@@ -36,13 +37,13 @@ defmodule TeiserverWeb.Battle.MatchLive.RatingsLiveTest do
 
     {:ok, conn} = Keyword.fetch(kw, :conn)
     {:ok, user} = Keyword.fetch(kw, :user)
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    now = DateTime.utc_now(:second)
     rating_type_id = MatchRatingLib.rating_type_name_lookup()["Large Team"]
 
     {:ok, match} =
       Battle.create_match(%{
-        uuid: Ecto.UUID.generate(),
-        server_uuid: Ecto.UUID.generate(),
+        uuid: UUID.generate(),
+        server_uuid: UUID.generate(),
         map: "Comet Catcher",
         tags: %{},
         team_count: 2,


### PR DESCRIPTION
Fixes #1500

## Cause

The ratings table made each match row clickable with Bootstrap’s `stretched-link`. Its absolutely positioned pseudo-element relied on `position: relative` on a `<tr>`. Safari/WebKit does not reliably use a positioned table row as that pseudo-element’s containing block, allowing the invisible link overlay to extend beyond its row and intercept taps on the rating-type filters.

## Fix

- Navigate from the row with `JS.navigate/1`, matching the existing clickable-table pattern used elsewhere in Teiserver.
- Keep a visually hidden real link for accessible navigation.
- Add regression coverage ensuring match rows remain navigable without `stretched-link` or `position-relative`.

## Testing

- `MIX_ENV=test TEI_PORT=0 TEI_METRICS_SERVER_PORT=0 mix test test/teiserver_web/live/battles/match/ratings_live_test.exs`
- Result: 3 tests, 0 failures.
- Human verification on a real iPhone after reproducing the issue on iPhone and iPad. Author confirmation: “manually confirmed, the fix works!”

## AI usage disclosure

OpenAI Codex was used to investigate the WebKit-specific interaction, author the HEEx change and regression test, and assist with this pull request description. The human contributor reproduced the original bug on iPhone and iPad, reviewed the intended behavior, and manually verified the fix on an iPhone.