### PR TITLE
Email change fix

### DIFF
--- a/lib/teiserver/account/libs/user_lib.ex
+++ b/lib/teiserver/account/libs/user_lib.ex
@@ -270,7 +270,7 @@ defmodule Teiserver.Account.UserLib do
       Repo.transact(fn ->
         with %Changeset{valid?: true} = changeset <- User.changeset(user, attrs, :email),
              {:ok, %User{} = user} <- Repo.update(changeset),
-             {:ok, %{}} <- EmailHelper.email_changed(user) do
+             {:ok, _any} <- EmailHelper.email_changed(user) do
           Logging.add_audit_log(user.id, ip_address, "email_change_success", %{})
 
           {:ok, user}


### PR DESCRIPTION
We got a success result of `{:ok, "OK id=REDACTED\r\n"}` but were expecting to match on a map. Given we don't use the map we now match purely on the :ok pair.