### PR TITLE
Add aiProfile command to long_battle_command_prefixes

### DIFF
--- a/lib/teiserver/protocols/spring/spring_in.ex
+++ b/lib/teiserver/protocols/spring/spring_in.ex
@@ -52,6 +52,7 @@ defmodule Teiserver.Protocols.SpringIn do
   # key=value pairs) and so get a 1024-char allowance instead of the default 256.
   @long_battle_command_prefixes [
     "$welcome-message",
+    "!aiProfile",
     "!welcome-message",
     "!mode ",
     "!bset mapmetadata"


### PR DESCRIPTION
When attempting to customize the BARbs by disabling many units, the resulting json gets truncated, resulting in an "Unable to parse profile info json dict" error. This is attributed to the fact that the aiProfile command is truncated at 256 chars. So any long list of disabledunits that would work in singleplayer cannot be used in multiplayer lobbies. 
This very simple PR adds the command to the already defined "whitelist" extending the char limit before truncation to 1,024 