### PR TITLE
Fix case in long_battle_command_prefixes

### DIFF
--- a/lib/teiserver/protocols/spring/spring_in.ex
+++ b/lib/teiserver/protocols/spring/spring_in.ex
@@ -52,7 +52,7 @@ defmodule Teiserver.Protocols.SpringIn do
   # key=value pairs) and so get a 1024-char allowance instead of the default 256.
   @long_battle_command_prefixes [
     "$welcome-message",
-    "!aiProfile",
+    "!aiprofile",
     "!welcome-message",
     "!mode ",
     "!bset mapmetadata"


### PR DESCRIPTION
Fix for my previous PR https://github.com/beyond-all-reason/teiserver/pull/1521 because I was blind and didn't notice that the chat message was lowercased (line 1244) but not the long_battle_command_prefix (during the check line 1255). Snippet for reference:

```ex
defp do_handle("SAYBATTLE", msg, _msg_id, state) do
    if Lobby.allow?(state.userid, :saybattle, state.lobby_id) do
      lowercase_msg = String.downcase(msg) # <<<<<<<< l.1244

      msg_sliced =
        cond do
          Auth.is_bot?(state.userid) ->
            msg

          String.starts_with?(lowercase_msg, "!bset tweakdefs") ||
              String.starts_with?(lowercase_msg, "!bset tweakunits") ->
            msg |> String.trim() |> String.slice(0..16_384)

          String.starts_with?(lowercase_msg, @long_battle_command_prefixes) -> # <<<<<< l.1255
            msg |> String.trim() |> String.slice(0..1024)

          true ->
            msg |> String.trim() |> String.slice(0..256)
        end
```