### PR TITLE
Search and pagination for anti abuse records

### DIFF
--- a/lib/teiserver/config/user_config_types/cache.ex
+++ b/lib/teiserver/config/user_config_types/cache.ex
@@ -3,6 +3,7 @@ defmodule Teiserver.Config.UserConfigTypes.Cache do
   Cache and setup for profile configuration
   """
 
+  alias Teiserver.Config.UserConfigTypes.LastUsedValueConfigs
   alias Teiserver.Config.UserConfigTypes.PrivacyConfigs
   alias Teiserver.Config.UserConfigTypes.ProfileConfigs
   alias Teiserver.Helpers.CacheHelper
@@ -12,7 +13,8 @@ defmodule Teiserver.Config.UserConfigTypes.Cache do
   def start_link(opts) do
     with {:ok, sup} <- Supervisor.start_link(__MODULE__, :ok, opts),
          :ok <- ProfileConfigs.create(),
-         :ok <- PrivacyConfigs.create() do
+         :ok <- PrivacyConfigs.create(),
+         :ok <- LastUsedValueConfigs.create() do
       {:ok, sup}
     end
   end

--- a/lib/teiserver/config/user_config_types/last_used_value_configs.ex
+++ b/lib/teiserver/config/user_config_types/last_used_value_configs.ex
@@ -1,0 +1,17 @@
+defmodule Teiserver.Config.UserConfigTypes.LastUsedValueConfigs do
+  @moduledoc """
+  A set of user configs used to track the last-used-state of various site components (e.g. search forms)
+  """
+
+  import Teiserver.Config, only: [add_user_config_type: 1]
+
+  @spec create() :: :ok
+  def create do
+    add_user_config_type(%{
+      key: "last_used.anti_abuse_search_page_size",
+      type: "integer",
+      default: 5,
+      visible: false
+    })
+  end
+end

--- a/lib/teiserver/helpers/query_helper.ex
+++ b/lib/teiserver/helpers/query_helper.ex
@@ -3,6 +3,8 @@ defmodule Teiserver.Helper.QueryHelpers do
   alias Teiserver.Repo
   import Ecto.Query, warn: false
 
+  @type t :: Query.t()
+
   defmacro lower(field) do
     quote do
       fragment("LOWER(?)", unquote(field))
@@ -107,5 +109,14 @@ defmodule Teiserver.Helper.QueryHelpers do
   def query_select(query, fields) do
     from stat_grids in query,
       select: ^fields
+  end
+
+  @spec paginate(t(), non_neg_integer(), pos_integer()) :: t()
+  def paginate(query, page, page_size) do
+    offset = page * page_size
+
+    query
+    |> offset_query(offset)
+    |> limit_query(page_size)
   end
 end

--- a/lib/teiserver/helpers/string_helper.ex
+++ b/lib/teiserver/helpers/string_helper.ex
@@ -179,8 +179,22 @@ defmodule Teiserver.Helper.StringHelper do
   end
 
   @doc """
+  Calls String.to_integer/1 but with a wrapper to catch nil and "" values (returns nil)
+  """
+  def maybe_to_integer(nil), do: nil
+  def maybe_to_integer(""), do: nil
+  def maybe_to_integer(v), do: String.to_integer(v)
+
+  @doc """
   Returns the first 8 digits of a UUID
   """
   def uuid_part(nil), do: nil
   def uuid_part(str), do: String.slice(str, 0..7)
+
+  @doc """
+  Used to parse booleans from a form with the caveat that an empty string is a nil value
+  """
+  def boolean_from_form("true"), do: true
+  def boolean_from_form("false"), do: false
+  def boolean_from_form(_any), do: nil
 end

--- a/lib/teiserver/moderation/queries/anti_abuse_record_queries.ex
+++ b/lib/teiserver/moderation/queries/anti_abuse_record_queries.ex
@@ -19,6 +19,44 @@ defmodule Teiserver.Moderation.AntiAbuseRecordQueries do
       where: anti_abuse_records.id == ^id
   end
 
+  @spec where_user_id(t(), User.id()) :: t()
+  def where_user_id(query, nil), do: query
+
+  def where_user_id(query, user_id) do
+    from anti_abuse_records in query,
+      where: anti_abuse_records.user_id == ^user_id
+  end
+
+  @spec where_clean(t(), nil | boolean()) :: t()
+  def where_clean(query, nil), do: query
+
+  def where_clean(query, clean?) do
+    from anti_abuse_records in query,
+      where: anti_abuse_records.clean == ^clean?
+  end
+
+  @spec where_restored(t(), nil | boolean()) :: t()
+  def where_restored(query, nil), do: query
+
+  def where_restored(query, true) do
+    from anti_abuse_records in query,
+      where: not is_nil(anti_abuse_records.restored_by_id)
+  end
+
+  def where_restored(query, false) do
+    from anti_abuse_records in query,
+      where: is_nil(anti_abuse_records.restored_by_id)
+  end
+
+  @spec where_restored_by_id(t(), nil | boolean()) :: t()
+  def where_restored_by_id(query, nil), do: query
+  def where_restored_by_id(query, ""), do: query
+
+  def where_restored_by_id(query, id) do
+    from anti_abuse_records in query,
+      where: anti_abuse_records.restored_by_id == ^id
+  end
+
   @spec load_user(t()) :: t()
   def load_user(query) do
     from anti_abuse_records in query,

--- a/lib/teiserver_web.ex
+++ b/lib/teiserver_web.ex
@@ -110,6 +110,7 @@ defmodule TeiserverWeb do
   def live_view do
     quote do
       alias Phoenix.LiveView
+      alias Phoenix.LiveView.Socket
 
       use Phoenix.LiveView,
         layout: {TeiserverWeb.Layouts, :app}

--- a/lib/teiserver_web/components/admin/anti_abuse_record_components.ex
+++ b/lib/teiserver_web/components/admin/anti_abuse_record_components.ex
@@ -1,0 +1,91 @@
+defmodule TeiserverWeb.Admin.AntiAbuseRecordComponents do
+  @moduledoc false
+  alias TeiserverWeb.LiveComponents.UserPicker
+
+  use TeiserverWeb, :component
+
+  import TeiserverWeb.CoreComponents, only: [simple_form: 1, input_tw: 1]
+
+  @doc """
+  <TeiserverWeb.Admin.AntiAbuseRecordComponents.search_form
+    :if={assigns[:search]}
+    params={@search}
+  />
+
+  You will need to implement the following event handlers:
+
+  handle_event("update-search", params, %Socket{} = socket)
+  handle_event("validate-search", params, %Socket{} = socket)
+  handle_event("reset-search", _params, %Socket{} = socket)
+  """
+  attr :params, :map, required: true
+
+  def search_form(%{params: params} = assigns) do
+    form = to_form(params)
+
+    assigns =
+      assigns
+      |> assign(form: form)
+
+    ~H"""
+    <.simple_form for={@form} phx-change="validate-search" phx-submit="update-search">
+      <div class="grid grid-flow-row-dense grid-cols-3">
+        <div class="m-2">
+          <div class="fieldset">
+            <.live_component
+              module={UserPicker}
+              id="restored_by_id-user-picker"
+              field={@form[:restored_by_id]}
+              label="Restored by:"
+            />
+          </div>
+        </div>
+
+        <div class="m-2">
+          <.input_tw
+            type="text"
+            field={@form[:user_id]}
+            label="User ID"
+          />
+        </div>
+
+        <div class="m-2">
+          <.input_tw
+            type="select"
+            field={@form[:clean?]}
+            label="Clean?"
+            options={[{"Any", nil}, {"Clean", true}, {"Unclean", false}]}
+          />
+        </div>
+
+        <div class="m-2">
+          <.input_tw
+            type="select"
+            field={@form[:restored?]}
+            label="Restored?"
+            options={[{"Any", nil}, {"Restored", true}, {"Not restored", false}]}
+          />
+        </div>
+
+        <div class="m-2">
+          <.input_tw
+            type="select"
+            field={@form[:page_size]}
+            label="Records per page"
+            options={[5, 10, 25, 50]}
+          />
+        </div>
+      </div>
+
+      <div class="float-right">
+        <div phx-click="reset-search" class="btn btn-neutral btn-soft">
+          <Fontawesome.icon icon="rotate-left" style="regular" /> Reset
+        </div>
+        <button class="btn btn-primary btn-soft">
+          <Fontawesome.icon icon="search" style="regular" /> Update results
+        </button>
+      </div>
+    </.simple_form>
+    """
+  end
+end

--- a/lib/teiserver_web/components/core_components.ex
+++ b/lib/teiserver_web/components/core_components.ex
@@ -625,7 +625,7 @@ defmodule TeiserverWeb.CoreComponents do
 
   def label(assigns) do
     ~H"""
-    <label for={@for} class="control-label">
+    <label for={@for} class="label control-label">
       {render_slot(@inner_block)}
     </label>
     """
@@ -688,6 +688,11 @@ defmodule TeiserverWeb.CoreComponents do
   attr :row_click, :any, default: nil, doc: "the function for handling phx-click on each row"
   attr :row_class, :any, default: nil, doc: "the function for setting the tr class"
 
+  attr :minimum_rows, :integer,
+    default: nil,
+    doc:
+      "the minimum number of rows to show, if there are fewer rows than this number then empty rows are inserted, will likely not work with streamed data"
+
   attr :table_class, :string, default: ""
 
   attr :row_item, :any,
@@ -701,10 +706,18 @@ defmodule TeiserverWeb.CoreComponents do
   slot :action, doc: "the slot for showing user actions in the last table column"
 
   def table(assigns) do
+    extra_row_count =
+      if assigns[:minimum_rows] do
+        max(assigns[:minimum_rows] - Enum.count(assigns[:rows]), 0)
+      else
+        0
+      end
+
     assigns =
       with %{rows: %Phoenix.LiveView.LiveStream{}} <- assigns do
         assign(assigns, row_id: assigns.row_id || fn {id, _item} -> id end)
       end
+      |> assign(extra_row_count: extra_row_count)
 
     ~H"""
     <div class="table-responsive">
@@ -735,6 +748,21 @@ defmodule TeiserverWeb.CoreComponents do
                   {render_slot(action, @row_item.(row))}
                 </span>
               </div>
+            </td>
+          </tr>
+          <tr
+            :for={_idx <- Range.new(1, max(@extra_row_count, 1))}
+            :if={@extra_row_count > 0}
+            class="extra-row"
+          >
+            <td
+              :for={{_col, _i} <- Enum.with_index(@col)}
+              class={["", @row_click && "cursor-pointer"]}
+            >
+              &nbsp;
+            </td>
+            <td class="">
+              &nbsp;
             </td>
           </tr>
         </tbody>

--- a/lib/teiserver_web/components/pagination_components.ex
+++ b/lib/teiserver_web/components/pagination_components.ex
@@ -13,7 +13,7 @@ defmodule TeiserverWeb.PaginationComponents do
       <.pagination
         page={@page}
         total_pages={@total_pages}
-        base_url="/admin/users"
+        base_url={~p"/admin/users"}
         class="mt-3"
       />
 
@@ -21,7 +21,7 @@ defmodule TeiserverWeb.PaginationComponents do
       <.pagination
         page={@page}
         total_pages={@total_pages}
-        base_url="/admin/users"
+        base_url={~p"/admin/users"}
         limit={@limit}
         total_count={@total_count}
         current_count={@current_count}
@@ -35,7 +35,7 @@ defmodule TeiserverWeb.PaginationComponents do
       <.pagination
         page={@page}
         total_pages={@total_pages}
-        base_url="/moderation/overwatch"
+        base_url={~p"/moderation/overwatch"}
         limit={@limit}
         total_count={@total_count}
         current_count={@current_count}
@@ -437,5 +437,73 @@ defmodule TeiserverWeb.PaginationComponents do
           Enum.to_list((current_page - half)..(current_page + half)) ++
           [:ellipsis, total_pages - 1]
     end
+  end
+
+  @doc """
+  Renders a pagination component with page numbers, navigation, and search parameter preservation. The parent is responsible for managing state and query parameters, the tw_pagination component purely renders the controls and sends events to the parent liveview.
+
+  ## Example
+
+      <.tw_pagination
+        page={@page}
+        page_count={@page_count}
+
+        # Optionally
+        size="md"
+      />
+
+  """
+  attr :page, :integer, required: true, doc: "The current page you are on, we start with page 0"
+
+  attr :page_count, :integer,
+    required: true,
+    doc: "The number of pages available to the entire dataset"
+
+  attr :size, :string,
+    values: ["xs", "sm", "md", "lg", "xl"],
+    default: "md",
+    doc: "The size class used for the pagination buttons"
+
+  def tw_pagination(%{page_count: page_count} = assigns) when page_count <= 1 do
+    ~H"""
+    """
+  end
+
+  def tw_pagination(assigns) do
+    ~H"""
+    <div class="join">
+      <button
+        class={["join-item btn btn-#{@size}", @page <= 0 && "btn-disabled"]}
+        phx-value-page="0"
+        phx-click="set-page"
+      >
+        <Fontawesome.icon icon="angles-left" style="regular" />
+      </button>
+      <button
+        class={["join-item btn btn-#{@size}", @page <= 0 && "btn-disabled"]}
+        phx-value-page={@page - 1}
+        phx-click="set-page"
+      >
+        <Fontawesome.icon icon="angle-left" style="regular" />
+      </button>
+      <button class={"join-item btn btn-#{@size}"}>
+        Page {@page + 1} of {@page_count}
+      </button>
+      <button
+        class={["join-item btn btn-#{@size}", @page >= @page_count - 1 && "btn-disabled"]}
+        phx-value-page={@page + 1}
+        phx-click="set-page"
+      >
+        <Fontawesome.icon icon="angle-right" style="regular" />
+      </button>
+      <button
+        class={["join-item btn btn-#{@size}", @page >= @page_count - 1 && "btn-disabled"]}
+        phx-value-page={@page_count - 1}
+        phx-click="set-page"
+      >
+        <Fontawesome.icon icon="angles-right" style="regular" />
+      </button>
+    </div>
+    """
   end
 end

--- a/lib/teiserver_web/live/admin/anti_abuse_record/list.ex
+++ b/lib/teiserver_web/live/admin/anti_abuse_record/list.ex
@@ -1,34 +1,128 @@
 defmodule TeiserverWeb.Admin.AntiAbuseRecordLive.List do
   @moduledoc false
+  alias Teiserver.Helper.QueryHelpers
   alias Teiserver.Moderation
   alias Teiserver.Moderation.AntiAbuseRecordQueries
   alias Teiserver.Repo
 
   use TeiserverWeb, :live_view
 
-  import Teiserver.Helper.StringHelper, only: [uuid_part: 1]
+  import Teiserver.Helper.StringHelper,
+    only: [uuid_part: 1, boolean_from_form: 1, maybe_to_integer: 1]
+
+  import Teiserver.Config, only: [get_user_config_cache: 2, set_user_config: 3]
+
+  @page_size_config_key "last_used.anti_abuse_search_page_size"
 
   @impl Phoenix.LiveView
-  def mount(_params, _session, %{assigns: %{scope: scope}} = socket) when is_connected?(socket) do
+  def mount(params, _session, %Socket{assigns: %{scope: scope}} = socket)
+      when is_connected?(socket) do
     Moderation.log_anti_abuse_record_access(nil, scope, :list)
 
+    socket
+    |> assign(page: 0)
+    |> init_search_params(params)
+    |> get_records()
+    |> get_record_count()
+    |> ok()
+  end
+
+  def mount(_params, _session, %Socket{} = socket) do
+    socket
+    |> assign(records: [], record_count: 0, page: 0, page_count: 1, search: %{})
+    |> ok()
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("set-page", %{"page" => page}, %Socket{} = socket) do
+    page = String.to_integer(page)
+
+    socket
+    |> assign(page: page)
+    |> get_records()
+    |> noreply()
+  end
+
+  def handle_event("validate-search", _params, %Socket{} = socket) do
+    socket
+    |> noreply()
+  end
+
+  def handle_event("update-search", params, %Socket{assigns: assigns} = socket) do
+    params = convert_search_params(params)
+
+    new_search = Map.merge(assigns.search, params)
+
+    set_user_config(socket, @page_size_config_key, params["page_size"])
+
+    socket
+    |> assign(search: new_search)
+    |> get_record_count()
+    |> get_records()
+    |> noreply()
+  end
+
+  def handle_event("reset-search", _params, %Socket{} = socket) do
+    socket
+    |> init_search_params(%{})
+    |> get_record_count()
+    |> get_records()
+    |> noreply()
+  end
+
+  defp init_search_params(%Socket{assigns: _assigns} = socket, params) do
+    params =
+      params
+      |> convert_search_params()
+      |> Map.merge(%{
+        "page_size" => get_user_config_cache(socket, @page_size_config_key)
+      })
+      |> Map.reject(fn {_k, v} -> is_nil(v) end)
+
+    socket
+    |> assign(search: params)
+  end
+
+  defp convert_search_params(params) do
+    %{
+      "user_id" => maybe_to_integer(params["user_id"]),
+      "page_size" => maybe_to_integer(params["page_size"]),
+      "clean?" => boolean_from_form(params["clean?"]),
+      "restored?" => boolean_from_form(params["restored?"]),
+      "restored_by_id" => params["restored_by_id"]
+    }
+  end
+
+  defp record_query(%Socket{assigns: %{search: search}} = _socket) do
+    AntiAbuseRecordQueries.anti_abuse_records()
+    |> AntiAbuseRecordQueries.where_user_id(search["user_id"])
+    |> AntiAbuseRecordQueries.where_clean(search["clean?"])
+    |> AntiAbuseRecordQueries.where_restored(search["restored?"])
+    |> AntiAbuseRecordQueries.where_restored_by_id(search["restored_by_id"])
+  end
+
+  defp get_records(%Socket{assigns: assigns} = socket) do
     records =
-      AntiAbuseRecordQueries.anti_abuse_records()
+      record_query(socket)
       |> AntiAbuseRecordQueries.load_user()
       |> AntiAbuseRecordQueries.load_restorer()
       |> AntiAbuseRecordQueries.order_by_inserted_at(:desc)
+      |> QueryHelpers.paginate(assigns.page, assigns.search["page_size"])
       |> Repo.all()
 
     socket
     |> assign(records: records)
-    |> ok()
   end
 
-  def mount(_params, _session, socket) do
-    records = []
+  defp get_record_count(%Socket{assigns: assigns} = socket) do
+    record_count =
+      record_query(socket)
+      |> QueryHelpers.count()
+
+    page_count = :math.ceil(record_count / assigns.search["page_size"]) |> round()
 
     socket
-    |> assign(records: records)
-    |> ok()
+    |> assign(record_count: record_count)
+    |> assign(page_count: page_count)
   end
 end

--- a/lib/teiserver_web/live/admin/anti_abuse_record/list.html.heex
+++ b/lib/teiserver_web/live/admin/anti_abuse_record/list.html.heex
@@ -2,10 +2,13 @@
   Anti-abuse records
 </h1>
 
+<TeiserverWeb.Admin.AntiAbuseRecordComponents.search_form params={@search} />
+
 <.table
   id="anti-abuse-records-table"
   rows={@records}
   table_class="table-sm table-zebra mt-4"
+  minimum_rows={min(@search["page_size"], @record_count)}
 >
   <:col :let={record} label="ID">{uuid_part(record.id)}</:col>
   <:col :let={record} label="User ID">{record.user.id}</:col>
@@ -22,3 +25,10 @@
     </.link>
   </:action>
 </.table>
+
+<div class="grid place-items-center mt-4">
+  <TeiserverWeb.PaginationComponents.tw_pagination
+    page={@page}
+    page_count={@page_count}
+  />
+</div>

--- a/lib/teiserver_web/live/battles/match/index.html.heex
+++ b/lib/teiserver_web/live/battles/match/index.html.heex
@@ -87,7 +87,7 @@
           <.pagination
             page={@page}
             total_pages={@total_pages}
-            base_url="/battle"
+            base_url={~p"/battle"}
             limit={@limit}
             total_count={@total_count}
             current_count={@current_count}

--- a/lib/teiserver_web/live/battles/match/ratings.html.heex
+++ b/lib/teiserver_web/live/battles/match/ratings.html.heex
@@ -158,8 +158,8 @@
         total_pages={@total_pages}
         base_url={
           if @rating_type == "Large Team",
-            do: "/battle/ratings",
-            else: "/battle/ratings/#{@rating_type}"
+            do: ~p"/battle/ratings",
+            else: ~p"/battle/ratings/#{@rating_type}"
         }
         limit={@limit}
         total_count={@total_count}

--- a/lib/teiserver_web/live_components/user_picker.ex
+++ b/lib/teiserver_web/live_components/user_picker.ex
@@ -5,16 +5,16 @@ defmodule TeiserverWeb.LiveComponents.UserPicker do
   It will submit the ID value of the selected user but will display the ID and name of the user.
 
   <.live_component
-      module={TeiserverWeb.LiveComponents.UserPicker}
-      id="user-picker"
-      field={@form[:smurf_user_id]}
-      label="User to link to:"
-    />
+    module={TeiserverWeb.LiveComponents.UserPicker}
+    id="user-picker"
+    field={@form[:smurf_user_id]}
+    label="User to link to:"
+  />
   """
+  alias Teiserver.Account
   alias Teiserver.Account.User
   alias Teiserver.Account.UserQueries
   alias Teiserver.Repo
-  alias TeiserverWeb.CoreComponents
 
   use TeiserverWeb, :live_component
 
@@ -38,11 +38,13 @@ defmodule TeiserverWeb.LiveComponents.UserPicker do
   def render(assigns) do
     ~H"""
     <div>
-      <CoreComponents.label :if={@label} for={@id}>{@label}</CoreComponents.label>
+      <label :if={@label} for={@id}>
+        <span class="label">{@label}</span>
+      </label>
       <div>
         <div class="join">
           <div
-            class="btn btn-success join-item user-picker-search-button"
+            class="btn btn-primary join-item user-picker-search-button"
             phx-click={
               JS.push("show-picker")
               |> JS.toggle(to: "##{@uniq_id}-picker-form")
@@ -55,7 +57,7 @@ defmodule TeiserverWeb.LiveComponents.UserPicker do
           <label class="input validator join-item">
             <input
               type="text"
-              class="input w-full min-w-lg"
+              class="input w-full min-w-xs"
               placeholder=""
               disabled
               name="none"
@@ -89,6 +91,16 @@ defmodule TeiserverWeb.LiveComponents.UserPicker do
   end
 
   def update(assigns, socket) do
+    # If we are given a user_id for the component but no user then we need to go
+    # get that user so we can render the component correct at first load
+    assigns =
+      if assigns.field.value != nil and assigns.field.value != "" and assigns[:value] == nil do
+        user = Account.get_user_by_id!(assigns.field.value)
+        Map.put(assigns, :value, user)
+      else
+        assigns
+      end
+
     socket
     |> assign(assigns)
     |> update_input_values()

--- a/lib/teiserver_web/templates/admin/match/index.html.heex
+++ b/lib/teiserver_web/templates/admin/match/index.html.heex
@@ -74,7 +74,7 @@
           <.pagination
             page={@page}
             total_pages={@total_pages}
-            base_url="/teiserver/admin/matches"
+            base_url={~p"/teiserver/admin/matches"}
             limit={@limit}
             total_count={@total_count}
             current_count={@current_count}

--- a/lib/teiserver_web/templates/admin/user/index.html.heex
+++ b/lib/teiserver_web/templates/admin/user/index.html.heex
@@ -133,7 +133,7 @@ is_moderator = allow?(@conn, "Moderator") %>
           <.pagination
             page={@page}
             total_pages={@total_pages}
-            base_url="/teiserver/admin/user"
+            base_url={~p"/teiserver/admin/user"}
             limit={@limit}
             total_count={@total_count}
             current_count={@current_count}

--- a/lib/teiserver_web/templates/moderation/action/index.html.heex
+++ b/lib/teiserver_web/templates/moderation/action/index.html.heex
@@ -84,7 +84,7 @@
           <.pagination
             page={@page}
             total_pages={@total_pages}
-            base_url="/moderation/action"
+            base_url={~p"/moderation/action"}
             limit={@limit}
             total_count={@total_count}
             current_count={@current_count}

--- a/lib/teiserver_web/templates/moderation/ban/index.html.heex
+++ b/lib/teiserver_web/templates/moderation/ban/index.html.heex
@@ -65,7 +65,7 @@
           <.pagination
             page={@page}
             total_pages={@total_pages}
-            base_url="/moderation/ban"
+            base_url={~p"/moderation/ban"}
             limit={@limit}
             total_count={@total_count}
             current_count={@current_count}

--- a/lib/teiserver_web/templates/moderation/report/index.html.heex
+++ b/lib/teiserver_web/templates/moderation/report/index.html.heex
@@ -156,7 +156,7 @@
           <.pagination
             page={@page}
             total_pages={@total_pages}
-            base_url="/moderation/report"
+            base_url={~p"/moderation/report"}
             limit={@limit}
             total_count={@total_count}
             current_count={@current_count}

--- a/lib/teiserver_web/templates/telemetry/infolog/index.html.heex
+++ b/lib/teiserver_web/templates/telemetry/infolog/index.html.heex
@@ -113,7 +113,7 @@
           <.pagination
             page={@page}
             total_pages={@total_pages}
-            base_url="/telemetry/infolog"
+            base_url={~p"/telemetry/infolog"}
             limit={@limit}
             total_count={@total_count}
             current_count={@current_count}

--- a/test/teiserver_web/live/moderation/action_live/smurf_link_test.exs
+++ b/test/teiserver_web/live/moderation/action_live/smurf_link_test.exs
@@ -51,7 +51,7 @@ defmodule TeiserverWeb.Live.Moderation.ActionLive.SmurfLinkTest do
         |> render()
 
       assert text_field_html ==
-               ~s(<input type="text" class="input w-full min-w-lg" placeholder="" disabled="" name="none" value="##{origin.id} - origin_user_testname"/>)
+               ~s(<input type="text" class="input w-full min-w-xs" placeholder="" disabled="" name="none" value="##{origin.id} - origin_user_testname"/>)
 
       hidden_field_html =
         view


### PR DESCRIPTION
* Updated some pagination links to use ~p sigil
* Expanded AAR list page with search and pagination
* Created a new tailwind pagination component, simpler than the
  bootstrap one
* Added the ability to put empty rows into a table component (to prevent
  pagination component jumping around)
* AAR search component and functionality should be easy to port to other
  pages and create a new pattern
* Added two new parsing functions to StringHelper, maybe_to_integer and
  boolean_from_form
* Minor UserPicker fixes
* Added paginate function to QueryHelpers