### PR TITLE
Improves the visual design of the smurf link page, fixes to scopes

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -262,5 +262,9 @@ if enable_discord_bridge do
     bot_name: Teiserver.ConfigHelpers.get_env("TEI_DISCORD_BOT_NAME")
 end
 
+# If we are running the server locally this will conflict, this allows us to test
+# if it is already defined, if not then it will set it to a new value as a default
+monitoring_port = Application.get_env(:teiserver, TeiserverWeb.Monitoring)[:port] || 4001
+
 config :teiserver, TeiserverWeb.Monitoring,
-  port: Teiserver.ConfigHelpers.get_env("TEI_METRICS_SERVER_PORT", 4001, :int)
+  port: Teiserver.ConfigHelpers.get_env("TEI_METRICS_SERVER_PORT", monitoring_port, :int)

--- a/config/test.exs
+++ b/config/test.exs
@@ -80,3 +80,5 @@ config :teiserver, Teiserver.Mailer,
   adapter: Swoosh.Adapters.Test,
   noreply_address: "noreply@testsite.co.uk",
   contact_address: "info@testsite.co.uk"
+
+config :teiserver, TeiserverWeb.Monitoring, port: 4401

--- a/lib/teiserver/account/libs/auth_lib.ex
+++ b/lib/teiserver/account/libs/auth_lib.ex
@@ -10,6 +10,7 @@ defmodule Teiserver.Account.AuthLib do
   alias Teiserver.Account.Auth
   alias Teiserver.Account.Role
   alias Teiserver.Account.RoleLib
+  alias Teiserver.Account.Scope
   alias Teiserver.Account.TOTPLib
   alias Teiserver.Account.User
 
@@ -91,7 +92,7 @@ defmodule Teiserver.Account.AuthLib do
 
   # If you don't need permissions then lets not bother checking
   @spec allow?(
-          map() | Conn.t() | Socket.t() | Teiserver.Account.User.t(),
+          map() | Conn.t() | Socket.t() | Teiserver.Account.User.t() | Scope.t(),
           String.t() | [String.t()]
         ) :: boolean
   def allow?(nil, _any), do: false
@@ -116,6 +117,10 @@ defmodule Teiserver.Account.AuthLib do
     mfa_test(id, permissions_required) and
       permission_test(permissions_held, permissions_required)
   end
+
+  # Scope
+  def allow?(%Scope{user: user} = _scope, permissions_required),
+    do: allow?(user, permissions_required)
 
   # User and CacheUser
   def allow?(%{id: id, roles: roles}, permissions_required) do

--- a/lib/teiserver/helpers/general_test_lib.ex
+++ b/lib/teiserver/helpers/general_test_lib.ex
@@ -132,7 +132,7 @@ defmodule Teiserver.Helpers.GeneralTestLib do
   def scope_fixture(%User{} = user, attrs \\ %{}) do
     %Scope{
       user: user,
-      ip: attrs[:ip] || "127.0.0.1"
+      ip: attrs[:ip] || {0, 0, 0, 0, 0, 0, 0, 1}
     }
   end
 end

--- a/lib/teiserver/logging/lib/logging_helpers.ex
+++ b/lib/teiserver/logging/lib/logging_helpers.ex
@@ -41,7 +41,7 @@ defmodule Teiserver.Logging.Helpers do
         action: action,
         user_id: scope.user && scope.user.id,
         details: details,
-        ip: scope.ip
+        ip: scope.ip && scope.ip |> Tuple.to_list() |> Enum.join(".")
       })
 
     the_log

--- a/lib/teiserver_web/components/admin/user_components.ex
+++ b/lib/teiserver_web/components/admin/user_components.ex
@@ -2,10 +2,11 @@ defmodule TeiserverWeb.Components.Admin.UserComponents do
   @moduledoc """
   Components for User pages
   """
+  alias Teiserver.Account.Scope
   alias Teiserver.Account.User
 
   use TeiserverWeb, :component
-  import TeiserverWeb.NavComponents, only: [section_menu_button: 1]
+  import TeiserverWeb.NavComponents, only: [section_menu_button: 1, tw_section_menu_button: 1]
 
   @doc """
   <TeiserverWeb.Components.Admin.UserComponents.section_menu active={active} colour={} current_user={@current_user} />
@@ -158,6 +159,147 @@ defmodule TeiserverWeb.Components.Admin.UserComponents do
           </div>
         </form>
       </div>
+    </div>
+    """
+  end
+
+  @doc """
+  <TeiserverWeb.Components.Admin.UserComponents.tw_section_menu
+    active="some-link"
+    scope={@scope}
+  />
+  """
+  attr :scope, Scope, required: true
+  attr :active, :string, required: true
+  attr :search_value, :string
+  attr :search_autofocus, :boolean, default: false
+
+  def tw_section_menu(assigns) do
+    ~H"""
+    <div role="tablist" class="tabs tabs-box float-end">
+      <div class="tab">
+        <form action={~p"/teiserver/admin/user"} method="get" class="">
+          <div class="input-group">
+            <% input_opts = [
+              autofocus: @search_autofocus
+            ] %>
+            <input
+              type="text"
+              name="s"
+              id="quick_search"
+              value={assigns[:search_value]}
+              placeholder="Quick search"
+              class="input"
+              style="width: 150px; display: inline-block;"
+              {input_opts}
+            /> &nbsp;
+            <input
+              type="submit"
+              value="Search"
+              class="btn btn-primary float-end"
+              style="margin-top: 0px;"
+            />
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <div role="tablist" class="tabs tabs-box">
+      <.tw_section_menu_button
+        active={@active == "client_admin"}
+        icon={Teiserver.Account.ClientLib.icon()}
+        url={~p"/teiserver/admin/client"}
+      >
+        Client admin
+      </.tw_section_menu_button>
+
+      <.tw_section_menu_button
+        active={@active == "list"}
+        icon={Teiserver.Helper.StylingHelper.icon(:list)}
+        url={~p"/teiserver/admin/user"}
+      >
+        List
+      </.tw_section_menu_button>
+
+      <.tw_section_menu_button
+        active={@active == "search"}
+        icon={Teiserver.Helper.StylingHelper.icon(:search)}
+        url={~p"/teiserver/admin/user?search=true"}
+      >
+        Search
+      </.tw_section_menu_button>
+
+      <.tw_section_menu_button
+        :if={allow?(@scope, "admin")}
+        active={@active == "data_search"}
+        icon="fa-solid fa-magnifying-glass-chart"
+        url={~p"/teiserver/admin/users/data_search"}
+      >
+        Data search
+      </.tw_section_menu_button>
+
+      <.tw_section_menu_button
+        :if={@active == "show"}
+        active={true}
+        icon={Teiserver.Helper.StylingHelper.icon(:detail)}
+        url="#"
+      >
+        Show
+      </.tw_section_menu_button>
+
+      <.tw_section_menu_button
+        :if={@active == "edit"}
+        active={true}
+        icon={Teiserver.Helper.StylingHelper.icon(:edit)}
+        url="#"
+      >
+        Edit
+      </.tw_section_menu_button>
+
+      <.tw_section_menu_button
+        :if={@active == "smurf"}
+        active={true}
+        icon="fa-solid fa-face-angry"
+        url="#"
+      >
+        Smurf search
+      </.tw_section_menu_button>
+
+      <.tw_section_menu_button
+        :if={@active == "smurf_merge_form"}
+        active={true}
+        icon="fa-solid fa-merge"
+        url="#"
+      >
+        Smurf merge
+      </.tw_section_menu_button>
+
+      <.tw_section_menu_button
+        :if={@active == "ratings"}
+        active={true}
+        icon={"fa-solid #{Teiserver.Account.RatingLib.icon()}"}
+        url="#"
+      >
+        Ratings
+      </.tw_section_menu_button>
+
+      <.tw_section_menu_button
+        :if={@active == "ratings_form"}
+        active={true}
+        icon={"fa-solid #{Teiserver.Account.RatingLib.icon()}"}
+        url="#"
+      >
+        Ratings form
+      </.tw_section_menu_button>
+
+      <.tw_section_menu_button
+        :if={@active == "moderation"}
+        active={true}
+        icon={"fa-solid #{Teiserver.Moderation.icon()}"}
+        url="#"
+      >
+        Moderation
+      </.tw_section_menu_button>
     </div>
     """
   end

--- a/lib/teiserver_web/components/core_components.ex
+++ b/lib/teiserver_web/components/core_components.ex
@@ -511,7 +511,7 @@ defmodule TeiserverWeb.CoreComponents do
     |> assign(:errors, Enum.map(errors, &translate_error(&1)))
     |> assign_new(:name, fn -> if assigns.multiple, do: field.name <> "[]", else: field.name end)
     |> assign_new(:value, fn -> field.value end)
-    |> input()
+    |> input_tw()
   end
 
   def input_tw(%{type: "hidden"} = assigns) do

--- a/lib/teiserver_web/components/moderation/action_components.ex
+++ b/lib/teiserver_web/components/moderation/action_components.ex
@@ -3,8 +3,10 @@ defmodule TeiserverWeb.Components.Moderation.ActionComponents do
   Components for Action pages
   """
 
+  alias Teiserver.Account.Scope
+
   use TeiserverWeb, :component
-  import TeiserverWeb.NavComponents, only: [section_menu_button: 1]
+  import TeiserverWeb.NavComponents, only: [section_menu_button: 1, tw_section_menu_button: 1]
 
   @doc """
   <TeiserverWeb.Components.Moderation.ActionComponents.section_menu active={active} colour={} />
@@ -53,6 +55,64 @@ defmodule TeiserverWeb.Components.Moderation.ActionComponents do
         </.section_menu_button>
       <% _ -> %>
     <% end %>
+    """
+  end
+
+  @doc """
+  <TeiserverWeb.Components.Moderation.ActionComponents.section_menu
+    active="some-link"
+    scope={@scope}
+  />
+  """
+  attr :scope, Scope, required: true
+  attr :active, :string, required: true
+
+  def tw_section_menu(assigns) do
+    ~H"""
+    <div role="tablist" class="tabs tabs-box">
+      <.tw_section_menu_button
+        icon={StylingHelper.icon(:list)}
+        url={~p"/moderation/action"}
+        active={@active == "index"}
+      >
+        List
+      </.tw_section_menu_button>
+
+      <.tw_section_menu_button
+        icon={StylingHelper.icon(:search)}
+        url={~p"/moderation/action/search"}
+        active={@active == "search"}
+      >
+        Search
+      </.tw_section_menu_button>
+
+      <.tw_section_menu_button
+        :if={@active == "show"}
+        icon={StylingHelper.icon(:show)}
+        url="#"
+        active={true}
+      >
+        Show
+      </.tw_section_menu_button>
+
+      <.tw_section_menu_button
+        :if={@active == "edit"}
+        icon={StylingHelper.icon(:edit)}
+        url="#"
+        active={true}
+      >
+        Edit
+      </.tw_section_menu_button>
+
+      <.tw_section_menu_button
+        :if={@active == "smurf-link"}
+        active={true}
+        icon="fa-solid fa-code-compare"
+        url="#"
+      >
+        Smurf link
+      </.tw_section_menu_button>
+    </div>
     """
   end
 end

--- a/lib/teiserver_web/components/nav_components.ex
+++ b/lib/teiserver_web/components/nav_components.ex
@@ -402,18 +402,18 @@ defmodule TeiserverWeb.NavComponents do
   end
 
   @doc """
-  <.section_menu_button bsname={bsname} icon={lib} active={true/false} url={url}>
+  <.section_menu_button_patch bsname={bsname} icon={lib} active={true/false} url={url}>
     Text goes here
-  </.section_menu_button>
+  </.section_menu_button_patch>
 
-  <.section_menu_button
+  <.section_menu_button_patch
       bsname={@view_colour}
       icon={StylingHelper.icon(:list)}
       active={@active == "index"}
       url={~p"/account/relationship"}
     >
       List
-    </.section_menu_button>
+    </.section_menu_button_patch>
   """
   attr :icon, :string, default: nil
   attr :url, :string, required: true
@@ -431,6 +431,28 @@ defmodule TeiserverWeb.NavComponents do
       <Fontawesome.icon :if={@icon} icon={@icon} style={if @active, do: "solid", else: "regular"} />
       {render_slot(@inner_block)}
     </.link>
+    """
+  end
+
+  @doc """
+  <.tw_section_menu_button bsname={bsname} icon={lib} active={true/false} url={url}>
+    Text goes here
+  </.tw_section_menu_button>
+  """
+  attr :icon, :string, default: nil
+  attr :url, :string, required: true
+  attr :active, :boolean, default: false
+  slot :inner_block, required: true
+
+  def tw_section_menu_button(assigns) do
+    assigns =
+      assigns
+      |> assign(:active_class, if(assigns[:active], do: "tab-active"))
+
+    ~H"""
+    <a href={@url} class={["tab", @active_class]}>
+      <Fontawesome.icon :if={@icon} icon={@icon} style="solid" /> &nbsp; {render_slot(@inner_block)}
+    </a>
     """
   end
 

--- a/lib/teiserver_web/controllers/moderation/action_controller.ex
+++ b/lib/teiserver_web/controllers/moderation/action_controller.ex
@@ -65,6 +65,13 @@ defmodule TeiserverWeb.Moderation.ActionController do
     |> render("index.html")
   end
 
+  @spec search(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def search(conn, params) do
+    conn
+    |> assign(:show_search, true)
+    |> index(params)
+  end
+
   defp extract_search_params(params) do
     search_params = []
 

--- a/lib/teiserver_web/endpoint.ex
+++ b/lib/teiserver_web/endpoint.ex
@@ -9,7 +9,9 @@ defmodule TeiserverWeb.Endpoint do
     max_age: 1_814_400
   ]
 
-  socket("/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]])
+  socket("/live", Phoenix.LiveView.Socket,
+    websocket: [connect_info: [:peer_data, session: @session_options]]
+  )
 
   # log: :debug reduces verbosity to avoid logging sensitive connection params
   socket("/socket", TeiserverWeb.UserSocket,

--- a/lib/teiserver_web/live/moderation/action_live/smurf_link.ex
+++ b/lib/teiserver_web/live/moderation/action_live/smurf_link.ex
@@ -6,6 +6,8 @@ defmodule TeiserverWeb.Moderation.ActionLive.SmurfLink do
 
   use TeiserverWeb, :live_view
 
+  require Logger
+
   @impl LiveView
   def mount(_params, _session, socket) do
     {:ok, socket}
@@ -14,11 +16,16 @@ defmodule TeiserverWeb.Moderation.ActionLive.SmurfLink do
   @impl LiveView
   def handle_params(%{"user_id" => user_id}, _url, socket) do
     user = Account.get_user(user_id)
+    existing_smurf_of = user.smurf_of_id && Account.get_user(user.smurf_of_id)
 
     case UserLib.has_access(user, socket) do
       {true, _role} ->
         socket
-        |> assign(user: user, page_title: "Smurf link - #{user.name}")
+        |> assign(
+          user: user,
+          existing_smurf_of: existing_smurf_of,
+          page_title: "Smurf link - #{user.name}"
+        )
         |> assign_new(:form, fn ->
           to_form(%{
             "smurf_user_id" => nil
@@ -60,9 +67,7 @@ defmodule TeiserverWeb.Moderation.ActionLive.SmurfLink do
               |> noreply()
 
             _result ->
-              IO.puts("")
-              IO.inspect(result, label: "#{__MODULE__}:#{__ENV__.line}")
-              IO.puts("")
+              Logger.error("Error saving smurf link form: #{inspect(result)}")
 
               socket
               |> put_flash(:warning, "Internal error")

--- a/lib/teiserver_web/live/moderation/action_live/smurf_link.html.heex
+++ b/lib/teiserver_web/live/moderation/action_live/smurf_link.html.heex
@@ -1,29 +1,41 @@
-<.header>
-  Smurf link user
-</.header>
+<TeiserverWeb.Components.Moderation.ActionComponents.tw_section_menu
+  active="smurf-link"
+  scope={@scope}
+/>
 
 <div class="p-4 mb-4 content-div">
   <.header>
     Marking <strong>{@user.name}</strong> as a smurf of:
   </.header>
 
+  <div :if={@existing_smurf_of}>
+    Currently marked as a smurf of
+    <a href={~p"/teiserver/admin/user/#{@existing_smurf_of.id}"}>{@existing_smurf_of.name}</a>
+  </div>
+
   <.simple_form
     for={@form}
     id="smurf-link-form"
     phx-change="validate"
     phx-submit="save"
+    class="mt-4"
   >
-    <.live_component
-      module={TeiserverWeb.LiveComponents.UserPicker}
-      id="user-picker"
-      field={@form[:smurf_user_id]}
-      ignore_ids={[@current_user.id, @user.id]}
-      label="User to link to:"
-    />
-
-    <:actions>
-      <.button phx-disable-with="Saving...">Add smurf link</.button>
-    </:actions>
+    <div class="flex">
+      <div class="flex-1">
+        <.live_component
+          module={TeiserverWeb.LiveComponents.UserPicker}
+          id="user-picker"
+          field={@form[:smurf_user_id]}
+          ignore_ids={[@current_user.id, @user.id]}
+          value={@existing_smurf_of}
+        />
+      </div>
+      <div class="flex-1">
+        <.button phx-disable-with="Saving...">
+          <Fontawesome.icon icon="link" style="regular" /> Create smurf link
+        </.button>
+      </div>
+    </div>
   </.simple_form>
 </div>
 

--- a/lib/teiserver_web/live_components/user_picker.ex
+++ b/lib/teiserver_web/live_components/user_picker.ex
@@ -38,12 +38,11 @@ defmodule TeiserverWeb.LiveComponents.UserPicker do
   def render(assigns) do
     ~H"""
     <div>
+      <CoreComponents.label :if={@label} for={@id}>{@label}</CoreComponents.label>
       <div>
-        <CoreComponents.label :if={@label} for={@id}>{@label}</CoreComponents.label>
-
-        <div class="w-full inline-flex border rounded-lg">
+        <div class="join">
           <div
-            class="w-15 text-center pt-3 bg-green-400 text-green-900 dark:bg-green-800 dark:text-green-50 cursor-pointer rounded-l-lg user-picker-search-button"
+            class="btn btn-success join-item user-picker-search-button"
             phx-click={
               JS.push("show-picker")
               |> JS.toggle(to: "##{@uniq_id}-picker-form")
@@ -51,15 +50,20 @@ defmodule TeiserverWeb.LiveComponents.UserPicker do
             }
             phx-target={@myself}
           >
-            <i class="fa-solid fa-lg fa-fw fa-magnifying-glass"></i>
+            <Fontawesome.icon icon="search" style="regular" /> Search
           </div>
+          <label class="input validator join-item">
+            <input
+              type="text"
+              class="input w-full min-w-lg"
+              placeholder=""
+              disabled
+              name="none"
+              value={@shown_value}
+            />
+          </label>
 
-          <.input_tw
-            name="none"
-            value={@shown_value}
-            placeholder="Click green button to search"
-          />
-          <.input_tw
+          <.input
             field={@field}
             value={@actual_value}
             type="hidden"
@@ -241,7 +245,7 @@ defmodule TeiserverWeb.LiveComponents.UserPicker do
     ~H"""
     <div class={["mt-2", not @show && "hidden"]} id={"#{@uniq_id}-picker-form"}>
       Search for user by name or ID, search will take place as soon as you stop typing
-      <.input
+      <.input_tw
         id={"#{@uniq_id}-search-input"}
         name="user-search-term"
         value={@search_term}

--- a/lib/teiserver_web/router.ex
+++ b/lib/teiserver_web/router.ex
@@ -3,8 +3,6 @@ defmodule TeiserverWeb.Router do
 
   use TeiserverWeb, :router
 
-  import TeiserverWeb.UserAuthentication
-
   pipeline :logging_live_auth do
     plug Bodyguard.Plug.Authorize,
       fallback: TeiserverWeb.Controllers.BodyguardFallback,
@@ -38,7 +36,6 @@ defmodule TeiserverWeb.Router do
     plug(Teiserver.Account.AuthPipeline)
     plug(Teiserver.Account.AuthPlug)
     plug(Teiserver.Plugs.CachePlug)
-    plug :fetch_current_scope_for_user
   end
 
   pipeline :tailwind do
@@ -493,8 +490,8 @@ defmodule TeiserverWeb.Router do
     put("/report/:id/close", ReportController, :close)
     put("/report/:id/open", ReportController, :open)
 
-    get("/action/search", ActionController, :index)
-    post("/action/search", ActionController, :index)
+    get("/action/search", ActionController, :search)
+    post("/action/search", ActionController, :search)
     get("/action/new_with_user", ActionController, :new_with_user)
     put("/action/halt/:id", ActionController, :halt)
     put("/action/re-post/:id", ActionController, :re_post)
@@ -510,12 +507,12 @@ defmodule TeiserverWeb.Router do
   end
 
   scope "/moderation", TeiserverWeb.Moderation, as: :moderation do
-    pipe_through([:browser, :app_layout, :protected, :tailwind])
+    pipe_through([:live_browser, :app_layout, :protected, :tailwind])
 
     live_session :actions,
       layout: {TeiserverWeb.Layouts, :moderation_tw},
       on_mount: [
-        {Teiserver.Account.DefaultsPlug, {:set, %{site_menu_active: "users"}}},
+        {Teiserver.Account.DefaultsPlug, {:set, %{site_menu_active: "moderation"}}},
         {UserAuthentication, :ensure_authenticated},
         {UserAuthentication, {:authorise, "Moderator"}}
       ] do

--- a/lib/teiserver_web/templates/moderation/action/index.html.heex
+++ b/lib/teiserver_web/templates/moderation/action/index.html.heex
@@ -10,11 +10,11 @@
     <div class={"card border-#{bsname}"}>
       <div class="card-body">
         <TeiserverWeb.Components.Moderation.ActionComponents.section_menu
-          active="index"
+          active={if assigns[:show_search], do: "search", else: "index"}
           colour={bsname}
         />
 
-        <%= if @conn.params["search"] != nil do %>
+        <%= if @conn.params["search"] != nil or assigns[:show_search] do %>
           {render(TeiserverWeb.Moderation.ActionView, "search.html", assigns)}
         <% end %>
 

--- a/lib/teiserver_web/user_authentication.ex
+++ b/lib/teiserver_web/user_authentication.ex
@@ -11,7 +11,6 @@ defmodule TeiserverWeb.UserAuthentication do
   alias Teiserver.Account.Guardian
   alias Teiserver.Account.Scope
   alias Teiserver.Account.User
-  alias Teiserver.Logging.LoggingPlug
 
   use TeiserverWeb, :verified_routes
 
@@ -106,6 +105,7 @@ defmodule TeiserverWeb.UserAuthentication do
       end
 
     Component.assign_new(socket, :current_user, fn -> user end)
+    |> fetch_current_scope_for_user()
   end
 
   defp mount_current_user(socket, _session) do
@@ -154,15 +154,17 @@ defmodule TeiserverWeb.UserAuthentication do
   @doc """
   Populates the scope for the user if one is assigned
   """
-  def fetch_current_scope_for_user(%{assigns: %{current_user: %User{} = user}} = conn, _opts) do
+  def fetch_current_scope_for_user(%{assigns: %{current_user: %User{} = user}} = socket) do
+    peer_data = LiveView.get_connect_info(socket, :peer_data)
+
     scope = %Scope{
       user: user,
-      ip: LoggingPlug.get_ip_from_conn(conn)
+      ip: peer_data.address
     }
 
-    assign(conn, :scope, scope)
+    Component.assign_new(socket, :scope, fn -> scope end)
   end
 
   # Fallback for no user assigned
-  def fetch_current_scope_for_user(conn, _opts), do: conn
+  def fetch_current_scope_for_user(socket), do: socket
 end

--- a/test/teiserver_web/live/moderation/action_live/smurf_link_test.exs
+++ b/test/teiserver_web/live/moderation/action_live/smurf_link_test.exs
@@ -51,7 +51,7 @@ defmodule TeiserverWeb.Live.Moderation.ActionLive.SmurfLinkTest do
         |> render()
 
       assert text_field_html ==
-               ~s(<input type="text" name="none" value="##{origin.id} - origin_user_testname" class="w-full input" placeholder="Click green button to search"/>)
+               ~s(<input type="text" class="input w-full min-w-lg" placeholder="" disabled="" name="none" value="##{origin.id} - origin_user_testname"/>)
 
       hidden_field_html =
         view


### PR DESCRIPTION
Improves the css styling of the smurf link page and fixes issues with the way Scopes are assigned within liveview pages.

Light mode - Empty form
<img width="613" height="375" alt="image" src="https://github.com/user-attachments/assets/54451921-cbaa-4e13-8281-29531859c15e" />

Dark mode - Empty form
<img width="610" height="353" alt="image" src="https://github.com/user-attachments/assets/39781443-a85c-4cbc-b40b-c9fb05294f49" />

Light mode - Mid search
<img width="832" height="588" alt="image" src="https://github.com/user-attachments/assets/b20446b1-fc7a-4d99-bb3b-48220cbe62f0" />


Dark mode - Mid search
<img width="803" height="574" alt="image" src="https://github.com/user-attachments/assets/539d1568-ccf3-4e91-9a69-749d04994588" />

Additionally:
- Allows running of tests while running the server locally (test port conflict)
- Fixes issue with getting connection IP from LiveView sockets
- Fixes Moderation/Action search button