### PR TITLE
Split out user changesets by tier

### DIFF
--- a/lib/teiserver/account.ex
+++ b/lib/teiserver/account.ex
@@ -113,9 +113,17 @@ defmodule Teiserver.Account do
           {:ok, User.t()} | {:error, Ecto.Changeset.t()}
   defdelegate update_user_email(user, attrs, ip), to: UserLib
 
-  @spec server_limited_update_user(User.t(), map) ::
+  @spec admin_update_user(User.t(), map) ::
           {:ok, User.t()} | {:error, Ecto.Changeset.t()}
-  defdelegate server_limited_update_user(user, attrs), to: UserLib
+  defdelegate admin_update_user(user, attrs), to: UserLib
+
+  @spec senior_moderator_update_user(User.t(), map) ::
+          {:ok, User.t()} | {:error, Ecto.Changeset.t()}
+  defdelegate senior_moderator_update_user(user, attrs), to: UserLib
+
+  @spec moderator_update_user(User.t(), map) ::
+          {:ok, User.t()} | {:error, Ecto.Changeset.t()}
+  defdelegate moderator_update_user(user, attrs), to: UserLib
 
   @spec server_update_user(User.t(), map) :: {:ok, User.t()} | {:error, Ecto.Changeset.t()}
   defdelegate server_update_user(user, attrs), to: UserLib

--- a/lib/teiserver/account/libs/user_lib.ex
+++ b/lib/teiserver/account/libs/user_lib.ex
@@ -308,11 +308,33 @@ defmodule Teiserver.Account.UserLib do
     end
   end
 
-  def server_limited_update_user(%User{} = user, attrs) do
+  def admin_update_user(%User{} = user, attrs) do
     Account.deprecated_recache_user(user.id)
 
     user
-    |> User.changeset(attrs, :server_limited_update_user)
+    |> User.changeset(attrs, :admin_update_user)
+    |> Repo.update()
+    |> broadcast_update_user()
+    |> cache_put_on_ok(:users_by_id)
+    |> UserCacheLib.decache_user_on_ok()
+  end
+
+  def senior_moderator_update_user(%User{} = user, attrs) do
+    Account.deprecated_recache_user(user.id)
+
+    user
+    |> User.changeset(attrs, :senior_moderator_update_user)
+    |> Repo.update()
+    |> broadcast_update_user()
+    |> cache_put_on_ok(:users_by_id)
+    |> UserCacheLib.decache_user_on_ok()
+  end
+
+  def moderator_update_user(%User{} = user, attrs) do
+    Account.deprecated_recache_user(user.id)
+
+    user
+    |> User.changeset(attrs, :moderator_update_user)
     |> Repo.update()
     |> broadcast_update_user()
     |> cache_put_on_ok(:users_by_id)

--- a/lib/teiserver/account/schemas/user.ex
+++ b/lib/teiserver/account/schemas/user.ex
@@ -128,7 +128,27 @@ defmodule Teiserver.Account.User do
     cast(struct, %{permissions: permissions}, [:permissions])
   end
 
-  def changeset(user, attrs, :server_limited_update_user) do
+  def changeset(user, attrs, :admin_update_user) do
+    user
+    |> cast(
+      attrs,
+      ~w(name email icon colour data roles permissions)a
+    )
+    |> validate_required([:name])
+    |> validate_name_change()
+  end
+
+  def changeset(user, attrs, :senior_moderator_update_user) do
+    user
+    |> cast(
+      attrs,
+      ~w(name email icon colour data roles permissions)a
+    )
+    |> validate_required([:name])
+    |> validate_name_change()
+  end
+
+  def changeset(user, attrs, :moderator_update_user) do
     user
     |> cast(
       attrs,

--- a/lib/teiserver_web/controllers/admin/user_controller.ex
+++ b/lib/teiserver_web/controllers/admin/user_controller.ex
@@ -368,10 +368,13 @@ defmodule TeiserverWeb.Admin.UserController do
               Account.server_update_user(user, user_params)
 
             allow?(conn, "Admin") ->
-              Account.server_limited_update_user(user, user_params)
+              Account.admin_update_user(user, user_params)
+
+            allow?(conn, "Senior moderator") ->
+              Account.senior_moderator_update_user(user, user_params)
 
             allow?(conn, "Moderator") ->
-              Account.server_limited_update_user(user, user_params)
+              Account.moderator_update_user(user, user_params)
           end
 
         case change_result do

--- a/test/teiserver/account/user_lib_test.exs
+++ b/test/teiserver/account/user_lib_test.exs
@@ -191,21 +191,56 @@ defmodule Teiserver.Account.UserLibTest do
                })
     end
 
-    test "server_limited_update_user/2" do
+    test "admin_update_user/2 - success" do
+      user = AccountFixtures.user_fixture()
+
+      assert {:ok, %{name: "AdminUser"}} =
+               UserLib.admin_update_user(user, %{"name" => "AdminUser"})
+    end
+
+    test "admin_update_user/2 - error" do
       user = AccountFixtures.user_fixture()
 
       assert {:error, %{errors: [name: _error]}} =
-               UserLib.server_limited_update_user(user, %{name: @disallowed_name})
+               UserLib.admin_update_user(user, %{name: @disallowed_name})
     end
 
-    test "server_update_user/2" do
+    test "senior_moderator_update_user/2 - success" do
+      user = AccountFixtures.user_fixture()
+
+      assert {:ok, %{name: "SeniorModeratorUser"}} =
+               UserLib.senior_moderator_update_user(user, %{"name" => "SeniorModeratorUser"})
+    end
+
+    test "senior_moderator_update_user/2 - error" do
+      user = AccountFixtures.user_fixture()
+
+      assert {:error, %{errors: [name: _error]}} =
+               UserLib.senior_moderator_update_user(user, %{name: @disallowed_name})
+    end
+
+    test "moderator_update_user/2 - success" do
+      user = AccountFixtures.user_fixture()
+
+      assert {:ok, %{name: "ModeratorUser"}} =
+               UserLib.moderator_update_user(user, %{"name" => "ModeratorUser"})
+    end
+
+    test "moderator_update_user/2 - error" do
+      user = AccountFixtures.user_fixture()
+
+      assert {:error, %{errors: [name: _error]}} =
+               UserLib.moderator_update_user(user, %{name: @disallowed_name})
+    end
+
+    test "server_update_user/2 - error" do
       user = AccountFixtures.user_fixture()
 
       assert {:error, %{errors: [name: _error]}} =
                UserLib.server_update_user(user, %{name: @disallowed_name})
     end
 
-    test "script_update_user/2" do
+    test "script_update_user/2 - error" do
       user = AccountFixtures.user_fixture()
 
       assert {:error, %{errors: [name: _error]}} =


### PR DESCRIPTION
Removes the server_limited changeset for users and swaps in admin, moderator and senior_moderator. In the process this fixes an issue where senior moderators were unable to edit user email addresses.