### PR TITLE
Correctly clean session state when getting kicked from lobby

### DIFF
--- a/lib/teiserver/player.ex
+++ b/lib/teiserver/player.ex
@@ -100,6 +100,8 @@ defmodule Teiserver.Player do
   defdelegate lobby_join_battle(user_id, battle_data, battle_start_data, password),
     to: Player.Session
 
+  defdelegate notify_left_lobby(user_id, lobby_id, reason), to: Player.Session
+
   @doc """
   Let the player know they've been invited to a party
   """

--- a/lib/teiserver/player/session.ex
+++ b/lib/teiserver/player/session.ex
@@ -222,6 +222,12 @@ defmodule Teiserver.Player.Session do
     |> GenServer.cast({:battle, {:lobby_join, battle_data, battle_start_data, password}})
   end
 
+  def notify_left_lobby(user_id, lobby_id, reason) do
+    user_id
+    |> via_tuple()
+    |> GenServer.cast({:lobby, {:left, lobby_id, reason}})
+  end
+
   @doc """
   notify the teiserver side that the player left a battle. This is coming
   from the engine
@@ -1658,6 +1664,16 @@ defmodule Teiserver.Player.Session do
     end
   end
 
+  def handle_cast({:lobby, {:left, lobby_id, _reason}}, %PT.Data{} = state)
+      when state.lobby.id != lobby_id,
+      do: {:noreply, state}
+
+  def handle_cast({:lobby, {:left, lobby_id, reason}}, %PT.Data{} = state) do
+    msg = {:lobby, lobby_id, {:left, reason}}
+    send_to_player!(msg, state)
+    {:noreply, %{state | lobby: nil}}
+  end
+
   @impl GenServer
   def handle_info({:DOWN, ref, :process, _pid, reason}, %PT.Data{} = state) do
     val = MC.get_val(state.monitors, ref)
@@ -1759,7 +1775,7 @@ defmodule Teiserver.Player.Session do
         case TachyonLobby.lookup_primary(lobby_id) do
           nil ->
             Logger.info("Lobby #{lobby_id} went down because #{inspect(reason)}")
-            send_to_player!({:lobby, lobby_id, {:left, "lobby crashed"}}, state)
+            send_to_player!({:lobby, lobby_id, {:left, {:error, "lobby crashed"}}}, state)
             {:noreply, %{state | lobby: nil}}
 
           pid ->

--- a/lib/teiserver/player/tachyon_handler.ex
+++ b/lib/teiserver/player/tachyon_handler.ex
@@ -254,14 +254,16 @@ defmodule Teiserver.Player.TachyonHandler do
   end
 
   def handle_info({:lobby, lobby_id, {:left, reason}}, state) do
-    {:event, "lobby/left", %{id: lobby_id, reason: reason}, state}
-  end
-
-  def handle_info({:lobby, lobby_id, {:left, reason, ban_until}}, state) do
     data =
-      case ban_until do
-        nil -> %{id: lobby_id, reason: reason}
-        dt -> %{id: lobby_id, reason: reason, bannedUntil: DateTime.to_unix(dt, :microsecond)}
+      case reason do
+        :kicked ->
+          %{id: lobby_id, reason: "kicked"}
+
+        {:error, msg} ->
+          %{id: lobby_id, reason: msg}
+
+        {:banned, dt} ->
+          %{id: lobby_id, reason: "banned", bannedUntil: DateTime.to_unix(dt, :microsecond)}
       end
 
     {:event, "lobby/left", data, state}

--- a/lib/teiserver/tachyon_lobby/events/kickban.ex
+++ b/lib/teiserver/tachyon_lobby/events/kickban.ex
@@ -57,9 +57,8 @@ defimpl Teiserver.TachyonLobby.Event, for: Teiserver.TachyonLobby.Events.Kickban
 
     effects =
       if target_pid do
-        reason = if effective_ban_until != nil, do: "banned", else: "kicked"
-        message = {:lobby, agg.data.id, {:left, reason, effective_ban_until}}
-        effect = {:send_to_user, target_pid, message}
+        reason = if effective_ban_until != nil, do: {:banned, effective_ban_until}, else: :kicked
+        effect = {:kicked, ev.user_id, reason}
         [effect | agg.side_effects]
       else
         agg.side_effects

--- a/lib/teiserver/tachyon_lobby/lobby.ex
+++ b/lib/teiserver/tachyon_lobby/lobby.ex
@@ -1723,6 +1723,16 @@ defmodule Teiserver.TachyonLobby.Lobby do
     if primary?, do: send(pid, message)
   end
 
+  defp process_event_action(
+         {:kicked, user_id, reason},
+         primary?,
+         %LT.Data{} = fsm_data
+       ) do
+    if primary? do
+      Teiserver.Player.notify_left_lobby(user_id, fsm_data.id, reason)
+    end
+  end
+
   # create a default vote object
   defp new_vote(state, initiator_id, action) do
     vote_duration_s = 60

--- a/test/teiserver/tachyon_lobby/lobby_test.exs
+++ b/test/teiserver/tachyon_lobby/lobby_test.exs
@@ -3,6 +3,7 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
   alias Teiserver.AssetFixtures
   alias Teiserver.Autohost.Types, as: AT
   alias Teiserver.KvStore
+  alias Teiserver.Player.SessionRegistry
   alias Teiserver.Tachyon, as: TachyonLib
   alias Teiserver.TachyonLobby, as: Lobby
   alias Teiserver.TachyonLobby.Lobby, as: LobbyProcess
@@ -1727,10 +1728,11 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
         |> Lobby.create()
 
       {:ok, _lobby_pid, _details} = Lobby.join(id, mk_player("user2"), self())
+      SessionRegistry.register("user2", nil)
       assert_receive {:lobby, ^id, {:updated, _}}
 
       :ok = Lobby.kickban(id, @default_user_id, "user2")
-      assert_receive {:lobby, ^id, {:left, "kicked", nil}}
+      assert_receive {:"$gen_cast", {:lobby, {:left, ^id, :kicked}}}
 
       {:ok, details} = LobbyProcess.get_details(id)
       refute is_map_key(details.spectators, "user2")
@@ -1762,10 +1764,11 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
         |> Lobby.create()
 
       {:ok, _lobby_pid, _details} = Lobby.join(id, mk_player("user2"), self())
+      SessionRegistry.register("user2", nil)
 
       :ok = Lobby.kickban(id, @default_user_id, "user2")
 
-      assert_receive {:lobby, ^id, {:left, "kicked", nil}}
+      assert_receive {:"$gen_cast", {:lobby, {:left, ^id, :kicked}}}
       refute_receive {:lobby, ^id, {:updated, _}}, 30
     end
 
@@ -1776,12 +1779,13 @@ defmodule Teiserver.TachyonLobby.LobbyTest do
         |> Lobby.create()
 
       {:ok, _lobby_pid, _details} = Lobby.join(id, mk_player("user2"), self())
+      SessionRegistry.register("user2", nil)
       assert_receive {:lobby, ^id, {:updated, _}}
 
       {:ok, _details} = Lobby.join_ally_team(id, "user2", 0)
 
       :ok = Lobby.kickban(id, @default_user_id, "user2")
-      assert_receive {:lobby, ^id, {:left, "kicked", nil}}
+      assert_receive {:"$gen_cast", {:lobby, {:left, ^id, :kicked}}}
 
       {:ok, details} = LobbyProcess.get_details(id)
       refute is_map_key(details.players, "user2")

--- a/test/teiserver_web/tachyon/lobby_test.exs
+++ b/test/teiserver_web/tachyon/lobby_test.exs
@@ -606,6 +606,12 @@ defmodule TeiserverWeb.Tachyon.LobbyTest do
 
       %{"commandId" => "lobby/left", "data" => data} = Tachyon.recv_message!(ctx2[:client])
       assert data["reason"] == "kicked"
+
+      # check that user/self is also correct after reconnection
+      Tachyon.abrupt_disconnect!(ctx2[:client])
+      client2 = Tachyon.connect(ctx2[:token], swallow_first_event: false)
+      %{"commandId" => "user/self", "data" => data} = Tachyon.recv_message!(client2)
+      assert data["user"]["currentLobby"] == nil
     end
 
     test "invalid user id returns error" do


### PR DESCRIPTION
Also comes with a small refactoring so that the message sent to the session genserver isn't created outside the module.