### PR TITLE
Altered login flow for users with gdpr_forget_after set

### DIFF
--- a/lib/teiserver/account/libs/user_lib.ex
+++ b/lib/teiserver/account/libs/user_lib.ex
@@ -604,6 +604,9 @@ defmodule Teiserver.Account.UserLib do
       Account.get_user_totp_status(user.id) == :active ->
         {:requires_mfa, user}
 
+      gdpr_forget_in_progress?(user) ->
+        {:gdpr_forget_is_set, user}
+
       true ->
         :ok
     end
@@ -682,5 +685,14 @@ defmodule Teiserver.Account.UserLib do
       {:ok, :ok} -> :ok
       error -> error
     end
+  end
+
+  @doc """
+  If a GDPR forget is in progress then we can't let the user login via the game client
+  and they must instead login via the website to explicitly cancel the forget process
+  or have the process cancelled by a Moderator.
+  """
+  def gdpr_forget_in_progress?(%User{gdpr_forget_after: gdpr_forget_after}) do
+    not is_nil(gdpr_forget_after)
   end
 end

--- a/lib/teiserver/account/plugs/auth_plug.ex
+++ b/lib/teiserver/account/plugs/auth_plug.ex
@@ -2,16 +2,13 @@ defmodule Teiserver.Account.AuthPlug do
   @moduledoc false
 
   alias ExULID.ULID
-  alias Phoenix.Component
   alias Phoenix.Controller
   alias Phoenix.LiveView
   alias Phoenix.LiveView.Utils
   alias Teiserver.Account
-  alias Teiserver.Account.AuthLib
   alias Teiserver.Account.Guardian
   alias Teiserver.Account.Guardian.Plug, as: GuardianPlug
   alias Teiserver.Account.TOTPLib
-  alias Teiserver.Plugs.CachePlug
 
   use TeiserverWeb, :verified_routes
 
@@ -104,94 +101,4 @@ defmodule Teiserver.Account.AuthPlug do
         false
     end
   end
-
-  @doc """
-  Handles mounting and authenticating the current_user in LiveViews.
-
-  ## `on_mount` arguments
-
-    * `:mount_current_user` - Assigns current_user
-      to socket assigns based on user_token, or nil if
-      there's no user_token or no matching user.
-
-    * `:ensure_authenticated` - Authenticates the user from the session,
-      and assigns the current_user to socket assigns based
-      on user_token.
-      Redirects to login page if there's no logged user.
-
-    * `:redirect_if_user_is_authenticated` - Authenticates the user from the session.
-      Redirects to signed_in_path if there's a logged user.
-
-  ## Examples
-
-  Use the `on_mount` lifecycle macro in LiveViews to mount or authenticate
-  the current_user:
-
-      defmodule ApolloWeb.PageLive do
-
-        use ApolloWeb, :live_view
-
-        on_mount {ApolloWeb.UserAuth, :mount_current_user}
-        ...
-      end
-
-  Or use the `live_session` of your router to invoke the on_mount callback:
-
-      live_session :authenticated, on_mount: [{ApolloWeb.UserAuth, :ensure_authenticated}] do
-        live "/profile", ProfileLive, :index
-      end
-  """
-  def on_mount(:mount_current_user, _params, session, socket) do
-    {:cont, mount_current_user(socket, session)}
-  end
-
-  def on_mount(:ensure_authenticated, _params, session, socket) do
-    socket = mount_current_user(socket, session)
-
-    if socket.assigns.current_user do
-      {:cont, socket}
-    else
-      socket =
-        socket
-        |> LiveView.put_flash(:error, "You must log in to access this page.")
-        |> LiveView.redirect(to: ~p"/login")
-
-      {:halt, socket}
-    end
-  end
-
-  def on_mount(:redirect_if_user_is_authenticated, _params, session, socket) do
-    socket = mount_current_user(socket, session)
-
-    if socket.assigns.current_user do
-      {:halt, LiveView.redirect(socket, to: signed_in_path(socket))}
-    else
-      {:cont, socket}
-    end
-  end
-
-  def on_mount({:authorise, permissions}, _params, _session, socket) do
-    if AuthLib.allow?(socket.assigns.current_user, permissions) do
-      {:cont, socket}
-    else
-      socket =
-        socket
-        |> LiveView.put_flash(:error, "You do not have permission to view that page.")
-        |> LiveView.redirect(to: ~p"/")
-
-      {:halt, socket}
-    end
-  end
-
-  defp mount_current_user(socket, session) do
-    Component.assign_new(socket, :current_user, fn ->
-      case Guardian.resource_from_token(session["guardian_default_token"]) do
-        {:ok, user, _claims} -> Account.get_user!(user.id)
-        _error -> nil
-      end
-    end)
-    |> CachePlug.live_call()
-  end
-
-  defp signed_in_path(_conn), do: ~p"/"
 end

--- a/lib/teiserver/data/cache_user.ex
+++ b/lib/teiserver/data/cache_user.ex
@@ -824,15 +824,6 @@ defmodule Teiserver.CacheUser do
         {:error, "No user found for '#{username}'"}
 
       user ->
-        # # If they're a smurf, log them in as the smurf!
-        # {user, username} =
-        #   if user.smurf_of_id != nil do
-        #     origin_user = deprecated_get_user_by_id(user.smurf_of_id)
-
-        #     {origin_user, origin_user.name}
-        #   else
-        #     {user, user.name}
-        #   end
         db_user = Account.get_user(user.id)
 
         cond do
@@ -894,6 +885,13 @@ defmodule Teiserver.CacheUser do
             })
 
             {:error, "Unverified", user.id}
+
+          # This is also defined in UserLib but that imports CacheUser so we
+          # repeat it here as we don't want a circular dependency and the plan is to remove
+          # this module later.
+          not is_nil(db_user.gdpr_forget_after) ->
+            host = Application.get_env(:teiserver, TeiserverWeb.Endpoint)[:url][:host]
+            {:error, "You must login via the website to activate this account - #{host}/login"}
 
           true ->
             if Client.get_client_by_id(user.id) != nil do
@@ -977,6 +975,13 @@ defmodule Teiserver.CacheUser do
         :telemetry.execute([:tachyon, :login, :error], %{count: 1}, %{reason: :not_verified})
 
         {:error, "Account is not verified"}
+
+      # This is also defined in UserLib but that imports CacheUser so we
+      # repeat it here as we don't want a circular dependency and the plan is to remove
+      # this module later.
+      not is_nil(db_user.gdpr_forget_after) ->
+        host = Application.get_env(:teiserver, TeiserverWeb.Endpoint)[:url][:host]
+        {:error, "You must login via the website to activate this account - #{host}/login"}
 
       true ->
         # TODO: copy/paste the capacity restriction and queuing from try_md5_login later

--- a/lib/teiserver_web/controllers/account/session_controller.ex
+++ b/lib/teiserver_web/controllers/account/session_controller.ex
@@ -7,9 +7,12 @@ defmodule TeiserverWeb.Account.SessionController do
   alias Teiserver.Config
   alias Teiserver.EmailHelper
   alias Teiserver.Helper.DateHelper
+  alias Teiserver.Logging.AuditLog
   alias Teiserver.Logging.Helpers, as: LoggingHelpers
   alias Teiserver.Logging.LoggingPlug
+
   use TeiserverWeb, :controller
+
   require Logger
 
   @spec new(Conn.t(), map()) :: Conn.t()
@@ -48,6 +51,11 @@ defmodule TeiserverWeb.Account.SessionController do
         conn
         |> put_session(:pending_mfa_user_id, user.id)
         |> redirect(to: ~p"/otp")
+
+      {:gdpr_forget_is_set, user} ->
+        conn
+        |> put_session(:gdpr_forget_user_id, user.id)
+        |> redirect(to: ~p"/gdpr_forget")
 
       {:error, reason} ->
         login_reply({:error, reason}, conn)
@@ -379,6 +387,59 @@ defmodule TeiserverWeb.Account.SessionController do
               value: value
             )
         end
+    end
+  end
+
+  @spec gdpr_forget_warning(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def gdpr_forget_warning(conn, _params) do
+    user_id = get_session(conn, :gdpr_forget_user_id)
+    %User{} = user = Account.get_user!(user_id)
+
+    # Need to assign it for the audit log to attach to the correct user though
+    # they are not logged in at this point
+    conn =
+      conn
+      |> assign(:current_user, user)
+
+    if UserLib.gdpr_forget_in_progress?(user) do
+      %AuditLog{} = LoggingHelpers.add_audit_log(conn, "GDPR forget login warning", %{})
+      website_url = Application.get_env(:teiserver, Teiserver)[:main_website]
+
+      conn
+      |> assign(:user, user)
+      |> assign(:website_url, website_url)
+      |> render("gdpr_forget_warning.html")
+    else
+      conn
+      |> redirect(to: ~p"/login")
+    end
+  end
+
+  @spec gdpr_forget_cancel_confirm(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def gdpr_forget_cancel_confirm(conn, _params) do
+    user_id = get_session(conn, :gdpr_forget_user_id)
+    %User{} = user = Account.get_user(user_id)
+
+    # Need to assign it for the audit log to attach to the correct user though
+    # they are not logged in at this point
+    conn =
+      conn
+      |> assign(:current_user, user)
+
+    with {:ok, %User{gdpr_forget_after: nil}} <- UserLib.clear_gdpr_forget(user),
+         %AuditLog{} <- LoggingHelpers.add_audit_log(conn, "Self-cleared GDPR forget", %{}) do
+      conn
+      |> put_flash(:success, "GDPR forget process cancelled, you can login normally again.")
+      |> redirect(to: ~p"/login")
+    else
+      error_result ->
+        Logger.error(
+          "Unable to execute gdpr_forget_cancel_confirm page, got: #{inspect(error_result)}"
+        )
+
+        conn
+        |> put_flash(:error, "Unable to cancel GDPR forget process. Please raise a ticket.")
+        |> redirect(to: ~p"/gdpr_forget")
     end
   end
 end

--- a/lib/teiserver_web/router.ex
+++ b/lib/teiserver_web/router.ex
@@ -86,7 +86,7 @@ defmodule TeiserverWeb.Router do
 
     live_session :general_index,
       on_mount: [
-        {Teiserver.Account.AuthPlug, :ensure_authenticated}
+        {UserAuthentication, :ensure_authenticated}
       ] do
       live "/", HomeLive.Index, :index
     end
@@ -99,7 +99,7 @@ defmodule TeiserverWeb.Router do
 
     live_session :microblog_root,
       on_mount: [
-        {Teiserver.Account.AuthPlug, :mount_current_user}
+        {UserAuthentication, :mount_current_user}
       ] do
       live "/", BlogLive.Index, :index
       live "/all", BlogLive.Index, :all
@@ -112,15 +112,15 @@ defmodule TeiserverWeb.Router do
 
     live_session :microblog_user,
       on_mount: [
-        {Teiserver.Account.AuthPlug, :ensure_authenticated}
+        {UserAuthentication, :ensure_authenticated}
       ] do
       live "/preferences", BlogLive.Preferences, :index
     end
 
     live_session :microblog_admin,
       on_mount: [
-        {Teiserver.Account.AuthPlug, :ensure_authenticated},
-        {Teiserver.Account.AuthPlug, {:authorise, "Contributor"}}
+        {UserAuthentication, :ensure_authenticated},
+        {UserAuthentication, {:authorise, "Contributor"}}
       ] do
       live "/admin/posts", Admin.PostLive.Index, :index
       live "/admin/posts/:id", Admin.PostLive.Show, :show
@@ -135,6 +135,13 @@ defmodule TeiserverWeb.Router do
   scope "/microblog", TeiserverWeb.Microblog do
     get "/rss", RssController, :index
     get "/rss/html", RssController, :html_mode
+  end
+
+  scope "/", TeiserverWeb.Account do
+    pipe_through([:browser, :nomenu_layout, :tailwind])
+
+    get("/gdpr_forget", SessionController, :gdpr_forget_warning)
+    post("/gdpr_forget", SessionController, :gdpr_forget_cancel_confirm)
   end
 
   scope "/", TeiserverWeb.Account, as: :account do
@@ -230,7 +237,7 @@ defmodule TeiserverWeb.Router do
 
     live_session :relationships,
       on_mount: [
-        {Teiserver.Account.AuthPlug, :ensure_authenticated}
+        {UserAuthentication, :ensure_authenticated}
       ] do
       live "/relationship", RelationshipLive.Index, :friend
       live "/relationship/friend", RelationshipLive.Index, :friend
@@ -242,7 +249,7 @@ defmodule TeiserverWeb.Router do
 
     live_session :account_settings,
       on_mount: [
-        {Teiserver.Account.AuthPlug, :ensure_authenticated}
+        {UserAuthentication, :ensure_authenticated}
       ] do
       live "/settings", SettingsLive.Index, :index
       live "/settings/:key", SettingsLive.Index, :selected
@@ -254,7 +261,7 @@ defmodule TeiserverWeb.Router do
 
     live_session :profiles,
       on_mount: [
-        {Teiserver.Account.AuthPlug, :mount_current_user}
+        {UserAuthentication, :mount_current_user}
       ] do
       live "/", ProfileLive.Self, :index
       live "/name/:username", ProfileLive.Username, :index
@@ -268,8 +275,8 @@ defmodule TeiserverWeb.Router do
 
     live_session :authed_profiles,
       on_mount: [
-        {Teiserver.Account.AuthPlug, :mount_current_user},
-        {Teiserver.Account.AuthPlug, :ensure_authenticated}
+        {UserAuthentication, :mount_current_user},
+        {UserAuthentication, :ensure_authenticated}
       ] do
       live "/:userid/appearance", ProfileLive.Appearance, :appearance
       live "/:userid/relationships", ProfileLive.Relationships, :relationships
@@ -282,7 +289,7 @@ defmodule TeiserverWeb.Router do
 
     live_session :maps,
       on_mount: [
-        {Teiserver.Account.AuthPlug, :mount_current_user}
+        {UserAuthentication, :mount_current_user}
       ] do
       live "/", Index, :index
     end
@@ -322,7 +329,7 @@ defmodule TeiserverWeb.Router do
 
     live_session :board_view,
       on_mount: [
-        {Teiserver.Account.AuthPlug, :ensure_authenticated}
+        {UserAuthentication, :ensure_authenticated}
       ] do
       live "/ratings", MatchLive.Ratings, :index
       live "/ratings/:rating_type", MatchLive.Ratings, :index
@@ -471,7 +478,7 @@ defmodule TeiserverWeb.Router do
 
     live_session :report_user,
       on_mount: [
-        {Teiserver.Account.AuthPlug, :mount_current_user}
+        {UserAuthentication, :mount_current_user}
       ] do
       live "/report_user", ReportUserLive.Index, :index
       live "/report_user/:id", ReportUserLive.Index, :selected
@@ -504,7 +511,7 @@ defmodule TeiserverWeb.Router do
     resources("/ban", BanController, only: [:index, :show, :new, :create, :edit, :update])
   end
 
-  scope "/moderation", TeiserverWeb.ModerationLive, as: :moderation do
+  scope "/moderation", TeiserverWeb.ModerationLive do
     pipe_through([:live_browser, :app_layout, :protected, :tailwind])
 
     live_session :moderation_menu,
@@ -606,7 +613,7 @@ defmodule TeiserverWeb.Router do
 
     live_session :chat_liveview,
       on_mount: [
-        {Teiserver.Account.AuthPlug, :ensure_authenticated}
+        {UserAuthentication, :ensure_authenticated}
       ] do
       live "/", ChatLive.Index, :index
       live "/room", ChatLive.Room, :index
@@ -641,16 +648,16 @@ defmodule TeiserverWeb.Router do
 
     live_session :admin_chat_liveview,
       on_mount: [
-        {Teiserver.Account.AuthPlug, :ensure_authenticated},
-        {Teiserver.Account.AuthPlug, {:authorise, "Reviewer"}}
+        {UserAuthentication, :ensure_authenticated},
+        {UserAuthentication, {:authorise, "Reviewer"}}
       ] do
       live "/chat", ChatLive.Index, :index
     end
 
     live_session :admin_matchmaking_liveview,
       on_mount: [
-        {Teiserver.Account.AuthPlug, :ensure_authenticated},
-        {Teiserver.Account.AuthPlug, {:authorise, "Admin"}}
+        {UserAuthentication, :ensure_authenticated},
+        {UserAuthentication, {:authorise, "Admin"}}
       ] do
       live "/matchmaking", MatchmakingLive.Index, :index
     end
@@ -733,8 +740,8 @@ defmodule TeiserverWeb.Router do
 
     live_session :admin_bot_liveview,
       on_mount: [
-        {Teiserver.Account.AuthPlug, :ensure_authenticated},
-        {Teiserver.Account.AuthPlug, {:authorise, "Admin"}}
+        {UserAuthentication, :ensure_authenticated},
+        {UserAuthentication, {:authorise, "Admin"}}
       ] do
       live "/bot", BotLive.Index, :index
       live "/bot/new", BotLive.Index, :new

--- a/lib/teiserver_web/templates/account/session/gdpr_forget_warning.html.heex
+++ b/lib/teiserver_web/templates/account/session/gdpr_forget_warning.html.heex
@@ -1,0 +1,30 @@
+<div class="hero bg-base-200 min-h-screen">
+  <div
+    class="hero-content text-center text-neutral"
+    style="background-color: oklab(0.9856 0.00146784 0.0150486);"
+  >
+    <div class="max-w-600">
+      <h1 class="text-5xl font-bold">Your account is scheduled for deletion</h1>
+      <div class="p-6 m-4 text-lg text-left">
+        You asked us to delete your Beyond All Reason account <span class="font-bold">{@user.name}</span>. It is scheduled for permanent deletion on <span class="font-bold">{Calendar.strftime(@user.gdpr_forget_after, "%Y-%m-%d %I:%M:%S")} UTC</span>. Nothing has been deleted yet.
+        <br /><br /> Logging in now cancels that request and keeps your account. <br /><br />
+        If you still want your account deleted, do not log in. Close this page and the deletion goes ahead on <span class="font-bold">{Calendar.strftime(@user.gdpr_forget_after, "%Y-%m-%d %I:%M:%S")} UTC</span>.
+      </div>
+
+      <form method="POST">
+        <input type="hidden" name="_csrf_token" value={Phoenix.Controller.get_csrf_token()} />
+
+        <div class="flex">
+          <div class="flex-1">
+            <a href={@website_url} class="btn btn-lg btn-secondary min-w-100">
+              Keep deletion scheduled
+            </a>
+          </div>
+          <div class="flex-1">
+            <button class="btn btn-lg btn-warning min-w-100">Cancel deletion and log in</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/lib/teiserver_web/user_authentication.ex
+++ b/lib/teiserver_web/user_authentication.ex
@@ -59,16 +59,39 @@ defmodule TeiserverWeb.UserAuthentication do
 
   def on_mount(:ensure_authenticated, _params, session, socket) do
     socket = mount_current_user(socket, session)
+    user = socket.assigns[:current_user]
 
-    if socket.assigns.current_user do
-      {:cont, socket}
-    else
-      socket =
-        socket
-        |> LiveView.put_flash(:error, "You must log in to access this page.")
-        |> LiveView.redirect(to: ~p"/login")
+    cond do
+      # Not logged in
+      is_nil(user) ->
+        socket =
+          socket
+          |> LiveView.put_flash(:error, "You must log in to access this page.")
+          |> LiveView.redirect(to: ~p"/login")
 
-      {:halt, socket}
+        {:halt, socket}
+
+      # GDPR forget is set, we need to log them out to force them
+      # into the cancel-flow option
+      not is_nil(user.gdpr_forget_after) ->
+        socket =
+          socket
+          |> LiveView.redirect(to: ~p"/logout")
+
+        {:halt, socket}
+
+      # Banned
+      Account.restricted?(user, ["Login"]) ->
+        socket =
+          socket
+          |> LiveView.put_flash(:error, "Your account is banned and cannot login.")
+          |> LiveView.redirect(to: ~p"/")
+
+        {:halt, socket}
+
+      # All good, lets carry on
+      true ->
+        {:cont, socket}
     end
   end
 
@@ -118,12 +141,16 @@ defmodule TeiserverWeb.UserAuthentication do
           nil
       end
 
-    Component.assign_new(socket, :current_user, fn -> user end)
+    socket
+    |> Component.assign_new(:current_user, fn -> user end)
+    |> Component.assign_new(:tz, fn -> nil end)
     |> fetch_current_scope_for_user()
   end
 
   defp mount_current_user(socket, _session) do
-    Component.assign_new(socket, :current_user, fn -> nil end)
+    socket
+    |> Component.assign_new(:current_user, fn -> nil end)
+    |> Component.assign_new(:tz, fn -> nil end)
   end
 
   @doc """

--- a/test/teiserver/account/user_lib_test.exs
+++ b/test/teiserver/account/user_lib_test.exs
@@ -383,7 +383,7 @@ defmodule Teiserver.Account.UserLibTest do
     end
   end
 
-  describe "changesets" do
+  describe "gdpr_forget" do
     test "clear_gdpr_forget_changeset and set_gdpr_forget_changeset" do
       user = AccountFixtures.user_fixture()
       now = DateTime.utc_now(:second)

--- a/test/teiserver_web/live/general/home/index_live_test.exs
+++ b/test/teiserver_web/live/general/home/index_live_test.exs
@@ -1,7 +1,9 @@
 defmodule TeiserverWeb.General.Home.IndexLiveTest do
   @moduledoc false
 
+  alias Teiserver.Account.User
   alias Teiserver.Helpers.GeneralTestLib
+  alias Teiserver.Repo
   alias Teiserver.TeiserverTestLib
 
   use TeiserverWeb.ConnCase
@@ -34,6 +36,28 @@ defmodule TeiserverWeb.General.Home.IndexLiveTest do
 
       assert html =~ "Logout"
       assert html =~ "Account"
+    end
+  end
+
+  describe "GDPR forget" do
+    setup [:auth_setup]
+
+    test "users set to forget cannot access other pages", %{conn: conn, user: user} do
+      # First ensure we can access the homepage
+      {:ok, _index_live, _html} = live(conn, ~p"/")
+
+      # Now we set the user to be forgotten
+      {:ok, _new_user} =
+        user
+        |> User.set_gdpr_forget_changeset(%{gdpr_forget_after: DateTime.utc_now()})
+        |> Repo.update()
+
+      # Now when we go to access the homepage it should redirect to the logout page
+      {:error, {:redirect, %{to: "/logout", flash: _flash}}} = live(conn, ~p"/")
+
+      # Try a different page, it's not just the homepage this happens with
+      {:error, {:redirect, %{to: "/logout", flash: _flash}}} =
+        live(conn, ~p"/account/relationship")
     end
   end
 end


### PR DESCRIPTION
Users with `gdpr_forget_after` set are unable to login via the normal protocol and must instead go via the website where we can ensure they are explicitly told that logging in will remove the forget process (and log the entire thing).

Screenshot of the forgotten confirmation page
<img width="1399" height="677" alt="image" src="https://github.com/user-attachments/assets/7163fde8-cc14-413b-a2fa-8ee1dc22ce47" />
