### PR TITLE
First stage of GDPR forget and restore task

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -161,5 +161,6 @@
   {"lib/teiserver/account/tasks/merge_accounts_task.ex", :no_return},
   {"test/support/fixtures/moderation_fixtures.ex"},
   {"lib/teiserver/moderation.ex"},
-  {"lib/teiserver_web/live/battles/match/show.ex"}
+  {"lib/teiserver_web/live/battles/match/show.ex"},
+  {"lib/teiserver/moderation/tasks/create_anti_abuse_record_task.ex"}
 ]

--- a/lib/teiserver/moderation/queries/anti_abuse_record_queries.ex
+++ b/lib/teiserver/moderation/queries/anti_abuse_record_queries.ex
@@ -57,6 +57,12 @@ defmodule Teiserver.Moderation.AntiAbuseRecordQueries do
       where: anti_abuse_records.restored_by_id == ^id
   end
 
+  @spec where_identifier(t(), String.t(), String.t()) :: t()
+  def where_identifier(query, identifier_type, identifier) do
+    from anti_abuse_records in query,
+      where: fragment("? ->> ? = ?", anti_abuse_records.hashes, ^identifier_type, ^identifier)
+  end
+
   @spec load_user(t()) :: t()
   def load_user(query) do
     from anti_abuse_records in query,

--- a/lib/teiserver/moderation/tasks/create_anti_abuse_record_task.ex
+++ b/lib/teiserver/moderation/tasks/create_anti_abuse_record_task.ex
@@ -1,0 +1,155 @@
+defmodule Teiserver.Moderation.CreateAntiAbuseRecordTask do
+  @moduledoc """
+  Given a user, create an Anti-Abuse record.
+
+  The core data (smurf keys, avoids etc) is stored as an encrypted blob of JSON. If we have
+  `encryption_key` we are able to decrypt it at a later stage, without `encryption_key`
+  we cannot decrypt it.
+
+  We then store `encryption_key` encrypted by each of the different identifiers
+  (email, discord, steam) meaning a user is able to restore their data through use
+  of said identifier but without the correct identifier you are unable to unlock and
+  thus access the data.
+
+  For more information about the Decryption process, see RestoreForgottenUserTask
+  """
+  alias Teiserver.Account
+  alias Teiserver.Account.Scope
+  alias Teiserver.Account.User
+  alias Teiserver.Moderation
+  alias Teiserver.Moderation.AntiAbuseRecord
+
+  @aad "teiserver-anti-abuse"
+
+  # A static salt so we can search the table based on a unique identifier for restoration
+  # if needed
+  @salt <<140, 38, 122, 4, 158, 123, 156, 216, 168, 10, 242, 248, 51, 40, 202, 130>>
+
+  @spec create_anti_abuse_record_from_user_id(User.id(), Scope.t(), String.t()) ::
+          {:ok, AntiAbuseRecord.t()} | {:error, any()}
+  def create_anti_abuse_record_from_user_id(user_id, %Scope{} = scope, notes) do
+    %User{} = user = Account.get_user!(user_id)
+
+    # The key we will use to encrypt the data in the record
+    encryption_key = :crypto.strong_rand_bytes(32)
+
+    # The main data in the record
+    restore_data =
+      get_restore_data(user)
+      |> Jason.encode!()
+      |> aes_encrypt(encryption_key)
+
+    # The user is considered clean if they have no active restrictions on their account
+    clean? = Enum.empty?(user.restrictions)
+
+    # If clean record then expire in 2 years, if not then
+    # expire in 5 years or when the restriction expires
+    expires_at =
+      if clean? do
+        DateTime.utc_now()
+        |> DateTime.shift(year: 2)
+      else
+        five_years =
+          DateTime.utc_now()
+          |> DateTime.shift(year: 5)
+
+        # Whichever is greater is the one we use
+        if DateTime.compare(five_years, user.restricted_until) == :gt do
+          five_years
+        else
+          user.restricted_until
+        end
+      end
+
+    # To allow us to retrieve the encryption_key we will encrypt it once for every identifier
+    # we have, we need to make keys from each of the identifiers for the encryption process
+    email_key = key_from_string(user.email)
+    discord_key = user.discord_id && key_from_string(user.discord_id)
+    steam_key = user.steam_id && key_from_string(user.steam_id)
+
+    hashes = %{
+      email: Base.encode64(email_key),
+      discord_id: discord_key && Base.encode64(discord_key),
+      steam_id: steam_key && Base.encode64(steam_key),
+      decrypt_keys: %{
+        email: aes_encrypt(encryption_key, email_key),
+        discord_id: discord_key && aes_encrypt(encryption_key, discord_key),
+        steam_id: steam_key && aes_encrypt(encryption_key, steam_key)
+      },
+      restore_data: restore_data
+    }
+
+    # The attributes we will be using to create the record
+    attrs = %{
+      user_id: user_id,
+      expires_at: expires_at,
+      clean: clean?,
+      hashes: hashes,
+      notes: notes
+    }
+
+    Moderation.create_anti_abuse_record(attrs, scope)
+  end
+
+  def get_restore_data(%User{} = _user) do
+    %{
+      avoided_by: [],
+      blocked_by: [],
+      ignored_by: [],
+      smurf_keys: []
+    }
+  end
+
+  @doc """
+  Used to create an AES encryption key from a given string.
+  """
+  def key_from_string(key) do
+    :crypto.pbkdf2_hmac(
+      :sha256,
+      key,
+      @salt,
+      600_000,
+      32
+    )
+  end
+
+  @doc """
+  Given a message and encryption key will return an encrypted message.
+  """
+  def aes_encrypt(message, key) when byte_size(key) == 32 do
+    # Using an initialisation vector means even if we encrypted
+    # the same value multiple times we will get a different ciphertext
+    iv = :crypto.strong_rand_bytes(12)
+
+    {ciphertext, tag} =
+      :crypto.crypto_one_time_aead(
+        :aes_256_gcm,
+        key,
+        iv,
+        message,
+        @aad,
+        true
+      )
+
+    Base.encode64(iv <> tag <> ciphertext)
+  end
+
+  @doc """
+  Inverse to aes_encrypt, given encrypted data and a key it will
+  decrypt the data.
+  """
+  def aes_decrypt(encoded_data, key) when byte_size(key) == 32 do
+    <<iv::binary-size(12), tag::binary-size(16), ciphertext::binary>> =
+      Base.decode64!(encoded_data)
+
+    :crypto.crypto_one_time_aead(
+      :aes_256_gcm,
+      key,
+      iv,
+      ciphertext,
+      @aad,
+      tag,
+      false
+    )
+  end
+end

--- a/lib/teiserver/moderation/tasks/restore_forgotten_user_task.ex
+++ b/lib/teiserver/moderation/tasks/restore_forgotten_user_task.ex
@@ -1,0 +1,77 @@
+defmodule Teiserver.Moderation.RestoreForgottenUserTask do
+  @moduledoc """
+  The flip side of CreateAntiAbuseRecordTask, given an anti-abuse record
+  restore the user using the decryption key.
+
+  We use an identifier (email, discord_id, steam_id) and look for a record with the
+  hashed value of said identifier. With said identifier we can then retrieve the `encryption_key` which allows us to then decrypt the data used to restore the User.
+
+  At this stage we do not actually restore the User.
+
+  See CreateAntiAbuseRecordTask for more information about the creation/storage process.
+  """
+  alias Teiserver.Moderation.AntiAbuseRecord
+  alias Teiserver.Moderation.AntiAbuseRecordQueries
+  alias Teiserver.Moderation.CreateAntiAbuseRecordTask
+  alias Teiserver.Repo
+
+  import Teiserver.Moderation.CreateAntiAbuseRecordTask, only: [key_from_string: 1]
+
+  @spec find_record_from_identifier(:email | :steam_id | :discord_id, String.t()) ::
+          {:ok, AntiAbuseRecord.t()} | {:error, String.t()}
+  def find_record_from_identifier(:email, email) do
+    lookup_value =
+      email
+      |> key_from_string()
+      |> Base.encode64()
+
+    AntiAbuseRecordQueries.anti_abuse_records()
+    |> AntiAbuseRecordQueries.where_identifier("email", lookup_value)
+    |> Repo.one()
+  end
+
+  def find_record_from_identifier(:discord_id, discord_id) do
+    lookup_value =
+      discord_id
+      |> key_from_string()
+      |> Base.encode64()
+
+    AntiAbuseRecordQueries.anti_abuse_records()
+    |> AntiAbuseRecordQueries.where_identifier("discord_id", lookup_value)
+    |> Repo.one()
+  end
+
+  def find_record_from_identifier(:steam_id, steam_id) do
+    lookup_value =
+      steam_id
+      |> key_from_string()
+      |> Base.encode64()
+
+    AntiAbuseRecordQueries.anti_abuse_records()
+    |> AntiAbuseRecordQueries.where_identifier("steam_id", lookup_value)
+    |> Repo.one()
+  end
+
+  defp retrieve_data_from_record(%AntiAbuseRecord{} = record, encryption_key) do
+    # Now we have the encryption_key
+    record.hashes["restore_data"]
+    |> CreateAntiAbuseRecordTask.aes_decrypt(encryption_key)
+    |> Jason.decode!()
+  end
+
+  def restore_from_record(%AntiAbuseRecord{} = record, identifier_type, identifier_value) do
+    key_from_identifier = key_from_string(identifier_value)
+
+    encryption_key =
+      record.hashes["decrypt_keys"]
+      |> Map.get(to_string(identifier_type))
+      |> CreateAntiAbuseRecordTask.aes_decrypt(key_from_identifier)
+
+    data = retrieve_data_from_record(record, encryption_key)
+
+    # We do not currently actually restore the data, this will
+    # come with a later update. For now we return the data to show
+    # this has worked.
+    data
+  end
+end

--- a/test/teiserver/moderation/gdpr_forget_and_restore_test.exs
+++ b/test/teiserver/moderation/gdpr_forget_and_restore_test.exs
@@ -1,0 +1,107 @@
+defmodule Teiserver.Moderation.GDPRForgetAndRestoreTest do
+  alias Teiserver.AccountFixtures
+  alias Teiserver.Helpers.GeneralTestLib
+  alias Teiserver.Logging.LoggingTestLib
+  alias Teiserver.Moderation
+  alias Teiserver.Moderation.AntiAbuseRecord
+  alias Teiserver.Moderation.CreateAntiAbuseRecordTask
+  alias Teiserver.Moderation.RefreshUserRestrictionsTask
+  alias Teiserver.Moderation.RestoreForgottenUserTask
+
+  use Teiserver.DataCase, async: false
+
+  test "GDPR forget and restore" do
+    # Create a user, forget them, restore them
+    user = AccountFixtures.user_fixture()
+    admin = AccountFixtures.user_fixture()
+    scope = GeneralTestLib.scope_fixture(admin)
+
+    # Need to define this as a value since we can't later use it inside
+    # a match
+    user_id = user.id
+
+    {:ok, _action} =
+      Moderation.create_action(%{
+        target_id: user.id,
+        reason: "reason",
+        restrictions: ["Login"],
+        expires: DateTime.utc_now() |> DateTime.shift(year: 1),
+        score_modifier: 0
+      })
+
+    RefreshUserRestrictionsTask.refresh_user(user.id)
+
+    {:ok, %AntiAbuseRecord{} = record} =
+      CreateAntiAbuseRecordTask.create_anti_abuse_record_from_user_id(
+        user.id,
+        scope,
+        "no notes"
+      )
+
+    # We will test the contents shortly but for now we want to be sure
+    # we have not created keys in the wrong places
+    assert match?(
+             %{
+               user_id: ^user_id,
+               clean: false,
+               notes: "no notes",
+               restored_by_id: nil,
+               restored_at: nil,
+               hashes: %{
+                 email: "" <> _email,
+                 discord_id: nil,
+                 steam_id: nil,
+                 decrypt_keys: %{
+                   email: "" <> _email_key,
+                   discord_id: nil,
+                   steam_id: nil
+                 },
+                 restore_data: "" <> _encrypted_data
+               }
+             },
+             record
+           )
+
+    # Assert we have created the audit log too
+    audit_log = LoggingTestLib.get_most_recent_audit_log_for_user(admin.id)
+
+    assert match?(
+             %{
+               action: "Anti-abuse record access",
+               details: %{"action" => "create"}
+             },
+             audit_log
+           )
+
+    # Stage 2: Forget the user
+    # TODO
+
+    # Next up, we need to ensure we can find the record
+    assert is_nil(RestoreForgottenUserTask.find_record_from_identifier(:discord_id, user.email))
+    assert is_nil(RestoreForgottenUserTask.find_record_from_identifier(:steam_id, user.email))
+
+    found_record = RestoreForgottenUserTask.find_record_from_identifier(:email, user.email)
+
+    # The items are not identical because the record hashes uses atoms for keys as it
+    # is from the changeset, both having the same ID is acceptable as a check because we use UUIDs
+    # for AARs and as such won't accidentally end up with an identical ID
+    assert found_record.id == record.id
+
+    # Assert that this has not come back in an unencrypted format
+    assert match?(
+             {:error, %Jason.DecodeError{}},
+             Jason.decode(found_record.hashes["restore_data"])
+           )
+
+    # Now can we restore it?
+    # TODO actually restore it, for now we just want to ensure the decode process works
+    restore_data = RestoreForgottenUserTask.restore_from_record(found_record, :email, user.email)
+
+    assert restore_data == %{
+             "avoided_by" => [],
+             "blocked_by" => [],
+             "ignored_by" => [],
+             "smurf_keys" => []
+           }
+  end
+end


### PR DESCRIPTION
Provides the scaffolding around forgetting and restoring users, ensuring the forgotten data is encrypted appropriately.