### PR TITLE
Test tachyon envelope parsing errors

### DIFF
--- a/test/teiserver/tachyon/schema_test.exs
+++ b/test/teiserver/tachyon/schema_test.exs
@@ -25,44 +25,59 @@ defmodule Teiserver.Tachyon.SchemaTest do
     end
 
     test "must pass an object" do
-      {:error, _msg} = Schema.parse_envelope("not an object")
-      {:error, _msg} = Schema.parse_envelope(["also", "not", "an", "object"])
-      {:error, _msg} = Schema.parse_envelope(2)
+      expected_error = {:error, "Invalid tachyon message: invalid type, expected object"}
+
+      assert ^expected_error = Schema.parse_envelope("not an object")
+      assert ^expected_error = Schema.parse_envelope(["also", "not", "an", "object"])
+      assert ^expected_error = Schema.parse_envelope(2)
     end
 
     test "messageId required" do
       obj = %{"type" => "request", "commandId" => "ns/cmd"}
-      {:error, _msg} = Schema.parse_envelope(obj)
+
+      assert {:error, "Invalid tachyon message: missing key messageId"} =
+               Schema.parse_envelope(obj)
     end
 
     test "messageId must be a string" do
       obj = %{"type" => "request", "commandId" => "ns/cmd", "messageId" => 2}
-      {:error, _msg} = Schema.parse_envelope(obj)
+
+      assert {:error, "Invalid tachyon message: invalid type for key messageId"} =
+               Schema.parse_envelope(obj)
     end
 
     test "type required" do
       obj = %{"commandId" => "ns/cmd", "messageId" => "123"}
-      {:error, _msg} = Schema.parse_envelope(obj)
+      assert {:error, "Invalid tachyon message: missing key type"} = Schema.parse_envelope(obj)
     end
 
     test "type must be a string" do
       obj = %{"type" => 123, "commandId" => "ns/cmd", "messageId" => "123"}
-      {:error, _msg} = Schema.parse_envelope(obj)
+
+      assert {:error, "Invalid tachyon message: invalid type for key type"} =
+               Schema.parse_envelope(obj)
     end
 
     test "type must be one of event/request/response" do
       obj = %{"type" => "wat?", "commandId" => "ns/cmd", "messageId" => "123"}
-      {:error, _msg} = Schema.parse_envelope(obj)
+
+      assert {:error,
+              "Invalid tachyon message: type must be one of request, response, event but got wat?"} =
+               Schema.parse_envelope(obj)
     end
 
     test "commandId required" do
       obj = %{"type" => "request", "messageId" => "123"}
-      {:error, _msg} = Schema.parse_envelope(obj)
+
+      assert {:error, "Invalid tachyon message: missing key commandId"} =
+               Schema.parse_envelope(obj)
     end
 
     test "commandId must be a string" do
       obj = %{"type" => "request", "commandId" => 123, "messageId" => "123"}
-      {:error, _msg} = Schema.parse_envelope(obj)
+
+      assert {:error, "Invalid tachyon message: invalid type for key commandId"} =
+               Schema.parse_envelope(obj)
     end
   end
 end


### PR DESCRIPTION
## Summary

Replace wildcard matches in the tachyon envelope parser tests with the exact validation errors returned for each invalid input. This makes changes to the parser’s validation order or error text observable in the focused test.

Closes #1281.

## Verification

- Executed all 10 invalid-input cases directly against `Teiserver.Tachyon.Schema.parse_envelope/1` using Elixir 1.19.4 / OTP 27 in the official container; all exact results matched.
- Checked the changed test with the Elixir formatter and `git diff --check`.
- Attempted the focused Mix test in the same container. Dependency compilation was blocked by repeated HTTP 504 responses downloading the locked `lumis` 0.5.0 precompiled NIF from its GitHub release.

## AI disclosure

OpenAI Codex assisted with the test edits and initial description draft. I reviewed the changed assertions against the parser’s validation sequence, removed unnecessary explanation, and verified each exercised result as described above.